### PR TITLE
fix(wrapper): support Homebrew rustup with isolated HOME

### DIFF
--- a/bin/ocm
+++ b/bin/ocm
@@ -13,6 +13,19 @@ if [[ -z "${RUSTUP_HOME:-}" ]]; then
   CARGO_BIN="$(command -v cargo || true)"
   if [[ -n "$CARGO_BIN" && "$CARGO_BIN" == */.cargo/bin/cargo ]]; then
     export RUSTUP_HOME="${CARGO_BIN%/.cargo/bin/cargo}/.rustup"
+  elif [[ -n "$CARGO_BIN" && "$(readlink "$CARGO_BIN" || true)" == *rustup* ]]; then
+    USER_NAME="$(id -un 2>/dev/null || true)"
+    if [[ -n "$USER_NAME" ]] && command -v getent >/dev/null 2>&1; then
+      USER_HOME="$(getent passwd "$USER_NAME" 2>/dev/null | cut -d: -f6 || true)"
+    elif [[ -n "$USER_NAME" ]] && command -v dscl >/dev/null 2>&1; then
+      USER_HOME="$(
+        dscl . -read "/Users/$USER_NAME" NFSHomeDirectory 2>/dev/null |
+          sed 's/^[^:]*:[[:space:]]*//' || true
+      )"
+    fi
+    if [[ -n "${USER_HOME:-}" && -d "$USER_HOME/.rustup" ]]; then
+      export RUSTUP_HOME="$USER_HOME/.rustup"
+    fi
   fi
 fi
 

--- a/tests/bin_wrapper_tests.rs
+++ b/tests/bin_wrapper_tests.rs
@@ -1,8 +1,15 @@
 mod support;
 
+use std::path::PathBuf;
 use std::process::Command;
 
 use support::{TestDir, path_string, stderr, stdout};
+
+fn find_executable(name: &str) -> Option<PathBuf> {
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|dir| dir.join(name))
+        .find(|path| path.is_file())
+}
 
 #[test]
 fn bin_wrapper_runs_with_an_overridden_home() {
@@ -11,9 +18,18 @@ fn bin_wrapper_runs_with_an_overridden_home() {
     let wrapper = repo_root.join("bin/ocm");
     let home = root.child("isolated-home");
     let ocm_home = root.child("ocm-home");
+    let shim_bin = root.child("shim-bin");
 
     std::fs::create_dir_all(&home).unwrap();
     std::fs::create_dir_all(&ocm_home).unwrap();
+    std::fs::create_dir_all(&shim_bin).unwrap();
+
+    let rustup = find_executable("rustup").expect("rustup must be available for wrapper tests");
+    std::os::unix::fs::symlink(rustup, shim_bin.join("cargo")).unwrap();
+    let path = std::env::join_paths(std::iter::once(shim_bin).chain(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    )))
+    .unwrap();
 
     let mut command = Command::new(&wrapper);
     command.current_dir(&repo_root);
@@ -21,7 +37,7 @@ fn bin_wrapper_runs_with_an_overridden_home() {
     command.env_clear();
     command.env("HOME", path_string(&home));
     command.env("OCM_HOME", path_string(&ocm_home));
-    command.env("PATH", std::env::var("PATH").unwrap_or_default());
+    command.env("PATH", path);
     command.env_remove("RUSTUP_HOME");
 
     let output = command.output().unwrap();


### PR DESCRIPTION
## What Problem This Solves

`bin/ocm` supports callers that override `HOME`, but only inferred `RUSTUP_HOME` when Cargo lived under `~/.cargo/bin`. Homebrew installs Cargo as an external `cargo -> rustup-init` proxy, so an overridden `HOME` made rustup lose the installed toolchain and caused the wrapper and full test suite to fail.

## Why This Change Was Made

- Detect external Cargo symlinks whose target is a rustup proxy.
- Resolve the account home through `getent` on Linux or `dscl` on macOS.
- Keep account lookup best-effort so discovery failures fall through to Cargo instead of aborting the wrapper.
- Force the regression test through an external `cargo -> rustup` shim on every supported CI host.

This is intentionally separate from the OCM network/release performance work in https://github.com/shakkernerd/ocm/pull/4.

## User Impact

The development wrapper now works when tools isolate `HOME` on Homebrew rustup installations, while preserving the existing standard `~/.cargo/bin/cargo` path and explicit `RUSTUP_HOME` behavior.

## Evidence

- `bash -n bin/ocm`
- `cargo fmt -- --check`
- `cargo test --test bin_wrapper_tests`
- `cargo test` (full suite passed)
- Fresh branch autoreview: no actionable findings, correctness confidence 0.88
