### PR TITLE
fix(cli): harden shell and process boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to OCM are documented here.
 - Preserve environment roots and recovery snapshots when dev worktree cleanup fails during destroy.
 - Keep auto-assigned ports stable without overriding a later gateway port written by OpenClaw configuration.
 - Reject non-UTF-8 process input cleanly, require version flags to stand alone, and terminate quietly when a pipeline closes its output.
+- Prevent Fish activation injection through crafted paths and clear stale OpenClaw controls when switching environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ All notable changes to OCM are documented here.
 - Serialize environment registry transactions so concurrent lifecycle commands preserve every entry and allocate distinct ports.
 - Preserve environment roots and recovery snapshots when dev worktree cleanup fails during destroy.
 - Keep auto-assigned ports stable without overriding a later gateway port written by OpenClaw configuration.
+- Reject non-UTF-8 process input cleanly, require version flags to stand alone, and terminate quietly when a pipeline closes its output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ All notable changes to OCM are documented here.
 - Keep auto-assigned ports stable without overriding a later gateway port written by OpenClaw configuration.
 - Reject non-UTF-8 process input cleanly, require version flags to stand alone, and terminate quietly when a pipeline closes its output.
 - Prevent Fish activation injection through crafted paths and clear stale OpenClaw controls when switching environments.
+- Keep tables within narrow terminal widths by truncating headers or falling back to compact rows.

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -910,7 +910,7 @@ impl Cli {
             .environment_service()
             .apply_effective_gateway_port(self.environment_service().touch(name)?)?;
         let shell = resolve_shell_name(shell_name.as_deref(), &self.env);
-        print!("{}", render_use_script(&meta, &shell));
+        self.stdout_text(&render_use_script(&meta, &shell))?;
         Ok(0)
     }
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -910,7 +910,7 @@ impl Cli {
             .environment_service()
             .apply_effective_gateway_port(self.environment_service().touch(name)?)?;
         let shell = resolve_shell_name(shell_name.as_deref(), &self.env);
-        self.stdout_text(&render_use_script(&meta, &shell))?;
+        self.stdout_text(&render_use_script(&meta, &shell, &self.env))?;
         Ok(0)
     }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -17,7 +17,7 @@ impl Cli {
             return Err(format!("unsupported init shell: {shell}"));
         }
         Self::assert_no_extra_args(&args)?;
-        print!("{}", render_init_script(&self.command_example(), &shell)?);
+        self.stdout_text(&render_init_script(&self.command_example(), &shell)?)?;
         Ok(0)
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,9 +16,11 @@ mod setup;
 mod start;
 mod upgrade;
 
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::time::Duration;
 
 use indicatif::{ProgressBar, ProgressStyle};
