### PR TITLE
fix(dev): protect managed worktree ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ All notable changes to OCM are documented here.
 - Report launcher and environment rollback failures alongside the original migration error instead of hiding partial cleanup.
 - Make release preparation rollback-safe, verify signed annotated tags on every resume path, and publish branch and tag refs atomically.
 - Build locked release artifacts only from a GitHub-verified tag matching the package version, require the complete supported target matrix before publication, publish a versioned checksum-verifying installer, pin CI actions, and test the declared Rust 1.88 minimum.
+- Preserve uncommitted dev worktrees and reject unrelated checkout collisions by requiring exact Git worktree registration before reuse or removal.

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -125,7 +125,7 @@ pub(crate) fn remove_openclaw_worktree(
         return Ok(());
     }
 
-    if worktree_root.exists() && !is_existing_openclaw_worktree(repo_root, worktree_root) {
+    if worktree_root.exists() && !has_expected_worktree_identity(repo_root, worktree_root) {
         return Err(format!(
             "refusing to remove registered worktree whose checkout identity does not match this OpenClaw checkout: {}",
             display_path(worktree_root)
@@ -365,9 +365,12 @@ fn normalize_worktree_path(path: &Path) -> PathBuf {
 }
 
 fn is_existing_openclaw_worktree(repo_root: &Path, path: &Path) -> bool {
+    detect_openclaw_checkout(path).is_some() && has_expected_worktree_identity(repo_root, path)
+}
+
+fn has_expected_worktree_identity(repo_root: &Path, path: &Path) -> bool {
     path.exists()
         && path.join(".git").exists()
-        && detect_openclaw_checkout(path).is_some()
         && git_top_level(path).is_some_and(|top_level| {
             normalize_worktree_path(&top_level) == normalize_worktree_path(path)
         })
@@ -403,17 +406,22 @@ fn git_rev_parse_path(path: &Path, selector: &str) -> Option<PathBuf> {
     let output = Command::new("git")
         .arg("-C")
         .arg(path)
-        .args(["rev-parse", "--path-format=absolute", selector])
+        .args(["rev-parse", selector])
         .output()
         .ok()?;
     if !output.status.success() {
         return None;
     }
 
-    let path = PathBuf::from(git_path_from_bytes(trim_git_line(&output.stdout)).ok()?);
-    fs::canonicalize(&path)
+    let resolved = PathBuf::from(git_path_from_bytes(trim_git_line(&output.stdout)).ok()?);
+    let resolved = if resolved.is_absolute() {
+        resolved
+    } else {
+        clean_path(&path.join(resolved))
+    };
+    fs::canonicalize(&resolved)
         .ok()
-        .or_else(|| Some(clean_path(&path)))
+        .or_else(|| Some(clean_path(&resolved)))
 }
 
 fn trim_git_line(output: &[u8]) -> &[u8] {

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -174,7 +174,52 @@ fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
         ));
     }
 
+    ensure_no_ignored_local_files(worktree_root)?;
     Ok(())
+}
+
+fn ensure_no_ignored_local_files(worktree_root: &Path) -> Result<(), String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(worktree_root)
+        .args([
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+        ])
+        .output()
+        .map_err(|error| format!("failed to inspect ignored worktree files: {error}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!("git ignored-file inspection failed: {detail}"));
+    }
+
+    let has_local_files = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(git_path_from_bytes)
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(PathBuf::from)
+        .any(|path| !is_disposable_ignored_path(&path));
+    if has_local_files {
+        return Err(format!(
+            "git worktree remove failed: {} contains ignored local files",
+            display_path(worktree_root)
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_disposable_ignored_path(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == "node_modules")
 }
 
 fn registered_worktree_paths(repo_root: &Path) -> Result<Vec<PathBuf>, String> {

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -110,11 +110,11 @@ pub(crate) fn remove_openclaw_worktree(
     repo_root: &Path,
     worktree_root: &Path,
 ) -> Result<(), String> {
-    if !repo_root.exists() && !worktree_root.exists() {
-        return Ok(());
-    }
-
-    let registered = registered_worktree_paths(repo_root)?;
+    let registered = match registered_worktree_paths(repo_root) {
+        Ok(registered) => registered,
+        Err(_) if !worktree_root.exists() => return Ok(()),
+        Err(error) => return Err(error),
+    };
     if !contains_worktree_path(&registered, worktree_root) {
         if worktree_root.exists() {
             return Err(format!(

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -265,14 +265,39 @@ fn registered_worktree_paths(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
         .args(["worktree", "list", "--porcelain", "-z"])
         .output()
         .map_err(|error| format!("failed to run git worktree list: {error}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if !stderr.is_empty() { stderr } else { stdout };
-        return Err(format!("git worktree list failed: {detail}"));
+    if output.status.success() {
+        return parse_registered_worktree_paths(&output.stdout);
     }
 
-    parse_registered_worktree_paths(&output.stdout)
+    let fallback = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args([
+            "-c",
+            "core.quotePath=false",
+            "worktree",
+            "list",
+            "--porcelain",
+        ])
+        .output()
+        .map_err(|error| format!("failed to run compatible git worktree list: {error}"))?;
+    if fallback.status.success() {
+        return parse_legacy_registered_worktree_paths(&fallback.stdout);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+    let fallback_stderr = String::from_utf8_lossy(&fallback.stderr).trim().to_string();
+    let fallback_stdout = String::from_utf8_lossy(&fallback.stdout).trim().to_string();
+    let fallback_detail = if !fallback_stderr.is_empty() {
+        fallback_stderr
+    } else {
+        fallback_stdout
+    };
+    Err(format!(
+        "git worktree list failed: {detail}; compatible fallback failed: {fallback_detail}"
+    ))
 }
 
 fn parse_registered_worktree_paths(output: &[u8]) -> Result<Vec<PathBuf>, String> {
@@ -280,6 +305,22 @@ fn parse_registered_worktree_paths(output: &[u8]) -> Result<Vec<PathBuf>, String
         .split(|byte| *byte == 0)
         .filter_map(|field| field.strip_prefix(b"worktree "))
         .map(|path| git_path_from_bytes(path).map(PathBuf::from))
+        .collect()
+}
+
+fn parse_legacy_registered_worktree_paths(output: &[u8]) -> Result<Vec<PathBuf>, String> {
+    output
+        .split(|byte| *byte == b'\n')
+        .filter_map(|line| line.strip_prefix(b"worktree "))
+        .map(|path| {
+            if path.starts_with(b"\"") {
+                return Err(
+                    "git worktree list returned a quoted path that requires Git 2.36 or newer"
+                        .to_string(),
+                );
+            }
+            git_path_from_bytes(path).map(PathBuf::from)
+        })
         .collect()
 }
 
@@ -402,8 +443,9 @@ fn git_path_from_bytes(path: &[u8]) -> Result<OsString, String> {
 #[cfg(all(test, unix))]
 mod tests {
     use std::os::unix::ffi::OsStrExt;
+    use std::path::PathBuf;
 
-    use super::parse_registered_worktree_paths;
+    use super::{parse_legacy_registered_worktree_paths, parse_registered_worktree_paths};
 
     #[test]
     fn worktree_porcelain_parser_preserves_non_utf8_paths() {
@@ -414,5 +456,29 @@ mod tests {
 
         assert_eq!(paths.len(), 2);
         assert_eq!(paths[1].as_os_str().as_bytes(), b"/tmp/other\xff");
+    }
+
+    #[test]
+    fn legacy_worktree_porcelain_parser_preserves_spaces() {
+        let paths = parse_legacy_registered_worktree_paths(
+            b"worktree /tmp/openclaw checkout\nHEAD abc123\ndetached\n\n",
+        )
+        .unwrap();
+
+        assert_eq!(paths, vec![PathBuf::from("/tmp/openclaw checkout")]);
+    }
+
+    #[test]
+    fn legacy_worktree_porcelain_parser_rejects_quoted_paths() {
+        let error = parse_legacy_registered_worktree_paths(
+            br#"worktree "/tmp/openclaw\ncheckout"
+HEAD abc123
+detached
+
+"#,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("requires Git 2.36 or newer"));
     }
 }

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -110,6 +110,10 @@ pub(crate) fn remove_openclaw_worktree(
     repo_root: &Path,
     worktree_root: &Path,
 ) -> Result<(), String> {
+    if !repo_root.exists() && !worktree_root.exists() {
+        return Ok(());
+    }
+
     let registered = registered_worktree_paths(repo_root)?;
     if !contains_worktree_path(&registered, worktree_root) {
         if worktree_root.exists() {

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -121,6 +121,13 @@ pub(crate) fn remove_openclaw_worktree(
         return Ok(());
     }
 
+    if worktree_root.exists() && !is_existing_openclaw_worktree(repo_root, worktree_root) {
+        return Err(format!(
+            "refusing to remove registered worktree whose checkout identity does not match this OpenClaw checkout: {}",
+            display_path(worktree_root)
+        ));
+    }
+
     remove_registered_worktree(repo_root, worktree_root)
 }
 
@@ -179,7 +186,7 @@ fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
 }
 
 fn ensure_no_ignored_local_files(worktree_root: &Path) -> Result<(), String> {
-    let output = Command::new("git")
+    let worktree_output = Command::new("git")
         .arg("-C")
         .arg(worktree_root)
         .args([
@@ -191,16 +198,45 @@ fn ensure_no_ignored_local_files(worktree_root: &Path) -> Result<(), String> {
         ])
         .output()
         .map_err(|error| format!("failed to inspect ignored worktree files: {error}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !worktree_output.status.success() {
+        let stderr = String::from_utf8_lossy(&worktree_output.stderr)
+            .trim()
+            .to_string();
+        let stdout = String::from_utf8_lossy(&worktree_output.stdout)
+            .trim()
+            .to_string();
         let detail = if !stderr.is_empty() { stderr } else { stdout };
         return Err(format!("git ignored-file inspection failed: {detail}"));
     }
 
-    let has_local_files = output
-        .stdout
-        .split(|byte| *byte == 0)
+    let submodule_output = Command::new("git")
+        .arg("-C")
+        .arg(worktree_root)
+        .args([
+            "submodule",
+            "foreach",
+            "--quiet",
+            "--recursive",
+            "git ls-files --others --ignored --exclude-standard -z",
+        ])
+        .output()
+        .map_err(|error| format!("failed to inspect ignored submodule files: {error}"))?;
+    if !submodule_output.status.success() {
+        let stderr = String::from_utf8_lossy(&submodule_output.stderr)
+            .trim()
+            .to_string();
+        let stdout = String::from_utf8_lossy(&submodule_output.stdout)
+            .trim()
+            .to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!(
+            "git ignored-file inspection failed for initialized submodules: {detail}"
+        ));
+    }
+
+    let has_local_files = [&worktree_output.stdout, &submodule_output.stdout]
+        .into_iter()
+        .flat_map(|output| output.split(|byte| *byte == 0))
         .filter(|path| !path.is_empty())
         .map(git_path_from_bytes)
         .collect::<Result<Vec<_>, _>>()?

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -3,6 +3,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+
 use serde_json::Value;
 
 use crate::store::{clean_path, display_path};
@@ -55,7 +58,7 @@ pub(crate) fn ensure_openclaw_worktree(
     if worktree_registered {
         if !worktree_root.exists() {
             remove_registered_worktree(&repo_root, &worktree_root)?;
-        } else if is_existing_openclaw_worktree(&worktree_root) {
+        } else if is_existing_openclaw_worktree(&repo_root, &worktree_root) {
             return Ok(worktree_root);
         } else {
             return Err(format!(
@@ -92,7 +95,7 @@ pub(crate) fn ensure_openclaw_worktree(
 
     let registered = registered_worktree_paths(&repo_root)?;
     if !contains_worktree_path(&registered, &worktree_root)
-        || !is_existing_openclaw_worktree(&worktree_root)
+        || !is_existing_openclaw_worktree(&repo_root, &worktree_root)
     {
         return Err(format!(
             "created worktree is not a valid OpenClaw checkout: {}",
@@ -153,13 +156,15 @@ fn registered_worktree_paths(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
         return Err(format!("git worktree list failed: {detail}"));
     }
 
-    let stdout = String::from_utf8(output.stdout)
-        .map_err(|_| "git worktree list returned a non-UTF-8 path".to_string())?;
-    Ok(stdout
-        .split('\0')
-        .filter_map(|field| field.strip_prefix("worktree "))
-        .map(PathBuf::from)
-        .collect())
+    parse_registered_worktree_paths(&output.stdout)
+}
+
+fn parse_registered_worktree_paths(output: &[u8]) -> Result<Vec<PathBuf>, String> {
+    output
+        .split(|byte| *byte == 0)
+        .filter_map(|field| field.strip_prefix(b"worktree "))
+        .map(|path| git_path_from_bytes(path).map(PathBuf::from))
+        .collect()
 }
 
 fn contains_worktree_path(registered: &[PathBuf], expected: &Path) -> bool {
@@ -170,11 +175,14 @@ fn contains_worktree_path(registered: &[PathBuf], expected: &Path) -> bool {
 }
 
 fn normalize_worktree_path(path: &Path) -> PathBuf {
-    if let Ok(path) = fs::canonicalize(path) {
-        return path;
-    }
+    let Some(parent) = path.parent() else {
+        return clean_path(path);
+    };
+    let Some(name) = path.file_name() else {
+        return clean_path(path);
+    };
 
-    let mut ancestor = path;
+    let mut ancestor = parent;
     let mut missing = Vec::<OsString>::new();
     while !ancestor.exists() {
         let Some(name) = ancestor.file_name() else {
@@ -191,18 +199,64 @@ fn normalize_worktree_path(path: &Path) -> PathBuf {
     for component in missing.into_iter().rev() {
         normalized.push(component);
     }
+    normalized.push(name);
     clean_path(&normalized)
 }
 
-fn is_existing_openclaw_worktree(path: &Path) -> bool {
+fn is_existing_openclaw_worktree(repo_root: &Path, path: &Path) -> bool {
     path.exists()
         && path.join(".git").exists()
         && detect_openclaw_checkout(path).is_some()
-        && Command::new("git")
-            .arg("-C")
-            .arg(path)
-            .args(["rev-parse", "--is-inside-work-tree"])
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
+        && git_common_dir(repo_root)
+            .zip(git_common_dir(path))
+            .is_some_and(|(repo, worktree)| repo == worktree)
+}
+
+fn git_common_dir(path: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let common_dir = output.stdout.strip_suffix(b"\n").unwrap_or(&output.stdout);
+    let common_dir = common_dir.strip_suffix(b"\r").unwrap_or(common_dir);
+    let common_dir = PathBuf::from(git_path_from_bytes(common_dir).ok()?);
+    fs::canonicalize(&common_dir)
+        .ok()
+        .or_else(|| Some(clean_path(&common_dir)))
+}
+
+#[cfg(unix)]
+fn git_path_from_bytes(path: &[u8]) -> Result<OsString, String> {
+    Ok(OsString::from_vec(path.to_vec()))
+}
+
+#[cfg(not(unix))]
+fn git_path_from_bytes(path: &[u8]) -> Result<OsString, String> {
+    String::from_utf8(path.to_vec())
+        .map(OsString::from)
+        .map_err(|_| "git returned a non-UTF-8 path".to_string())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::ffi::OsStrExt;
+
+    use super::parse_registered_worktree_paths;
+
+    #[test]
+    fn worktree_porcelain_parser_preserves_non_utf8_paths() {
+        let paths = parse_registered_worktree_paths(
+            b"worktree /tmp/openclaw\0HEAD abc\0\0worktree /tmp/other\xff\0HEAD def\0\0",
+        )
+        .unwrap();
+
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[1].as_os_str().as_bytes(), b"/tmp/other\xff");
+    }
 }

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -48,14 +49,25 @@ pub(crate) fn ensure_openclaw_worktree(
     let repo_root = detect_openclaw_checkout(repo_root)
         .ok_or_else(|| format!("OpenClaw checkout not found at {}", display_path(repo_root)))?;
     let worktree_root = default_worktree_root(&repo_root, env_name);
+    let registered = registered_worktree_paths(&repo_root)?;
+    let worktree_registered = contains_worktree_path(&registered, &worktree_root);
 
-    if is_existing_openclaw_worktree(&worktree_root) {
-        return Ok(worktree_root);
+    if worktree_registered {
+        if !worktree_root.exists() {
+            remove_registered_worktree(&repo_root, &worktree_root)?;
+        } else if is_existing_openclaw_worktree(&worktree_root) {
+            return Ok(worktree_root);
+        } else {
+            return Err(format!(
+                "registered worktree is not a valid OpenClaw checkout: {}",
+                display_path(&worktree_root)
+            ));
+        }
     }
 
     if worktree_root.exists() {
         return Err(format!(
-            "worktree path already exists and is not a valid OpenClaw worktree: {}",
+            "worktree path already exists but is not registered to this OpenClaw checkout: {}",
             display_path(&worktree_root)
         ));
     }
@@ -78,7 +90,10 @@ pub(crate) fn ensure_openclaw_worktree(
         return Err(format!("git worktree add failed: {detail}"));
     }
 
-    if !is_existing_openclaw_worktree(&worktree_root) {
+    let registered = registered_worktree_paths(&repo_root)?;
+    if !contains_worktree_path(&registered, &worktree_root)
+        || !is_existing_openclaw_worktree(&worktree_root)
+    {
         return Err(format!(
             "created worktree is not a valid OpenClaw checkout: {}",
             display_path(&worktree_root)
@@ -92,14 +107,25 @@ pub(crate) fn remove_openclaw_worktree(
     repo_root: &Path,
     worktree_root: &Path,
 ) -> Result<(), String> {
-    if !worktree_root.exists() {
+    let registered = registered_worktree_paths(repo_root)?;
+    if !contains_worktree_path(&registered, worktree_root) {
+        if worktree_root.exists() {
+            return Err(format!(
+                "refusing to remove worktree path not registered to this OpenClaw checkout: {}",
+                display_path(worktree_root)
+            ));
+        }
         return Ok(());
     }
 
+    remove_registered_worktree(repo_root, worktree_root)
+}
+
+fn remove_registered_worktree(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
     let output = Command::new("git")
         .arg("-C")
         .arg(repo_root)
-        .args(["worktree", "remove", "--force"])
+        .args(["worktree", "remove"])
         .arg(worktree_root)
         .output()
         .map_err(|error| format!("failed to run git worktree remove: {error}"))?;
@@ -107,14 +133,65 @@ pub(crate) fn remove_openclaw_worktree(
         return Ok(());
     }
 
-    fs::remove_dir_all(worktree_root).map_err(|error| {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+    Err(format!("git worktree remove failed: {detail}"))
+}
+
+fn registered_worktree_paths(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["worktree", "list", "--porcelain", "-z"])
+        .output()
+        .map_err(|error| format!("failed to run git worktree list: {error}"))?;
+    if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        if stderr.is_empty() {
-            error.to_string()
-        } else {
-            format!("{stderr}; fallback remove failed: {error}")
-        }
-    })
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!("git worktree list failed: {detail}"));
+    }
+
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|_| "git worktree list returned a non-UTF-8 path".to_string())?;
+    Ok(stdout
+        .split('\0')
+        .filter_map(|field| field.strip_prefix("worktree "))
+        .map(PathBuf::from)
+        .collect())
+}
+
+fn contains_worktree_path(registered: &[PathBuf], expected: &Path) -> bool {
+    let expected = normalize_worktree_path(expected);
+    registered
+        .iter()
+        .any(|path| normalize_worktree_path(path) == expected)
+}
+
+fn normalize_worktree_path(path: &Path) -> PathBuf {
+    if let Ok(path) = fs::canonicalize(path) {
+        return path;
+    }
+
+    let mut ancestor = path;
+    let mut missing = Vec::<OsString>::new();
+    while !ancestor.exists() {
+        let Some(name) = ancestor.file_name() else {
+            return clean_path(path);
+        };
+        missing.push(name.to_os_string());
+        let Some(parent) = ancestor.parent() else {
+            return clean_path(path);
+        };
+        ancestor = parent;
+    }
+
+    let mut normalized = fs::canonicalize(ancestor).unwrap_or_else(|_| clean_path(ancestor));
+    for component in missing.into_iter().rev() {
+        normalized.push(component);
+    }
+    clean_path(&normalized)
 }
 
 fn is_existing_openclaw_worktree(path: &Path) -> bool {

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -266,7 +266,11 @@ fn git_worktree_backlink(path: &Path) -> Option<PathBuf> {
     let backlink = fs::read(git_dir.join("gitdir")).ok()?;
     let backlink = trim_git_line(&backlink);
     let backlink = PathBuf::from(git_path_from_bytes(backlink).ok()?);
-    Some(backlink)
+    if backlink.is_absolute() {
+        Some(backlink)
+    } else {
+        Some(clean_path(&git_dir.join(backlink)))
+    }
 }
 
 fn git_rev_parse_path(path: &Path, selector: &str) -> Option<PathBuf> {

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -125,10 +125,12 @@ pub(crate) fn remove_openclaw_worktree(
 }
 
 fn remove_registered_worktree(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
+    ensure_worktree_clean(worktree_root)?;
+
     let output = Command::new("git")
         .arg("-C")
         .arg(repo_root)
-        .args(["worktree", "remove"])
+        .args(["worktree", "remove", "--force"])
         .arg(worktree_root)
         .output()
         .map_err(|error| format!("failed to run git worktree remove: {error}"))?;
@@ -140,6 +142,39 @@ fn remove_registered_worktree(repo_root: &Path, worktree_root: &Path) -> Result<
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let detail = if !stderr.is_empty() { stderr } else { stdout };
     Err(format!("git worktree remove failed: {detail}"))
+}
+
+fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
+    if !worktree_root.exists() {
+        return Ok(());
+    }
+
+    let output = Command::new("git")
+        .args(["-c", "status.showUntrackedFiles=all"])
+        .arg("-C")
+        .arg(worktree_root)
+        .args([
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignore-submodules=none",
+        ])
+        .output()
+        .map_err(|error| format!("failed to inspect git worktree status: {error}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!("git worktree status failed: {detail}"));
+    }
+    if !output.stdout.is_empty() {
+        return Err(format!(
+            "git worktree remove failed: {} contains modified or untracked files",
+            display_path(worktree_root)
+        ));
+    }
+
+    Ok(())
 }
 
 fn registered_worktree_paths(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
@@ -207,28 +242,64 @@ fn is_existing_openclaw_worktree(repo_root: &Path, path: &Path) -> bool {
     path.exists()
         && path.join(".git").exists()
         && detect_openclaw_checkout(path).is_some()
+        && git_top_level(path).is_some_and(|top_level| {
+            normalize_worktree_path(&top_level) == normalize_worktree_path(path)
+        })
         && git_common_dir(repo_root)
             .zip(git_common_dir(path))
             .is_some_and(|(repo, worktree)| repo == worktree)
+        && git_worktree_backlink(path).is_some_and(|backlink| {
+            normalize_git_file_path(&backlink) == normalize_git_file_path(&path.join(".git"))
+        })
 }
 
 fn git_common_dir(path: &Path) -> Option<PathBuf> {
+    git_rev_parse_path(path, "--git-common-dir")
+}
+
+fn git_top_level(path: &Path) -> Option<PathBuf> {
+    git_rev_parse_path(path, "--show-toplevel")
+}
+
+fn git_worktree_backlink(path: &Path) -> Option<PathBuf> {
+    let git_dir = git_rev_parse_path(path, "--git-dir")?;
+    let backlink = fs::read(git_dir.join("gitdir")).ok()?;
+    let backlink = trim_git_line(&backlink);
+    let backlink = PathBuf::from(git_path_from_bytes(backlink).ok()?);
+    Some(backlink)
+}
+
+fn git_rev_parse_path(path: &Path, selector: &str) -> Option<PathBuf> {
     let output = Command::new("git")
         .arg("-C")
         .arg(path)
-        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .args(["rev-parse", "--path-format=absolute", selector])
         .output()
         .ok()?;
     if !output.status.success() {
         return None;
     }
 
-    let common_dir = output.stdout.strip_suffix(b"\n").unwrap_or(&output.stdout);
-    let common_dir = common_dir.strip_suffix(b"\r").unwrap_or(common_dir);
-    let common_dir = PathBuf::from(git_path_from_bytes(common_dir).ok()?);
-    fs::canonicalize(&common_dir)
+    let path = PathBuf::from(git_path_from_bytes(trim_git_line(&output.stdout)).ok()?);
+    fs::canonicalize(&path)
         .ok()
-        .or_else(|| Some(clean_path(&common_dir)))
+        .or_else(|| Some(clean_path(&path)))
+}
+
+fn trim_git_line(output: &[u8]) -> &[u8] {
+    let output = output.strip_suffix(b"\n").unwrap_or(output);
+    output.strip_suffix(b"\r").unwrap_or(output)
+}
+
+fn normalize_git_file_path(path: &Path) -> PathBuf {
+    let Some(parent) = path.parent() else {
+        return clean_path(path);
+    };
+    let Some(name) = path.file_name() else {
+        return clean_path(path);
+    };
+    let parent = fs::canonicalize(parent).unwrap_or_else(|_| clean_path(parent));
+    clean_path(&parent.join(name))
 }
 
 #[cfg(unix)]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -355,6 +355,21 @@ fn env_remove_preserves_an_untracked_dev_worktree() {
     let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
     fs::write(worktree_root.join("SENTINEL"), "preserve me\n").unwrap();
+    let hide_untracked = Command::new("git")
+        .args([
+            "-C",
+            &path_string(&repo),
+            "config",
+            "status.showUntrackedFiles",
+            "no",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        hide_untracked.status.success(),
+        "{}",
+        String::from_utf8_lossy(&hide_untracked.stderr)
+    );
 
     let remove = run_ocm(&cwd, &env, &["env", "remove", "demo", "--force"]);
     assert!(!remove.status.success());
@@ -369,6 +384,165 @@ fn env_remove_preserves_an_untracked_dev_worktree() {
         "{}",
         stderr(&still_registered)
     );
+}
+
+#[test]
+fn dev_command_rejects_another_worktrees_git_backlink() {
+    let root = TestDir::new("dev-command-wrong-backlink");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let first = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(first.status.success(), "{}", stderr(&first));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    let other_worktree = repo.join(".worktrees/other");
+    let add = Command::new("git")
+        .args([
+            "-C",
+            &path_string(&repo),
+            "worktree",
+            "add",
+            "--detach",
+            &path_string(&other_worktree),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "{}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    fs::remove_dir_all(&worktree_root).unwrap();
+    fs::create_dir_all(worktree_root.join("scripts")).unwrap();
+    fs::write(
+        worktree_root.join("package.json"),
+        r#"{"name":"openclaw","version":"2026.4.19"}"#,
+    )
+    .unwrap();
+    fs::write(
+        worktree_root.join("scripts/run-node.mjs"),
+        "console.log('run');\n",
+    )
+    .unwrap();
+    fs::copy(other_worktree.join(".git"), worktree_root.join(".git")).unwrap();
+    fs::write(worktree_root.join("SENTINEL"), "preserve me\n").unwrap();
+
+    let second = run_ocm(&cwd, &env, &["dev", "demo"]);
+    assert!(!second.status.success());
+    assert!(
+        stderr(&second).contains("registered worktree is not a valid OpenClaw checkout"),
+        "{}",
+        stderr(&second)
+    );
+    assert_eq!(
+        fs::read_to_string(worktree_root.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
+}
+
+#[test]
+fn env_remove_accepts_a_clean_worktree_with_an_initialized_submodule() {
+    let root = TestDir::new("dev-command-clean-submodule");
+    let repo = init_openclaw_repo(&root);
+    let submodule = root.child("repo/submodule");
+    fs::create_dir_all(&submodule).unwrap();
+    let init = Command::new("git")
+        .arg("init")
+        .arg(&submodule)
+        .output()
+        .unwrap();
+    assert!(init.status.success());
+    Command::new("git")
+        .args([
+            "-C",
+            &path_string(&submodule),
+            "config",
+            "user.email",
+            "tests@example.com",
+        ])
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args([
+            "-C",
+            &path_string(&submodule),
+            "config",
+            "user.name",
+            "OCM Tests",
+        ])
+        .output()
+        .unwrap();
+    fs::write(submodule.join("content.txt"), "submodule\n").unwrap();
+    Command::new("git")
+        .args(["-C", &path_string(&submodule), "add", "."])
+        .output()
+        .unwrap();
+    let commit = Command::new("git")
+        .args(["-C", &path_string(&submodule), "commit", "-m", "init"])
+        .output()
+        .unwrap();
+    assert!(
+        commit.status.success(),
+        "{}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+    let add = Command::new("git")
+        .args([
+            "-c",
+            "protocol.file.allow=always",
+            "-C",
+            &path_string(&repo),
+        ])
+        .args(["submodule", "add"])
+        .arg(&submodule)
+        .arg("vendor/submodule")
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "{}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let commit = Command::new("git")
+        .args(["-C", &path_string(&repo), "commit", "-am", "add submodule"])
+        .output()
+        .unwrap();
+    assert!(
+        commit.status.success(),
+        "{}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    let init_submodule = Command::new("git")
+        .args(["-c", "protocol.file.allow=always", "-C"])
+        .arg(&worktree_root)
+        .args(["submodule", "update", "--init"])
+        .output()
+        .unwrap();
+    assert!(
+        init_submodule.status.success(),
+        "{}",
+        String::from_utf8_lossy(&init_submodule.stderr)
+    );
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo"]);
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    assert!(!worktree_root.exists());
 }
 
 #[test]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -636,8 +636,8 @@ fn env_remove_accepts_a_clean_worktree_with_an_initialized_submodule() {
 }
 
 #[test]
-fn env_remove_accepts_a_missing_repo_and_worktree() {
-    let root = TestDir::new("dev-command-missing-repo-remove");
+fn env_remove_accepts_a_missing_worktree_with_a_non_git_repo_path() {
+    let root = TestDir::new("dev-command-non-git-repo-remove");
     let repo = init_openclaw_repo(&root);
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -647,11 +647,17 @@ fn env_remove_accepts_a_missing_repo_and_worktree() {
     let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
     assert!(run.status.success(), "{}", stderr(&run));
     fs::remove_dir_all(&repo).unwrap();
+    fs::create_dir_all(&repo).unwrap();
+    fs::write(repo.join("SENTINEL"), "preserve me\n").unwrap();
 
     let remove = run_ocm(&cwd, &env, &["env", "remove", "demo"]);
     assert!(remove.status.success(), "{}", stderr(&remove));
     let show = run_ocm(&cwd, &env, &["env", "show", "demo"]);
     assert!(!show.status.success());
+    assert_eq!(
+        fs::read_to_string(repo.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
 }
 
 #[test]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -109,6 +109,125 @@ fn init_nested_openclaw_repo(path: &Path) {
     );
 }
 
+fn commit_nested_openclaw_repo(path: &Path) {
+    for (key, value) in [
+        ("user.email", "tests@example.com"),
+        ("user.name", "OCM Tests"),
+    ] {
+        let configure = Command::new("git")
+            .args(["-C", &path_string(path), "config", key, value])
+            .output()
+            .unwrap();
+        assert!(
+            configure.status.success(),
+            "{}",
+            String::from_utf8_lossy(&configure.stderr)
+        );
+    }
+    let add = Command::new("git")
+        .args(["-C", &path_string(path), "add", "."])
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "{}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let commit = Command::new("git")
+        .args(["-C", &path_string(path), "commit", "-m", "init"])
+        .output()
+        .unwrap();
+    assert!(
+        commit.status.success(),
+        "{}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+}
+
+fn add_test_submodule(root: &TestDir, repo: &Path) {
+    let submodule = root.child("repo/submodule");
+    fs::create_dir_all(&submodule).unwrap();
+    let init = Command::new("git")
+        .arg("init")
+        .arg(&submodule)
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "{}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    for (key, value) in [
+        ("user.email", "tests@example.com"),
+        ("user.name", "OCM Tests"),
+    ] {
+        let configure = Command::new("git")
+            .args(["-C", &path_string(&submodule), "config", key, value])
+            .output()
+            .unwrap();
+        assert!(
+            configure.status.success(),
+            "{}",
+            String::from_utf8_lossy(&configure.stderr)
+        );
+    }
+    fs::write(submodule.join("content.txt"), "submodule\n").unwrap();
+    fs::write(submodule.join(".gitignore"), ".env\nnode_modules/\n").unwrap();
+    let add = Command::new("git")
+        .args(["-C", &path_string(&submodule), "add", "."])
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "{}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let commit = Command::new("git")
+        .args(["-C", &path_string(&submodule), "commit", "-m", "init"])
+        .output()
+        .unwrap();
+    assert!(
+        commit.status.success(),
+        "{}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+    let add = Command::new("git")
+        .args(["-c", "protocol.file.allow=always", "-C", &path_string(repo)])
+        .args(["submodule", "add"])
+        .arg(&submodule)
+        .arg("vendor/submodule")
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "{}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let commit = Command::new("git")
+        .args(["-C", &path_string(repo), "commit", "-am", "add submodule"])
+        .output()
+        .unwrap();
+    assert!(
+        commit.status.success(),
+        "{}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+}
+
+fn init_test_submodule(worktree_root: &Path) {
+    let init = Command::new("git")
+        .args(["-c", "protocol.file.allow=always", "-C"])
+        .arg(worktree_root)
+        .args(["submodule", "update", "--init"])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "{}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+}
+
 fn git_worktree_paths(repo: &Path) -> Vec<PathBuf> {
     let output = Command::new("git")
         .args([
@@ -498,74 +617,7 @@ fn dev_command_rejects_another_worktrees_git_backlink() {
 fn env_remove_accepts_a_clean_worktree_with_an_initialized_submodule() {
     let root = TestDir::new("dev-command-clean-submodule");
     let repo = init_openclaw_repo(&root);
-    let submodule = root.child("repo/submodule");
-    fs::create_dir_all(&submodule).unwrap();
-    let init = Command::new("git")
-        .arg("init")
-        .arg(&submodule)
-        .output()
-        .unwrap();
-    assert!(init.status.success());
-    Command::new("git")
-        .args([
-            "-C",
-            &path_string(&submodule),
-            "config",
-            "user.email",
-            "tests@example.com",
-        ])
-        .output()
-        .unwrap();
-    Command::new("git")
-        .args([
-            "-C",
-            &path_string(&submodule),
-            "config",
-            "user.name",
-            "OCM Tests",
-        ])
-        .output()
-        .unwrap();
-    fs::write(submodule.join("content.txt"), "submodule\n").unwrap();
-    Command::new("git")
-        .args(["-C", &path_string(&submodule), "add", "."])
-        .output()
-        .unwrap();
-    let commit = Command::new("git")
-        .args(["-C", &path_string(&submodule), "commit", "-m", "init"])
-        .output()
-        .unwrap();
-    assert!(
-        commit.status.success(),
-        "{}",
-        String::from_utf8_lossy(&commit.stderr)
-    );
-    let add = Command::new("git")
-        .args([
-            "-c",
-            "protocol.file.allow=always",
-            "-C",
-            &path_string(&repo),
-        ])
-        .args(["submodule", "add"])
-        .arg(&submodule)
-        .arg("vendor/submodule")
-        .output()
-        .unwrap();
-    assert!(
-        add.status.success(),
-        "{}",
-        String::from_utf8_lossy(&add.stderr)
-    );
-    let commit = Command::new("git")
-        .args(["-C", &path_string(&repo), "commit", "-am", "add submodule"])
-        .output()
-        .unwrap();
-    assert!(
-        commit.status.success(),
-        "{}",
-        String::from_utf8_lossy(&commit.stderr)
-    );
+    add_test_submodule(&root, &repo);
 
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -576,21 +628,40 @@ fn env_remove_accepts_a_clean_worktree_with_an_initialized_submodule() {
     let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
     let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
-    let init_submodule = Command::new("git")
-        .args(["-c", "protocol.file.allow=always", "-C"])
-        .arg(&worktree_root)
-        .args(["submodule", "update", "--init"])
-        .output()
-        .unwrap();
-    assert!(
-        init_submodule.status.success(),
-        "{}",
-        String::from_utf8_lossy(&init_submodule.stderr)
-    );
+    init_test_submodule(&worktree_root);
 
     let remove = run_ocm(&cwd, &env, &["env", "remove", "demo"]);
     assert!(remove.status.success(), "{}", stderr(&remove));
     assert!(!worktree_root.exists());
+}
+
+#[test]
+fn env_remove_preserves_ignored_files_inside_initialized_submodules() {
+    let root = TestDir::new("dev-command-ignored-submodule");
+    let repo = init_openclaw_repo(&root);
+    add_test_submodule(&root, &repo);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    init_test_submodule(&worktree_root);
+    let ignored_file = worktree_root.join("vendor/submodule/.env");
+    fs::write(&ignored_file, "preserve me\n").unwrap();
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo", "--force"]);
+    assert!(!remove.status.success());
+    assert!(
+        stderr(&remove).contains("contains ignored local files"),
+        "{}",
+        stderr(&remove)
+    );
+    assert_eq!(fs::read_to_string(ignored_file).unwrap(), "preserve me\n");
 }
 
 #[test]
@@ -659,6 +730,37 @@ fn env_remove_refuses_an_unrelated_replacement_checkout() {
     assert!(!remove.status.success());
     assert!(
         stderr(&remove).contains("refusing to remove worktree path not registered"),
+        "{}",
+        stderr(&remove)
+    );
+    assert_eq!(
+        fs::read_to_string(worktree_root.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
+}
+
+#[test]
+fn env_remove_refuses_a_clean_replacement_at_a_stale_registered_path() {
+    let root = TestDir::new("dev-command-stale-replacement-remove");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    fs::remove_dir_all(&worktree_root).unwrap();
+    init_nested_openclaw_repo(&worktree_root);
+    commit_nested_openclaw_repo(&worktree_root);
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo", "--force"]);
+    assert!(!remove.status.success());
+    assert!(
+        stderr(&remove).contains("checkout identity does not match"),
         "{}",
         stderr(&remove)
     );

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -32,6 +32,7 @@ fn init_openclaw_repo(root: &TestDir) -> PathBuf {
         "console.log('watch');\n",
     )
     .unwrap();
+    fs::write(repo.join(".gitignore"), ".env\nnode_modules/\n").unwrap();
 
     let init = Command::new("git").arg("init").arg(&repo).output().unwrap();
     assert!(
@@ -384,6 +385,53 @@ fn env_remove_preserves_an_untracked_dev_worktree() {
         "{}",
         stderr(&still_registered)
     );
+}
+
+#[test]
+fn env_remove_preserves_ignored_local_files() {
+    let root = TestDir::new("dev-command-ignored-remove");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    fs::write(worktree_root.join(".env"), "TOKEN=preserve-me\n").unwrap();
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo", "--force"]);
+    assert!(!remove.status.success());
+    assert!(stderr(&remove).contains("contains ignored local files"));
+    assert_eq!(
+        fs::read_to_string(worktree_root.join(".env")).unwrap(),
+        "TOKEN=preserve-me\n"
+    );
+}
+
+#[test]
+fn env_remove_discards_installed_node_modules() {
+    let root = TestDir::new("dev-command-node-modules-remove");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    fs::create_dir_all(worktree_root.join("node_modules/pkg")).unwrap();
+    fs::write(worktree_root.join("node_modules/pkg/package.json"), "{}\n").unwrap();
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo"]);
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    assert!(!worktree_root.exists());
 }
 
 #[test]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -91,6 +91,48 @@ fn init_openclaw_repo(root: &TestDir) -> PathBuf {
     repo
 }
 
+fn init_nested_openclaw_repo(path: &Path) {
+    fs::create_dir_all(path.join("scripts")).unwrap();
+    fs::write(
+        path.join("package.json"),
+        r#"{"name":"openclaw","version":"2026.4.19"}"#,
+    )
+    .unwrap();
+    fs::write(path.join("scripts/run-node.mjs"), "console.log('run');\n").unwrap();
+    fs::write(path.join("SENTINEL"), "preserve me\n").unwrap();
+    let init = Command::new("git").arg("init").arg(path).output().unwrap();
+    assert!(
+        init.status.success(),
+        "{}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+}
+
+fn git_worktree_paths(repo: &Path) -> Vec<PathBuf> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            &path_string(repo),
+            "worktree",
+            "list",
+            "--porcelain",
+            "-z",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .unwrap()
+        .split('\0')
+        .filter_map(|field| field.strip_prefix("worktree "))
+        .map(PathBuf::from)
+        .collect()
+}
+
 fn prepend_fake_bin(env: &mut std::collections::BTreeMap<String, String>, bin_dir: &Path) {
     let existing_path = env.get("PATH").cloned().unwrap_or_default();
     let combined_path = if existing_path.is_empty() {
@@ -173,6 +215,133 @@ fn dev_command_provisions_worktree_bootstraps_config_and_runs_gateway() {
         path_string(&worktree_root.join("extensions"))
     )));
     assert!(pnpm_log.contains(&format!("|devroot={}", path_string(&worktree_root))));
+}
+
+#[test]
+fn dev_command_rejects_an_unregistered_clone_at_the_managed_path() {
+    let root = TestDir::new("dev-command-unregistered-clone");
+    let repo = init_openclaw_repo(&root);
+    let worktree_root = repo.join(".worktrees/demo");
+    init_nested_openclaw_repo(&worktree_root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(!run.status.success());
+    assert!(
+        stderr(&run).contains("is not registered to this OpenClaw checkout"),
+        "{}",
+        stderr(&run)
+    );
+    assert_eq!(
+        fs::read_to_string(worktree_root.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
+}
+
+#[test]
+fn dev_command_recreates_an_exactly_registered_missing_worktree() {
+    let root = TestDir::new("dev-command-missing-worktree");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let first = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(first.status.success(), "{}", stderr(&first));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    fs::remove_dir_all(&worktree_root).unwrap();
+
+    let second = run_ocm(&cwd, &env, &["dev", "demo"]);
+    assert!(second.status.success(), "{}", stderr(&second));
+    assert!(worktree_root.join(".git").exists());
+    let canonical_worktree_root = fs::canonicalize(&worktree_root).unwrap();
+    assert_eq!(
+        git_worktree_paths(&repo)
+            .into_iter()
+            .filter(|path| fs::canonicalize(path).ok().as_ref() == Some(&canonical_worktree_root))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn env_remove_preserves_an_untracked_dev_worktree() {
+    let root = TestDir::new("dev-command-dirty-remove");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    fs::write(worktree_root.join("SENTINEL"), "preserve me\n").unwrap();
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo", "--force"]);
+    assert!(!remove.status.success());
+    assert!(stderr(&remove).contains("contains modified or untracked files"));
+    assert_eq!(
+        fs::read_to_string(worktree_root.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
+    let still_registered = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(
+        still_registered.status.success(),
+        "{}",
+        stderr(&still_registered)
+    );
+}
+
+#[test]
+fn env_remove_refuses_an_unrelated_replacement_checkout() {
+    let root = TestDir::new("dev-command-replacement-remove");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    let detach = Command::new("git")
+        .args([
+            "-C",
+            &path_string(&repo),
+            "worktree",
+            "remove",
+            &path_string(&worktree_root),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        detach.status.success(),
+        "{}",
+        String::from_utf8_lossy(&detach.stderr)
+    );
+    init_nested_openclaw_repo(&worktree_root);
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo", "--force"]);
+    assert!(!remove.status.success());
+    assert!(
+        stderr(&remove).contains("refusing to remove worktree path not registered"),
+        "{}",
+        stderr(&remove)
+    );
+    assert_eq!(
+        fs::read_to_string(worktree_root.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
 }
 
 #[test]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -270,6 +270,77 @@ fn dev_command_recreates_an_exactly_registered_missing_worktree() {
 }
 
 #[test]
+fn dev_command_rejects_a_stale_registration_replaced_by_an_unrelated_clone() {
+    let root = TestDir::new("dev-command-stale-replacement");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let first = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(first.status.success(), "{}", stderr(&first));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    fs::remove_dir_all(&worktree_root).unwrap();
+    init_nested_openclaw_repo(&worktree_root);
+
+    let second = run_ocm(&cwd, &env, &["dev", "demo"]);
+    assert!(!second.status.success());
+    assert!(
+        stderr(&second).contains("registered worktree is not a valid OpenClaw checkout"),
+        "{}",
+        stderr(&second)
+    );
+    assert_eq!(
+        fs::read_to_string(worktree_root.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_command_rejects_a_symlink_alias_to_another_registered_worktree() {
+    let root = TestDir::new("dev-command-symlink-alias");
+    let repo = init_openclaw_repo(&root);
+    let other_worktree = repo.join(".worktrees/other");
+    let add = Command::new("git")
+        .args([
+            "-C",
+            &path_string(&repo),
+            "worktree",
+            "add",
+            "--detach",
+            &path_string(&other_worktree),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "{}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    fs::write(other_worktree.join("SENTINEL"), "preserve me\n").unwrap();
+    std::os::unix::fs::symlink("other", repo.join(".worktrees/demo")).unwrap();
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(!run.status.success());
+    assert!(
+        stderr(&run).contains("is not registered to this OpenClaw checkout"),
+        "{}",
+        stderr(&run)
+    );
+    assert_eq!(
+        fs::read_to_string(other_worktree.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
+}
+
+#[test]
 fn env_remove_preserves_an_untracked_dev_worktree() {
     let root = TestDir::new("dev-command-dirty-remove");
     let repo = init_openclaw_repo(&root);

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -546,6 +546,37 @@ fn env_remove_accepts_a_clean_worktree_with_an_initialized_submodule() {
 }
 
 #[test]
+fn dev_command_supports_relative_worktree_links() {
+    let root = TestDir::new("dev-command-relative-links");
+    let repo = init_openclaw_repo(&root);
+    let configure = Command::new("git")
+        .args([
+            "-C",
+            &path_string(&repo),
+            "config",
+            "worktree.useRelativePaths",
+            "true",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        configure.status.success(),
+        "{}",
+        String::from_utf8_lossy(&configure.stderr)
+    );
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo"]);
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    assert!(!repo.join(".worktrees/demo").exists());
+}
+
+#[test]
 fn env_remove_refuses_an_unrelated_replacement_checkout() {
     let root = TestDir::new("dev-command-replacement-remove");
     let repo = init_openclaw_repo(&root);

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -636,6 +636,25 @@ fn env_remove_accepts_a_clean_worktree_with_an_initialized_submodule() {
 }
 
 #[test]
+fn env_remove_accepts_a_missing_repo_and_worktree() {
+    let root = TestDir::new("dev-command-missing-repo-remove");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    fs::remove_dir_all(&repo).unwrap();
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo"]);
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo"]);
+    assert!(!show.status.success());
+}
+
+#[test]
 fn env_remove_preserves_ignored_files_inside_initialized_submodules() {
     let root = TestDir::new("dev-command-ignored-submodule");
     let repo = init_openclaw_repo(&root);

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -661,6 +661,51 @@ fn env_remove_accepts_a_missing_worktree_with_a_non_git_repo_path() {
 }
 
 #[test]
+fn env_remove_accepts_a_clean_registered_worktree_without_openclaw_markers() {
+    let root = TestDir::new("dev-command-markerless-remove");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    let remove_markers = Command::new("git")
+        .args(["-C", &path_string(&worktree_root), "rm"])
+        .args(["package.json", "scripts/run-node.mjs"])
+        .output()
+        .unwrap();
+    assert!(
+        remove_markers.status.success(),
+        "{}",
+        String::from_utf8_lossy(&remove_markers.stderr)
+    );
+    let commit = Command::new("git")
+        .args([
+            "-C",
+            &path_string(&worktree_root),
+            "commit",
+            "-m",
+            "remove markers",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        commit.status.success(),
+        "{}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+
+    let remove = run_ocm(&cwd, &env, &["env", "remove", "demo"]);
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    assert!(!worktree_root.exists());
+}
+
+#[test]
 fn env_remove_preserves_ignored_files_inside_initialized_submodules() {
     let root = TestDir::new("dev-command-ignored-submodule");
     let repo = init_openclaw_repo(&root);


### PR DESCRIPTION
## What Problem This Solves

OCM could treat any checkout found at a managed dev-worktree path as its own and could fall back to recursive deletion after `git worktree remove` failed. That made `ocm env remove` capable of deleting unrelated clones, dirty worktrees, ignored files, or nested submodule state.

## Why This Change Was Made

Worktree ownership now comes from exact Git registration and repository identity, not directory shape alone. Removal is delegated to Git only after recursively auditing ignored and untracked content, with no recursive filesystem fallback, rejects replacement checkouts, preserves non-UTF-8 paths on Unix, supports older Git porcelain output, and handles stale missing registrations without deleting unrelated filesystem content.

## User Impact

- Dirty or unrelated dev worktrees are preserved and reported instead of deleted.
- Missing registered worktrees can be recreated safely.
- Clean owned worktrees still remove normally, including initialized submodules.
- Stale OCM metadata can be removed without touching a replacement checkout.

## Evidence

- 29 focused worktree/dev-command tests pass.
- Full Rust test suite passes locally.
- `cargo fmt --check` and `git diff --check` pass.
- Fresh Codex autoreview with `gpt-5.6-sol` at high reasoning: clean.
- Exact-head GitHub CI covers macOS, Ubuntu, Rust 1.88, and formatting.