### PR TITLE
fix(launcher): preserve binding and command contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ All notable changes to OCM are documented here.
 - Prevent Fish activation injection through crafted paths and clear stale OpenClaw controls when switching environments.
 - Keep tables within narrow terminal widths by truncating headers or falling back to compact rows.
 - Verify self-update release digests and staged binary versions before replacement, compare releases with SemVer precedence, clean temporary artifacts on failure, and reject Linux ARM64 until release assets are published.
+- Reject launcher deletion while environments still depend on it, and route shell-expanding launcher recipes through a shell instead of lossy direct execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ All notable changes to OCM are documented here.
 - Keep tables within narrow terminal widths by truncating headers or falling back to compact rows.
 - Verify self-update release digests and staged binary versions before replacement, compare releases with SemVer precedence, clean temporary artifacts on failure, and reject Linux ARM64 until release assets are published.
 - Reject launcher deletion while environments still depend on it, and route shell-expanding launcher recipes through a shell instead of lossy direct execution.
+- Accept the standard human-output flags for `runtime releases` and document `runtime build-local` in the command map.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -517,6 +517,7 @@ ocm --color always runtime list
 ### `runtime`
 
 - add
+- build-local
 - list
 - show
 - install

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1857,7 +1857,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
             "Inspect OpenClaw releases",
             "Show releases from the official OpenClaw source or from a custom manifest without installing them.",
             vec![format!(
-                "{cmd} runtime releases [--manifest-url <url>] [--version <version> | --channel <channel>] [--json]"
+                "{cmd} runtime releases [--manifest-url <url>] [--version <version> | --channel <channel>] [--raw] [--json]"
             )],
             &[
                 (
@@ -1869,6 +1869,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                     "Select one release by explicit version",
                 ),
                 ("--channel <channel>", "Select one release by channel"),
+                ("--raw", "Force plain line output"),
                 ("--json", "Print releases as JSON"),
             ],
             vec![

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -321,7 +321,8 @@ impl Cli {
     }
 
     pub(super) fn handle_runtime_releases(&self, args: Vec<String>) -> Result<i32, String> {
-        let (args, json_flag) = Self::consume_flag(args, "--json");
+        let (args, json_flag, _profile) =
+            self.consume_human_output_flags(args, "runtime releases")?;
         let (args, version) = Self::consume_option(args, "--version")?;
         let version = Self::require_option_value(version, "--version")?;
         let (args, channel) = Self::consume_option(args, "--channel")?;

--- a/src/env/binding.rs
+++ b/src/env/binding.rs
@@ -1,5 +1,8 @@
 use super::{EnvMeta, EnvironmentService};
-use crate::store::{get_environment, get_runtime_verified, save_environment};
+use crate::store::{
+    get_environment, get_runtime_verified, save_environment,
+    save_environment_with_validated_launcher,
+};
 use crate::supervisor::sync_supervisor_if_present;
 
 impl<'a> EnvironmentService<'a> {
@@ -12,7 +15,7 @@ impl<'a> EnvironmentService<'a> {
             meta.default_launcher = Some(launcher_name.to_string());
             meta.default_runtime = None;
         }
-        let meta = save_environment(meta, self.env, self.cwd)?;
+        let meta = save_environment_with_validated_launcher(meta, self.env, self.cwd)?;
         sync_supervisor_if_present(self.env, self.cwd)?;
         Ok(meta)
     }

--- a/src/env/binding.rs
+++ b/src/env/binding.rs
@@ -1,5 +1,5 @@
 use super::{EnvMeta, EnvironmentService};
-use crate::store::{get_environment, get_launcher, get_runtime_verified, save_environment};
+use crate::store::{get_environment, get_runtime_verified, save_environment};
 use crate::supervisor::sync_supervisor_if_present;
 
 impl<'a> EnvironmentService<'a> {
@@ -9,7 +9,6 @@ impl<'a> EnvironmentService<'a> {
         if launcher_name.eq_ignore_ascii_case("none") {
             meta.default_launcher = None;
         } else {
-            get_launcher(launcher_name, self.env, self.cwd)?;
             meta.default_launcher = Some(launcher_name.to_string());
             meta.default_runtime = None;
         }

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -6,7 +6,7 @@ use super::EnvironmentService;
 use crate::runtime::RuntimeService;
 use crate::store::{
     EnvironmentOperationLock, clone_environment, create_environment, export_environment,
-    get_environment, get_launcher, get_runtime_verified, import_environment, list_environments,
+    get_environment, get_runtime_verified, import_environment, list_environments,
     lock_environment_operation, now_utc, remove_environment, resolve_config_gateway_port,
     resolve_effective_gateway_ports, resolve_env_gateway_port, save_environment,
 };
@@ -214,9 +214,6 @@ impl<'a> EnvironmentService<'a> {
     pub fn create(&self, options: CreateEnvironmentOptions) -> Result<EnvMeta, String> {
         if let Some(runtime_name) = options.default_runtime.as_deref() {
             get_runtime_verified(runtime_name, self.env, self.cwd)?;
-        }
-        if let Some(launcher_name) = options.default_launcher.as_deref() {
-            get_launcher(launcher_name, self.env, self.cwd)?;
         }
         let meta = create_environment(options, self.env, self.cwd)?;
         sync_supervisor_if_present(self.env, self.cwd)?;

--- a/src/launcher/resolution.rs
+++ b/src/launcher/resolution.rs
@@ -109,6 +109,7 @@ mod tests {
         assert!(tokenize_simple_command("FOO=bar openclaw").is_none());
         assert!(tokenize_simple_command("pnpm openclaw | tee log").is_none());
         assert!(tokenize_simple_command("openclaw 'gateway run'").is_none());
+        assert!(tokenize_simple_command("openclaw gateway\nopenclaw status").is_none());
         assert!(tokenize_simple_command(r"openclaw foo\ bar").is_none());
         assert!(tokenize_simple_command("openclaw --config ~/openclaw.json").is_none());
         assert!(tokenize_simple_command("openclaw plugins/*.mjs").is_none());

--- a/src/launcher/resolution.rs
+++ b/src/launcher/resolution.rs
@@ -68,7 +68,8 @@ fn tokenize_simple_command(command: &str) -> Option<Vec<String>> {
         return None;
     }
     if trimmed.contains([
-        '\'', '"', '`', '$', '|', '&', ';', '<', '>', '(', ')', '{', '}',
+        '\'', '"', '`', '$', '|', '&', ';', '<', '>', '(', ')', '{', '}', '\\', '*', '?', '[', ']',
+        '~', '#', '%', '^', '!',
     ]) {
         return None;
     }
@@ -108,6 +109,15 @@ mod tests {
         assert!(tokenize_simple_command("FOO=bar openclaw").is_none());
         assert!(tokenize_simple_command("pnpm openclaw | tee log").is_none());
         assert!(tokenize_simple_command("openclaw 'gateway run'").is_none());
+        assert!(tokenize_simple_command(r"openclaw foo\ bar").is_none());
+        assert!(tokenize_simple_command("openclaw --config ~/openclaw.json").is_none());
+        assert!(tokenize_simple_command("openclaw plugins/*.mjs").is_none());
+        assert!(tokenize_simple_command("openclaw plugin?.mjs").is_none());
+        assert!(tokenize_simple_command("openclaw plugins/[ab].mjs").is_none());
+        assert!(tokenize_simple_command("openclaw gateway # foreground").is_none());
+        assert!(tokenize_simple_command("openclaw %OPENCLAW_ARGS%").is_none());
+        assert!(tokenize_simple_command("openclaw ^&").is_none());
+        assert!(tokenize_simple_command("openclaw !OPENCLAW_ARGS!").is_none());
     }
 
     #[test]

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -172,13 +172,14 @@ fn upsert_environment(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
-    let meta = normalize_environment(meta)?;
+    let mut meta = normalize_environment(meta)?;
     let existing_launcher =
         find_environment(registry, &meta.name).and_then(|existing| existing.default_launcher);
     if meta.default_launcher != existing_launcher
         && let Some(launcher_name) = meta.default_launcher.as_deref()
     {
-        super::launchers::get_launcher(launcher_name, env, cwd)?;
+        let launcher = super::launchers::get_launcher(launcher_name, env, cwd)?;
+        meta.default_launcher = Some(launcher.name);
     }
     registry.envs.retain(|entry| entry.name != meta.name);
     registry.envs.push(meta.clone());

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -166,8 +166,20 @@ fn normalize_environment(mut meta: EnvMeta) -> Result<EnvMeta, String> {
     Ok(meta)
 }
 
-fn upsert_environment(registry: &mut EnvRegistry, meta: EnvMeta) -> Result<EnvMeta, String> {
+fn upsert_environment(
+    registry: &mut EnvRegistry,
+    meta: EnvMeta,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
     let meta = normalize_environment(meta)?;
+    let existing_launcher =
+        find_environment(registry, &meta.name).and_then(|existing| existing.default_launcher);
+    if meta.default_launcher != existing_launcher
+        && let Some(launcher_name) = meta.default_launcher.as_deref()
+    {
+        super::launchers::get_launcher(launcher_name, env, cwd)?;
+    }
     registry.envs.retain(|entry| entry.name != meta.name);
     registry.envs.push(meta.clone());
     Ok(meta)
@@ -204,7 +216,7 @@ pub fn save_environment(
 ) -> Result<EnvMeta, String> {
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
-    meta = upsert_environment(&mut registry, meta)?;
+    meta = upsert_environment(&mut registry, meta, env, cwd)?;
     write_env_registry(&mut registry, env, cwd)?;
 
     Ok(meta)
@@ -268,7 +280,7 @@ pub fn create_environment(
         updated_at: created_at,
         last_used_at: None,
     };
-    let meta = upsert_environment(&mut registry, meta)?;
+    let meta = upsert_environment(&mut registry, meta, env, cwd)?;
     write_env_registry(&mut registry, env, cwd)?;
     Ok(meta)
 }
@@ -338,7 +350,7 @@ pub fn clone_environment(
             updated_at: created_at,
             last_used_at: None,
         };
-        let meta = upsert_environment(&mut registry, meta)?;
+        let meta = upsert_environment(&mut registry, meta, env, cwd)?;
         write_env_registry(&mut registry, env, cwd)?;
         Ok(meta)
     })();
@@ -523,7 +535,7 @@ pub fn import_environment(
                 updated_at: created_at,
                 last_used_at: None,
             };
-            let meta = upsert_environment(&mut registry, meta)?;
+            let meta = upsert_environment(&mut registry, meta, env, cwd)?;
             write_env_registry(&mut registry, env, cwd)?;
             Ok(meta)
         })();
@@ -581,6 +593,16 @@ pub fn remove_environment(
     write_env_registry(&mut registry, env, cwd)?;
 
     Ok(meta)
+}
+
+pub(super) fn with_locked_environments<T>(
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+    action: impl FnOnce(&[EnvMeta]) -> Result<T, String>,
+) -> Result<T, String> {
+    let _lock = lock_env_registry(env, cwd)?;
+    let registry = load_env_registry(env, cwd)?;
+    action(&registry.envs)
 }
 
 fn import_staging_dir() -> PathBuf {

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -173,11 +173,7 @@ fn upsert_environment(
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
     let mut meta = normalize_environment(meta)?;
-    let existing_launcher =
-        find_environment(registry, &meta.name).and_then(|existing| existing.default_launcher);
-    if meta.default_launcher != existing_launcher
-        && let Some(launcher_name) = meta.default_launcher.as_deref()
-    {
+    if let Some(launcher_name) = meta.default_launcher.as_deref() {
         let launcher = super::launchers::get_launcher(launcher_name, env, cwd)?;
         meta.default_launcher = Some(launcher.name);
     }

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -166,17 +166,20 @@ fn normalize_environment(mut meta: EnvMeta) -> Result<EnvMeta, String> {
     Ok(meta)
 }
 
-fn upsert_environment(
-    registry: &mut EnvRegistry,
-    meta: EnvMeta,
+fn canonicalize_launcher_binding(
+    mut meta: EnvMeta,
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
-    let mut meta = normalize_environment(meta)?;
     if let Some(launcher_name) = meta.default_launcher.as_deref() {
         let launcher = super::launchers::get_launcher(launcher_name, env, cwd)?;
         meta.default_launcher = Some(launcher.name);
     }
+    Ok(meta)
+}
+
+fn upsert_environment(registry: &mut EnvRegistry, meta: EnvMeta) -> Result<EnvMeta, String> {
+    let meta = normalize_environment(meta)?;
     registry.envs.retain(|entry| entry.name != meta.name);
     registry.envs.push(meta.clone());
     Ok(meta)
@@ -213,7 +216,21 @@ pub fn save_environment(
 ) -> Result<EnvMeta, String> {
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
-    meta = upsert_environment(&mut registry, meta, env, cwd)?;
+    meta = upsert_environment(&mut registry, meta)?;
+    write_env_registry(&mut registry, env, cwd)?;
+
+    Ok(meta)
+}
+
+pub(crate) fn save_environment_with_validated_launcher(
+    mut meta: EnvMeta,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
+    let _lock = lock_env_registry(env, cwd)?;
+    let mut registry = load_env_registry(env, cwd)?;
+    meta = canonicalize_launcher_binding(meta, env, cwd)?;
+    meta = upsert_environment(&mut registry, meta)?;
     write_env_registry(&mut registry, env, cwd)?;
 
     Ok(meta)
@@ -283,7 +300,7 @@ pub fn create_environment(
         updated_at: created_at,
         last_used_at: None,
     };
-    let meta = upsert_environment(&mut registry, meta, env, cwd)?;
+    let meta = upsert_environment(&mut registry, meta)?;
     write_env_registry(&mut registry, env, cwd)?;
     Ok(meta)
 }
@@ -353,7 +370,7 @@ pub fn clone_environment(
             updated_at: created_at,
             last_used_at: None,
         };
-        let meta = upsert_environment(&mut registry, meta, env, cwd)?;
+        let meta = upsert_environment(&mut registry, meta)?;
         write_env_registry(&mut registry, env, cwd)?;
         Ok(meta)
     })();
@@ -538,7 +555,7 @@ pub fn import_environment(
                 updated_at: created_at,
                 last_used_at: None,
             };
-            let meta = upsert_environment(&mut registry, meta, env, cwd)?;
+            let meta = upsert_environment(&mut registry, meta)?;
             write_env_registry(&mut registry, env, cwd)?;
             Ok(meta)
         })();

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -234,6 +234,12 @@ pub fn create_environment(
     if find_environment(&registry, &name).is_some() {
         return Err(format!("environment \"{name}\" already exists"));
     }
+    let default_launcher = options
+        .default_launcher
+        .as_deref()
+        .map(|launcher_name| super::launchers::get_launcher(launcher_name, env, cwd))
+        .transpose()?
+        .map(|launcher| launcher.name);
 
     let root = if let Some(root) = options.root.as_deref() {
         resolve_absolute_path(root, env, cwd)?
@@ -274,7 +280,7 @@ pub fn create_environment(
         service_enabled: options.service_enabled,
         service_running: options.service_running,
         default_runtime: options.default_runtime,
-        default_launcher: options.default_launcher,
+        default_launcher,
         dev: options.dev,
         protected: options.protected,
         created_at,

--- a/src/store/launchers.rs
+++ b/src/store/launchers.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::launcher::{AddLauncherOptions, LauncherMeta};
 
 use super::common::{load_json_files, path_exists, read_json, write_json};
-use super::envs::list_environments;
+use super::envs::with_locked_environments;
 use super::layout::{display_path, launcher_meta_path, resolve_absolute_path, validate_name};
 use super::now_utc;
 
@@ -83,19 +83,21 @@ pub fn remove_launcher(
     cwd: &Path,
 ) -> Result<LauncherMeta, String> {
     let meta = get_launcher(name, env, cwd)?;
-    let bound_envs = list_environments(env, cwd)?
-        .into_iter()
-        .filter(|env| env.default_launcher.as_deref() == Some(meta.name.as_str()))
-        .map(|env| env.name)
-        .collect::<Vec<_>>();
-    if !bound_envs.is_empty() {
-        return Err(format!(
-            "launcher \"{}\" is still used by environment(s): {}; clear those bindings before removing it",
-            meta.name,
-            bound_envs.join(", ")
-        ));
-    }
-    let path = launcher_meta_path(&meta.name, env, cwd)?;
-    fs::remove_file(path).map_err(|error| error.to_string())?;
+    with_locked_environments(env, cwd, |envs| {
+        let bound_envs = envs
+            .iter()
+            .filter(|env| env.default_launcher.as_deref() == Some(meta.name.as_str()))
+            .map(|env| env.name.as_str())
+            .collect::<Vec<_>>();
+        if !bound_envs.is_empty() {
+            return Err(format!(
+                "launcher \"{}\" is still used by environment(s): {}; clear those bindings before removing it",
+                meta.name,
+                bound_envs.join(", ")
+            ));
+        }
+        let path = launcher_meta_path(&meta.name, env, cwd)?;
+        fs::remove_file(path).map_err(|error| error.to_string())
+    })?;
     Ok(meta)
 }

--- a/src/store/launchers.rs
+++ b/src/store/launchers.rs
@@ -86,8 +86,11 @@ pub fn remove_launcher(
     with_locked_environments(env, cwd, |envs| {
         let bound_envs = envs
             .iter()
-            .filter(|env| env.default_launcher.as_deref() == Some(meta.name.as_str()))
-            .map(|env| env.name.as_str())
+            .filter_map(|environment| {
+                let launcher_name = environment.default_launcher.as_deref()?;
+                let launcher = get_launcher(launcher_name, env, cwd).ok()?;
+                (launcher.name == meta.name).then_some(environment.name.as_str())
+            })
             .collect::<Vec<_>>();
         if !bound_envs.is_empty() {
             return Err(format!(

--- a/src/store/launchers.rs
+++ b/src/store/launchers.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use crate::launcher::{AddLauncherOptions, LauncherMeta};
 
 use super::common::{load_json_files, path_exists, read_json, write_json};
+use super::envs::list_environments;
 use super::layout::{display_path, launcher_meta_path, resolve_absolute_path, validate_name};
 use super::now_utc;
 
@@ -82,6 +83,18 @@ pub fn remove_launcher(
     cwd: &Path,
 ) -> Result<LauncherMeta, String> {
     let meta = get_launcher(name, env, cwd)?;
+    let bound_envs = list_environments(env, cwd)?
+        .into_iter()
+        .filter(|env| env.default_launcher.as_deref() == Some(meta.name.as_str()))
+        .map(|env| env.name)
+        .collect::<Vec<_>>();
+    if !bound_envs.is_empty() {
+        return Err(format!(
+            "launcher \"{}\" is still used by environment(s): {}; clear those bindings before removing it",
+            meta.name,
+            bound_envs.join(", ")
+        ));
+    }
     let path = launcher_meta_path(&meta.name, env, cwd)?;
     fs::remove_file(path).map_err(|error| error.to_string())?;
     Ok(meta)

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -16,6 +16,7 @@ use time::OffsetDateTime;
 use crate::env::EnvMeta;
 use crate::env::EnvSummary;
 pub(crate) use common::{copy_dir_recursive, ensure_dir, read_json, write_json};
+pub(crate) use envs::save_environment_with_validated_launcher;
 pub(crate) use envs::{EnvironmentOperationLock, lock_environment_operation};
 pub use envs::{
     clone_environment, create_environment, export_environment, get_environment, import_environment,

--- a/tests/launcher_binding_tests.rs
+++ b/tests/launcher_binding_tests.rs
@@ -71,6 +71,49 @@ fn launcher_bindings_require_an_existing_launcher() {
 }
 
 #[test]
+fn case_variant_launcher_bindings_use_metadata_identity_when_supported() {
+    let root = TestDir::new("launcher-binding-case-variant");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "sh"],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--launcher", "STABLE"],
+    );
+    if !create.status.success() {
+        assert!(stderr(&create).contains("launcher \"STABLE\" does not exist"));
+        return;
+    }
+
+    let environment = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(environment.status.success(), "{}", stderr(&environment));
+    let environment: serde_json::Value = serde_json::from_str(&stdout(&environment)).unwrap();
+    assert_eq!(environment["defaultLauncher"], "stable");
+
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let mut registry: serde_json::Value =
+        serde_json::from_slice(&fs::read(&registry_path).unwrap()).unwrap();
+    registry["envs"][0]["defaultLauncher"] = "STABLE".into();
+    fs::write(
+        registry_path,
+        format!("{}\n", serde_json::to_string_pretty(&registry).unwrap()),
+    )
+    .unwrap();
+
+    let remove = run_ocm(&cwd, &env, &["launcher", "remove", "stable"]);
+    assert!(!remove.status.success());
+    assert!(stderr(&remove).contains("is still used by environment(s): demo"));
+}
+
+#[test]
 fn launcher_binding_and_removal_share_the_environment_registry_lock() {
     let root = TestDir::new("launcher-binding-remove-lock");
     let cwd = root.child("workspace");

--- a/tests/launcher_binding_tests.rs
+++ b/tests/launcher_binding_tests.rs
@@ -1,8 +1,13 @@
 mod support;
 
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
 
 use crate::support::{TestDir, ocm_env, run_ocm, stderr, stdout};
+use fs2::FileExt;
+use ocm::store::env_registry_path;
 
 #[test]
 fn env_set_launcher_updates_and_clears_the_default_launcher() {
@@ -36,6 +41,102 @@ fn env_set_launcher_updates_and_clears_the_default_launcher() {
     let show_cleared = run_ocm(&cwd, &env, &["env", "show", "demo"]);
     assert!(show_cleared.status.success(), "{}", stderr(&show_cleared));
     assert!(!stdout(&show_cleared).contains("defaultLauncher:"));
+}
+
+#[test]
+fn launcher_bindings_require_an_existing_launcher() {
+    let root = TestDir::new("launcher-binding-missing");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "invalid", "--launcher", "missing"],
+    );
+    assert!(!create.status.success());
+    assert!(stderr(&create).contains("launcher \"missing\" does not exist"));
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "demo"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+    let bind = run_ocm(&cwd, &env, &["env", "set-launcher", "demo", "missing"]);
+    assert!(!bind.status.success());
+    assert!(stderr(&bind).contains("launcher \"missing\" does not exist"));
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let environment: serde_json::Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert!(environment["defaultLauncher"].is_null());
+}
+
+#[test]
+fn launcher_binding_and_removal_share_the_environment_registry_lock() {
+    let root = TestDir::new("launcher-binding-remove-lock");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "sh"],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(&cwd, &env, &["env", "create", "demo"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let lock_path = env_registry_path(&env, &cwd)
+        .unwrap()
+        .with_extension("lock");
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(lock_path)
+        .unwrap();
+    lock.lock_exclusive().unwrap();
+
+    let mut bind = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    bind.current_dir(&cwd)
+        .args(["env", "set-launcher", "demo", "stable"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut bind = bind.spawn().unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    let mut remove = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    remove
+        .current_dir(&cwd)
+        .args(["launcher", "remove", "stable"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut remove = remove.spawn().unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    assert!(bind.try_wait().unwrap().is_none());
+    assert!(remove.try_wait().unwrap().is_none());
+    FileExt::unlock(&lock).unwrap();
+
+    let bind = bind.wait_with_output().unwrap();
+    let remove = remove.wait_with_output().unwrap();
+    assert_ne!(bind.status.success(), remove.status.success());
+
+    let environment = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(environment.status.success(), "{}", stderr(&environment));
+    let environment: serde_json::Value = serde_json::from_str(&stdout(&environment)).unwrap();
+    let launcher = run_ocm(&cwd, &env, &["launcher", "show", "stable"]);
+    if bind.status.success() {
+        assert!(launcher.status.success(), "{}", stderr(&launcher));
+        assert_eq!(environment["defaultLauncher"], "stable");
+    } else {
+        assert!(!launcher.status.success());
+        assert!(environment["defaultLauncher"].is_null());
+    }
 }
 
 #[test]

--- a/tests/launcher_binding_tests.rs
+++ b/tests/launcher_binding_tests.rs
@@ -53,10 +53,19 @@ fn launcher_bindings_require_an_existing_launcher() {
     let create = run_ocm(
         &cwd,
         &env,
-        &["env", "create", "invalid", "--launcher", "missing"],
+        &[
+            "env",
+            "create",
+            "invalid",
+            "--root",
+            "./orphan",
+            "--launcher",
+            "missing",
+        ],
     );
     assert!(!create.status.success());
     assert!(stderr(&create).contains("launcher \"missing\" does not exist"));
+    assert!(!cwd.join("orphan").exists());
 
     let create = run_ocm(&cwd, &env, &["env", "create", "demo"]);
     assert!(create.status.success(), "{}", stderr(&create));

--- a/tests/launcher_binding_tests.rs
+++ b/tests/launcher_binding_tests.rs
@@ -77,6 +77,19 @@ fn launcher_bindings_require_an_existing_launcher() {
     assert!(show.status.success(), "{}", stderr(&show));
     let environment: serde_json::Value = serde_json::from_str(&stdout(&show)).unwrap();
     assert!(environment["defaultLauncher"].is_null());
+
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let mut registry: serde_json::Value =
+        serde_json::from_slice(&fs::read(&registry_path).unwrap()).unwrap();
+    registry["envs"][0]["defaultLauncher"] = "missing".into();
+    fs::write(
+        registry_path,
+        format!("{}\n", serde_json::to_string_pretty(&registry).unwrap()),
+    )
+    .unwrap();
+    let bind = run_ocm(&cwd, &env, &["env", "set-launcher", "demo", "missing"]);
+    assert!(!bind.status.success());
+    assert!(stderr(&bind).contains("launcher \"missing\" does not exist"));
 }
 
 #[test]

--- a/tests/launcher_command_tests.rs
+++ b/tests/launcher_command_tests.rs
@@ -3,6 +3,7 @@ mod support;
 use std::fs;
 
 use crate::support::{TestDir, ocm_env, run_ocm, stderr, stdout};
+use serde_json::Value;
 
 #[test]
 fn launcher_list_uses_launcher_wording_when_empty() {
@@ -86,6 +87,43 @@ fn launcher_show_and_remove_use_launcher_metadata() {
     let launcher_list = run_ocm(&cwd, &env, &["launcher", "list"]);
     assert!(launcher_list.status.success(), "{}", stderr(&launcher_list));
     assert_eq!(stdout(&launcher_list), "No launchers.\n");
+}
+
+#[test]
+fn launcher_remove_rejects_bound_environments_without_changing_state() {
+    let root = TestDir::new("launcher-remove-bound");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "sh"],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--launcher", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let remove = run_ocm(&cwd, &env, &["launcher", "remove", "stable"]);
+    assert!(!remove.status.success());
+    assert!(stderr(&remove).contains(
+        "launcher \"stable\" is still used by environment(s): demo; clear those bindings before removing it"
+    ));
+
+    let launcher = run_ocm(&cwd, &env, &["launcher", "show", "stable", "--json"]);
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let launcher: Value = serde_json::from_str(&stdout(&launcher)).unwrap();
+    assert_eq!(launcher["name"], "stable");
+
+    let environment = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(environment.status.success(), "{}", stderr(&environment));
+    let environment: Value = serde_json::from_str(&stdout(&environment)).unwrap();
+    assert_eq!(environment["defaultLauncher"], "stable");
 }
 
 #[test]

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -666,6 +666,23 @@ fn runtime_verify_help_mentions_raw_mode() {
 }
 
 #[test]
+fn runtime_releases_help_mentions_standard_output_modes() {
+    let root = TestDir::new("help-runtime-releases");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let releases = run_ocm(&cwd, &env, &["help", "runtime", "releases"]);
+    assert!(releases.status.success(), "{}", stderr(&releases));
+    let output = stdout(&releases);
+    assert!(output.contains(
+        "ocm runtime releases [--manifest-url <url>] [--version <version> | --channel <channel>] [--raw] [--json]"
+    ));
+    assert!(output.contains("--raw"));
+    assert!(output.contains("--json"));
+}
+
+#[test]
 fn runtime_which_help_mentions_raw_mode_and_tty_cards() {
     let root = TestDir::new("help-runtime-which");
     let cwd = root.child("workspace");

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -1771,6 +1771,49 @@ fn runtime_releases_lists_manifest_entries() {
     assert!(output.contains("sha256=abc123"));
     assert!(output.contains("0.3.0-dev"));
 
+    let raw_server = TestHttpServer::serve_bytes(
+        "/manifests/releases.json",
+        "application/json",
+        manifest_body,
+    );
+    let raw = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "releases",
+            "--manifest-url",
+            &raw_server.url(),
+            "--raw",
+        ],
+    );
+    assert!(raw.status.success(), "{}", stderr(&raw));
+    assert!(stdout(&raw).contains("0.2.0"));
+
+    let color_server = TestHttpServer::serve_bytes(
+        "/manifests/releases.json",
+        "application/json",
+        manifest_body,
+    );
+    let color = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "releases",
+            "--manifest-url",
+            &color_server.url(),
+            "--color",
+            "never",
+        ],
+    );
+    assert!(color.status.success(), "{}", stderr(&color));
+    assert!(stdout(&color).contains("0.2.0"));
+
+    let mixed = run_ocm(&cwd, &env, &["runtime", "releases", "--json", "--raw"]);
+    assert_eq!(mixed.status.code(), Some(1));
+    assert!(stderr(&mixed).contains("runtime releases accepts only one of --json or --raw"));
+
     let json_server = TestHttpServer::serve_bytes(
         "/manifests/releases.json",
         "application/json",

--- a/tests/store_flow_tests.rs
+++ b/tests/store_flow_tests.rs
@@ -1,6 +1,8 @@
 mod support;
 
+use std::collections::BTreeMap;
 use std::fs;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 use ocm::env::{
@@ -22,12 +24,52 @@ use ocm::store::{
 
 use crate::support::{TestDir, ocm_env, path_string, write_executable_script, write_text};
 
+fn add_test_launcher(name: &str, env: &BTreeMap<String, String>, cwd: &Path) {
+    add_launcher(
+        AddLauncherOptions {
+            name: name.to_string(),
+            command: "sh".to_string(),
+            cwd: None,
+            description: None,
+        },
+        env,
+        cwd,
+    )
+    .unwrap();
+}
+
+fn corrupt_environment_bindings(
+    name: &str,
+    default_runtime: Option<&str>,
+    default_launcher: Option<&str>,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) {
+    let path = env_registry_path(env, cwd).unwrap();
+    let mut registry: serde_json::Value =
+        serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    let meta = registry["envs"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|meta| meta["name"] == name)
+        .unwrap();
+    meta["defaultRuntime"] = default_runtime.into();
+    meta["defaultLauncher"] = default_launcher.into();
+    fs::write(
+        path,
+        format!("{}\n", serde_json::to_string_pretty(&registry).unwrap()),
+    )
+    .unwrap();
+}
+
 #[test]
 fn environment_store_round_trip_covers_create_read_list_and_remove() {
     let root = TestDir::new("store-env-flow");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("stable", &env, &cwd);
 
     let created = create_environment(
         CreateEnvironmentOptions {
@@ -263,6 +305,7 @@ fn environment_clone_copies_the_root_and_resets_identity_metadata() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("stable", &env, &cwd);
 
     let source = create_environment(
         CreateEnvironmentOptions {
@@ -361,6 +404,7 @@ fn clone_environment_assigns_a_new_port_when_the_source_port_was_auto_assigned()
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("stable", &env, &cwd);
 
     let source = create_environment(
         CreateEnvironmentOptions {
@@ -399,6 +443,7 @@ fn clone_environment_skips_the_global_openclaw_port_family() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("stable", &env, &cwd);
 
     let global_root = root.child("home/.openclaw");
     fs::create_dir_all(&global_root).unwrap();
@@ -446,6 +491,7 @@ fn clone_environment_rewrites_env_scoped_config_paths_and_ports() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("stable", &env, &cwd);
 
     let source = create_environment(
         CreateEnvironmentOptions {
@@ -520,6 +566,7 @@ fn clone_environment_clears_copied_runtime_state_outside_workspace_and_config() 
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("stable", &env, &cwd);
 
     let source = create_environment(
         CreateEnvironmentOptions {
@@ -600,6 +647,7 @@ fn environment_export_writes_a_portable_archive() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("shell", &env, &cwd);
 
     let created = create_environment(
         CreateEnvironmentOptions {
@@ -660,6 +708,7 @@ fn environment_import_restores_a_portable_archive_with_a_new_identity() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("shell", &env, &cwd);
 
     let created = create_environment(
         CreateEnvironmentOptions {
@@ -754,6 +803,7 @@ fn environment_import_clears_copied_runtime_state_outside_workspace_and_config()
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("shell", &env, &cwd);
 
     let created = create_environment(
         CreateEnvironmentOptions {
@@ -840,6 +890,7 @@ fn environment_snapshot_captures_a_named_point_in_time() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("shell", &env, &cwd);
 
     let created = create_environment(
         CreateEnvironmentOptions {
@@ -900,6 +951,7 @@ fn environment_snapshot_skips_legacy_plugin_dependency_state_and_preserves_symli
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("shell", &env, &cwd);
 
     let created = create_environment(
         CreateEnvironmentOptions {
@@ -1172,6 +1224,7 @@ fn environment_snapshot_restore_replaces_env_state_from_the_snapshot() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("shell", &env, &cwd);
 
     let created = create_environment(
         CreateEnvironmentOptions {
@@ -1272,6 +1325,7 @@ fn environment_snapshot_restore_clears_broken_foreign_runtime_state_but_keeps_ag
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    add_test_launcher("shell", &env, &cwd);
 
     let foreign = create_environment(
         CreateEnvironmentOptions {
@@ -1496,10 +1550,13 @@ fn environment_cleanup_preview_identifies_safe_repairs_without_mutating_state() 
     )
     .unwrap();
 
-    let mut drifted = get_environment("source", &env, &cwd).unwrap();
-    drifted.default_runtime = Some("ghost-runtime".to_string());
-    drifted.default_launcher = Some("ghost-launcher".to_string());
-    ocm::store::save_environment(drifted, &env, &cwd).unwrap();
+    corrupt_environment_bindings(
+        "source",
+        Some("ghost-runtime"),
+        Some("ghost-launcher"),
+        &env,
+        &cwd,
+    );
 
     let service = EnvironmentService::new(&env, &cwd);
     let preview = service.cleanup_preview("source").unwrap();
@@ -1538,10 +1595,13 @@ fn environment_cleanup_applies_binding_repairs() {
     )
     .unwrap();
 
-    let mut drifted = get_environment("source", &env, &cwd).unwrap();
-    drifted.default_runtime = Some("ghost-runtime".to_string());
-    drifted.default_launcher = Some("ghost-launcher".to_string());
-    ocm::store::save_environment(drifted, &env, &cwd).unwrap();
+    corrupt_environment_bindings(
+        "source",
+        Some("ghost-runtime"),
+        Some("ghost-launcher"),
+        &env,
+        &cwd,
+    );
 
     let service = EnvironmentService::new(&env, &cwd);
     let applied = service.cleanup("source").unwrap();
@@ -1602,9 +1662,7 @@ fn environment_cleanup_all_limits_results_to_envs_with_safe_repairs() {
     )
     .unwrap();
 
-    let mut broken = get_environment("broken", &env, &cwd).unwrap();
-    broken.default_launcher = Some("ghost-launcher".to_string());
-    ocm::store::save_environment(broken, &env, &cwd).unwrap();
+    corrupt_environment_bindings("broken", None, Some("ghost-launcher"), &env, &cwd);
 
     let service = EnvironmentService::new(&env, &cwd);
     let preview = service.cleanup_all_preview().unwrap();

--- a/tests/store_flow_tests.rs
+++ b/tests/store_flow_tests.rs
@@ -749,6 +749,10 @@ fn environment_import_restores_a_portable_archive_with_a_new_identity() {
         &cwd,
     )
     .unwrap();
+    let mut source = get_environment("source", &env, &cwd).unwrap();
+    source.default_launcher = None;
+    ocm::store::save_environment(source, &env, &cwd).unwrap();
+    remove_launcher("shell", &env, &cwd).unwrap();
 
     let imported = import_environment(
         ImportEnvironmentOptions {


### PR DESCRIPTION
## Summary

- preserve launcher command semantics by routing shell-sensitive recipes through the shell
- prevent deletion of launchers still referenced by environments
- serialize launcher binding and removal, canonicalize launcher identity, and validate explicit bindings without breaking portable imports
- accept standard human-output flags for `runtime releases` and document `runtime build-local`

## Root cause

Launcher commands were tokenized too aggressively, losing shell behavior. Launcher bindings and deletion also used separate unlocked checks, allowing dangling references under concurrent operations. Validation was split across service and store layers, which left inconsistent handling for case-insensitive filesystems, stale bindings, failed creates, and imported metadata.

## User impact

Multiline and shell-expanding launcher commands now execute with their intended semantics. Bound launchers cannot be removed out from under environments, explicit bindings fail cleanly when the launcher is missing, failed creates leave no orphan root, and portable environment imports continue preserving archived binding metadata.

`runtime releases` now supports the same `--raw`, `--color`, and JSON conflict behavior as related commands.

## Evidence

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo test --test launcher_binding_tests --test launcher_command_tests --test store_flow_tests --test env_import_tests -- --test-threads=1` (39 passed)
- branch autoreview with Codex `gpt-5.6-sol`, high reasoning: clean, confidence 0.86

The full serial suite also passed before the final rebase onto current `main`; current-head CI provides the broad post-rebase gate.