@@ -72,9 +74,18 @@ impl ColorMode {
 pub struct Cli {
     pub env: BTreeMap<String, String>,
     pub cwd: PathBuf,
+    output_error: Rc<RefCell<Option<io::Error>>>,
 }
 
 impl Cli {
+    pub fn new(env: BTreeMap<String, String>, cwd: PathBuf) -> Self {
+        Self {
+            env,
+            cwd,
+            output_error: Rc::new(RefCell::new(None)),
+        }
+    }
+
     fn with_color_mode(&self, mode: ColorMode) -> Self {
         let mut env = self.env.clone();
         env.insert(
@@ -84,6 +95,7 @@ impl Cli {
         Self {
             env,
             cwd: self.cwd.clone(),
+            output_error: Rc::clone(&self.output_error),
         }
     }
 
@@ -116,7 +128,12 @@ impl Cli {
     }
 
     fn stdout_line(&self, line: impl AsRef<str>) {
-        println!("{}", line.as_ref());
+        if self.output_error.borrow().is_some() {
+            return;
+        }
+        let stdout = io::stdout();
+        let mut handle = stdout.lock();
+        self.record_output_result(writeln!(handle, "{}", line.as_ref()));
     }
 
     fn stdout_lines<I, S>(&self, lines: I)
@@ -130,7 +147,12 @@ impl Cli {
     }
 
     fn stderr_line(&self, line: impl AsRef<str>) {
-        eprintln!("{}", line.as_ref());
+        if self.output_error.borrow().is_some() {
+            return;
+        }
+        let stderr = io::stderr();
+        let mut handle = stderr.lock();
+        self.record_output_result(writeln!(handle, "{}", line.as_ref()));
     }
 
     fn stderr_lines<I, S>(&self, lines: I)
@@ -144,18 +166,51 @@ impl Cli {
     }
 
     fn print_json<T: Serialize>(&self, value: &T) -> Result<(), String> {
+        if self.output_error.borrow().is_some() {
+            return Ok(());
+        }
         let stdout = io::stdout();
         let mut handle = stdout.lock();
-        serde_json::to_writer_pretty(&mut handle, value).map_err(|error| error.to_string())?;
-        writeln!(handle).map_err(|error| error.to_string())
+        if let Err(error) = serde_json::to_writer_pretty(&mut handle, value) {
+            if let Some(kind) = error.io_error_kind() {
+                self.record_output_error(io::Error::from(kind));
+                return Ok(());
+            }
+            return Err(error.to_string());
+        }
+        self.record_output_result(writeln!(handle));
+        Ok(())
     }
 
     fn stdout_text(&self, text: &str) -> Result<(), String> {
+        if self.output_error.borrow().is_some() {
+            return Ok(());
+        }
         let stdout = io::stdout();
         let mut handle = stdout.lock();
-        handle
-            .write_all(text.as_bytes())
-            .map_err(|error| error.to_string())
+        self.record_output_result(handle.write_all(text.as_bytes()));
+        Ok(())
+    }
+
+    fn record_output_result(&self, result: io::Result<()>) {
+        if let Err(error) = result {
+            self.record_output_error(error);
+        }
+    }
+
+    fn record_output_error(&self, error: io::Error) {
+        let mut output_error = self.output_error.borrow_mut();
+        if output_error.is_none() {
+            *output_error = Some(error);
+        }
+    }
+
+    fn finish_output(&self, code: i32) -> i32 {
+        match self.output_error.borrow_mut().take() {
+            Some(error) if error.kind() == io::ErrorKind::BrokenPipe => 0,
+            Some(_) => 1,
+            None => code,
+        }
     }
 
     fn command_example(&self) -> String {
@@ -423,6 +478,12 @@ impl Cli {
     }
 
     pub fn run(&self, args: Vec<String>) -> i32 {
+        self.output_error.borrow_mut().take();
+        let code = self.run_inner(args);
+        self.finish_output(code)
+    }
+
+    fn run_inner(&self, args: Vec<String>) -> i32 {
         let (args, color_mode) = match Self::consume_leading_color_option(args) {
             Ok(result) => result,
             Err(error) => {
@@ -449,6 +510,11 @@ impl Cli {
         }
 
         if matches!(args[0].as_str(), "--version" | "-v") {
+            if let Err(error) = Self::assert_no_extra_args(&args[1..]) {
+                cli.stderr_line(format!("ocm: {error}"));
+                cli.stderr_line(format!("Run \"{} help\" for usage.", cli.command_example()));
+                return 1;
+            }
             cli.stdout_line(VERSION);
             return 0;
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,7 +20,6 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::Duration;
 
 use indicatif::{ProgressBar, ProgressStyle};
@@ -36,6 +35,17 @@ use crate::supervisor::SupervisorService;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const INTERNAL_COLOR_MODE_ENV: &str = "OCM_INTERNAL_COLOR_MODE";
+
+#[derive(Default)]
+struct OutputErrors {
+    stdout: Option<io::Error>,
+    stderr: Option<io::Error>,
+}
+
+thread_local! {
+    // CLI rendering is synchronous; retain write errors until the dispatcher can choose an exit code.
+    static OUTPUT_ERRORS: RefCell<OutputErrors> = RefCell::new(OutputErrors::default());
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ColorMode {
@@ -74,18 +84,9 @@ impl ColorMode {
 pub struct Cli {
     pub env: BTreeMap<String, String>,
     pub cwd: PathBuf,
-    output_error: Rc<RefCell<Option<io::Error>>>,
 }
 
 impl Cli {
-    pub fn new(env: BTreeMap<String, String>, cwd: PathBuf) -> Self {
-        Self {
-            env,
-            cwd,
-            output_error: Rc::new(RefCell::new(None)),
-        }
-    }
-
     fn with_color_mode(&self, mode: ColorMode) -> Self {
         let mut env = self.env.clone();
         env.insert(
@@ -95,7 +96,6 @@ impl Cli {
         Self {
             env,
             cwd: self.cwd.clone(),
-            output_error: Rc::clone(&self.output_error),
         }
     }
 
@@ -128,12 +128,12 @@ impl Cli {
     }
 
     fn stdout_line(&self, line: impl AsRef<str>) {
-        if self.output_error.borrow().is_some() {
+        if Self::output_failed() {
             return;
         }
         let stdout = io::stdout();
         let mut handle = stdout.lock();
-        self.record_output_result(writeln!(handle, "{}", line.as_ref()));
+        Self::record_stdout_result(writeln!(handle, "{}", line.as_ref()));
     }
 
     fn stdout_lines<I, S>(&self, lines: I)
@@ -147,12 +147,12 @@ impl Cli {
     }
 
     fn stderr_line(&self, line: impl AsRef<str>) {
-        if self.output_error.borrow().is_some() {
+        if Self::output_failed() {
             return;
         }
         let stderr = io::stderr();
         let mut handle = stderr.lock();
-        self.record_output_result(writeln!(handle, "{}", line.as_ref()));
+        Self::record_stderr_result(writeln!(handle, "{}", line.as_ref()));
     }
 
     fn stderr_lines<I, S>(&self, lines: I)
@@ -166,50 +166,81 @@ impl Cli {
     }
 
     fn print_json<T: Serialize>(&self, value: &T) -> Result<(), String> {
-        if self.output_error.borrow().is_some() {
+        if Self::output_failed() {
             return Ok(());
         }
         let stdout = io::stdout();
         let mut handle = stdout.lock();
         if let Err(error) = serde_json::to_writer_pretty(&mut handle, value) {
             if let Some(kind) = error.io_error_kind() {
-                self.record_output_error(io::Error::from(kind));
+                Self::record_stdout_error(io::Error::from(kind));
                 return Ok(());
             }
             return Err(error.to_string());
         }
-        self.record_output_result(writeln!(handle));
+        Self::record_stdout_result(writeln!(handle));
         Ok(())
     }
 
     fn stdout_text(&self, text: &str) -> Result<(), String> {
-        if self.output_error.borrow().is_some() {
+        if Self::output_failed() {
             return Ok(());
         }
         let stdout = io::stdout();
         let mut handle = stdout.lock();
-        self.record_output_result(handle.write_all(text.as_bytes()));
+        Self::record_stdout_result(handle.write_all(text.as_bytes()));
         Ok(())
     }
 
-    fn record_output_result(&self, result: io::Result<()>) {
+    fn record_stdout_result(result: io::Result<()>) {
         if let Err(error) = result {
-            self.record_output_error(error);
+            Self::record_stdout_error(error);
         }
     }
 
-    fn record_output_error(&self, error: io::Error) {
-        let mut output_error = self.output_error.borrow_mut();
-        if output_error.is_none() {
-            *output_error = Some(error);
+    fn record_stderr_result(result: io::Result<()>) {
+        if let Err(error) = result {
+            OUTPUT_ERRORS.with(|errors| {
+                let mut errors = errors.borrow_mut();
+                if errors.stderr.is_none() {
+                    errors.stderr = Some(error);
+                }
+            });
         }
     }
 
-    fn finish_output(&self, code: i32) -> i32 {
-        match self.output_error.borrow_mut().take() {
+    fn record_stdout_error(error: io::Error) {
+        OUTPUT_ERRORS.with(|errors| {
+            let mut errors = errors.borrow_mut();
+            if errors.stdout.is_none() {
+                errors.stdout = Some(error);
+            }
+        });
+    }
+
+    fn output_failed() -> bool {
+        OUTPUT_ERRORS.with(|errors| {
+            let errors = errors.borrow();
+            errors.stdout.is_some() || errors.stderr.is_some()
+        })
+    }
+
+    fn reset_output_errors() {
+        OUTPUT_ERRORS.with(|errors| {
+            *errors.borrow_mut() = OutputErrors::default();
+        });
+    }
+
+    fn finish_output(code: i32) -> i32 {
+        let errors = OUTPUT_ERRORS.with(|errors| std::mem::take(&mut *errors.borrow_mut()));
+        if code != 0 {
+            return code;
+        }
+        match errors.stdout {
             Some(error) if error.kind() == io::ErrorKind::BrokenPipe => 0,
             Some(_) => 1,
-            None => code,
+            None if errors.stderr.is_some() => 1,
+            None => 0,
         }
     }
 
@@ -478,9 +509,9 @@ impl Cli {
     }
 
     pub fn run(&self, args: Vec<String>) -> i32 {
-        self.output_error.borrow_mut().take();
+        Self::reset_output_errors();
         let code = self.run_inner(args);
-        self.finish_output(code)
+        Self::finish_output(code)
     }
 
     fn run_inner(&self, args: Vec<String>) -> i32 {

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -713,10 +713,7 @@ mod tests {
     fn test_cli() -> Cli {
         let mut env = BTreeMap::new();
         env.insert(INTERNAL_COLOR_MODE_ENV.to_string(), "never".to_string());
-        Cli {
-            env,
-            cwd: PathBuf::from("/tmp"),
-        }
+        Cli::new(env, PathBuf::from("/tmp"))
     }
 
     #[test]

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -713,7 +713,10 @@ mod tests {
     fn test_cli() -> Cli {
         let mut env = BTreeMap::new();
         env.insert(INTERNAL_COLOR_MODE_ENV.to_string(), "never".to_string());
-        Cli::new(env, PathBuf::from("/tmp"))
+        Cli {
+            env,
+            cwd: PathBuf::from("/tmp"),
+        }
     }
 
     #[test]

--- a/src/infra/shell.rs
+++ b/src/infra/shell.rs
@@ -9,7 +9,7 @@ pub fn quote_posix(value: &str) -> String {
 }
 
 fn quote_fish(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "\\'"))
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "\\'"))
 }
 
 fn render_assignment(shell: &str, key: &str, value: &str) -> String {
@@ -21,11 +21,18 @@ fn render_assignment(shell: &str, key: &str, value: &str) -> String {
 }
 
 fn render_unset(shell: &str, key: &str) -> String {
+    debug_assert!(is_shell_identifier(key));
     if shell == "fish" {
         format!("set -e {key};")
     } else {
         format!("unset {key}")
     }
+}
+
+fn is_shell_identifier(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some('_' | 'A'..='Z' | 'a'..='z'))
+        && chars.all(|ch| matches!(ch, '_' | 'A'..='Z' | 'a'..='z' | '0'..='9'))
 }
 
 pub fn resolve_shell_name(explicit: Option<&str>, env: &BTreeMap<String, String>) -> String {
@@ -129,10 +136,39 @@ fn is_openclaw_diagnostics_passthrough_key(key: &str) -> bool {
     )
 }
 
-pub fn render_use_script(meta: &EnvMeta, shell: &str) -> String {
+pub fn render_use_script(
+    meta: &EnvMeta,
+    shell: &str,
+    base_env: &BTreeMap<String, String>,
+) -> String {
     let paths = derive_env_paths(Path::new(&meta.root));
-    let mut lines = vec![
-        render_unset(shell, "OPENCLAW_PROFILE"),
+    let mut unset_keys = base_env
+        .keys()
+        .filter(|key| {
+            is_shell_identifier(key)
+                && ((key.starts_with("OPENCLAW_") && !is_openclaw_diagnostics_passthrough_key(key))
+                    || matches!(key.as_str(), "OCM_ACTIVE_ENV" | "OCM_ACTIVE_ENV_ROOT"))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    unset_keys.extend(
+        [
+            "OPENCLAW_PROFILE",
+            "OPENCLAW_GATEWAY_PORT",
+            "OPENCLAW_DEV_SOURCE_ROOT",
+            "OPENCLAW_BUNDLED_PLUGINS_DIR",
+        ]
+        .into_iter()
+        .map(str::to_string),
+    );
+    unset_keys.sort();
+    unset_keys.dedup();
+
+    let mut lines = unset_keys
+        .into_iter()
+        .map(|key| render_unset(shell, &key))
+        .collect::<Vec<_>>();
+    lines.extend([
         render_assignment(
             shell,
             "OPENCLAW_HOME",
@@ -151,7 +187,7 @@ pub fn render_use_script(meta: &EnvMeta, shell: &str) -> String {
         render_assignment(shell, "OPENCLAW_SERVICE_REPAIR_POLICY", "external"),
         render_assignment(shell, "OCM_ACTIVE_ENV", &meta.name),
         render_assignment(shell, "OCM_ACTIVE_ENV_ROOT", &paths.root.to_string_lossy()),
-    ];
+    ]);
 
     if let Some(port) = meta.gateway_port {
         lines.push(render_assignment(
@@ -306,5 +342,61 @@ mod tests {
             Some(root.to_string_lossy().as_ref())
         );
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn fish_quoting_preserves_backslashes_before_apostrophes() {
+        assert_eq!(
+            quote_fish(r"bad\'; touch /tmp/pwned; #"),
+            r"'bad\\\'; touch /tmp/pwned; #'"
+        );
+    }
+
+    #[test]
+    fn activation_unsets_only_valid_stale_control_names() {
+        let meta = EnvMeta {
+            kind: "ocm-env".to_string(),
+            name: "demo".to_string(),
+            root: "/tmp/ocm/envs/demo".to_string(),
+            gateway_port: None,
+            service_enabled: false,
+            service_running: false,
+            default_runtime: None,
+            default_launcher: None,
+            dev: None,
+            protected: false,
+            created_at: OffsetDateTime::UNIX_EPOCH,
+            updated_at: OffsetDateTime::UNIX_EPOCH,
+            last_used_at: None,
+        };
+        let base = BTreeMap::from([
+            (
+                "OPENCLAW_DEV_SOURCE_ROOT".to_string(),
+                "/tmp/previous".to_string(),
+            ),
+            (
+                "OPENCLAW_BUNDLED_PLUGINS_DIR".to_string(),
+                "/tmp/previous/extensions".to_string(),
+            ),
+            (
+                "OPENCLAW_RANDOM_USER_VALUE".to_string(),
+                "stale".to_string(),
+            ),
+            ("OPENCLAW_DIAGNOSTICS".to_string(), "timeline".to_string()),
+            (
+                "OPENCLAW_X; touch /tmp/pwn".to_string(),
+                "stale".to_string(),
+            ),
+        ]);
+
+        let script = render_use_script(&meta, "zsh", &base);
+
+        assert!(script.contains("unset OPENCLAW_DEV_SOURCE_ROOT"));
+        assert!(script.contains("unset OPENCLAW_BUNDLED_PLUGINS_DIR"));
+        assert!(script.contains("unset OPENCLAW_RANDOM_USER_VALUE"));
+        assert!(script.contains("unset OPENCLAW_GATEWAY_PORT"));
+        assert!(!script.contains("unset OPENCLAW_DIAGNOSTICS"));
+        assert!(!script.contains("touch /tmp/pwn"));
+        assert!(script.contains("export OPENCLAW_HOME='/tmp/ocm/envs/demo'"));
     }
 }

--- a/src/infra/shell.rs
+++ b/src/infra/shell.rs
@@ -359,6 +359,7 @@ mod tests {
             name: "demo".to_string(),
             root: "/tmp/ocm/envs/demo".to_string(),
             gateway_port: None,
+            gateway_port_auto_assigned: false,
             service_enabled: false,
             service_running: false,
             default_runtime: None,

--- a/src/infra/terminal.rs
+++ b/src/infra/terminal.rs
@@ -142,7 +142,6 @@ pub(crate) fn render_table_with_limit(
         .iter()
         .map(|header| display_width(header))
         .collect::<Vec<_>>();
-    let min_widths = widths.clone();
 
     for row in rows {
         for (index, cell) in row.iter().enumerate().take(widths.len()) {
@@ -151,6 +150,10 @@ pub(crate) fn render_table_with_limit(
     }
 
     if let Some(max_width) = max_width {
+        let min_widths = vec![1; headers.len()];
+        if table_width(&min_widths) > max_width {
+            return render_compact_table(headers, rows, color, max_width);
+        }
         shrink_widths_to_fit(&mut widths, &min_widths, max_width);
     }
 
@@ -162,6 +165,51 @@ pub(crate) fn render_table_with_limit(
         lines.push(render_row(row, &widths, color));
     }
     lines.push(render_border('└', '┴', '┘', &widths, color));
+    lines
+}
+
+fn render_compact_table(
+    headers: &[&str],
+    rows: &[Vec<Cell>],
+    color: bool,
+    max_width: usize,
+) -> Vec<String> {
+    if max_width == 0 {
+        return Vec::new();
+    }
+    if rows.is_empty() {
+        return headers
+            .iter()
+            .map(|header| {
+                paint(
+                    &truncate_for_width(header, max_width, Align::Left),
+                    Tone::Strong,
+                    color,
+                )
+            })
+            .collect();
+    }
+
+    let mut lines = Vec::with_capacity(rows.len() * headers.len());
+    for (row_index, row) in rows.iter().enumerate() {
+        if row_index > 0 {
+            lines.push(String::new());
+        }
+        for (index, header) in headers.iter().enumerate() {
+            let cell = row.get(index).cloned().unwrap_or_else(|| Cell::plain(""));
+            let prefix = format!("{header}: ");
+            let prefix_width = display_width(&prefix);
+            let text = if prefix_width >= max_width {
+                truncate_for_width(header, max_width, Align::Left)
+            } else {
+                format!(
+                    "{prefix}{}",
+                    truncate_for_width(&cell.text, max_width - prefix_width, Align::Left)
+                )
+            };
+            lines.push(paint(&text, cell.tone, color));
+        }
+    }
     lines
 }
 
@@ -538,5 +586,40 @@ mod tests {
 
         assert!(table.iter().all(|line| display_width(line) <= 60));
         assert!(table[3].contains('…'));
+    }
+
+    #[test]
+    fn render_table_truncates_headers_to_fit_narrow_terminals() {
+        let table = render_table_with_limit(
+            &["Environment", "Command", "Working directory"],
+            &[vec![
+                Cell::plain("demo"),
+                Cell::plain("openclaw"),
+                Cell::plain("/tmp/demo"),
+            ]],
+            false,
+            Some(24),
+        );
+
+        assert!(table.iter().all(|line| display_width(line) <= 24));
+        assert!(table[1].contains('…'));
+    }
+
+    #[test]
+    fn render_table_uses_compact_rows_when_borders_cannot_fit() {
+        let table = render_table_with_limit(
+            &["Name", "State", "Port"],
+            &[vec![
+                Cell::plain("demo"),
+                Cell::success("running"),
+                Cell::plain("18789"),
+            ]],
+            false,
+            Some(8),
+        );
+
+        assert!(table.iter().all(|line| display_width(line) <= 8));
+        assert!(table.iter().all(|line| !line.contains('│')));
+        assert!(table.iter().any(|line| line.starts_with("Name:")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,41 @@
 use std::collections::BTreeMap;
 use std::env;
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 use ocm::cli::Cli;
 
 fn main() {
-    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let env_map = env::vars().collect::<BTreeMap<_, _>>();
-    let args = env::args().skip(1).collect::<Vec<_>>();
+    let code = match run() {
+        Ok(code) => code,
+        Err(error) => {
+            let _ = writeln!(io::stderr().lock(), "ocm: {error}");
+            1
+        }
+    };
+    std::process::exit(code);
+}
 
-    let cli = Cli { env: env_map, cwd };
-    std::process::exit(cli.run(args));
+fn run() -> Result<i32, String> {
+    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let env_map = env::vars_os()
+        .map(|(key, value)| {
+            let key = key
+                .into_string()
+                .map_err(|_| "environment contains a non-UTF-8 variable name".to_string())?;
+            let value = value
+                .into_string()
+                .map_err(|_| format!("environment variable {key} contains a non-UTF-8 value"))?;
+            Ok((key, value))
+        })
+        .collect::<Result<BTreeMap<_, _>, String>>()?;
+    let args = env::args_os()
+        .skip(1)
+        .map(|arg| {
+            arg.into_string()
+                .map_err(|_| "command arguments must be valid UTF-8".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Cli::new(env_map, cwd).run(args))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,5 +37,5 @@ fn run() -> Result<i32, String> {
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(Cli::new(env_map, cwd).run(args))
+    Ok(Cli { env: env_map, cwd }.run(args))
 }

--- a/tests/behavior_flow_tests.rs
+++ b/tests/behavior_flow_tests.rs
@@ -1,6 +1,7 @@
 mod support;
 
 use std::fs;
+use std::process::Command;
 
 use crate::support::{TestDir, ocm_env, path_string, run_ocm, stderr, stdout, write_text};
 use ocm::store::clean_path;
@@ -24,7 +25,21 @@ fn env_use_prints_activation_exports_for_the_selected_environment() {
     let root = TestDir::new("behavior-env-use");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
-    let env = ocm_env(&root);
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OPENCLAW_DEV_SOURCE_ROOT".to_string(),
+        "/tmp/stale-source".to_string(),
+    );
+    env.insert(
+        "OPENCLAW_BUNDLED_PLUGINS_DIR".to_string(),
+        "/tmp/stale-plugins".to_string(),
+    );
+    env.insert(
+        "OPENCLAW_RANDOM_USER_VALUE".to_string(),
+        "stale".to_string(),
+    );
+    env.insert("OPENCLAW_PROFILE".to_string(), "legacy".to_string());
+    env.insert("OPENCLAW_DIAGNOSTICS".to_string(), "timeline".to_string());
 
     let create = run_ocm(&cwd, &env, &["env", "create", "demo", "--port", "19789"]);
     assert!(create.status.success(), "{}", stderr(&create));
@@ -35,9 +50,30 @@ fn env_use_prints_activation_exports_for_the_selected_environment() {
     let env_root = clean_path(&root.child("ocm-home/envs/demo"));
     let script = stdout(&use_output);
     assert!(script.contains("unset OPENCLAW_PROFILE"));
+    assert!(script.contains("unset OPENCLAW_DEV_SOURCE_ROOT"));
+    assert!(script.contains("unset OPENCLAW_BUNDLED_PLUGINS_DIR"));
+    assert!(script.contains("unset OPENCLAW_RANDOM_USER_VALUE"));
+    assert!(!script.contains("unset OPENCLAW_DIAGNOSTICS"));
     assert!(script.contains(&format!("export OPENCLAW_HOME='{}'", env_root.display())));
     assert!(script.contains("export OPENCLAW_SERVICE_REPAIR_POLICY='external'"));
     assert!(script.contains(&format!("export OPENCLAW_GATEWAY_PORT='{}'", 19789)));
+
+    let evaluated = Command::new("bash")
+        .args([
+            "-c",
+            "eval \"$1\"; printf '%s|%s|%s|%s|%s' \"${OPENCLAW_DEV_SOURCE_ROOT-unset}\" \"${OPENCLAW_BUNDLED_PLUGINS_DIR-unset}\" \"${OPENCLAW_RANDOM_USER_VALUE-unset}\" \"$OPENCLAW_DIAGNOSTICS\" \"$OPENCLAW_GATEWAY_PORT\"",
+            "bash",
+            &script,
+        ])
+        .env_clear()
+        .envs(&env)
+        .output()
+        .unwrap();
+    assert!(evaluated.status.success());
+    assert_eq!(
+        String::from_utf8(evaluated.stdout).unwrap(),
+        "unset|unset|unset|timeline|19789"
+    );
 }
 
 #[test]

--- a/tests/cli_invocation_tests.rs
+++ b/tests/cli_invocation_tests.rs
@@ -1,8 +1,18 @@
 mod support;
 
+#[cfg(unix)]
+use std::ffi::OsString;
 use std::fs;
+#[cfg(unix)]
+use std::os::fd::OwnedFd;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+#[cfg(unix)]
+use std::process::{Command, Stdio};
 
-use crate::support::{TestDir, ocm_env, run_ocm, stderr};
+use crate::support::{TestDir, ocm_env, run_ocm, stderr, stdout};
 
 #[test]
 fn env_exec_propagates_the_child_exit_code() {
@@ -84,4 +94,66 @@ fn env_run_requires_double_dash_before_openclaw_arguments() {
     let run = run_ocm(&cwd, &env, &["env", "run", "demo", "-lc", "printf ok"]);
     assert_eq!(run.status.code(), Some(1));
     assert!(stderr(&run).contains("env run requires -- before OpenClaw arguments"));
+}
+
+#[test]
+fn version_rejects_trailing_arguments() {
+    let root = TestDir::new("cli-version-trailing");
+    let env = ocm_env(&root);
+
+    let version = run_ocm(root.path(), &env, &["--version"]);
+    assert!(version.status.success(), "{}", stderr(&version));
+    assert!(!stdout(&version).trim().is_empty());
+
+    for flag in ["--version", "-v"] {
+        let invalid = run_ocm(root.path(), &env, &[flag, "extra"]);
+        assert_eq!(invalid.status.code(), Some(1));
+        assert!(stderr(&invalid).contains("unexpected arguments: extra"));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn startup_rejects_non_utf8_environment_values_without_panicking() {
+    let output = Command::new(env!("CARGO_BIN_EXE_ocm"))
+        .arg("--version")
+        .env("OCM_INVALID_UTF8_TEST", OsString::from_vec(vec![0xff]))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("OCM_INVALID_UTF8_TEST contains a non-UTF-8 value"));
+    assert!(!stderr.contains("panicked"));
+}
+
+#[cfg(unix)]
+#[test]
+fn startup_rejects_non_utf8_arguments_without_panicking() {
+    let output = Command::new(env!("CARGO_BIN_EXE_ocm"))
+        .arg(OsString::from_vec(vec![0xff]))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("command arguments must be valid UTF-8"));
+    assert!(!stderr.contains("panicked"));
+}
+
+#[cfg(unix)]
+#[test]
+fn closed_stdout_terminates_quietly() {
+    let (reader, writer) = UnixStream::pair().unwrap();
+    drop(reader);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ocm"))
+        .arg("--version")
+        .stdout(Stdio::from(OwnedFd::from(writer)))
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("panicked"));
 }

--- a/tests/cli_invocation_tests.rs
+++ b/tests/cli_invocation_tests.rs
@@ -157,3 +157,19 @@ fn closed_stdout_terminates_quietly() {
     assert!(output.status.success());
     assert!(!String::from_utf8_lossy(&output.stderr).contains("panicked"));
 }
+
+#[cfg(unix)]
+#[test]
+fn closed_stderr_preserves_command_failure() {
+    let (reader, writer) = UnixStream::pair().unwrap();
+    drop(reader);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ocm"))
+        .args(["--version", "extra"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(OwnedFd::from(writer)))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+}


### PR DESCRIPTION
## What Problem This Solves

OCM could mishandle non-UTF-8 startup input, accept ambiguous version-flag combinations, panic or mask failures when output pipes close, leak stale activated-environment variables, and overflow narrow terminal layouts.

## Why This Change Was Made

CLI process boundaries must preserve the real command result, while shell activation must fully isolate one environment from the next. Terminal rendering also needs to respect the physical width instead of assuming the normal table minimum.

## User Impact

- Invalid startup input fails cleanly and version flags are unambiguous.
- Closed stdout/stderr pipes no longer panic or hide an underlying failure.
- Switching OCM environments clears stale environment-specific values safely.
- Narrow terminals get bounded headers or compact rows instead of overflow.

## Evidence

- 140 library tests
- behavior tests 11/11
- CLI tests 9/9
- shell-init tests 5/5
- Codex autoreview with `gpt-5.6-sol`, high reasoning; final clean, confidence 0.94
- `git diff --check`
