### PR TITLE
Fix single-env service restart reloading unrelated gateways

### DIFF
--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -92,21 +92,67 @@ pub fn restart_service(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<ServiceActionSummary, String> {
+    ensure_gateway_binding(name, env, cwd)?;
     let env_service = EnvironmentService::new(env, cwd);
     let meta = env_service.get(name)?;
-    if meta.service_enabled && meta.service_running {
-        env_service.set_service_policy(name, Some(true), Some(false))?;
+    if !(meta.service_enabled && meta.service_running) {
+        return update_service(
+            name,
+            "restart",
+            Some(true),
+            Some(true),
+            false,
+            ServiceSupervisorPolicy::EnsureRunning,
+            env,
+            cwd,
+        );
     }
-    update_service(
-        name,
-        "restart",
-        Some(true),
-        Some(true),
-        true,
-        ServiceSupervisorPolicy::EnsureRunning,
-        env,
-        cwd,
-    )
+
+    let before = super::inspect::service_status_fast(name, env, cwd)?;
+    let Some(previous_pid) = before.child_pid else {
+        return update_service(
+            name,
+            "restart",
+            Some(true),
+            Some(true),
+            false,
+            ServiceSupervisorPolicy::EnsureRunning,
+            env,
+            cwd,
+        );
+    };
+    if !(before.ocm_service_running && before.running) {
+        return update_service(
+            name,
+            "restart",
+            Some(true),
+            Some(true),
+            false,
+            ServiceSupervisorPolicy::EnsureRunning,
+            env,
+            cwd,
+        );
+    }
+
+    let supervisor = SupervisorService::new(env, cwd);
+    let request_id = supervisor.request_child_restart(name)?;
+    let restart_result = wait_for_restart_action_summary(name, previous_pid, env, cwd);
+    let clear_result = supervisor.clear_child_restart_request(name, &request_id);
+    match (restart_result, clear_result) {
+        (Ok((summary, warnings)), Ok(())) => {
+            Ok(service_action_summary("restart", summary, warnings))
+        }
+        (Ok((summary, mut warnings)), Err(clear_error)) => {
+            warnings.push(format!(
+                "restart completed, but failed to clear restart request: {clear_error}"
+            ));
+            Ok(service_action_summary("restart", summary, warnings))
+        }
+        (Err(restart_error), Ok(())) => Err(restart_error),
+        (Err(restart_error), Err(clear_error)) => Err(format!(
+            "{restart_error}; additionally failed to clear restart request: {clear_error}"
+        )),
+    }
 }
 
 pub fn uninstall_service(
@@ -197,6 +243,34 @@ fn wait_for_action_summary(
         );
     }
     Ok((latest, warnings))
+}
+
+fn wait_for_restart_action_summary(
+    name: &str,
+    previous_pid: u32,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<(ServiceSummary, Vec<String>), String> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut latest = super::inspect::service_status_fast(name, env, cwd)?;
+    while Instant::now() < deadline {
+        if latest.running
+            && latest
+                .child_pid
+                .is_some_and(|child_pid| child_pid != previous_pid)
+        {
+            return Ok((latest, Vec::new()));
+        }
+        sleep(Duration::from_millis(100));
+        latest = super::inspect::service_status_fast(name, env, cwd)?;
+    }
+
+    Ok((
+        latest,
+        vec![format!(
+            "gateway restart is still in progress; previous child pid was {previous_pid}"
+        )],
+    ))
 }
 
 fn service_action_summary(

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -36,6 +36,12 @@ enum ServiceSupervisorPolicy {
     EnsureRunning,
 }
 
+struct RestartActionStatus {
+    summary: ServiceSummary,
+    warnings: Vec<String>,
+    observed_restart: bool,
+}
+
 pub fn install_service(
     name: &str,
     env: &BTreeMap<String, String>,
@@ -137,21 +143,23 @@ pub fn restart_service(
     let supervisor = SupervisorService::new(env, cwd);
     let request_id = supervisor.request_child_restart(name)?;
     let restart_result = wait_for_restart_action_summary(name, previous_pid, env, cwd);
-    let clear_result = supervisor.clear_child_restart_request(name, &request_id);
-    match (restart_result, clear_result) {
-        (Ok((summary, warnings)), Ok(())) => {
-            Ok(service_action_summary("restart", summary, warnings))
+    match restart_result {
+        Ok(mut status) => {
+            if status.observed_restart {
+                if let Err(clear_error) = supervisor.clear_child_restart_request(name, &request_id)
+                {
+                    status.warnings.push(format!(
+                        "restart completed, but failed to clear restart request: {clear_error}"
+                    ));
+                }
+            }
+            Ok(service_action_summary(
+                "restart",
+                status.summary,
+                status.warnings,
+            ))
         }
-        (Ok((summary, mut warnings)), Err(clear_error)) => {
-            warnings.push(format!(
-                "restart completed, but failed to clear restart request: {clear_error}"
-            ));
-            Ok(service_action_summary("restart", summary, warnings))
-        }
-        (Err(restart_error), Ok(())) => Err(restart_error),
-        (Err(restart_error), Err(clear_error)) => Err(format!(
-            "{restart_error}; additionally failed to clear restart request: {clear_error}"
-        )),
+        Err(restart_error) => Err(restart_error),
     }
 }
 
@@ -250,7 +258,7 @@ fn wait_for_restart_action_summary(
     previous_pid: u32,
     env: &BTreeMap<String, String>,
     cwd: &Path,
-) -> Result<(ServiceSummary, Vec<String>), String> {
+) -> Result<RestartActionStatus, String> {
     let deadline = Instant::now() + Duration::from_secs(30);
     let mut latest = super::inspect::service_status_fast(name, env, cwd)?;
     while Instant::now() < deadline {
@@ -259,18 +267,23 @@ fn wait_for_restart_action_summary(
                 .child_pid
                 .is_some_and(|child_pid| child_pid != previous_pid)
         {
-            return Ok((latest, Vec::new()));
+            return Ok(RestartActionStatus {
+                summary: latest,
+                warnings: Vec::new(),
+                observed_restart: true,
+            });
         }
         sleep(Duration::from_millis(100));
         latest = super::inspect::service_status_fast(name, env, cwd)?;
     }
 
-    Ok((
-        latest,
-        vec![format!(
+    Ok(RestartActionStatus {
+        summary: latest,
+        warnings: vec![format!(
             "gateway restart is still in progress; previous child pid was {previous_pid}"
         )],
-    ))
+        observed_restart: false,
+    })
 }
 
 fn service_action_summary(

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -115,19 +115,7 @@ pub fn restart_service(
     }
 
     let before = super::inspect::service_status_fast(name, env, cwd)?;
-    let Some(previous_pid) = before.child_pid else {
-        return update_service(
-            name,
-            "restart",
-            Some(true),
-            Some(true),
-            false,
-            ServiceSupervisorPolicy::EnsureRunning,
-            env,
-            cwd,
-        );
-    };
-    if !(before.ocm_service_running && before.running) {
+    if !before.ocm_service_running {
         return update_service(
             name,
             "restart",
@@ -142,7 +130,7 @@ pub fn restart_service(
 
     let supervisor = SupervisorService::new(env, cwd);
     let request_id = supervisor.request_child_restart(name)?;
-    let restart_result = wait_for_restart_action_summary(name, previous_pid, env, cwd);
+    let restart_result = wait_for_restart_action_summary(name, before.child_pid, env, cwd);
     match restart_result {
         Ok(mut status) => {
             if status.observed_restart {
@@ -255,7 +243,7 @@ fn wait_for_action_summary(
 
 fn wait_for_restart_action_summary(
     name: &str,
-    previous_pid: u32,
+    previous_pid: Option<u32>,
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<RestartActionStatus, String> {
@@ -265,7 +253,7 @@ fn wait_for_restart_action_summary(
         if latest.running
             && latest
                 .child_pid
-                .is_some_and(|child_pid| child_pid != previous_pid)
+                .is_some_and(|child_pid| previous_pid != Some(child_pid))
         {
             return Ok(RestartActionStatus {
                 summary: latest,
@@ -277,11 +265,16 @@ fn wait_for_restart_action_summary(
         latest = super::inspect::service_status_fast(name, env, cwd)?;
     }
 
+    let warning = match previous_pid {
+        Some(previous_pid) => {
+            format!("gateway restart is still in progress; previous child pid was {previous_pid}")
+        }
+        None => "gateway restart is still in progress; no replacement child pid has been observed"
+            .to_string(),
+    };
     Ok(RestartActionStatus {
         summary: latest,
-        warnings: vec![format!(
-            "gateway restart is still in progress; previous child pid was {previous_pid}"
-        )],
+        warnings: vec![warning],
         observed_restart: false,
     })
 }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -249,8 +249,9 @@ impl<'a> SupervisorService<'a> {
     }
 
     pub fn sync(&self) -> Result<SupervisorView, String> {
-        let state = self.build_state()?;
         let state_path = supervisor_state_path(self.env, self.cwd)?;
+        let mut state = self.build_state()?;
+        preserve_persisted_restart_requests(&state_path, &mut state);
         if let Some(parent) = state_path.parent() {
             ensure_dir(parent)?;
         }
@@ -327,7 +328,11 @@ impl<'a> SupervisorService<'a> {
     }
 
     pub fn request_child_restart(&self, name: &str) -> Result<String, String> {
-        let (state_path, mut state) = self.read_persisted_state()?;
+        let (mut state_path, mut state) = self.read_or_rebuild_persisted_state()?;
+        if active_child_spec(&state, name).is_none() {
+            let _ = self.sync()?;
+            (state_path, state) = self.read_persisted_state()?;
+        }
         if active_child_spec(&state, name).is_none() {
             return Err(format!(
                 "env \"{name}\" is not present in the persisted supervisor state"
@@ -454,6 +459,16 @@ impl<'a> SupervisorService<'a> {
         }
         let state = read_json(&state_path)?;
         Ok((state_path, state))
+    }
+
+    fn read_or_rebuild_persisted_state(&self) -> Result<(PathBuf, SupervisorState), String> {
+        match self.read_persisted_state() {
+            Ok(state) => Ok(state),
+            Err(_) => {
+                let _ = self.sync()?;
+                self.read_persisted_state()
+            }
+        }
     }
 
     fn refresh_daemon(&self, action: &str) -> Result<SupervisorDaemonSummary, String> {
@@ -854,6 +869,30 @@ fn child_map(children: &[SupervisorChildSpec]) -> BTreeMap<String, SupervisorChi
         .cloned()
         .map(|child| (child.env_name.clone(), child))
         .collect()
+}
+
+fn preserve_persisted_restart_requests(state_path: &Path, state: &mut SupervisorState) {
+    let Ok(persisted_state) = read_json::<SupervisorState>(state_path) else {
+        return;
+    };
+
+    preserve_restart_requests(state, persisted_state.restart_requests);
+}
+
+fn preserve_restart_requests(
+    state: &mut SupervisorState,
+    requests: impl IntoIterator<Item = SupervisorRestartRequest>,
+) {
+    for request in requests {
+        if active_child_spec(state, &request.env_name).is_none()
+            || state.restart_requests.iter().any(|existing| {
+                existing.env_name == request.env_name && existing.request_id == request.request_id
+            })
+        {
+            continue;
+        }
+        state.restart_requests.push(request);
+    }
 }
 
 fn read_updated_supervisor_state(
@@ -2102,6 +2141,32 @@ mod tests {
 
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].request_id, "restart-2");
+    }
+
+    #[test]
+    fn preserve_restart_requests_keeps_only_active_children() {
+        let mut state = supervisor_state(Vec::new());
+        preserve_restart_requests(
+            &mut state,
+            [
+                SupervisorRestartRequest {
+                    env_name: "demo".to_string(),
+                    request_id: "restart-1".to_string(),
+                },
+                SupervisorRestartRequest {
+                    env_name: "missing".to_string(),
+                    request_id: "restart-2".to_string(),
+                },
+            ],
+        );
+
+        assert_eq!(
+            state.restart_requests,
+            vec![SupervisorRestartRequest {
+                env_name: "demo".to_string(),
+                request_id: "restart-1".to_string(),
+            }]
+        );
     }
 
     #[test]

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -46,14 +46,8 @@ const SERVICE_PROXY_ENV_KEYS: [&str; 8] = [
     "all_proxy",
 ];
 const SERVICE_EXTRA_ENV_KEYS: [&str; 2] = ["NODE_EXTRA_CA_CERTS", "NODE_USE_SYSTEM_CA"];
-const SUPERVISED_CHILD_BASE_ENV_KEYS: [&str; 6] = [
-    "HOME",
-    "PATH",
-    "TMPDIR",
-    "OCM_HOME",
-    "OCM_SELF",
-    "SHELL",
-];
+const SUPERVISED_CHILD_BASE_ENV_KEYS: [&str; 6] =
+    ["HOME", "PATH", "TMPDIR", "OCM_HOME", "OCM_SELF", "SHELL"];
 const OPENCLAW_SERVICE_MARKER: &str = "openclaw";
 const OPENCLAW_GATEWAY_SERVICE_KIND: &str = "gateway";
 const OPENCLAW_RESTART_HANDOFF_FILE: &str = "gateway-supervisor-restart-handoff.json";
@@ -1565,20 +1559,58 @@ fn build_supervised_openclaw_env(
     process_env
 }
 
-fn stable_supervised_child_env(
-    process_env: BTreeMap<String, String>,
-) -> BTreeMap<String, String> {
-    process_env
-        .into_iter()
-        .filter(|(key, value)| {
-            !value.trim().is_empty()
-                && (key.starts_with("OPENCLAW_")
-                    || key.starts_with("OCM_")
-                    || SUPERVISED_CHILD_BASE_ENV_KEYS.contains(&key.as_str())
-                    || SERVICE_PROXY_ENV_KEYS.contains(&key.as_str())
-                    || SERVICE_EXTRA_ENV_KEYS.contains(&key.as_str()))
-        })
-        .collect()
+fn stable_supervised_child_env(process_env: BTreeMap<String, String>) -> BTreeMap<String, String> {
+    let mut stable_env = BTreeMap::new();
+    for (key, value) in process_env {
+        let value = value.trim();
+        if value.is_empty()
+            || !(key.starts_with("OPENCLAW_")
+                || key.starts_with("OCM_")
+                || SUPERVISED_CHILD_BASE_ENV_KEYS.contains(&key.as_str())
+                || SERVICE_PROXY_ENV_KEYS.contains(&key.as_str())
+                || SERVICE_EXTRA_ENV_KEYS.contains(&key.as_str()))
+        {
+            continue;
+        }
+
+        let value = if key == "PATH" {
+            stable_supervised_child_path(value).unwrap_or_else(|| DEFAULT_SERVICE_PATH.to_string())
+        } else {
+            value.to_string()
+        };
+        stable_env.insert(key, value);
+    }
+    stable_env
+}
+
+fn stable_supervised_child_path(path: &str) -> Option<String> {
+    let mut entries = Vec::new();
+    for raw_entry in path.split(':') {
+        let entry = raw_entry.trim();
+        if entry.is_empty() || volatile_supervised_path_entry(entry) {
+            continue;
+        }
+        if !entries.iter().any(|existing| existing == entry) {
+            entries.push(entry.to_string());
+        }
+    }
+
+    if entries.is_empty() {
+        None
+    } else {
+        Some(entries.join(":"))
+    }
+}
+
+fn volatile_supervised_path_entry(entry: &str) -> bool {
+    let normalized = entry.replace('\\', "/");
+    normalized.contains("/codex-home/tmp/")
+        || normalized.contains("/.codex/tmp/")
+        || normalized.contains("/tmp/arg0/")
+        || (normalized.contains("/node_modules/@openai/codex")
+            && normalized.ends_with("/codex-path"))
+        || normalized.contains("/Cellar/node/")
+        || normalized.contains("/Cellar/node@")
 }
 
 fn write_supervisor_runtime_state(
@@ -1889,14 +1921,20 @@ mod tests {
                 ("HTTPS_PROXY".to_string(), "http://proxy".to_string()),
                 ("GH_TOKEN".to_string(), "caller-token".to_string()),
                 ("PWD".to_string(), "/tmp/caller-workspace".to_string()),
-                ("XPC_SERVICE_NAME".to_string(), "agent-heartbeat".to_string()),
+                (
+                    "XPC_SERVICE_NAME".to_string(),
+                    "agent-heartbeat".to_string(),
+                ),
                 ("CODEX_SESSION_ID".to_string(), "session-123".to_string()),
             ]),
             "ai.openclaw.ocm",
             ServiceManagerKind::Launchd,
         );
 
-        assert_eq!(process_env.get("HOME").map(String::as_str), Some("/Users/demo"));
+        assert_eq!(
+            process_env.get("HOME").map(String::as_str),
+            Some("/Users/demo")
+        );
         assert_eq!(
             process_env.get("OPENCLAW_HOME").map(String::as_str),
             Some("/Users/demo/.ocm/envs/rescue/.openclaw")
@@ -1909,10 +1947,45 @@ mod tests {
             process_env.get("HTTPS_PROXY").map(String::as_str),
             Some("http://proxy")
         );
+        assert_eq!(
+            process_env.get("PATH").map(String::as_str),
+            Some("/usr/bin:/bin")
+        );
         assert!(!process_env.contains_key("GH_TOKEN"));
         assert!(!process_env.contains_key("PWD"));
         assert!(!process_env.contains_key("XPC_SERVICE_NAME"));
         assert!(!process_env.contains_key("CODEX_SESSION_ID"));
+    }
+
+    #[test]
+    fn supervised_child_env_sanitizes_volatile_path_entries() {
+        let process_env = build_supervised_openclaw_env(
+            BTreeMap::from([
+                ("HOME".to_string(), "/Users/demo".to_string()),
+                (
+                    "PATH".to_string(),
+                    [
+                        "/opt/homebrew/bin",
+                        "/usr/bin",
+                        "/bin",
+                        "/usr/bin",
+                        "/Users/demo/.ocm/envs/rescue/.openclaw/agents/main/agent/codex-home/tmp/arg0/codex-arg0abc",
+                        "/Users/demo/.codex/tmp/arg0/codex-arg0def",
+                        "/Users/demo/.ocm/envs/rescue/.openclaw/npm/projects/openclaw-codex/node_modules/@openclaw/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path",
+                        "/opt/homebrew/Cellar/node/26.3.0/bin",
+                        "/Users/demo/.local/bin",
+                    ]
+                    .join(":"),
+                ),
+            ]),
+            "ai.openclaw.ocm",
+            ServiceManagerKind::Launchd,
+        );
+
+        assert_eq!(
+            process_env.get("PATH").map(String::as_str),
+            Some("/opt/homebrew/bin:/usr/bin:/bin:/Users/demo/.local/bin")
+        );
     }
 
     #[test]

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -46,6 +46,14 @@ const SERVICE_PROXY_ENV_KEYS: [&str; 8] = [
     "all_proxy",
 ];
 const SERVICE_EXTRA_ENV_KEYS: [&str; 2] = ["NODE_EXTRA_CA_CERTS", "NODE_USE_SYSTEM_CA"];
+const SUPERVISED_CHILD_BASE_ENV_KEYS: [&str; 6] = [
+    "HOME",
+    "PATH",
+    "TMPDIR",
+    "OCM_HOME",
+    "OCM_SELF",
+    "SHELL",
+];
 const OPENCLAW_SERVICE_MARKER: &str = "openclaw";
 const OPENCLAW_GATEWAY_SERVICE_KIND: &str = "gateway";
 const OPENCLAW_RESTART_HANDOFF_FILE: &str = "gateway-supervisor-restart-handoff.json";
@@ -1526,10 +1534,11 @@ fn supervisor_service_environment(
 }
 
 fn build_supervised_openclaw_env(
-    mut process_env: BTreeMap<String, String>,
+    process_env: BTreeMap<String, String>,
     service_label: &str,
     service_manager: ServiceManagerKind,
 ) -> BTreeMap<String, String> {
+    let mut process_env = stable_supervised_child_env(process_env);
     process_env.insert(
         "OPENCLAW_SERVICE_MARKER".to_string(),
         OPENCLAW_SERVICE_MARKER.to_string(),
@@ -1554,6 +1563,22 @@ fn build_supervised_openclaw_env(
         ServiceManagerKind::Unsupported => {}
     }
     process_env
+}
+
+fn stable_supervised_child_env(
+    process_env: BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    process_env
+        .into_iter()
+        .filter(|(key, value)| {
+            !value.trim().is_empty()
+                && (key.starts_with("OPENCLAW_")
+                    || key.starts_with("OCM_")
+                    || SUPERVISED_CHILD_BASE_ENV_KEYS.contains(&key.as_str())
+                    || SERVICE_PROXY_ENV_KEYS.contains(&key.as_str())
+                    || SERVICE_EXTRA_ENV_KEYS.contains(&key.as_str()))
+        })
+        .collect()
 }
 
 fn write_supervisor_runtime_state(
@@ -1846,6 +1871,48 @@ mod tests {
                 .map(String::as_str),
             Some("ai.openclaw.ocm")
         );
+    }
+
+    #[test]
+    fn supervised_child_env_drops_volatile_caller_context() {
+        let process_env = build_supervised_openclaw_env(
+            BTreeMap::from([
+                ("HOME".to_string(), "/Users/demo".to_string()),
+                ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+                ("TMPDIR".to_string(), "/tmp/demo".to_string()),
+                ("OCM_HOME".to_string(), "/Users/demo/.ocm".to_string()),
+                ("OCM_ACTIVE_ENV".to_string(), "rescue".to_string()),
+                (
+                    "OPENCLAW_HOME".to_string(),
+                    "/Users/demo/.ocm/envs/rescue/.openclaw".to_string(),
+                ),
+                ("HTTPS_PROXY".to_string(), "http://proxy".to_string()),
+                ("GH_TOKEN".to_string(), "caller-token".to_string()),
+                ("PWD".to_string(), "/tmp/caller-workspace".to_string()),
+                ("XPC_SERVICE_NAME".to_string(), "agent-heartbeat".to_string()),
+                ("CODEX_SESSION_ID".to_string(), "session-123".to_string()),
+            ]),
+            "ai.openclaw.ocm",
+            ServiceManagerKind::Launchd,
+        );
+
+        assert_eq!(process_env.get("HOME").map(String::as_str), Some("/Users/demo"));
+        assert_eq!(
+            process_env.get("OPENCLAW_HOME").map(String::as_str),
+            Some("/Users/demo/.ocm/envs/rescue/.openclaw")
+        );
+        assert_eq!(
+            process_env.get("OCM_ACTIVE_ENV").map(String::as_str),
+            Some("rescue")
+        );
+        assert_eq!(
+            process_env.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://proxy")
+        );
+        assert!(!process_env.contains_key("GH_TOKEN"));
+        assert!(!process_env.contains_key("PWD"));
+        assert!(!process_env.contains_key("XPC_SERVICE_NAME"));
+        assert!(!process_env.contains_key("CODEX_SESSION_ID"));
     }
 
     #[test]

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -48,6 +48,8 @@ const SERVICE_PROXY_ENV_KEYS: [&str; 8] = [
 const SERVICE_EXTRA_ENV_KEYS: [&str; 2] = ["NODE_EXTRA_CA_CERTS", "NODE_USE_SYSTEM_CA"];
 const SUPERVISED_CHILD_BASE_ENV_KEYS: [&str; 6] =
     ["HOME", "PATH", "TMPDIR", "OCM_HOME", "OCM_SELF", "SHELL"];
+const SUPERVISED_CHILD_RUNTIME_ENV_KEYS: [&str; 4] =
+    ["NODE_OPTIONS", "NODE_ENV", "NODE_PATH", "PNPM_HOME"];
 const OPENCLAW_SERVICE_MARKER: &str = "openclaw";
 const OPENCLAW_GATEWAY_SERVICE_KIND: &str = "gateway";
 const OPENCLAW_RESTART_HANDOFF_FILE: &str = "gateway-supervisor-restart-handoff.json";
@@ -1762,13 +1764,7 @@ fn stable_supervised_child_env(process_env: BTreeMap<String, String>) -> BTreeMa
     let mut stable_env = BTreeMap::new();
     for (key, value) in process_env {
         let value = value.trim();
-        if value.is_empty()
-            || !(key.starts_with("OPENCLAW_")
-                || key.starts_with("OCM_")
-                || SUPERVISED_CHILD_BASE_ENV_KEYS.contains(&key.as_str())
-                || SERVICE_PROXY_ENV_KEYS.contains(&key.as_str())
-                || SERVICE_EXTRA_ENV_KEYS.contains(&key.as_str()))
-        {
+        if value.is_empty() || !stable_supervised_child_env_key(&key) {
             continue;
         }
 
@@ -1780,6 +1776,18 @@ fn stable_supervised_child_env(process_env: BTreeMap<String, String>) -> BTreeMa
         stable_env.insert(key, value);
     }
     stable_env
+}
+
+fn stable_supervised_child_env_key(key: &str) -> bool {
+    key.starts_with("OPENCLAW_")
+        || key.starts_with("OCM_")
+        || key.starts_with("NPM_CONFIG_")
+        || key.starts_with("npm_config_")
+        || key.starts_with("COREPACK_")
+        || SUPERVISED_CHILD_BASE_ENV_KEYS.contains(&key)
+        || SUPERVISED_CHILD_RUNTIME_ENV_KEYS.contains(&key)
+        || SERVICE_PROXY_ENV_KEYS.contains(&key)
+        || SERVICE_EXTRA_ENV_KEYS.contains(&key)
 }
 
 fn stable_supervised_child_path(path: &str) -> Option<String> {
@@ -2332,6 +2340,63 @@ mod tests {
             process_env.get("PATH").map(String::as_str),
             Some("/opt/homebrew/bin:/usr/bin:/bin:/Users/demo/.local/bin")
         );
+    }
+
+    #[test]
+    fn supervised_child_env_preserves_stable_runtime_tool_env() {
+        let process_env = build_supervised_openclaw_env(
+            BTreeMap::from([
+                (
+                    "NODE_OPTIONS".to_string(),
+                    "--max-old-space-size=4096".to_string(),
+                ),
+                ("NODE_ENV".to_string(), "production".to_string()),
+                (
+                    "NPM_CONFIG_REGISTRY".to_string(),
+                    "https://registry.example".to_string(),
+                ),
+                ("npm_config_cache".to_string(), "/tmp/npm-cache".to_string()),
+                (
+                    "COREPACK_HOME".to_string(),
+                    "/Users/demo/.cache/corepack".to_string(),
+                ),
+                (
+                    "PNPM_HOME".to_string(),
+                    "/Users/demo/.local/share/pnpm".to_string(),
+                ),
+                ("GH_TOKEN".to_string(), "caller-token".to_string()),
+                ("PWD".to_string(), "/tmp/caller-workspace".to_string()),
+            ]),
+            "ai.openclaw.ocm",
+            ServiceManagerKind::Launchd,
+        );
+
+        assert_eq!(
+            process_env.get("NODE_OPTIONS").map(String::as_str),
+            Some("--max-old-space-size=4096")
+        );
+        assert_eq!(
+            process_env.get("NODE_ENV").map(String::as_str),
+            Some("production")
+        );
+        assert_eq!(
+            process_env.get("NPM_CONFIG_REGISTRY").map(String::as_str),
+            Some("https://registry.example")
+        );
+        assert_eq!(
+            process_env.get("npm_config_cache").map(String::as_str),
+            Some("/tmp/npm-cache")
+        );
+        assert_eq!(
+            process_env.get("COREPACK_HOME").map(String::as_str),
+            Some("/Users/demo/.cache/corepack")
+        );
+        assert_eq!(
+            process_env.get("PNPM_HOME").map(String::as_str),
+            Some("/Users/demo/.local/share/pnpm")
+        );
+        assert!(!process_env.contains_key("GH_TOKEN"));
+        assert!(!process_env.contains_key("PWD"));
     }
 
     #[test]

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -330,8 +330,12 @@ impl<'a> SupervisorService<'a> {
     }
 
     pub fn request_child_restart(&self, name: &str) -> Result<String, String> {
-        let _ = self.sync()?;
-        let (state_path, mut state) = self.read_persisted_state()?;
+        let state_path = supervisor_state_path(self.env, self.cwd)?;
+        let mut state = self.build_state()?;
+        if let Ok(persisted_state) = read_json::<SupervisorState>(&state_path) {
+            preserve_persisted_child_specs_except(&mut state, persisted_state.children, name);
+            preserve_restart_requests(&mut state, persisted_state.restart_requests);
+        }
         if active_child_spec(&state, name).is_none() {
             return Err(format!(
                 "env \"{name}\" is not present in the persisted supervisor state"
@@ -346,6 +350,10 @@ impl<'a> SupervisorService<'a> {
             env_name: name.to_string(),
             request_id: request_id.clone(),
         });
+        if let Some(parent) = state_path.parent() {
+            ensure_dir(parent)?;
+        }
+        ensure_dir(&supervisor_logs_dir(self.env, self.cwd)?)?;
         write_json(&state_path, &state)?;
         Ok(request_id)
     }
@@ -866,6 +874,25 @@ fn preserve_persisted_restart_requests(state_path: &Path, state: &mut Supervisor
     };
 
     preserve_restart_requests(state, persisted_state.restart_requests);
+}
+
+fn preserve_persisted_child_specs_except(
+    state: &mut SupervisorState,
+    persisted_children: Vec<SupervisorChildSpec>,
+    refreshed_env_name: &str,
+) {
+    let persisted = persisted_children
+        .into_iter()
+        .map(|child| (child.env_name.clone(), child))
+        .collect::<BTreeMap<_, _>>();
+    for child in &mut state.children {
+        if child.env_name == refreshed_env_name {
+            continue;
+        }
+        if let Some(persisted_child) = persisted.get(&child.env_name) {
+            *child = persisted_child.clone();
+        }
+    }
 }
 
 fn preserve_restart_requests(
@@ -1803,8 +1830,6 @@ fn volatile_supervised_path_entry(entry: &str) -> bool {
         || normalized.contains("/tmp/arg0/")
         || (normalized.contains("/node_modules/@openai/codex")
             && normalized.ends_with("/codex-path"))
-        || normalized.contains("/Cellar/node/")
-        || normalized.contains("/Cellar/node@")
 }
 
 fn write_supervisor_runtime_state(
@@ -2314,6 +2339,7 @@ mod tests {
                         "/Users/demo/.codex/tmp/arg0/codex-arg0def",
                         "/Users/demo/.ocm/envs/rescue/.openclaw/npm/projects/openclaw-codex/node_modules/@openclaw/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path",
                         "/opt/homebrew/Cellar/node/26.3.0/bin",
+                        "/opt/homebrew/Cellar/node@22/22.17.0/bin",
                         "/Users/demo/.local/bin",
                     ]
                     .join(":"),
@@ -2325,7 +2351,9 @@ mod tests {
 
         assert_eq!(
             process_env.get("PATH").map(String::as_str),
-            Some("/opt/homebrew/bin:/usr/bin:/bin:/Users/demo/.local/bin")
+            Some(
+                "/opt/homebrew/bin:/usr/bin:/bin:/opt/homebrew/Cellar/node/26.3.0/bin:/opt/homebrew/Cellar/node@22/22.17.0/bin:/Users/demo/.local/bin"
+            )
         );
     }
 

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -330,11 +330,8 @@ impl<'a> SupervisorService<'a> {
     }
 
     pub fn request_child_restart(&self, name: &str) -> Result<String, String> {
-        let (mut state_path, mut state) = self.read_or_rebuild_persisted_state()?;
-        if active_child_spec(&state, name).is_none() {
-            let _ = self.sync()?;
-            (state_path, state) = self.read_persisted_state()?;
-        }
+        let _ = self.sync()?;
+        let (state_path, mut state) = self.read_persisted_state()?;
         if active_child_spec(&state, name).is_none() {
             return Err(format!(
                 "env \"{name}\" is not present in the persisted supervisor state"
@@ -461,16 +458,6 @@ impl<'a> SupervisorService<'a> {
         }
         let state = read_json(&state_path)?;
         Ok((state_path, state))
-    }
-
-    fn read_or_rebuild_persisted_state(&self) -> Result<(PathBuf, SupervisorState), String> {
-        match self.read_persisted_state() {
-            Ok(state) => Ok(state),
-            Err(_) => {
-                let _ = self.sync()?;
-                self.read_persisted_state()
-            }
-        }
     }
 
     fn refresh_daemon(&self, action: &str) -> Result<SupervisorDaemonSummary, String> {

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -82,6 +82,13 @@ pub struct SkippedSupervisorEnv {
     pub reason: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SupervisorRestartRequest {
+    pub env_name: String,
+    pub request_id: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SupervisorState {
@@ -91,6 +98,8 @@ pub struct SupervisorState {
     pub generated_at: OffsetDateTime,
     pub children: Vec<SupervisorChildSpec>,
     pub skipped_envs: Vec<SkippedSupervisorEnv>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub restart_requests: Vec<SupervisorRestartRequest>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -317,6 +326,38 @@ impl<'a> SupervisorService<'a> {
         self.activate_daemon("install")
     }
 
+    pub fn request_child_restart(&self, name: &str) -> Result<String, String> {
+        let (state_path, mut state) = self.read_persisted_state()?;
+        if active_child_spec(&state, name).is_none() {
+            return Err(format!(
+                "env \"{name}\" is not present in the persisted supervisor state"
+            ));
+        }
+
+        let request_id = supervisor_restart_request_id(name);
+        state
+            .restart_requests
+            .retain(|request| request.env_name != name);
+        state.restart_requests.push(SupervisorRestartRequest {
+            env_name: name.to_string(),
+            request_id: request_id.clone(),
+        });
+        write_json(&state_path, &state)?;
+        Ok(request_id)
+    }
+
+    pub fn clear_child_restart_request(&self, name: &str, request_id: &str) -> Result<(), String> {
+        let (state_path, mut state) = self.read_persisted_state()?;
+        let previous_len = state.restart_requests.len();
+        state
+            .restart_requests
+            .retain(|request| !(request.env_name == name && request.request_id == request_id));
+        if state.restart_requests.len() != previous_len {
+            write_json(&state_path, &state)?;
+        }
+        Ok(())
+    }
+
     pub fn daemon_status(&self) -> Result<SupervisorDaemonSummary, String> {
         self.daemon_summary("status")
     }
@@ -400,6 +441,7 @@ impl<'a> SupervisorService<'a> {
             generated_at: now_utc(),
             children,
             skipped_envs,
+            restart_requests: Vec::new(),
         })
     }
 
@@ -846,9 +888,13 @@ fn refresh_active_state(
     let Some(next_state) = read_updated_supervisor_state(state_path, active_state) else {
         return false;
     };
-    let runtime_dirty = reconcile_running_children(running, pending, inactive, &next_state);
+    let restart_requests = new_supervisor_restart_requests(active_state, &next_state);
+    let mut runtime_dirty = reconcile_running_children(running, pending, inactive, &next_state);
+    runtime_dirty |=
+        reconcile_restart_requests(&restart_requests, running, pending, inactive, &next_state);
     *managed_child_count = next_state.children.len();
     *active_state = next_state;
+    clear_processed_restart_requests(state_path, &restart_requests);
     runtime_dirty
 }
 
@@ -921,6 +967,115 @@ fn reconcile_running_children(
     }
     queue_missing_children(pending, running, &desired_state.children, 0, Instant::now());
     runtime_dirty
+}
+
+fn reconcile_restart_requests(
+    restart_requests: &[SupervisorRestartRequest],
+    running: &mut BTreeMap<String, RunningSupervisorChild>,
+    pending: &mut BTreeMap<String, PendingSupervisorChild>,
+    inactive: &mut BTreeMap<String, InactiveSupervisorChild>,
+    desired_state: &SupervisorState,
+) -> bool {
+    if restart_requests.is_empty() {
+        return false;
+    }
+
+    let desired = child_map(&desired_state.children);
+    let mut runtime_dirty = false;
+    for request in restart_requests {
+        let Some(next_spec) = desired.get(&request.env_name).cloned() else {
+            continue;
+        };
+
+        if let Some(mut existing) = running.remove(&request.env_name) {
+            eprintln!(
+                "ocm service: restarting {} ({})",
+                existing.spec.env_name,
+                child_binding_label(&next_spec)
+            );
+            let restart_count = existing.restart_count + 1;
+            stop_supervisor_child(&mut existing);
+            pending.insert(
+                request.env_name.clone(),
+                pending_supervisor_child(next_spec, restart_count, 0, 0, None, None),
+            );
+            inactive.remove(&request.env_name);
+            runtime_dirty = true;
+            continue;
+        }
+
+        if let Some(pending_child) = pending.get_mut(&request.env_name) {
+            pending_child.spec = next_spec;
+            pending_child.retry_at = Instant::now();
+            pending_child.retry_at_utc = now_utc();
+            pending_child.last_error = None;
+            pending_child.last_event_at = Some(now_utc());
+            inactive.remove(&request.env_name);
+            runtime_dirty = true;
+            continue;
+        }
+
+        pending.insert(
+            request.env_name.clone(),
+            pending_supervisor_child(next_spec, 0, 0, 0, None, None),
+        );
+        inactive.remove(&request.env_name);
+        runtime_dirty = true;
+    }
+    runtime_dirty
+}
+
+fn new_supervisor_restart_requests(
+    active_state: &SupervisorState,
+    next_state: &SupervisorState,
+) -> Vec<SupervisorRestartRequest> {
+    next_state
+        .restart_requests
+        .iter()
+        .filter(|request| {
+            !active_state.restart_requests.iter().any(|existing| {
+                existing.env_name == request.env_name && existing.request_id == request.request_id
+            })
+        })
+        .cloned()
+        .collect()
+}
+
+fn clear_processed_restart_requests(
+    state_path: &Path,
+    restart_requests: &[SupervisorRestartRequest],
+) {
+    if restart_requests.is_empty() {
+        return;
+    }
+
+    let mut state = match read_json::<SupervisorState>(state_path) {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!(
+                "ocm service: failed reading state to clear processed restart request {}: {}",
+                display_path(state_path),
+                error
+            );
+            return;
+        }
+    };
+    let previous_len = state.restart_requests.len();
+    state.restart_requests.retain(|request| {
+        !restart_requests.iter().any(|processed| {
+            processed.env_name == request.env_name && processed.request_id == request.request_id
+        })
+    });
+    if state.restart_requests.len() == previous_len {
+        return;
+    }
+    if let Err(error) = write_json(state_path, &state) {
+        eprintln!(
+            "ocm service: failed clearing processed restart request {}: {}",
+            display_path(state_path),
+            error
+        );
+    }
 }
 
 fn collect_exited_children(
@@ -1158,6 +1313,10 @@ fn now_millis() -> u64 {
         .unwrap_or(0)
 }
 
+fn supervisor_restart_request_id(name: &str) -> String {
+    format!("{}-{}-{}", name, std::process::id(), now_millis())
+}
+
 fn read_openclaw_restart_handoff(path: &Path) -> Option<OpenClawRestartHandoff> {
     let metadata = fs::symlink_metadata(path).ok()?;
     if !metadata.file_type().is_file()
@@ -1353,6 +1512,7 @@ fn supervisor_state_equivalent(left: &SupervisorState, right: &SupervisorState) 
         && left.ocm_home == right.ocm_home
         && left.children == right.children
         && left.skipped_envs == right.skipped_envs
+        && left.restart_requests == right.restart_requests
 }
 
 fn active_child_spec<'a>(
@@ -1713,6 +1873,36 @@ fn supervisor_runtime_service_inactive(
 mod tests {
     use super::*;
 
+    fn child_spec(name: &str, child_port: u32) -> SupervisorChildSpec {
+        SupervisorChildSpec {
+            env_name: name.to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: "stable".to_string(),
+            command: None,
+            binary_path: Some("/usr/bin/true".to_string()),
+            runtime_source_kind: Some("managed".to_string()),
+            runtime_release_version: Some("1.0.0".to_string()),
+            runtime_release_channel: Some("stable".to_string()),
+            args: Vec::new(),
+            run_dir: format!("/tmp/{name}"),
+            child_port,
+            stdout_path: format!("/tmp/{name}.stdout.log"),
+            stderr_path: format!("/tmp/{name}.stderr.log"),
+            process_env: BTreeMap::new(),
+        }
+    }
+
+    fn supervisor_state(restart_requests: Vec<SupervisorRestartRequest>) -> SupervisorState {
+        SupervisorState {
+            kind: SUPERVISOR_STATE_KIND.to_string(),
+            ocm_home: "/tmp/ocm".to_string(),
+            generated_at: OffsetDateTime::UNIX_EPOCH,
+            children: vec![child_spec("demo", 19999)],
+            skipped_envs: Vec::new(),
+            restart_requests,
+        }
+    }
+
     fn exited_child(
         exit_code: Option<i32>,
         restart_count: usize,
@@ -1877,6 +2067,97 @@ mod tests {
             decision.last_error.unwrap(),
             "process exited with 1; retrying after backoff"
         );
+    }
+
+    #[test]
+    fn restart_requests_are_part_of_supervisor_state_equivalence() {
+        let active = supervisor_state(Vec::new());
+        let requested = supervisor_state(vec![SupervisorRestartRequest {
+            env_name: "demo".to_string(),
+            request_id: "restart-1".to_string(),
+        }]);
+
+        assert!(!supervisor_state_equivalent(&active, &requested));
+        assert!(supervisor_state_equivalent(&requested, &requested));
+    }
+
+    #[test]
+    fn new_restart_requests_only_include_unseen_ids() {
+        let active = supervisor_state(vec![SupervisorRestartRequest {
+            env_name: "demo".to_string(),
+            request_id: "restart-1".to_string(),
+        }]);
+        let next = supervisor_state(vec![
+            SupervisorRestartRequest {
+                env_name: "demo".to_string(),
+                request_id: "restart-1".to_string(),
+            },
+            SupervisorRestartRequest {
+                env_name: "demo".to_string(),
+                request_id: "restart-2".to_string(),
+            },
+        ]);
+
+        let requests = new_supervisor_restart_requests(&active, &next);
+
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].request_id, "restart-2");
+    }
+
+    #[test]
+    fn restart_request_requeues_only_target_pending_child() {
+        let next_rescue = child_spec("rescue", 18790);
+        let main = child_spec("main", 19123);
+        let state = SupervisorState {
+            kind: SUPERVISOR_STATE_KIND.to_string(),
+            ocm_home: "/tmp/ocm".to_string(),
+            generated_at: OffsetDateTime::UNIX_EPOCH,
+            children: vec![main.clone(), next_rescue.clone()],
+            skipped_envs: Vec::new(),
+            restart_requests: Vec::new(),
+        };
+        let mut running = BTreeMap::new();
+        let mut pending = BTreeMap::from([
+            (
+                "main".to_string(),
+                pending_supervisor_child(
+                    main.clone(),
+                    7,
+                    0,
+                    30_000,
+                    Some(1),
+                    Some("backoff".to_string()),
+                ),
+            ),
+            (
+                "rescue".to_string(),
+                pending_supervisor_child(
+                    child_spec("rescue", 11111),
+                    5,
+                    0,
+                    30_000,
+                    Some(1),
+                    Some("backoff".to_string()),
+                ),
+            ),
+        ]);
+        let mut inactive = BTreeMap::new();
+
+        let runtime_dirty = reconcile_restart_requests(
+            &[SupervisorRestartRequest {
+                env_name: "rescue".to_string(),
+                request_id: "restart-1".to_string(),
+            }],
+            &mut running,
+            &mut pending,
+            &mut inactive,
+            &state,
+        );
+
+        assert!(runtime_dirty);
+        assert_eq!(pending.get("rescue").unwrap().spec, next_rescue);
+        assert_eq!(pending.get("main").unwrap().spec, main);
+        assert_eq!(pending.get("main").unwrap().restart_count, 7);
     }
 
     #[test]

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -524,7 +524,7 @@ fn env_changes_refresh_persisted_service_state_without_extra_commands() {
 fn child_restart_request_rebuilds_missing_or_stale_state() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("restart-request-rebuilds-state");
-    let (cwd, env) = setup_service_fixture(&root);
+    let (cwd, mut env) = setup_service_fixture(&root);
     let service = SupervisorService::new(&env, &cwd);
     let state_path = root.child("ocm-home/supervisor/state.json");
 
@@ -562,6 +562,32 @@ fn child_restart_request_rebuilds_missing_or_stale_state() {
             .iter()
             .any(|request| request["envName"] == "demo"
                 && request["requestId"] == stale_state_request)
+    );
+
+    env.insert(
+        "NODE_OPTIONS".to_string(),
+        "--max-old-space-size=2048".to_string(),
+    );
+    let service = SupervisorService::new(&env, &cwd);
+    let refreshed_env_request = service.request_child_restart("demo").unwrap();
+    let state = read_persisted_service_state(&state_path);
+    let demo = state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "demo")
+        .expect("demo child spec should be rebuilt");
+    assert_eq!(
+        demo["processEnv"]["NODE_OPTIONS"],
+        "--max-old-space-size=2048"
+    );
+    assert!(
+        state["restartRequests"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|request| request["envName"] == "demo"
+                && request["requestId"] == refreshed_env_request)
     );
 }
 

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -770,6 +770,59 @@ fn service_restart_restarts_only_the_target_child() {
 }
 
 #[test]
+fn service_restart_requeues_a_stopped_desired_child() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-restart-stopped-child");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+    let service = SupervisorService::new(&env, &cwd);
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+
+    let exit_once = root.child("exit-once");
+    let started = root.child("started.txt");
+    let script = root.child("bin/openclaw");
+    fs::write(&exit_once, "1\n").unwrap();
+    write_executable_script(
+        &script,
+        &format!(
+            "#!/bin/sh\nif [ -f '{}' ]; then rm -f '{}'; exit 0; fi\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&exit_once),
+            path_string(&exit_once),
+            path_string(&started),
+        ),
+    );
+
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "dev", "--command", &path_string(&script)],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+
+    let created = run_ocm(&cwd, &env, &["env", "create", "demo", "--launcher", "dev"]);
+    assert!(created.status.success(), "{}", stderr(&created));
+    set_service_enabled(&cwd, &env, "demo", true);
+    service.sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    wait_for_runtime_service_state(&runtime_path, "demo", "stopped", Duration::from_secs(5))
+        .expect("daemon runtime state did not report the quick clean exit as stopped");
+    assert!(!started.exists());
+
+    let restart = run_ocm(&cwd, &env, &["service", "restart", "demo", "--json"]);
+    assert!(restart.status.success(), "{}", stderr(&restart));
+    let runtime =
+        wait_for_runtime_children(&runtime_path, 1, Some("demo"), Duration::from_secs(10))
+            .expect("service restart did not requeue the stopped desired child");
+
+    assert!(runtime_child_pid(&runtime, "demo").is_some());
+    assert!(wait_for_file(&started, Duration::from_secs(5)));
+
+    stop_process(&mut daemon);
+}
+
+#[test]
 fn daemon_keeps_running_when_one_env_fails_to_spawn() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("daemon-run-spawn-failure");

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -109,6 +109,40 @@ fn wait_for_runtime_service_state(
     None
 }
 
+fn runtime_child_pid(body: &Value, env_name: &str) -> Option<u64> {
+    body["children"].as_array().and_then(|children| {
+        children
+            .iter()
+            .find(|child| child["envName"] == env_name)
+            .and_then(|child| child["pid"].as_u64())
+    })
+}
+
+fn wait_for_runtime_child_pid_change(
+    path: &Path,
+    target_env: &str,
+    previous_target_pid: u64,
+    sibling_env: &str,
+    previous_sibling_pid: u64,
+    timeout: Duration,
+) -> Option<Value> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(raw) = fs::read(path)
+            && let Ok(body) = serde_json::from_slice::<Value>(&raw)
+            && body["children"].as_array().map(|children| children.len()) == Some(2)
+            && let Some(target_pid) = runtime_child_pid(&body, target_env)
+            && let Some(sibling_pid) = runtime_child_pid(&body, sibling_env)
+            && target_pid != previous_target_pid
+            && sibling_pid == previous_sibling_pid
+        {
+            return Some(body);
+        }
+        sleep(Duration::from_millis(50));
+    }
+    None
+}
+
 fn restart_handoff_shell_snippet() -> &'static str {
     r#"mkdir -p "$OPENCLAW_STATE_DIR"
 now=$(( $(date +%s) * 1000 ))
@@ -121,6 +155,11 @@ JSON
 
 fn read_persisted_service_state(path: &Path) -> Value {
     serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+}
+
+fn write_persisted_service_state(path: &Path, value: &Value) {
+    let raw = serde_json::to_string_pretty(value).unwrap();
+    fs::write(path, format!("{raw}\n")).unwrap();
 }
 
 fn stop_process(child: &mut Child) {
@@ -482,6 +521,51 @@ fn env_changes_refresh_persisted_service_state_without_extra_commands() {
 }
 
 #[test]
+fn child_restart_request_rebuilds_missing_or_stale_state() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("restart-request-rebuilds-state");
+    let (cwd, env) = setup_service_fixture(&root);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+
+    service.sync().unwrap();
+    fs::remove_file(&state_path).unwrap();
+
+    let missing_state_request = service.request_child_restart("demo").unwrap();
+    let state = read_persisted_service_state(&state_path);
+    assert!(
+        state["restartRequests"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|request| request["envName"] == "demo"
+                && request["requestId"] == missing_state_request)
+    );
+
+    let mut stale_state = state.clone();
+    stale_state["children"] = Value::Array(Vec::new());
+    write_persisted_service_state(&state_path, &stale_state);
+
+    let stale_state_request = service.request_child_restart("demo").unwrap();
+    let state = read_persisted_service_state(&state_path);
+    assert!(
+        state["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|child| child["envName"] == "demo")
+    );
+    assert!(
+        state["restartRequests"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|request| request["envName"] == "demo"
+                && request["requestId"] == stale_state_request)
+    );
+}
+
+#[test]
 fn daemon_run_reloads_children_after_binding_changes() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("daemon-run-reconcile");
@@ -550,6 +634,111 @@ fn daemon_run_reloads_children_after_binding_changes() {
 
     assert!(wait_for_file(&old_stopped, Duration::from_secs(5)));
     assert!(wait_for_file(&new_started, Duration::from_secs(5)));
+
+    stop_process(&mut daemon);
+}
+
+#[test]
+fn service_restart_restarts_only_the_target_child() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-targeted-service-restart");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+    let service = SupervisorService::new(&env, &cwd);
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+
+    let rescue_started = root.child("rescue-started.txt");
+    let rescue_stopped = root.child("rescue-stopped.txt");
+    let main_started = root.child("main-started.txt");
+    let main_stopped = root.child("main-stopped.txt");
+    let rescue_script = root.child("bin/rescue-openclaw");
+    let main_script = root.child("bin/main-openclaw");
+    write_executable_script(
+        &rescue_script,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&rescue_started),
+            path_string(&rescue_stopped),
+        ),
+    );
+    write_executable_script(
+        &main_script,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&main_started),
+            path_string(&main_stopped),
+        ),
+    );
+
+    let rescue_launcher = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "launcher",
+            "add",
+            "rescue",
+            "--command",
+            &path_string(&rescue_script),
+        ],
+    );
+    assert!(
+        rescue_launcher.status.success(),
+        "{}",
+        stderr(&rescue_launcher)
+    );
+    let main_launcher = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "launcher",
+            "add",
+            "main",
+            "--command",
+            &path_string(&main_script),
+        ],
+    );
+    assert!(main_launcher.status.success(), "{}", stderr(&main_launcher));
+
+    let rescue_env = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "rescue", "--launcher", "rescue"],
+    );
+    assert!(rescue_env.status.success(), "{}", stderr(&rescue_env));
+    set_service_enabled(&cwd, &env, "rescue", true);
+    let main_env = run_ocm(&cwd, &env, &["env", "create", "main", "--launcher", "main"]);
+    assert!(main_env.status.success(), "{}", stderr(&main_env));
+    set_service_enabled(&cwd, &env, "main", true);
+    service.sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    assert!(wait_for_file(&rescue_started, Duration::from_secs(5)));
+    assert!(wait_for_file(&main_started, Duration::from_secs(5)));
+    let initial_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(5))
+        .expect("daemon runtime state did not report both running children");
+    let rescue_pid = runtime_child_pid(&initial_runtime, "rescue").unwrap();
+    let main_pid = runtime_child_pid(&initial_runtime, "main").unwrap();
+
+    let restart = run_ocm(&cwd, &env, &["service", "restart", "rescue", "--json"]);
+    assert!(restart.status.success(), "{}", stderr(&restart));
+    let restarted = wait_for_runtime_child_pid_change(
+        &runtime_path,
+        "rescue",
+        rescue_pid,
+        "main",
+        main_pid,
+        Duration::from_secs(10),
+    )
+    .expect("targeted restart did not replace only the requested child");
+
+    assert_eq!(runtime_child_pid(&restarted, "main"), Some(main_pid));
+    assert_ne!(runtime_child_pid(&restarted, "rescue"), Some(rescue_pid));
+    assert!(wait_for_file(&rescue_stopped, Duration::from_secs(5)));
+    assert!(
+        !main_stopped.exists(),
+        "sibling child was stopped by targeted restart"
+    );
 
     stop_process(&mut daemon);
 }

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -746,7 +746,16 @@ fn service_restart_restarts_only_the_target_child() {
     let rescue_pid = runtime_child_pid(&initial_runtime, "rescue").unwrap();
     let main_pid = runtime_child_pid(&initial_runtime, "main").unwrap();
 
-    let restart = run_ocm(&cwd, &env, &["service", "restart", "rescue", "--json"]);
+    let mut restart_env = env.clone();
+    restart_env.insert(
+        "NODE_OPTIONS".to_string(),
+        "--max-old-space-size=2048".to_string(),
+    );
+    let restart = run_ocm(
+        &cwd,
+        &restart_env,
+        &["service", "restart", "rescue", "--json"],
+    );
     assert!(restart.status.success(), "{}", stderr(&restart));
     let restarted = wait_for_runtime_child_pid_change(
         &runtime_path,


### PR DESCRIPTION
## Summary

Fixes #1.

This fixes two supervisor behaviors that could make a targeted `ocm service restart <env>` restart unrelated managed gateways:

- supervised gateway child specs now keep only stable environment keys instead of inheriting arbitrary caller/session context
- `ocm service restart <env>` now writes a targeted restart request for the selected child instead of temporarily removing that env from the shared desired-state file

## Root Cause

The OCM daemon reconciles running children by comparing the stored `SupervisorChildSpec` with the next generated spec. Those specs included `process_env`, which was previously derived from the caller environment. When a different agent session or LaunchAgent rewrote supervisor state, unrelated child specs could differ because of caller-only values such as `PWD`, `XPC_SERVICE_NAME`, `GH_TOKEN`, Codex/session variables, or volatile `PATH` entries.

The restart command also used environment metadata as a control channel: it briefly marked the target env stopped, synced global supervisor state, then marked it running again. During that global state transition, the daemon could reload siblings whose regenerated specs looked different.

## What Changed

Supervised gateway child environments are now built from a stable allowlist:

- env-specific `OPENCLAW_*` / `OCM_*` values
- stable service/runtime keys: `HOME`, `PATH`, `TMPDIR`, `SHELL`, `OCM_HOME`, `OCM_SELF`
- proxy and certificate-related service keys already recognized by the supervisor

The retained child `PATH` is also sanitized to drop volatile Codex temp paths and direct Homebrew Cellar Node paths before the spec is written.

For already-running services, `ocm service restart <env>` now appends a one-child restart request to supervisor state. The daemon consumes and clears that request, stops only the targeted running child, and queues only that child to restart. The old start/sync path is still used when the env is not already enabled and running.

## Validation

- `cargo test`
- `cargo build --release`
- Installed locally and restarted the OCM daemon
- Live verification: `ocm service restart rescue` changed only `rescue` from PID `71696` to `72723`; `clawpatrol`, `main`, and `openclaw` stayed at `71692`, `71693`, and `71694`