### PR TITLE
Fix restart recovery when supervisor misses a child restart

### DIFF
--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -141,12 +141,12 @@ pub fn restart_service(
                     ));
                 }
             } else {
-                match supervisor.ensure_daemon_running() {
+                match supervisor.recover_child_restart(name) {
                     Ok(_) => status.warnings.push(
-                        "gateway restart was not observed; restart request was retained and the supervisor was rechecked".to_string(),
+                        "gateway restart was not observed; the targeted restart request was requeued and the supervisor was rechecked".to_string(),
                     ),
                     Err(error) => status.warnings.push(format!(
-                        "gateway restart was not observed; restart request was retained, but supervisor recovery failed: {error}"
+                        "gateway restart was not observed; targeted supervisor recovery failed: {error}"
                     )),
                 }
             }

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -140,6 +140,15 @@ pub fn restart_service(
                         "restart completed, but failed to clear restart request: {clear_error}"
                     ));
                 }
+            } else {
+                match supervisor.ensure_daemon_running() {
+                    Ok(_) => status.warnings.push(
+                        "gateway restart was not observed; restart request was retained and the supervisor was rechecked".to_string(),
+                    ),
+                    Err(error) => status.warnings.push(format!(
+                        "gateway restart was not observed; restart request was retained, but supervisor recovery failed: {error}"
+                    )),
+                }
             }
             Ok(service_action_summary(
                 "restart",

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -332,6 +332,16 @@ impl<'a> SupervisorService<'a> {
         self.activate_daemon("install")
     }
 
+    pub fn recover_child_restart(&self, name: &str) -> Result<SupervisorDaemonSummary, String> {
+        // Reissue only the target request; a full sync could reload unrelated children.
+        let _ = self.request_child_restart(name)?;
+        let status = self.daemon_status()?;
+        if status.running {
+            return Ok(status);
+        }
+        self.activate_daemon("install")
+    }
+
     pub fn request_child_restart(&self, name: &str) -> Result<String, String> {
         let state_path = supervisor_state_path(self.env, self.cwd)?;
         let mut state = self.build_state()?;

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -595,6 +595,64 @@ fn child_restart_request_rebuilds_missing_or_stale_state() {
 }
 
 #[test]
+fn child_restart_recovery_preserves_unrelated_child_specs() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("restart-recovery-preserves-siblings");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_systemd_tools(&root, &mut env);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+
+    for name in ["rescue", "main"] {
+        let launcher = run_ocm(
+            &cwd,
+            &env,
+            &["launcher", "add", name, "--command", "openclaw"],
+        );
+        assert!(launcher.status.success(), "{}", stderr(&launcher));
+        let created = run_ocm(&cwd, &env, &["env", "create", name, "--launcher", name]);
+        assert!(created.status.success(), "{}", stderr(&created));
+        set_service_enabled(&cwd, &env, name, true);
+    }
+
+    SupervisorService::new(&env, &cwd).sync().unwrap();
+
+    let mut restart_env = env.clone();
+    restart_env.insert(
+        "NODE_OPTIONS".to_string(),
+        "--max-old-space-size=2048".to_string(),
+    );
+    SupervisorService::new(&restart_env, &cwd)
+        .recover_child_restart("rescue")
+        .unwrap();
+
+    let state = read_persisted_service_state(&state_path);
+    let children = state["children"].as_array().unwrap();
+    let rescue = children
+        .iter()
+        .find(|child| child["envName"] == "rescue")
+        .unwrap();
+    let main = children
+        .iter()
+        .find(|child| child["envName"] == "main")
+        .unwrap();
+
+    assert_eq!(
+        rescue["processEnv"]["NODE_OPTIONS"],
+        "--max-old-space-size=2048"
+    );
+    assert!(main["processEnv"]["NODE_OPTIONS"].is_null());
+    assert!(
+        state["restartRequests"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|request| request["envName"] == "rescue")
+    );
+}
+
+#[test]
 fn daemon_run_reloads_children_after_binding_changes() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("daemon-run-reconcile");


### PR DESCRIPTION
## Summary

When `ocm service restart <env>` cannot observe a replacement child within its wait window, requeue only that child's durable restart request and recheck the OCM supervisor.

## Failure mode

A supervisor or gateway interruption can occur after the restart request is written but before a new child PID is observed. Recovery must retain the targeted-restart isolation from #2: rebuilding global supervisor state can reload unrelated gateways.

## What changed

- Reissue only the target child's restart request when restart observation times out.
- Activate the OCM supervisor without running a global state sync.
- Preserve persisted sibling child specs during recovery.
- Report clearly whether targeted supervisor recovery succeeded.
- Add a two-child regression test proving recovery cannot rewrite the sibling spec.

## Validation

- `cargo fmt --all --check`
- `cargo test --test daemon_runtime_tests --test service_command_tests -- --test-threads=1` (41 passed)
- Both unrelated timing failures from an earlier parallel run passed individually.
- Autoreview: clean, no actionable findings, confidence 0.88.
