### PR TITLE
fix(dev): serialize and own source watch lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,4 @@ All notable changes to OCM are documented here.
 - Build locked release artifacts only from a GitHub-verified tag matching the package version, require the complete supported target matrix before publication, publish a versioned checksum-verifying installer, pin CI actions, and test the declared Rust 1.88 minimum.
 - Preserve uncommitted dev worktrees and reject unrelated checkout collisions by requiring exact Git worktree registration before reuse or removal.
 - Make single and merged log following rotation-safe and byte-safe, preserving split or invalid UTF-8, multiline record ordering, and boundaries around unterminated records.
-- Prevent overlapping source watches, remove the unleased override mutation path, reclaim stale watch locks, and restore background-service policy when takeover cannot stop or exits with an error.
+- Prevent overlapping source watches, remove the unleased override mutation path, reclaim stale watch locks, handle termination signals, and restore background-service policy when takeover cannot stop or exits with an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,4 @@ All notable changes to OCM are documented here.
 - Build locked release artifacts only from a GitHub-verified tag matching the package version, require the complete supported target matrix before publication, publish a versioned checksum-verifying installer, pin CI actions, and test the declared Rust 1.88 minimum.
 - Preserve uncommitted dev worktrees and reject unrelated checkout collisions by requiring exact Git worktree registration before reuse or removal.
 - Make single and merged log following rotation-safe and byte-safe, preserving split or invalid UTF-8, multiline record ordering, and boundaries around unterminated records.
-- Prevent overlapping source watches, reclaim stale watch locks, and restore background-service policy when takeover cannot stop or exits with an error.
+- Prevent overlapping source watches, remove the unleased override mutation path, reclaim stale watch locks, and restore background-service policy when takeover cannot stop or exits with an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,4 @@ All notable changes to OCM are documented here.
 - Build locked release artifacts only from a GitHub-verified tag matching the package version, require the complete supported target matrix before publication, publish a versioned checksum-verifying installer, pin CI actions, and test the declared Rust 1.88 minimum.
 - Preserve uncommitted dev worktrees and reject unrelated checkout collisions by requiring exact Git worktree registration before reuse or removal.
 - Make single and merged log following rotation-safe and byte-safe, preserving split or invalid UTF-8, multiline record ordering, and boundaries around unterminated records.
-- Prevent overlapping source watches, remove the unleased override mutation path, reclaim stale watch locks, handle termination signals, and restore background-service policy when takeover cannot stop or exits with an error.
+- Prevent overlapping source watches, remove the unleased override mutation path, reclaim stale watch locks, preserve terminal job control, handle termination signals, and restore background-service policy when takeover cannot stop or exits with an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to OCM are documented here.
 - Build locked release artifacts only from a GitHub-verified tag matching the package version, require the complete supported target matrix before publication, publish a versioned checksum-verifying installer, pin CI actions, and test the declared Rust 1.88 minimum.
 - Preserve uncommitted dev worktrees and reject unrelated checkout collisions by requiring exact Git worktree registration before reuse or removal.
 - Make single and merged log following rotation-safe and byte-safe, preserving split or invalid UTF-8, multiline record ordering, and boundaries around unterminated records.
+- Prevent overlapping source watches, reclaim stale watch locks, and restore background-service policy when takeover cannot stop or exits with an error.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ unicode-width = "0.2"
 terminal_size = "0.4"
 dialoguer = { version = "0.12", default-features = false }
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
-ctrlc = "3.4"
+ctrlc = { version = "3.4", features = ["termination"] }
 libc = "0.2"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,17 @@ zip = { version = "8.5", default-features = false, features = ["deflate"] }
 ctrlc = "3.4"
 libc = "0.2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
 
 [profile.release]
 lto = "thin"

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -1090,6 +1090,36 @@ fn wait_for_source_watch_child(
         if stop_requested.load(Ordering::SeqCst) {
             return stop_source_watch_child(child, process_guard);
         }
+        #[cfg(unix)]
+        {
+            let mut status = 0;
+            let waited = unsafe {
+                libc::waitpid(
+                    child.id() as libc::pid_t,
+                    &mut status,
+                    libc::WNOHANG | libc::WUNTRACED,
+                )
+            };
+            if waited == -1 {
+                let error = io::Error::last_os_error();
+                if error.kind() != io::ErrorKind::Interrupted {
+                    return Err(SourceWatchError::unverified(format!(
+                        "failed checking source watch job-control state: {error}"
+                    )));
+                }
+            } else if waited != 0 {
+                if libc::WIFSTOPPED(status) {
+                    process_guard
+                        .suspend_with_child(child.id())
+                        .map_err(SourceWatchError::unverified)?;
+                } else if libc::WIFEXITED(status) || libc::WIFSIGNALED(status) {
+                    process_guard
+                        .stop_remaining(child.id())
+                        .map_err(SourceWatchError::unverified)?;
+                    return Ok(std::process::ExitStatus::from_raw(status));
+                }
+            }
+        }
         thread::sleep(Duration::from_millis(50));
     }
 }
@@ -1103,9 +1133,9 @@ struct SourceWatchProcessGuard {
 
 #[cfg(unix)]
 struct SourceWatchTerminalGuard {
-    original_process_group: libc::pid_t,
-    startup_reader: UnixStream,
-    startup_writer: UnixStream,
+    parent_process_group: libc::pid_t,
+    startup_reader: Option<UnixStream>,
+    startup_writer: Option<UnixStream>,
     foreground_assigned: AtomicBool,
 }
 
@@ -1114,18 +1144,25 @@ impl SourceWatchProcessGuard {
         #[cfg(unix)]
         {
             let terminal = if unsafe { libc::isatty(libc::STDIN_FILENO) } == 1 {
-                let original_process_group = unsafe { libc::tcgetpgrp(libc::STDIN_FILENO) };
-                if original_process_group == -1 {
+                let foreground_process_group = unsafe { libc::tcgetpgrp(libc::STDIN_FILENO) };
+                if foreground_process_group == -1 {
                     return Err(format!(
                         "failed reading source watch terminal ownership: {}",
                         io::Error::last_os_error()
                     ));
                 }
-                let (startup_reader, startup_writer) = UnixStream::pair().map_err(|error| {
-                    format!("failed creating source watch startup gate: {error}")
-                })?;
+                let parent_process_group = unsafe { libc::getpgrp() };
+                let (startup_reader, startup_writer) =
+                    if foreground_process_group == parent_process_group {
+                        let (reader, writer) = UnixStream::pair().map_err(|error| {
+                            format!("failed creating source watch startup gate: {error}")
+                        })?;
+                        (Some(reader), Some(writer))
+                    } else {
+                        (None, None)
+                    };
                 Some(SourceWatchTerminalGuard {
-                    original_process_group,
+                    parent_process_group,
                     startup_reader,
                     startup_writer,
                     foreground_assigned: AtomicBool::new(false),
@@ -1179,8 +1216,12 @@ impl SourceWatchProcessGuard {
 
     fn configure_command(&mut self, command: &mut Command) -> Result<(), String> {
         #[cfg(unix)]
-        if let Some(terminal) = &self.terminal {
-            let startup_fd = terminal.startup_reader.as_raw_fd();
+        if let Some(startup_reader) = self
+            .terminal
+            .as_ref()
+            .and_then(|terminal| terminal.startup_reader.as_ref())
+        {
+            let startup_fd = startup_reader.as_raw_fd();
             command.env("OCM_SOURCE_WATCH_START_FD", startup_fd.to_string());
             unsafe {
                 command.pre_exec(move || {
@@ -1221,7 +1262,9 @@ impl SourceWatchProcessGuard {
             }
         }
         #[cfg(unix)]
-        if let Some(terminal) = &self.terminal {
+        if let Some(terminal) = &self.terminal
+            && terminal.startup_reader.is_some()
+        {
             set_terminal_foreground_process_group(child.id() as libc::pid_t)?;
             terminal.foreground_assigned.store(true, Ordering::SeqCst);
         }
@@ -1232,8 +1275,12 @@ impl SourceWatchProcessGuard {
 
     fn start_child(&self, _child: &std::process::Child) -> Result<(), String> {
         #[cfg(unix)]
-        if let Some(terminal) = &self.terminal {
-            let mut writer = &terminal.startup_writer;
+        if let Some(startup_writer) = self
+            .terminal
+            .as_ref()
+            .and_then(|terminal| terminal.startup_writer.as_ref())
+        {
+            let mut writer = startup_writer;
             writer
                 .write_all(&[1])
                 .map_err(|error| format!("failed releasing source watch startup gate: {error}"))?;
@@ -1248,8 +1295,28 @@ impl SourceWatchProcessGuard {
         if let Some(terminal) = &self.terminal
             && terminal.foreground_assigned.swap(false, Ordering::SeqCst)
         {
-            set_terminal_foreground_process_group(terminal.original_process_group)?;
+            set_terminal_foreground_process_group(terminal.parent_process_group)?;
         }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn suspend_with_child(&self, child_pid: u32) -> Result<(), String> {
+        self.restore_terminal()?;
+        if unsafe { libc::kill(libc::getpid(), libc::SIGSTOP) } == -1 {
+            return Err(format!(
+                "failed suspending OCM with source watch: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        if let Some(terminal) = &self.terminal {
+            let foreground_process_group = unsafe { libc::tcgetpgrp(libc::STDIN_FILENO) };
+            if foreground_process_group == terminal.parent_process_group {
+                set_terminal_foreground_process_group(child_pid as libc::pid_t)?;
+                terminal.foreground_assigned.store(true, Ordering::SeqCst);
+            }
+        }
+        signal_unix_process_group(child_pid, libc::SIGCONT)?;
         Ok(())
     }
 

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -234,7 +234,7 @@ impl Cli {
                     ),
                     stderr_profile,
                 ));
-                self.stop_service_for_source_watch(&meta.name)?;
+                self.stop_service_for_source_watch(&meta.name, meta.service_running)?;
             }
             self.stderr_lines(render_dev_run_step(
                 "Watch",
@@ -352,7 +352,7 @@ impl Cli {
                 ),
                 stderr_profile,
             ));
-            self.stop_service_for_source_watch(&meta.name)?;
+            self.stop_service_for_source_watch(&meta.name, meta.service_running)?;
         }
 
         self.stderr_lines(render_dev_run_step(
@@ -389,7 +389,11 @@ impl Cli {
         combine_watch_and_restore_results(watch_result, restore_result, &meta.name)
     }
 
-    fn stop_service_for_source_watch(&self, env_name: &str) -> Result<(), String> {
+    fn stop_service_for_source_watch(
+        &self,
+        env_name: &str,
+        restore_running_policy: bool,
+    ) -> Result<(), String> {
         let stop_result = self.service_service().stop(env_name);
         let stop_error = match stop_result {
             Ok(summary) if !summary.running => return Ok(()),
@@ -397,6 +401,9 @@ impl Cli {
             Err(error) => format!("failed stopping background service for {env_name}: {error}"),
         };
 
+        if !restore_running_policy {
+            return Err(stop_error);
+        }
         match self.service_service().start(env_name) {
             Ok(_) => Err(format!(
                 "{stop_error}; restored the background service policy and did not start source watch"
@@ -722,33 +729,33 @@ impl Cli {
         let mut child = command
             .spawn()
             .map_err(|error| format!("failed to run \"node\": {error}"))?;
-        let source_watch = match self.environment_service().create_source_watch_override(
-            CreateSourceWatchOverrideOptions {
-                env_name: meta.name.clone(),
-                repo_root: repo_root.to_path_buf(),
-                watch_pid: child.id(),
-            },
-        ) {
+        let source_watch = match self
+            .environment_service()
+            .create_source_watch_override_with_lease(
+                CreateSourceWatchOverrideOptions {
+                    env_name: meta.name.clone(),
+                    repo_root: repo_root.to_path_buf(),
+                    watch_pid: child.id(),
+                },
+                _source_watch_lease,
+            ) {
             Ok(source_watch) => source_watch,
             Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
+                let _ = stop_source_watch_child(&mut child);
                 return Err(error);
             }
         };
         let mut tee_threads = Vec::new();
         if let Some(log_files) = log_files.take() {
             let Some(stdout) = child.stdout.take() else {
-                let _ = child.kill();
-                let _ = child.wait();
+                let _ = stop_source_watch_child(&mut child);
                 let _ = self
                     .environment_service()
                     .clear_source_watch_override(&meta.name, &source_watch.token);
                 return Err("failed to capture source watch stdout".to_string());
             };
             let Some(stderr) = child.stderr.take() else {
-                let _ = child.kill();
-                let _ = child.wait();
+                let _ = stop_source_watch_child(&mut child);
                 let _ = self
                     .environment_service()
                     .clear_source_watch_override(&meta.name, &source_watch.token);
@@ -770,8 +777,7 @@ impl Cli {
 
         let status_result =
             wait_for_source_watch_child(&mut child, &stop_requested).map_err(|error| {
-                let _ = child.kill();
-                let _ = child.wait();
+                let _ = stop_source_watch_child(&mut child);
                 error
             });
         let tee_result = wait_for_tee_threads(tee_threads);
@@ -881,15 +887,46 @@ fn wait_for_source_watch_child(
             return Ok(status);
         }
         if stop_requested.load(Ordering::SeqCst) {
-            child
-                .kill()
-                .map_err(|error| format!("failed stopping source watch: {error}"))?;
-            return child
-                .wait()
-                .map_err(|error| format!("failed waiting for stopped source watch: {error}"));
+            return stop_source_watch_child(child);
         }
         thread::sleep(Duration::from_millis(50));
     }
+}
+
+fn stop_source_watch_child(
+    child: &mut std::process::Child,
+) -> Result<std::process::ExitStatus, String> {
+    #[cfg(unix)]
+    {
+        let pid = child.id().to_string();
+        // OpenClaw's watch-node handler forwards TERM to its detached gateway
+        // process group; allow its shutdown grace before forcing the wrapper down.
+        let signal = Command::new("kill")
+            .args(["-TERM", &pid])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        if signal.as_ref().is_ok_and(|status| status.success()) {
+            let deadline = std::time::Instant::now() + Duration::from_secs(7);
+            while std::time::Instant::now() < deadline {
+                if let Some(status) = child
+                    .try_wait()
+                    .map_err(|error| format!("failed waiting for source watch shutdown: {error}"))?
+                {
+                    return Ok(status);
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+
+    child
+        .kill()
+        .map_err(|error| format!("failed stopping source watch: {error}"))?;
+    child
+        .wait()
+        .map_err(|error| format!("failed waiting for stopped source watch: {error}"))
 }
 
 fn render_dev_status(summary: &DevStatusSummary, profile: RenderProfile) -> Vec<String> {

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -10,6 +10,8 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(windows)]
 use std::os::windows::{io::AsRawHandle, process::CommandExt as _};
 
@@ -36,6 +38,32 @@ use crate::store::{
 
 const DEV_PREFERENCES_KIND: &str = "ocm-dev-preferences";
 const SOURCE_WATCH_TREE_ACTIVE_ERROR: &str = "source watch process tree is still active";
+
+type SourceWatchResult<T> = Result<T, SourceWatchError>;
+
+#[derive(Debug)]
+struct SourceWatchError {
+    message: String,
+    cleanup_verified: bool,
+}
+
+impl SourceWatchError {
+    fn unverified(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            cleanup_verified: false,
+        }
+    }
+}
+
+impl From<String> for SourceWatchError {
+    fn from(message: String) -> Self {
+        Self {
+            message,
+            cleanup_verified: true,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -678,7 +706,7 @@ impl Cli {
         &self,
         meta: &EnvMeta,
         source_watch_lease: &SourceWatchLease,
-    ) -> Result<i32, String> {
+    ) -> SourceWatchResult<i32> {
         let dev = meta
             .dev
             .as_ref()
@@ -697,7 +725,7 @@ impl Cli {
         repo_root: &Path,
         tee_to_env_logs: bool,
         _source_watch_lease: &SourceWatchLease,
-    ) -> Result<i32, String> {
+    ) -> SourceWatchResult<i32> {
         let args = vec![
             "scripts/watch-node.mjs".to_string(),
             "gateway".to_string(),
@@ -715,7 +743,6 @@ impl Cli {
         let mut command = Command::new("node");
         command
             .args(&args)
-            .stdin(Stdio::inherit())
             .env_clear()
             .envs(build_openclaw_dev_source_env(meta, &self.env, repo_root))
             .current_dir(repo_root);
@@ -814,12 +841,15 @@ impl Cli {
         }
 
         let status_result =
-            wait_for_source_watch_child(&mut child, &stop_requested, &process_guard)
-                .map_err(|error| stop_source_watch_after_error(&mut child, &process_guard, error));
-        let tee_result = if status_result
-            .as_ref()
-            .is_err_and(|error| error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR))
-        {
+            match wait_for_source_watch_child(&mut child, &stop_requested, &process_guard) {
+                Ok(status) => Ok(status),
+                Err(error) => Err(stop_source_watch_after_error(
+                    &mut child,
+                    &process_guard,
+                    error.message,
+                )),
+            };
+        let tee_result = if !source_watch_allows_service_restore(&status_result) {
             drop(tee_threads);
             Ok(())
         } else {
@@ -879,32 +909,35 @@ fn source_watch_stop_timeout_error(summary: &crate::service::ServiceActionSummar
 }
 
 fn combine_watch_and_restore_results(
-    watch_result: Result<i32, String>,
+    watch_result: SourceWatchResult<i32>,
     restore_result: Result<(), String>,
     env_name: &str,
 ) -> Result<i32, String> {
     match (watch_result, restore_result) {
         (Ok(code), Ok(())) => Ok(code),
-        (Err(watch_error), Ok(())) => Err(watch_error),
+        (Err(watch_error), Ok(())) => Err(watch_error.message),
         (Ok(_), Err(restore_error)) => Err(format!(
             "source watch ended, but failed restoring background service for {env_name}: {restore_error}"
         )),
         (Err(watch_error), Err(restore_error)) => Err(format!(
-            "{watch_error}; also failed restoring background service for {env_name}: {restore_error}"
+            "{}; also failed restoring background service for {env_name}: {restore_error}",
+            watch_error.message
         )),
     }
 }
 
 fn combine_source_watch_cleanup_results(
-    status_result: Result<std::process::ExitStatus, String>,
+    status_result: SourceWatchResult<std::process::ExitStatus>,
     tee_result: Result<(), String>,
     clear_result: Result<(), String>,
-) -> Result<std::process::ExitStatus, String> {
+) -> SourceWatchResult<std::process::ExitStatus> {
     let mut errors = Vec::new();
+    let mut cleanup_verified = true;
     let status = match status_result {
         Ok(status) => Some(status),
         Err(error) => {
-            errors.push(error);
+            cleanup_verified = error.cleanup_verified;
+            errors.push(error.message);
             None
         }
     };
@@ -915,9 +948,14 @@ fn combine_source_watch_cleanup_results(
         errors.push(error);
     }
     if errors.is_empty() {
-        status.ok_or_else(|| "source watch ended without an exit status".to_string())
+        status.ok_or_else(|| {
+            SourceWatchError::from("source watch ended without an exit status".to_string())
+        })
     } else {
-        Err(errors.join("; "))
+        Err(SourceWatchError {
+            message: errors.join("; "),
+            cleanup_verified,
+        })
     }
 }
 
@@ -925,45 +963,64 @@ fn wait_for_source_watch_child(
     child: &mut std::process::Child,
     stop_requested: &AtomicBool,
     process_guard: &SourceWatchProcessGuard,
-) -> Result<std::process::ExitStatus, String> {
-    let mut tracked_processes = Vec::new();
-    #[cfg(unix)]
-    let track_descendants = source_watch_needs_descendant_tracking();
-    #[cfg(unix)]
-    let tracking_started = std::time::Instant::now();
-    #[cfg(unix)]
-    let mut next_tracking_refresh = tracking_started;
+) -> SourceWatchResult<std::process::ExitStatus> {
     loop {
-        #[cfg(unix)]
-        if track_descendants && std::time::Instant::now() >= next_tracking_refresh {
-            // Non-TTY watch-node runners detach into their own process group. Sample quickly
-            // during startup, then throttle native process snapshots for long-running watches.
-            tracked_processes = refresh_tracked_unix_processes(child.id(), &tracked_processes)
-                .map_err(source_watch_tree_discovery_error)?;
-            let refresh_interval = if tracking_started.elapsed() < Duration::from_secs(2) {
-                Duration::from_millis(50)
-            } else {
-                Duration::from_secs(2)
-            };
-            next_tracking_refresh = std::time::Instant::now() + refresh_interval;
-        }
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|error| format!("failed waiting for source watch: {error}"))?
-        {
-            #[cfg(unix)]
-            stop_tracked_unix_processes(child.id(), &tracked_processes)?;
-            process_guard.stop_remaining(child.id())?;
+        if let Some(status) = child.try_wait().map_err(|error| {
+            SourceWatchError::unverified(format!("failed waiting for source watch: {error}"))
+        })? {
+            process_guard
+                .stop_remaining(child.id())
+                .map_err(SourceWatchError::unverified)?;
             return Ok(status);
         }
         if stop_requested.load(Ordering::SeqCst) {
-            return stop_source_watch_child(child, process_guard, &tracked_processes);
+            return stop_source_watch_child(child, process_guard);
         }
         thread::sleep(Duration::from_millis(50));
     }
 }
 
+#[cfg(unix)]
+fn open_source_watch_pty() -> Result<(File, File), String> {
+    let mut master_fd = -1;
+    let mut slave_fd = -1;
+    if unsafe {
+        libc::openpty(
+            &mut master_fd,
+            &mut slave_fd,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    } != 0
+    {
+        return Err(format!(
+            "failed creating source watch terminal: {}",
+            io::Error::last_os_error()
+        ));
+    }
+    let master = unsafe { File::from_raw_fd(master_fd) };
+    let slave = unsafe { File::from_raw_fd(slave_fd) };
+    for file in [&master, &slave] {
+        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+        if flags == -1
+            || unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, flags | libc::FD_CLOEXEC) }
+                == -1
+        {
+            return Err(format!(
+                "failed configuring source watch terminal: {}",
+                io::Error::last_os_error()
+            ));
+        }
+    }
+    Ok((master, slave))
+}
+
 struct SourceWatchProcessGuard {
+    #[cfg(unix)]
+    stdin_pty_master: Option<File>,
+    #[cfg(unix)]
+    stdin_pty_slave: Option<File>,
     #[cfg(windows)]
     job: windows_sys::Win32::Foundation::HANDLE,
 }
@@ -1008,14 +1065,44 @@ impl SourceWatchProcessGuard {
         }
         #[cfg(not(windows))]
         {
+            #[cfg(unix)]
+            {
+                let (stdin_pty_master, stdin_pty_slave) =
+                    if unsafe { libc::isatty(libc::STDIN_FILENO) } == 1 {
+                        (None, None)
+                    } else {
+                        // watch-node detaches its runner when stdin is not a TTY. Keep an inert
+                        // PTY open so every runner remains in OCM's owned process group.
+                        let (master, slave) = open_source_watch_pty()?;
+                        (Some(master), Some(slave))
+                    };
+                return Ok(Self {
+                    stdin_pty_master,
+                    stdin_pty_slave,
+                });
+            }
+            #[cfg(not(unix))]
             Ok(Self {})
         }
     }
 
     fn configure_command(&mut self, command: &mut Command) -> Result<(), String> {
+        #[cfg(unix)]
+        {
+            if let Some(slave) = self.stdin_pty_slave.take() {
+                command.stdin(Stdio::from(slave));
+            } else {
+                command.stdin(Stdio::inherit());
+            }
+            let _ = &self.stdin_pty_master;
+        }
         #[cfg(windows)]
-        command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
-        #[cfg(not(windows))]
+        {
+            command
+                .stdin(Stdio::inherit())
+                .creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
+        }
+        #[cfg(not(any(unix, windows)))]
         let _ = command;
         Ok(())
     }
@@ -1055,11 +1142,15 @@ impl SourceWatchProcessGuard {
             }
             return self.wait_for_windows_job_to_stop();
         }
-        #[cfg(not(windows))]
+        #[cfg(unix)]
         {
-            let _ = root_pid;
-            Ok(())
+            let _ = signal_unix_process_group(root_pid, libc::SIGKILL)?;
+            return wait_for_unix_process_group_to_stop(root_pid);
         }
+        #[cfg(not(any(unix, windows)))]
+        let _ = root_pid;
+        #[cfg(not(any(unix, windows)))]
+        Ok(())
     }
 
     #[cfg(windows)]
@@ -1113,149 +1204,96 @@ impl Drop for SourceWatchProcessGuard {
 fn stop_source_watch_child(
     child: &mut std::process::Child,
     process_guard: &SourceWatchProcessGuard,
-    tracked_processes: &[UnixProcessIdentity],
-) -> Result<std::process::ExitStatus, String> {
-    #[cfg(not(windows))]
-    let _ = process_guard;
+) -> SourceWatchResult<std::process::ExitStatus> {
     #[cfg(unix)]
     {
-        let mut tracked_processes = tracked_processes.to_vec();
-        let track_descendants = source_watch_needs_descendant_tracking();
-        if track_descendants {
-            tracked_processes = refresh_tracked_unix_processes(child.id(), &tracked_processes)
-                .map_err(source_watch_tree_discovery_error)?;
-        }
         // watch-node forwards TERM to its runner; allow that grace before
         // enforcing the process-group ownership boundary.
-        if signal_unix_process(child.id(), libc::SIGTERM)? {
+        if signal_unix_process(child.id(), libc::SIGTERM).map_err(SourceWatchError::unverified)? {
             let deadline = std::time::Instant::now() + Duration::from_secs(7);
             while std::time::Instant::now() < deadline {
-                if let Some(status) = child
-                    .try_wait()
-                    .map_err(|error| format!("failed waiting for source watch shutdown: {error}"))?
-                {
-                    stop_tracked_unix_processes(child.id(), &tracked_processes)?;
+                if let Some(status) = child.try_wait().map_err(|error| {
+                    SourceWatchError::unverified(format!(
+                        "failed waiting for source watch shutdown: {error}"
+                    ))
+                })? {
+                    process_guard
+                        .stop_remaining(child.id())
+                        .map_err(SourceWatchError::unverified)?;
                     return Ok(status);
-                }
-                if track_descendants {
-                    tracked_processes =
-                        refresh_tracked_unix_processes(child.id(), &tracked_processes)
-                            .map_err(source_watch_tree_discovery_error)?;
                 }
                 thread::sleep(Duration::from_millis(50));
             }
         }
-        signal_unix_process_group(child.id(), libc::SIGSTOP)?;
-        if track_descendants {
-            tracked_processes = refresh_tracked_unix_processes(child.id(), &tracked_processes)
-                .map_err(source_watch_tree_discovery_error)?;
-        }
-        kill_tracked_unix_processes(child.id(), true, &tracked_processes)?;
-        let status = child
-            .wait()
-            .map_err(|error| format!("failed waiting for stopped source watch: {error}"))?;
-        wait_for_unix_processes_to_stop(&tracked_processes)?;
+        signal_unix_process_group(child.id(), libc::SIGSTOP)
+            .map_err(SourceWatchError::unverified)?;
+        signal_unix_process_group(child.id(), libc::SIGKILL)
+            .map_err(SourceWatchError::unverified)?;
+        let status = child.wait().map_err(|error| {
+            SourceWatchError::unverified(format!(
+                "failed waiting for stopped source watch: {error}"
+            ))
+        })?;
+        wait_for_unix_process_group_to_stop(child.id()).map_err(SourceWatchError::unverified)?;
         return Ok(status);
     }
 
     #[cfg(windows)]
     {
-        process_guard.stop_remaining(child.id())?;
-        return child
-            .wait()
-            .map_err(|error| format!("failed waiting for stopped source watch: {error}"));
+        process_guard
+            .stop_remaining(child.id())
+            .map_err(SourceWatchError::unverified)?;
+        return child.wait().map_err(|error| {
+            SourceWatchError::unverified(format!(
+                "failed waiting for stopped source watch: {error}"
+            ))
+        });
     }
 
     #[cfg(not(any(unix, windows)))]
     {
-        child
-            .kill()
-            .map_err(|error| format!("failed stopping source watch: {error}"))?;
-        child
-            .wait()
-            .map_err(|error| format!("failed waiting for stopped source watch: {error}"))
-    }
-}
-
-#[cfg(unix)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct UnixProcessIdentity {
-    pid: u32,
-    parent_pid: u32,
-    process_group: u32,
-    start_id: u64,
-}
-
-#[cfg(not(unix))]
-type UnixProcessIdentity = ();
-
-#[cfg(unix)]
-fn refresh_tracked_unix_processes(
-    root_pid: u32,
-    tracked_processes: &[UnixProcessIdentity],
-) -> Result<Vec<UnixProcessIdentity>, String> {
-    let snapshot = unix_process_snapshot()?;
-    let tracked_identities = tracked_processes
-        .iter()
-        .map(|process| (process.pid, process.start_id))
-        .collect::<BTreeSet<_>>();
-    let descendants = unix_descendant_processes_from_snapshot(root_pid, snapshot.clone())
-        .into_iter()
-        .map(|process| (process.pid, process.start_id))
-        .collect::<BTreeSet<_>>();
-    Ok(snapshot
-        .into_iter()
-        .filter(|process| {
-            let identity = (process.pid, process.start_id);
-            descendants.contains(&identity) || tracked_identities.contains(&identity)
+        child.kill().map_err(|error| {
+            SourceWatchError::unverified(format!("failed stopping source watch: {error}"))
+        })?;
+        child.wait().map_err(|error| {
+            SourceWatchError::unverified(format!(
+                "failed waiting for stopped source watch: {error}"
+            ))
         })
-        .collect())
-}
-
-#[cfg(unix)]
-fn unix_descendant_processes_from_snapshot(
-    root_pid: u32,
-    processes: Vec<UnixProcessIdentity>,
-) -> Vec<UnixProcessIdentity> {
-    let mut tree = BTreeSet::from([root_pid]);
-    loop {
-        let before = tree.len();
-        for process in &processes {
-            if tree.contains(&process.parent_pid) {
-                tree.insert(process.pid);
-            }
-        }
-        if tree.len() == before {
-            break;
-        }
     }
-    processes
-        .into_iter()
-        .filter(|process| process.pid != root_pid && tree.contains(&process.pid))
-        .collect()
 }
 
 #[cfg(unix)]
-fn source_watch_needs_descendant_tracking() -> bool {
-    unsafe { libc::isatty(libc::STDIN_FILENO) != 1 }
+fn wait_for_unix_process_group_to_stop(process_group: u32) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if !unix_process_group_has_live_members(process_group)? {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(format!(
+                "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; process group {process_group} is still active; the background service was not restored"
+            ));
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 #[cfg(target_os = "linux")]
-fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
-    let mut processes = Vec::new();
+fn unix_process_group_has_live_members(process_group: u32) -> Result<bool, String> {
     for entry in fs::read_dir("/proc")
         .map_err(|error| format!("failed reading /proc for source watch processes: {error}"))?
     {
         let entry = entry.map_err(|error| {
             format!("failed reading /proc entry for source watch processes: {error}")
         })?;
-        let Some(pid) = entry
+        if !entry
             .file_name()
             .to_str()
-            .and_then(|name| name.parse::<u32>().ok())
-        else {
+            .is_some_and(|name| name.bytes().all(|byte| byte.is_ascii_digit()))
+        {
             continue;
-        };
+        }
         let Ok(stat) = fs::read_to_string(entry.path().join("stat")) else {
             continue;
         };
@@ -1263,27 +1301,18 @@ fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
             continue;
         };
         let fields = fields.split_whitespace().collect::<Vec<_>>();
-        let Some(parent_pid) = fields.get(1).and_then(|value| value.parse::<u32>().ok()) else {
-            continue;
-        };
-        let Some(process_group) = fields.get(2).and_then(|value| value.parse::<u32>().ok()) else {
-            continue;
-        };
-        let Some(start_id) = fields.get(19).and_then(|value| value.parse::<u64>().ok()) else {
-            continue;
-        };
-        processes.push(UnixProcessIdentity {
-            pid,
-            parent_pid,
-            process_group,
-            start_id,
-        });
+        let is_zombie = matches!(fields.first().copied(), Some("Z" | "X"));
+        let in_group =
+            fields.get(2).and_then(|value| value.parse::<u32>().ok()) == Some(process_group);
+        if in_group && !is_zombie {
+            return Ok(true);
+        }
     }
-    Ok(processes)
+    Ok(false)
 }
 
 #[cfg(target_os = "macos")]
-fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
+fn unix_process_group_has_live_members(process_group: u32) -> Result<bool, String> {
     let capacity = unsafe { libc::proc_listallpids(std::ptr::null_mut(), 0) };
     if capacity <= 0 {
         return Err(format!(
@@ -1304,7 +1333,6 @@ fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
             io::Error::last_os_error()
         ));
     }
-    let mut processes = Vec::new();
     for pid in pids.into_iter().take(count as usize).filter(|pid| *pid > 0) {
         let mut info = unsafe { std::mem::zeroed::<libc::proc_bsdinfo>() };
         let read = unsafe {
@@ -1316,106 +1344,19 @@ fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
                 std::mem::size_of_val(&info) as i32,
             )
         };
-        if read == std::mem::size_of_val(&info) as i32 {
-            processes.push(UnixProcessIdentity {
-                pid: info.pbi_pid,
-                parent_pid: info.pbi_ppid,
-                process_group: info.pbi_pgid,
-                start_id: ((info.pbi_start_tvsec as u64) << 32) | info.pbi_start_tvusec as u64,
-            });
+        if read == std::mem::size_of_val(&info) as i32
+            && info.pbi_pgid == process_group
+            && info.pbi_status != libc::SZOMB
+        {
+            return Ok(true);
         }
     }
-    Ok(processes)
+    Ok(false)
 }
 
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
-    Err("source watch process discovery is unsupported on this Unix platform".to_string())
-}
-
-#[cfg(unix)]
-fn current_tracked_unix_processes(
-    tracked_processes: &[UnixProcessIdentity],
-) -> Result<Vec<UnixProcessIdentity>, String> {
-    Ok(tracked_unix_processes_from_snapshot(
-        tracked_processes,
-        unix_process_snapshot()?,
-    ))
-}
-
-#[cfg(unix)]
-fn tracked_unix_processes_from_snapshot(
-    tracked_processes: &[UnixProcessIdentity],
-    snapshot: Vec<UnixProcessIdentity>,
-) -> Vec<UnixProcessIdentity> {
-    let tracked_identities = tracked_processes
-        .iter()
-        .map(|process| (process.pid, process.start_id))
-        .collect::<BTreeSet<_>>();
-    snapshot
-        .into_iter()
-        .filter(|current| tracked_identities.contains(&(current.pid, current.start_id)))
-        .collect()
-}
-
-#[cfg(unix)]
-fn kill_tracked_unix_processes(
-    root_pid: u32,
-    root_is_alive: bool,
-    tracked_processes: &[UnixProcessIdentity],
-) -> Result<(), String> {
-    let current_processes = current_tracked_unix_processes(tracked_processes)?;
-    let mut process_groups = current_processes
-        .iter()
-        .map(|process| process.process_group)
-        .collect::<BTreeSet<_>>();
-    // configure_child creates this group before exec. It remains our ownership boundary
-    // after the wrapper exits, including descendants that escaped the first snapshot.
-    process_groups.insert(root_pid);
-    for process_group in process_groups {
-        let _ = signal_unix_process_group(process_group, libc::SIGKILL)?;
-    }
-    for process in current_processes {
-        let _ = signal_unix_process(process.pid, libc::SIGKILL)?;
-    }
-    if root_is_alive {
-        let _ = signal_unix_process(root_pid, libc::SIGKILL)?;
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn stop_tracked_unix_processes(
-    root_pid: u32,
-    processes: &[UnixProcessIdentity],
-) -> Result<(), String> {
-    kill_tracked_unix_processes(root_pid, false, processes)?;
-    wait_for_unix_processes_to_stop(processes)
-}
-
-#[cfg(unix)]
-fn wait_for_unix_processes_to_stop(processes: &[UnixProcessIdentity]) -> Result<(), String> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(2);
-    loop {
-        let alive = current_tracked_unix_processes(processes)?
-            .iter()
-            .map(|process| process.pid)
-            .collect::<Vec<_>>();
-        if alive.is_empty() {
-            return Ok(());
-        }
-        if std::time::Instant::now() >= deadline {
-            return Err(format!(
-                "{SOURCE_WATCH_TREE_ACTIVE_ERROR}: {}; the background service was not restored",
-                alive
-                    .iter()
-                    .map(u32::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ));
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
+fn unix_process_group_has_live_members(process_group: u32) -> Result<bool, String> {
+    signal_unix_process_group(process_group, 0)
 }
 
 #[cfg(unix)]
@@ -1441,12 +1382,6 @@ fn signal_unix_target(target: i32, signal: i32) -> Result<bool, String> {
             "failed signaling source watch process target {target}: {error}"
         ))
     }
-}
-
-fn source_watch_tree_discovery_error(error: String) -> String {
-    format!(
-        "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; unable to verify the process tree: {error}; the background service was not restored"
-    )
 }
 
 #[cfg(windows)]
@@ -1501,15 +1436,13 @@ fn stop_source_watch_after_error(
     child: &mut std::process::Child,
     process_guard: &SourceWatchProcessGuard,
     primary_error: String,
-) -> String {
-    match stop_source_watch_child(child, process_guard, &[]) {
-        Ok(_) => primary_error,
-        Err(cleanup_error) if cleanup_error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR) => {
-            format!("{cleanup_error}; setup also failed: {primary_error}")
-        }
-        Err(cleanup_error) => {
-            format!("{primary_error}; also failed stopping source watch: {cleanup_error}")
-        }
+) -> SourceWatchError {
+    match stop_source_watch_child(child, process_guard) {
+        Ok(_) => SourceWatchError::from(primary_error),
+        Err(cleanup_error) => SourceWatchError::unverified(format!(
+            "{}; setup also failed: {primary_error}",
+            cleanup_error.message
+        )),
     }
 }
 
@@ -1517,17 +1450,17 @@ fn stop_source_watch_after_error(
 fn stop_suspended_source_watch_after_error(
     child: &mut std::process::Child,
     primary_error: String,
-) -> String {
+) -> SourceWatchError {
     if let Err(error) = child.kill() {
-        return format!(
+        return SourceWatchError::unverified(format!(
             "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; failed terminating a suspended watcher: {error}; setup also failed: {primary_error}"
-        );
+        ));
     }
     match child.wait() {
-        Ok(_) => primary_error,
-        Err(error) => format!(
+        Ok(_) => SourceWatchError::from(primary_error),
+        Err(error) => SourceWatchError::unverified(format!(
             "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; failed reaping a suspended watcher: {error}; setup also failed: {primary_error}"
-        ),
+        )),
     }
 }
 
@@ -1539,20 +1472,17 @@ fn source_watch_exit_code(status_code: Option<i32>, stop_requested: bool) -> i32
     }
 }
 
-fn source_watch_allows_service_restore(watch_result: &Result<i32, String>) -> bool {
-    !matches!(
-        watch_result,
-        Err(error) if error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR)
-    )
+fn source_watch_allows_service_restore<T>(watch_result: &SourceWatchResult<T>) -> bool {
+    match watch_result {
+        Ok(_) => true,
+        Err(error) => error.cleanup_verified,
+    }
 }
 
 fn source_watch_allows_override_clear(
-    watch_result: &Result<std::process::ExitStatus, String>,
+    watch_result: &SourceWatchResult<std::process::ExitStatus>,
 ) -> bool {
-    !matches!(
-        watch_result,
-        Err(error) if error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR)
-    )
+    source_watch_allows_service_restore(watch_result)
 }
 
 fn render_dev_status(summary: &DevStatusSummary, profile: RenderProfile) -> Vec<String> {
@@ -2207,12 +2137,10 @@ fn render_dev_status_list(summaries: &[DevStatusSummary], profile: RenderProfile
 #[cfg(test)]
 mod tests {
     use super::{
-        DevStatusSummary, RenderProfile, combine_watch_and_restore_results, render_dev_status,
-        source_watch_allows_service_restore, source_watch_exit_code,
+        DevStatusSummary, RenderProfile, SourceWatchError, combine_watch_and_restore_results,
+        render_dev_status, source_watch_allows_service_restore, source_watch_exit_code,
         source_watch_stop_timeout_error,
     };
-    #[cfg(unix)]
-    use super::{UnixProcessIdentity, tracked_unix_processes_from_snapshot};
     use crate::service::ServiceActionSummary;
 
     fn sample_summary() -> DevStatusSummary {
@@ -2285,7 +2213,7 @@ mod tests {
     #[test]
     fn source_watch_reports_watch_and_restore_failures_together() {
         let result = combine_watch_and_restore_results(
-            Err("watch failed".to_string()),
+            Err(SourceWatchError::from("watch failed".to_string())),
             Err("restore failed".to_string()),
             "demo",
         );
@@ -2308,33 +2236,15 @@ mod tests {
 
     #[test]
     fn source_watch_does_not_restore_over_a_live_process_tree() {
-        assert!(source_watch_allows_service_restore(&Ok(0)));
-        assert!(source_watch_allows_service_restore(&Err(
-            "source watch failed".to_string()
+        assert!(source_watch_allows_service_restore(&Ok::<
+            _,
+            SourceWatchError,
+        >(0)));
+        assert!(source_watch_allows_service_restore(&Err::<i32, _>(
+            SourceWatchError::from("source watch failed".to_string())
         )));
-        assert!(!source_watch_allows_service_restore(&Err(
-            "source watch process tree is still active: 123".to_string()
+        assert!(!source_watch_allows_service_restore(&Err::<i32, _>(
+            SourceWatchError::unverified("source watch process tree is still active: 123")
         )));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn source_watch_tracking_rejects_reused_process_ids() {
-        let tracked = UnixProcessIdentity {
-            pid: 42,
-            parent_pid: 10,
-            process_group: 42,
-            start_id: 100,
-        };
-        let reused = UnixProcessIdentity {
-            start_id: 101,
-            ..tracked
-        };
-
-        assert!(tracked_unix_processes_from_snapshot(&[tracked], vec![reused]).is_empty());
-        assert_eq!(
-            tracked_unix_processes_from_snapshot(&[tracked], vec![tracked]),
-            vec![tracked]
-        );
     }
 }

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -15,7 +15,10 @@ use serde_json::Value;
 
 use super::Cli;
 use super::render::RenderProfile;
-use crate::env::{CreateEnvironmentOptions, EnvDevMeta, EnvMeta, SourceWatchLease};
+use crate::env::{
+    CreateEnvironmentOptions, CreateSourceWatchOverrideOptions, EnvDevMeta, EnvMeta,
+    SourceWatchLease,
+};
 use crate::infra::process::run_direct;
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::infra::terminal::{Cell, KeyValueRow, Tone, paint, render_key_value_card, render_table};
@@ -680,7 +683,7 @@ impl Cli {
         meta: &EnvMeta,
         repo_root: &Path,
         tee_to_env_logs: bool,
-        source_watch_lease: &SourceWatchLease,
+        _source_watch_lease: &SourceWatchLease,
     ) -> Result<i32, String> {
         let args = vec![
             "scripts/watch-node.mjs".to_string(),
@@ -720,9 +723,11 @@ impl Cli {
             .spawn()
             .map_err(|error| format!("failed to run \"node\": {error}"))?;
         let source_watch = match self.environment_service().create_source_watch_override(
-            source_watch_lease,
-            repo_root,
-            child.id(),
+            CreateSourceWatchOverrideOptions {
+                env_name: meta.name.clone(),
+                repo_root: repo_root.to_path_buf(),
+                watch_pid: child.id(),
+            },
         ) {
             Ok(source_watch) => source_watch,
             Err(error) => {

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -10,8 +10,6 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-#[cfg(unix)]
-use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(windows)]
 use std::os::windows::{io::AsRawHandle, process::CommandExt as _};
 
@@ -38,6 +36,13 @@ use crate::store::{
 
 const DEV_PREFERENCES_KIND: &str = "ocm-dev-preferences";
 const SOURCE_WATCH_TREE_ACTIVE_ERROR: &str = "source watch process tree is still active";
+#[cfg(unix)]
+const SOURCE_WATCH_NODE_STDIN_SHIM: &str = r#"import path from "node:path";
+import { pathToFileURL } from "node:url";
+const script = path.resolve("scripts/watch-node.mjs");
+process.argv = [process.execPath, script, ...process.argv.slice(1)];
+Object.defineProperty(process.stdin, "isTTY", { value: true });
+await import(pathToFileURL(script).href);"#;
 
 type SourceWatchResult<T> = Result<T, SourceWatchError>;
 
@@ -741,8 +746,23 @@ impl Cli {
         .map_err(|error| format!("failed to install dev watch signal handler: {error}"))?;
 
         let mut command = Command::new("node");
+        #[cfg(unix)]
+        if unsafe { libc::isatty(libc::STDIN_FILENO) } != 1 {
+            // watch-node detaches its runner solely from stdin.isTTY. Override that decision
+            // while preserving the real noninteractive stdin and EOF inherited by the runner.
+            command.args([
+                "--input-type=module",
+                "--eval",
+                SOURCE_WATCH_NODE_STDIN_SHIM,
+            ]);
+            command.args(&args[1..]);
+        } else {
+            command.args(&args);
+        }
+        #[cfg(not(unix))]
+        command.args(&args);
         command
-            .args(&args)
+            .stdin(Stdio::inherit())
             .env_clear()
             .envs(build_openclaw_dev_source_env(meta, &self.env, repo_root))
             .current_dir(repo_root);
@@ -990,47 +1010,7 @@ fn wait_for_source_watch_child(
     }
 }
 
-#[cfg(unix)]
-fn open_source_watch_pty() -> Result<(File, File), String> {
-    let mut master_fd = -1;
-    let mut slave_fd = -1;
-    if unsafe {
-        libc::openpty(
-            &mut master_fd,
-            &mut slave_fd,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-        )
-    } != 0
-    {
-        return Err(format!(
-            "failed creating source watch terminal: {}",
-            io::Error::last_os_error()
-        ));
-    }
-    let master = unsafe { File::from_raw_fd(master_fd) };
-    let slave = unsafe { File::from_raw_fd(slave_fd) };
-    for file in [&master, &slave] {
-        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
-        if flags == -1
-            || unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, flags | libc::FD_CLOEXEC) }
-                == -1
-        {
-            return Err(format!(
-                "failed configuring source watch terminal: {}",
-                io::Error::last_os_error()
-            ));
-        }
-    }
-    Ok((master, slave))
-}
-
 struct SourceWatchProcessGuard {
-    #[cfg(unix)]
-    stdin_pty_master: Option<File>,
-    #[cfg(unix)]
-    stdin_pty_slave: Option<File>,
     #[cfg(windows)]
     job: windows_sys::Win32::Foundation::HANDLE,
 }
@@ -1075,44 +1055,16 @@ impl SourceWatchProcessGuard {
         }
         #[cfg(not(windows))]
         {
-            #[cfg(unix)]
-            {
-                let (stdin_pty_master, stdin_pty_slave) =
-                    if unsafe { libc::isatty(libc::STDIN_FILENO) } == 1 {
-                        (None, None)
-                    } else {
-                        // watch-node detaches its runner when stdin is not a TTY. Keep an inert
-                        // PTY open so every runner remains in OCM's owned process group.
-                        let (master, slave) = open_source_watch_pty()?;
-                        (Some(master), Some(slave))
-                    };
-                return Ok(Self {
-                    stdin_pty_master,
-                    stdin_pty_slave,
-                });
-            }
-            #[cfg(not(unix))]
             Ok(Self {})
         }
     }
 
     fn configure_command(&mut self, command: &mut Command) -> Result<(), String> {
-        #[cfg(unix)]
-        {
-            if let Some(slave) = self.stdin_pty_slave.take() {
-                command.stdin(Stdio::from(slave));
-            } else {
-                command.stdin(Stdio::inherit());
-            }
-            let _ = &self.stdin_pty_master;
-        }
         #[cfg(windows)]
         {
-            command
-                .stdin(Stdio::inherit())
-                .creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
+            command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
         }
-        #[cfg(not(any(unix, windows)))]
+        #[cfg(not(windows))]
         let _ = command;
         Ok(())
     }

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -1268,7 +1268,7 @@ impl SourceWatchProcessGuard {
         }
         #[cfg(unix)]
         {
-            let _ = signal_unix_process_group(root_pid, libc::SIGKILL)?;
+            let _ = signal_unix_process_group_for_cleanup(root_pid, libc::SIGKILL)?;
             return wait_for_unix_process_group_to_stop(root_pid);
         }
         #[cfg(not(any(unix, windows)))]
@@ -1390,9 +1390,9 @@ fn stop_source_watch_child(
                 thread::sleep(Duration::from_millis(50));
             }
         }
-        signal_unix_process_group(child.id(), libc::SIGSTOP)
+        signal_unix_process_group_for_cleanup(child.id(), libc::SIGSTOP)
             .map_err(SourceWatchError::unverified)?;
-        signal_unix_process_group(child.id(), libc::SIGKILL)
+        signal_unix_process_group_for_cleanup(child.id(), libc::SIGKILL)
             .map_err(SourceWatchError::unverified)?;
         let status = child.wait().map_err(|error| {
             SourceWatchError::unverified(format!(
@@ -1532,6 +1532,18 @@ fn signal_unix_process(pid: u32, signal: i32) -> Result<bool, String> {
 #[cfg(unix)]
 fn signal_unix_process_group(process_group: u32, signal: i32) -> Result<bool, String> {
     signal_unix_target(-(process_group as i32), signal)
+}
+
+#[cfg(unix)]
+fn signal_unix_process_group_for_cleanup(process_group: u32, signal: i32) -> Result<bool, String> {
+    match signal_unix_process_group(process_group, signal) {
+        Ok(signaled) => Ok(signaled),
+        Err(signal_error) => match unix_process_group_has_live_members(process_group) {
+            Ok(false) => Ok(false),
+            Ok(true) => Err(signal_error),
+            Err(verification_error) => Err(format!("{signal_error}; {verification_error}")),
+        },
+    }
 }
 
 #[cfg(unix)]

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -295,27 +295,35 @@ impl Cli {
                     .as_ref()
                     .ok_or_else(|| "source watch lease is missing".to_string())?,
             );
-            let restore_result =
-                if watch_takes_over_service && source_watch_allows_service_restore(&watch_result) {
-                    source_watch_lease
-                        .as_mut()
-                        .ok_or_else(|| "source watch lease is missing".to_string())?
-                        .begin_service_restore()?;
-                    self.stderr_lines(render_dev_run_step(
-                        "Restore",
-                        format!("Starting background service for {}", meta.name),
-                        stderr_profile,
-                    ));
-                    self.service_service().start(&meta.name).map(|_| {
-                        self.stdout_lines(render_dev_service_restored(
-                            &meta,
-                            &self.command_example(),
-                            self.dev_stdout_profile(),
+            let restore_result = if watch_takes_over_service
+                && source_watch_allows_service_restore(&watch_result)
+            {
+                let restore_state_result = source_watch_lease
+                    .as_mut()
+                    .ok_or_else(|| "source watch lease is missing".to_string())?
+                    .begin_service_restore();
+                match restore_state_result {
+                    Ok(()) => {
+                        self.stderr_lines(render_dev_run_step(
+                            "Restore",
+                            format!("Starting background service for {}", meta.name),
+                            stderr_profile,
                         ));
-                    })
-                } else {
-                    Ok(())
-                };
+                        self.service_service().start(&meta.name).map(|_| {
+                            self.stdout_lines(render_dev_service_restored(
+                                &meta,
+                                &self.command_example(),
+                                self.dev_stdout_profile(),
+                            ));
+                        })
+                    }
+                    Err(error) => Err(format!(
+                        "failed preparing background service restoration: {error}; the service remains stopped to preserve source-watch exclusivity"
+                    )),
+                }
+            } else {
+                Ok(())
+            };
             drop(source_watch_lease.take());
             return combine_watch_and_restore_results(watch_result, restore_result, &meta.name);
         }
@@ -431,28 +439,36 @@ impl Cli {
                 .ok_or_else(|| "source watch lease is missing".to_string())?,
         );
 
-        let restore_result =
-            if restore_service && source_watch_allows_service_restore(&watch_result) {
-                source_watch_lease
-                    .as_mut()
-                    .ok_or_else(|| "source watch lease is missing".to_string())?
-                    .begin_service_restore()?;
-                self.stderr_lines(render_dev_run_step(
-                    "Restore",
-                    format!("Starting background service for {}", meta.name),
-                    stderr_profile,
-                ));
-                self.service_service().start(&meta.name).map(|_| {
-                    self.stdout_lines(render_source_watch_service_restored(
-                        &meta,
-                        &repo_root,
-                        &self.command_example(),
-                        self.dev_stdout_profile(),
+        let restore_result = if restore_service
+            && source_watch_allows_service_restore(&watch_result)
+        {
+            let restore_state_result = source_watch_lease
+                .as_mut()
+                .ok_or_else(|| "source watch lease is missing".to_string())?
+                .begin_service_restore();
+            match restore_state_result {
+                Ok(()) => {
+                    self.stderr_lines(render_dev_run_step(
+                        "Restore",
+                        format!("Starting background service for {}", meta.name),
+                        stderr_profile,
                     ));
-                })
-            } else {
-                Ok(())
-            };
+                    self.service_service().start(&meta.name).map(|_| {
+                        self.stdout_lines(render_source_watch_service_restored(
+                            &meta,
+                            &repo_root,
+                            &self.command_example(),
+                            self.dev_stdout_profile(),
+                        ));
+                    })
+                }
+                Err(error) => Err(format!(
+                    "failed preparing background service restoration: {error}; the service remains stopped to preserve source-watch exclusivity"
+                )),
+            }
+        } else {
+            Ok(())
+        };
         drop(source_watch_lease.take());
 
         combine_watch_and_restore_results(watch_result, restore_result, &meta.name)
@@ -796,7 +812,10 @@ impl Cli {
         } else {
             command.args(&args);
         }
-        #[cfg(not(unix))]
+        #[cfg(windows)]
+        // watch-node never detaches runners on win32; the Job Object owns the full tree.
+        command.args(&args);
+        #[cfg(not(any(unix, windows)))]
         command.args(&args);
         command
             .stdin(Stdio::inherit())

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -1303,17 +1303,27 @@ impl SourceWatchProcessGuard {
     #[cfg(unix)]
     fn suspend_with_child(&self, child_pid: u32) -> Result<(), String> {
         self.restore_terminal()?;
-        if unsafe { libc::kill(libc::getpid(), libc::SIGSTOP) } == -1 {
-            return Err(format!(
-                "failed suspending OCM with source watch: {}",
-                io::Error::last_os_error()
-            ));
-        }
-        if let Some(terminal) = &self.terminal {
+        loop {
+            if unsafe { libc::kill(libc::getpid(), libc::SIGSTOP) } == -1 {
+                return Err(format!(
+                    "failed suspending OCM with source watch: {}",
+                    io::Error::last_os_error()
+                ));
+            }
+            let Some(terminal) = &self.terminal else {
+                break;
+            };
             let foreground_process_group = unsafe { libc::tcgetpgrp(libc::STDIN_FILENO) };
+            if foreground_process_group == -1 {
+                return Err(format!(
+                    "failed reading resumed source watch terminal ownership: {}",
+                    io::Error::last_os_error()
+                ));
+            }
             if foreground_process_group == terminal.parent_process_group {
                 set_terminal_foreground_process_group(child_pid as libc::pid_t)?;
                 terminal.foreground_assigned.store(true, Ordering::SeqCst);
+                break;
             }
         }
         signal_unix_process_group(child_pid, libc::SIGCONT)?;

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -765,6 +765,16 @@ impl Cli {
         let mut child = command
             .spawn()
             .map_err(|error| format!("failed to run \"node\": {error}"))?;
+        if let Err(error) = process_guard.assign_child(&child) {
+            #[cfg(windows)]
+            return Err(stop_suspended_source_watch_after_error(&mut child, error));
+            #[cfg(not(windows))]
+            return Err(stop_source_watch_after_error(
+                &mut child,
+                &process_guard,
+                error,
+            ));
+        }
         if let Err(error) = _source_watch_lease.attach_to_child(&child) {
             #[cfg(windows)]
             return Err(stop_suspended_source_watch_after_error(&mut child, error));
@@ -775,7 +785,7 @@ impl Cli {
                 error,
             ));
         }
-        if let Err(error) = process_guard.assign_and_start(&child) {
+        if let Err(error) = process_guard.start_child(&child) {
             #[cfg(windows)]
             return Err(stop_suspended_source_watch_after_error(&mut child, error));
             #[cfg(not(windows))]
@@ -1107,7 +1117,7 @@ impl SourceWatchProcessGuard {
         Ok(())
     }
 
-    fn assign_and_start(&self, child: &std::process::Child) -> Result<(), String> {
+    fn assign_child(&self, child: &std::process::Child) -> Result<(), String> {
         #[cfg(windows)]
         {
             let assigned = unsafe {
@@ -1122,8 +1132,15 @@ impl SourceWatchProcessGuard {
                     io::Error::last_os_error()
                 ));
             }
-            resume_windows_process(child.id())?;
         }
+        #[cfg(not(windows))]
+        let _ = child;
+        Ok(())
+    }
+
+    fn start_child(&self, child: &std::process::Child) -> Result<(), String> {
+        #[cfg(windows)]
+        resume_windows_process(child.id())?;
         #[cfg(not(windows))]
         let _ = child;
         Ok(())

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -929,13 +929,23 @@ fn wait_for_source_watch_child(
     let mut tracked_processes = Vec::new();
     #[cfg(unix)]
     let track_descendants = source_watch_needs_descendant_tracking();
+    #[cfg(unix)]
+    let tracking_started = std::time::Instant::now();
+    #[cfg(unix)]
+    let mut next_tracking_refresh = tracking_started;
     loop {
         #[cfg(unix)]
-        if track_descendants {
-            merge_unix_processes(
-                &mut tracked_processes,
-                unix_descendant_processes(child.id()).map_err(source_watch_tree_discovery_error)?,
-            );
+        if track_descendants && std::time::Instant::now() >= next_tracking_refresh {
+            // Non-TTY watch-node runners detach into their own process group. Sample quickly
+            // during startup, then throttle native process snapshots for long-running watches.
+            tracked_processes = refresh_tracked_unix_processes(child.id(), &tracked_processes)
+                .map_err(source_watch_tree_discovery_error)?;
+            let refresh_interval = if tracking_started.elapsed() < Duration::from_secs(2) {
+                Duration::from_millis(50)
+            } else {
+                Duration::from_secs(2)
+            };
+            next_tracking_refresh = std::time::Instant::now() + refresh_interval;
         }
         if let Some(status) = child
             .try_wait()
@@ -1103,7 +1113,7 @@ impl Drop for SourceWatchProcessGuard {
 fn stop_source_watch_child(
     child: &mut std::process::Child,
     process_guard: &SourceWatchProcessGuard,
-    tracked_processes: &[(u32, u32)],
+    tracked_processes: &[UnixProcessIdentity],
 ) -> Result<std::process::ExitStatus, String> {
     #[cfg(not(windows))]
     let _ = process_guard;
@@ -1112,10 +1122,8 @@ fn stop_source_watch_child(
         let mut tracked_processes = tracked_processes.to_vec();
         let track_descendants = source_watch_needs_descendant_tracking();
         if track_descendants {
-            merge_unix_processes(
-                &mut tracked_processes,
-                unix_descendant_processes(child.id()).map_err(source_watch_tree_discovery_error)?,
-            );
+            tracked_processes = refresh_tracked_unix_processes(child.id(), &tracked_processes)
+                .map_err(source_watch_tree_discovery_error)?;
         }
         // watch-node forwards TERM to its runner; allow that grace before
         // enforcing the process-group ownership boundary.
@@ -1130,23 +1138,19 @@ fn stop_source_watch_child(
                     return Ok(status);
                 }
                 if track_descendants {
-                    merge_unix_processes(
-                        &mut tracked_processes,
-                        unix_descendant_processes(child.id())
-                            .map_err(source_watch_tree_discovery_error)?,
-                    );
+                    tracked_processes =
+                        refresh_tracked_unix_processes(child.id(), &tracked_processes)
+                            .map_err(source_watch_tree_discovery_error)?;
                 }
                 thread::sleep(Duration::from_millis(50));
             }
         }
         signal_unix_process_group(child.id(), libc::SIGSTOP)?;
         if track_descendants {
-            merge_unix_processes(
-                &mut tracked_processes,
-                unix_descendant_processes(child.id()).map_err(source_watch_tree_discovery_error)?,
-            );
+            tracked_processes = refresh_tracked_unix_processes(child.id(), &tracked_processes)
+                .map_err(source_watch_tree_discovery_error)?;
         }
-        kill_tracked_unix_processes(child.id(), &tracked_processes)?;
+        kill_tracked_unix_processes(child.id(), true, &tracked_processes)?;
         let status = child
             .wait()
             .map_err(|error| format!("failed waiting for stopped source watch: {error}"))?;
@@ -1174,26 +1178,61 @@ fn stop_source_watch_child(
 }
 
 #[cfg(unix)]
-fn unix_descendant_processes(root_pid: u32) -> Result<Vec<(u32, u32)>, String> {
-    let processes = unix_process_snapshot()?;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct UnixProcessIdentity {
+    pid: u32,
+    parent_pid: u32,
+    process_group: u32,
+    start_id: u64,
+}
+
+#[cfg(not(unix))]
+type UnixProcessIdentity = ();
+
+#[cfg(unix)]
+fn refresh_tracked_unix_processes(
+    root_pid: u32,
+    tracked_processes: &[UnixProcessIdentity],
+) -> Result<Vec<UnixProcessIdentity>, String> {
+    let snapshot = unix_process_snapshot()?;
+    let tracked_identities = tracked_processes
+        .iter()
+        .map(|process| (process.pid, process.start_id))
+        .collect::<BTreeSet<_>>();
+    let descendants = unix_descendant_processes_from_snapshot(root_pid, snapshot.clone())
+        .into_iter()
+        .map(|process| (process.pid, process.start_id))
+        .collect::<BTreeSet<_>>();
+    Ok(snapshot
+        .into_iter()
+        .filter(|process| {
+            let identity = (process.pid, process.start_id);
+            descendants.contains(&identity) || tracked_identities.contains(&identity)
+        })
+        .collect())
+}
+
+#[cfg(unix)]
+fn unix_descendant_processes_from_snapshot(
+    root_pid: u32,
+    processes: Vec<UnixProcessIdentity>,
+) -> Vec<UnixProcessIdentity> {
     let mut tree = BTreeSet::from([root_pid]);
     loop {
         let before = tree.len();
-        for (pid, parent_pid, _) in &processes {
-            if tree.contains(parent_pid) {
-                tree.insert(*pid);
+        for process in &processes {
+            if tree.contains(&process.parent_pid) {
+                tree.insert(process.pid);
             }
         }
         if tree.len() == before {
             break;
         }
     }
-    Ok(processes
+    processes
         .into_iter()
-        .filter_map(|(pid, _, process_group)| {
-            (pid != root_pid && tree.contains(&pid)).then_some((pid, process_group))
-        })
-        .collect())
+        .filter(|process| process.pid != root_pid && tree.contains(&process.pid))
+        .collect()
 }
 
 #[cfg(unix)]
@@ -1202,7 +1241,7 @@ fn source_watch_needs_descendant_tracking() -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn unix_process_snapshot() -> Result<Vec<(u32, u32, u32)>, String> {
+fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
     let mut processes = Vec::new();
     for entry in fs::read_dir("/proc")
         .map_err(|error| format!("failed reading /proc for source watch processes: {error}"))?
@@ -1223,21 +1262,28 @@ fn unix_process_snapshot() -> Result<Vec<(u32, u32, u32)>, String> {
         let Some((_, fields)) = stat.rsplit_once(") ") else {
             continue;
         };
-        let mut fields = fields.split_whitespace();
-        let _state = fields.next();
-        let Some(parent_pid) = fields.next().and_then(|value| value.parse::<u32>().ok()) else {
+        let fields = fields.split_whitespace().collect::<Vec<_>>();
+        let Some(parent_pid) = fields.get(1).and_then(|value| value.parse::<u32>().ok()) else {
             continue;
         };
-        let Some(process_group) = fields.next().and_then(|value| value.parse::<u32>().ok()) else {
+        let Some(process_group) = fields.get(2).and_then(|value| value.parse::<u32>().ok()) else {
             continue;
         };
-        processes.push((pid, parent_pid, process_group));
+        let Some(start_id) = fields.get(19).and_then(|value| value.parse::<u64>().ok()) else {
+            continue;
+        };
+        processes.push(UnixProcessIdentity {
+            pid,
+            parent_pid,
+            process_group,
+            start_id,
+        });
     }
     Ok(processes)
 }
 
 #[cfg(target_os = "macos")]
-fn unix_process_snapshot() -> Result<Vec<(u32, u32, u32)>, String> {
+fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
     let capacity = unsafe { libc::proc_listallpids(std::ptr::null_mut(), 0) };
     if capacity <= 0 {
         return Err(format!(
@@ -1271,62 +1317,90 @@ fn unix_process_snapshot() -> Result<Vec<(u32, u32, u32)>, String> {
             )
         };
         if read == std::mem::size_of_val(&info) as i32 {
-            processes.push((info.pbi_pid, info.pbi_ppid, info.pbi_pgid));
+            processes.push(UnixProcessIdentity {
+                pid: info.pbi_pid,
+                parent_pid: info.pbi_ppid,
+                process_group: info.pbi_pgid,
+                start_id: ((info.pbi_start_tvsec as u64) << 32) | info.pbi_start_tvusec as u64,
+            });
         }
     }
     Ok(processes)
 }
 
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-fn unix_process_snapshot() -> Result<Vec<(u32, u32, u32)>, String> {
+fn unix_process_snapshot() -> Result<Vec<UnixProcessIdentity>, String> {
     Err("source watch process discovery is unsupported on this Unix platform".to_string())
 }
 
 #[cfg(unix)]
-fn merge_unix_processes(target: &mut Vec<(u32, u32)>, processes: Vec<(u32, u32)>) {
-    for process in processes {
-        if !target.contains(&process) {
-            target.push(process);
-        }
-    }
+fn current_tracked_unix_processes(
+    tracked_processes: &[UnixProcessIdentity],
+) -> Result<Vec<UnixProcessIdentity>, String> {
+    Ok(tracked_unix_processes_from_snapshot(
+        tracked_processes,
+        unix_process_snapshot()?,
+    ))
 }
 
 #[cfg(unix)]
-fn kill_tracked_unix_processes(root_pid: u32, processes: &[(u32, u32)]) -> Result<(), String> {
-    let mut process_groups = processes
+fn tracked_unix_processes_from_snapshot(
+    tracked_processes: &[UnixProcessIdentity],
+    snapshot: Vec<UnixProcessIdentity>,
+) -> Vec<UnixProcessIdentity> {
+    let tracked_identities = tracked_processes
         .iter()
-        .map(|(_, process_group)| *process_group)
+        .map(|process| (process.pid, process.start_id))
         .collect::<BTreeSet<_>>();
+    snapshot
+        .into_iter()
+        .filter(|current| tracked_identities.contains(&(current.pid, current.start_id)))
+        .collect()
+}
+
+#[cfg(unix)]
+fn kill_tracked_unix_processes(
+    root_pid: u32,
+    root_is_alive: bool,
+    tracked_processes: &[UnixProcessIdentity],
+) -> Result<(), String> {
+    let current_processes = current_tracked_unix_processes(tracked_processes)?;
+    let mut process_groups = current_processes
+        .iter()
+        .map(|process| process.process_group)
+        .collect::<BTreeSet<_>>();
+    // configure_child creates this group before exec. It remains our ownership boundary
+    // after the wrapper exits, including descendants that escaped the first snapshot.
     process_groups.insert(root_pid);
     for process_group in process_groups {
         let _ = signal_unix_process_group(process_group, libc::SIGKILL)?;
     }
-    for (pid, _) in processes {
-        let _ = signal_unix_process(*pid, libc::SIGKILL)?;
+    for process in current_processes {
+        let _ = signal_unix_process(process.pid, libc::SIGKILL)?;
     }
-    let _ = signal_unix_process(root_pid, libc::SIGKILL)?;
+    if root_is_alive {
+        let _ = signal_unix_process(root_pid, libc::SIGKILL)?;
+    }
     Ok(())
 }
 
 #[cfg(unix)]
-fn stop_tracked_unix_processes(root_pid: u32, processes: &[(u32, u32)]) -> Result<(), String> {
-    kill_tracked_unix_processes(root_pid, processes)?;
+fn stop_tracked_unix_processes(
+    root_pid: u32,
+    processes: &[UnixProcessIdentity],
+) -> Result<(), String> {
+    kill_tracked_unix_processes(root_pid, false, processes)?;
     wait_for_unix_processes_to_stop(processes)
 }
 
 #[cfg(unix)]
-fn wait_for_unix_processes_to_stop(processes: &[(u32, u32)]) -> Result<(), String> {
+fn wait_for_unix_processes_to_stop(processes: &[UnixProcessIdentity]) -> Result<(), String> {
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
     loop {
-        let alive = processes
+        let alive = current_tracked_unix_processes(processes)?
             .iter()
-            .map(|(pid, _)| *pid)
-            .filter_map(|pid| match unix_process_is_alive(pid) {
-                Ok(true) => Some(Ok(pid)),
-                Ok(false) => None,
-                Err(error) => Some(Err(error)),
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|process| process.pid)
+            .collect::<Vec<_>>();
         if alive.is_empty() {
             return Ok(());
         }
@@ -1352,11 +1426,6 @@ fn signal_unix_process(pid: u32, signal: i32) -> Result<bool, String> {
 #[cfg(unix)]
 fn signal_unix_process_group(process_group: u32, signal: i32) -> Result<bool, String> {
     signal_unix_target(-(process_group as i32), signal)
-}
-
-#[cfg(unix)]
-fn unix_process_is_alive(pid: u32) -> Result<bool, String> {
-    signal_unix_process(pid, 0)
 }
 
 #[cfg(unix)]
@@ -2142,6 +2211,8 @@ mod tests {
         source_watch_allows_service_restore, source_watch_exit_code,
         source_watch_stop_timeout_error,
     };
+    #[cfg(unix)]
+    use super::{UnixProcessIdentity, tracked_unix_processes_from_snapshot};
     use crate::service::ServiceActionSummary;
 
     fn sample_summary() -> DevStatusSummary {
@@ -2244,5 +2315,26 @@ mod tests {
         assert!(!source_watch_allows_service_restore(&Err(
             "source watch process tree is still active: 123".to_string()
         )));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_watch_tracking_rejects_reused_process_ids() {
+        let tracked = UnixProcessIdentity {
+            pid: 42,
+            parent_pid: 10,
+            process_group: 42,
+            start_id: 100,
+        };
+        let reused = UnixProcessIdentity {
+            start_id: 101,
+            ..tracked
+        };
+
+        assert!(tracked_unix_processes_from_snapshot(&[tracked], vec![reused]).is_empty());
+        assert_eq!(
+            tracked_unix_processes_from_snapshot(&[tracked], vec![tracked]),
+            vec![tracked]
+        );
     }
 }

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -8,13 +8,14 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::Cli;
 use super::render::RenderProfile;
-use crate::env::{CreateEnvironmentOptions, CreateSourceWatchOverrideOptions, EnvDevMeta, EnvMeta};
+use crate::env::{CreateEnvironmentOptions, EnvDevMeta, EnvMeta, SourceWatchLease};
 use crate::infra::process::run_direct;
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::infra::terminal::{Cell, KeyValueRow, Tone, paint, render_key_value_card, render_table};
@@ -162,6 +163,14 @@ impl Cli {
                 meta.name
             ));
         }
+        let source_watch_lease = if watch {
+            Some(
+                self.environment_service()
+                    .acquire_source_watch_lease(&meta.name)?,
+            )
+        } else {
+            None
+        };
         self.stderr_lines(render_dev_run_summary(
             &meta,
             created,
@@ -222,7 +231,7 @@ impl Cli {
                     ),
                     stderr_profile,
                 ));
-                self.service_service().stop(&meta.name)?;
+                self.stop_service_for_source_watch(&meta.name)?;
             }
             self.stderr_lines(render_dev_run_step(
                 "Watch",
@@ -233,21 +242,29 @@ impl Cli {
                 ),
                 stderr_profile,
             ));
-            let watch_result = self.run_dev_gateway_watch(&meta);
-            if watch_takes_over_service {
+            let watch_result = self.run_dev_gateway_watch(
+                &meta,
+                source_watch_lease
+                    .as_ref()
+                    .ok_or_else(|| "source watch lease is missing".to_string())?,
+            );
+            let restore_result = if watch_takes_over_service {
                 self.stderr_lines(render_dev_run_step(
                     "Restore",
                     format!("Starting background service for {}", meta.name),
                     stderr_profile,
                 ));
-                self.service_service().start(&meta.name)?;
-                self.stdout_lines(render_dev_service_restored(
-                    &meta,
-                    &self.command_example(),
-                    self.dev_stdout_profile(),
-                ));
-            }
-            return watch_result;
+                self.service_service().start(&meta.name).map(|_| {
+                    self.stdout_lines(render_dev_service_restored(
+                        &meta,
+                        &self.command_example(),
+                        self.dev_stdout_profile(),
+                    ));
+                })
+            } else {
+                Ok(())
+            };
+            return combine_watch_and_restore_results(watch_result, restore_result, &meta.name);
         }
 
         self.stderr_lines(render_dev_run_step(
@@ -307,6 +324,9 @@ impl Cli {
         let meta = self
             .environment_service()
             .apply_effective_gateway_port(existing)?;
+        let source_watch_lease = self
+            .environment_service()
+            .acquire_source_watch_lease(&meta.name)?;
         let stderr_profile = self.dev_stderr_profile();
         self.stderr_lines(render_source_watch_takeover_summary(
             &meta,
@@ -329,7 +349,7 @@ impl Cli {
                 ),
                 stderr_profile,
             ));
-            self.service_service().stop(&meta.name)?;
+            self.stop_service_for_source_watch(&meta.name)?;
         }
 
         self.stderr_lines(render_dev_run_step(
@@ -342,24 +362,46 @@ impl Cli {
             ),
             stderr_profile,
         ));
-        let watch_result = self.run_source_gateway_watch(&meta, &repo_root, true);
+        let watch_result =
+            self.run_source_gateway_watch(&meta, &repo_root, true, &source_watch_lease);
 
-        if restore_service {
+        let restore_result = if restore_service {
             self.stderr_lines(render_dev_run_step(
                 "Restore",
                 format!("Starting background service for {}", meta.name),
                 stderr_profile,
             ));
-            self.service_service().start(&meta.name)?;
-            self.stdout_lines(render_source_watch_service_restored(
-                &meta,
-                &repo_root,
-                &self.command_example(),
-                self.dev_stdout_profile(),
-            ));
-        }
+            self.service_service().start(&meta.name).map(|_| {
+                self.stdout_lines(render_source_watch_service_restored(
+                    &meta,
+                    &repo_root,
+                    &self.command_example(),
+                    self.dev_stdout_profile(),
+                ));
+            })
+        } else {
+            Ok(())
+        };
 
-        watch_result
+        combine_watch_and_restore_results(watch_result, restore_result, &meta.name)
+    }
+
+    fn stop_service_for_source_watch(&self, env_name: &str) -> Result<(), String> {
+        let stop_result = self.service_service().stop(env_name);
+        let stop_error = match stop_result {
+            Ok(summary) if !summary.running => return Ok(()),
+            Ok(summary) => source_watch_stop_timeout_error(&summary),
+            Err(error) => format!("failed stopping background service for {env_name}: {error}"),
+        };
+
+        match self.service_service().start(env_name) {
+            Ok(_) => Err(format!(
+                "{stop_error}; restored the background service policy and did not start source watch"
+            )),
+            Err(restore_error) => Err(format!(
+                "{stop_error}; also failed restoring the background service policy: {restore_error}"
+            )),
+        }
     }
 
     fn ensure_dev_env(
@@ -616,12 +658,21 @@ impl Cli {
         )
     }
 
-    fn run_dev_gateway_watch(&self, meta: &EnvMeta) -> Result<i32, String> {
+    fn run_dev_gateway_watch(
+        &self,
+        meta: &EnvMeta,
+        source_watch_lease: &SourceWatchLease,
+    ) -> Result<i32, String> {
         let dev = meta
             .dev
             .as_ref()
             .ok_or_else(|| format!("environment \"{}\" is missing its dev binding", meta.name))?;
-        self.run_source_gateway_watch(meta, Path::new(&dev.worktree_root), false)
+        self.run_source_gateway_watch(
+            meta,
+            Path::new(&dev.worktree_root),
+            false,
+            source_watch_lease,
+        )
     }
 
     fn run_source_gateway_watch(
@@ -629,6 +680,7 @@ impl Cli {
         meta: &EnvMeta,
         repo_root: &Path,
         tee_to_env_logs: bool,
+        source_watch_lease: &SourceWatchLease,
     ) -> Result<i32, String> {
         let args = vec![
             "scripts/watch-node.mjs".to_string(),
@@ -668,11 +720,9 @@ impl Cli {
             .spawn()
             .map_err(|error| format!("failed to run \"node\": {error}"))?;
         let source_watch = match self.environment_service().create_source_watch_override(
-            CreateSourceWatchOverrideOptions {
-                env_name: meta.name.clone(),
-                repo_root: repo_root.to_path_buf(),
-                watch_pid: child.id(),
-            },
+            source_watch_lease,
+            repo_root,
+            child.id(),
         ) {
             Ok(source_watch) => source_watch,
             Err(error) => {
@@ -683,14 +733,22 @@ impl Cli {
         };
         let mut tee_threads = Vec::new();
         if let Some(log_files) = log_files.take() {
-            let stdout = child
-                .stdout
-                .take()
-                .ok_or_else(|| "failed to capture source watch stdout".to_string())?;
-            let stderr = child
-                .stderr
-                .take()
-                .ok_or_else(|| "failed to capture source watch stderr".to_string())?;
+            let Some(stdout) = child.stdout.take() else {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = self
+                    .environment_service()
+                    .clear_source_watch_override(&meta.name, &source_watch.token);
+                return Err("failed to capture source watch stdout".to_string());
+            };
+            let Some(stderr) = child.stderr.take() else {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = self
+                    .environment_service()
+                    .clear_source_watch_override(&meta.name, &source_watch.token);
+                return Err("failed to capture source watch stderr".to_string());
+            };
             tee_threads.push(spawn_tee_thread(
                 stdout,
                 io::stdout(),
@@ -705,18 +763,19 @@ impl Cli {
             ));
         }
 
-        let status_result = child
-            .wait()
-            .map_err(|error| format!("failed waiting for source watch: {error}"));
+        let status_result =
+            wait_for_source_watch_child(&mut child, &stop_requested).map_err(|error| {
+                let _ = child.kill();
+                let _ = child.wait();
+                error
+            });
         let tee_result = wait_for_tee_threads(tee_threads);
         let clear_result = self
             .environment_service()
-            .clear_source_watch_override(&meta.name, &source_watch.token);
+            .clear_source_watch_override(&meta.name, &source_watch.token)
+            .map(|_| ());
 
-        let status = status_result?;
-        tee_result?;
-        clear_result?;
-
+        let status = combine_source_watch_cleanup_results(status_result, tee_result, clear_result)?;
         Ok(match status.code() {
             Some(code) => code,
             None if stop_requested.load(Ordering::SeqCst) => 130,
@@ -747,6 +806,84 @@ impl Cli {
             logs_command: format!("{} logs {} --follow", self.command_example(), env_name),
             status_command: format!("{} service status {}", self.command_example(), env_name),
         }))
+    }
+}
+
+fn source_watch_stop_timeout_error(summary: &crate::service::ServiceActionSummary) -> String {
+    let warnings = if summary.warnings.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", summary.warnings.join("; "))
+    };
+    format!(
+        "background service for {} is still running after the stop request{warnings}",
+        summary.env_name
+    )
+}
+
+fn combine_watch_and_restore_results(
+    watch_result: Result<i32, String>,
+    restore_result: Result<(), String>,
+    env_name: &str,
+) -> Result<i32, String> {
+    match (watch_result, restore_result) {
+        (Ok(code), Ok(())) => Ok(code),
+        (Err(watch_error), Ok(())) => Err(watch_error),
+        (Ok(_), Err(restore_error)) => Err(format!(
+            "source watch ended, but failed restoring background service for {env_name}: {restore_error}"
+        )),
+        (Err(watch_error), Err(restore_error)) => Err(format!(
+            "{watch_error}; also failed restoring background service for {env_name}: {restore_error}"
+        )),
+    }
+}
+
+fn combine_source_watch_cleanup_results(
+    status_result: Result<std::process::ExitStatus, String>,
+    tee_result: Result<(), String>,
+    clear_result: Result<(), String>,
+) -> Result<std::process::ExitStatus, String> {
+    let mut errors = Vec::new();
+    let status = match status_result {
+        Ok(status) => Some(status),
+        Err(error) => {
+            errors.push(error);
+            None
+        }
+    };
+    if let Err(error) = tee_result {
+        errors.push(error);
+    }
+    if let Err(error) = clear_result {
+        errors.push(error);
+    }
+    if errors.is_empty() {
+        status.ok_or_else(|| "source watch ended without an exit status".to_string())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
+fn wait_for_source_watch_child(
+    child: &mut std::process::Child,
+    stop_requested: &AtomicBool,
+) -> Result<std::process::ExitStatus, String> {
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("failed waiting for source watch: {error}"))?
+        {
+            return Ok(status);
+        }
+        if stop_requested.load(Ordering::SeqCst) {
+            child
+                .kill()
+                .map_err(|error| format!("failed stopping source watch: {error}"))?;
+            return child
+                .wait()
+                .map_err(|error| format!("failed waiting for stopped source watch: {error}"));
+        }
+        thread::sleep(Duration::from_millis(50));
     }
 }
 
@@ -1401,7 +1538,11 @@ fn render_dev_status_list(summaries: &[DevStatusSummary], profile: RenderProfile
 
 #[cfg(test)]
 mod tests {
-    use super::{DevStatusSummary, RenderProfile, render_dev_status};
+    use super::{
+        DevStatusSummary, RenderProfile, combine_watch_and_restore_results, render_dev_status,
+        source_watch_stop_timeout_error,
+    };
+    use crate::service::ServiceActionSummary;
 
     fn sample_summary() -> DevStatusSummary {
         DevStatusSummary {
@@ -1444,5 +1585,46 @@ mod tests {
                 .any(|line| line.contains("/tmp/demo/.openclaw/workspace"))
         );
         assert!(!lines.iter().any(|line| line.contains("Service enabled")));
+    }
+
+    #[test]
+    fn source_watch_stop_timeout_preserves_service_diagnostics() {
+        let summary = ServiceActionSummary {
+            env_name: "demo".to_string(),
+            service_kind: "supervisor".to_string(),
+            action: "stop".to_string(),
+            installed: true,
+            loaded: true,
+            running: true,
+            desired_running: false,
+            gateway_port: 18789,
+            binding_kind: Some("runtime".to_string()),
+            binding_name: Some("stable".to_string()),
+            stdout_path: None,
+            stderr_path: None,
+            warnings: vec!["gateway is still shutting down".to_string()],
+        };
+
+        assert_eq!(
+            source_watch_stop_timeout_error(&summary),
+            "background service for demo is still running after the stop request (gateway is still shutting down)"
+        );
+    }
+
+    #[test]
+    fn source_watch_reports_watch_and_restore_failures_together() {
+        let result = combine_watch_and_restore_results(
+            Err("watch failed".to_string()),
+            Err("restore failed".to_string()),
+            "demo",
+        );
+
+        assert_eq!(
+            result,
+            Err(
+                "watch failed; also failed restoring background service for demo: restore failed"
+                    .to_string()
+            )
+        );
     }
 }

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -203,7 +203,7 @@ impl Cli {
                 meta.name
             ));
         }
-        let source_watch_lease = if watch {
+        let mut source_watch_lease = if watch {
             Some(
                 self.environment_service()
                     .acquire_source_watch_lease(&meta.name)?,
@@ -271,7 +271,12 @@ impl Cli {
                     ),
                     stderr_profile,
                 ));
-                self.stop_service_for_source_watch(&meta.name, meta.service_running)?;
+                if let Err(stop_error) = self.stop_service_for_source_watch(&meta.name) {
+                    drop(source_watch_lease.take());
+                    return Err(
+                        self.restore_service_policy_after_failed_takeover(&meta.name, stop_error)
+                    );
+                }
             }
             self.stderr_lines(render_dev_run_step(
                 "Watch",
@@ -288,6 +293,7 @@ impl Cli {
                     .as_ref()
                     .ok_or_else(|| "source watch lease is missing".to_string())?,
             );
+            drop(source_watch_lease.take());
             let restore_result =
                 if watch_takes_over_service && source_watch_allows_service_restore(&watch_result) {
                     self.stderr_lines(render_dev_run_step(
@@ -365,9 +371,10 @@ impl Cli {
         let meta = self
             .environment_service()
             .apply_effective_gateway_port(existing)?;
-        let source_watch_lease = self
-            .environment_service()
-            .acquire_source_watch_lease(&meta.name)?;
+        let mut source_watch_lease = Some(
+            self.environment_service()
+                .acquire_source_watch_lease(&meta.name)?,
+        );
         let stderr_profile = self.dev_stderr_profile();
         self.stderr_lines(render_source_watch_takeover_summary(
             &meta,
@@ -390,7 +397,12 @@ impl Cli {
                 ),
                 stderr_profile,
             ));
-            self.stop_service_for_source_watch(&meta.name, meta.service_running)?;
+            if let Err(stop_error) = self.stop_service_for_source_watch(&meta.name) {
+                drop(source_watch_lease.take());
+                return Err(
+                    self.restore_service_policy_after_failed_takeover(&meta.name, stop_error)
+                );
+            }
         }
 
         self.stderr_lines(render_dev_run_step(
@@ -403,8 +415,15 @@ impl Cli {
             ),
             stderr_profile,
         ));
-        let watch_result =
-            self.run_source_gateway_watch(&meta, &repo_root, true, &source_watch_lease);
+        let watch_result = self.run_source_gateway_watch(
+            &meta,
+            &repo_root,
+            true,
+            source_watch_lease
+                .as_ref()
+                .ok_or_else(|| "source watch lease is missing".to_string())?,
+        );
+        drop(source_watch_lease.take());
 
         let restore_result =
             if restore_service && source_watch_allows_service_restore(&watch_result) {
@@ -428,28 +447,29 @@ impl Cli {
         combine_watch_and_restore_results(watch_result, restore_result, &meta.name)
     }
 
-    fn stop_service_for_source_watch(
+    fn stop_service_for_source_watch(&self, env_name: &str) -> Result<(), String> {
+        let stop_result = self.service_service().stop(env_name);
+        match stop_result {
+            Ok(summary) if !summary.running => return Ok(()),
+            Ok(summary) => Err(source_watch_stop_timeout_error(&summary)),
+            Err(error) => Err(format!(
+                "failed stopping background service for {env_name}: {error}"
+            )),
+        }
+    }
+
+    fn restore_service_policy_after_failed_takeover(
         &self,
         env_name: &str,
-        restore_running_policy: bool,
-    ) -> Result<(), String> {
-        let stop_result = self.service_service().stop(env_name);
-        let stop_error = match stop_result {
-            Ok(summary) if !summary.running => return Ok(()),
-            Ok(summary) => source_watch_stop_timeout_error(&summary),
-            Err(error) => format!("failed stopping background service for {env_name}: {error}"),
-        };
-
-        if !restore_running_policy {
-            return Err(stop_error);
-        }
+        stop_error: String,
+    ) -> String {
         match self.service_service().start(env_name) {
-            Ok(_) => Err(format!(
+            Ok(_) => format!(
                 "{stop_error}; restored the background service policy and did not start source watch"
-            )),
-            Err(restore_error) => Err(format!(
+            ),
+            Err(restore_error) => format!(
                 "{stop_error}; also failed restoring the background service policy: {restore_error}"
-            )),
+            ),
         }
     }
 

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -10,6 +10,9 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -32,6 +35,7 @@ use crate::store::{
 };
 
 const DEV_PREFERENCES_KIND: &str = "ocm-dev-preferences";
+const SOURCE_WATCH_TREE_ACTIVE_ERROR: &str = "source watch process tree is still active";
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -251,22 +255,23 @@ impl Cli {
                     .as_ref()
                     .ok_or_else(|| "source watch lease is missing".to_string())?,
             );
-            let restore_result = if watch_takes_over_service {
-                self.stderr_lines(render_dev_run_step(
-                    "Restore",
-                    format!("Starting background service for {}", meta.name),
-                    stderr_profile,
-                ));
-                self.service_service().start(&meta.name).map(|_| {
-                    self.stdout_lines(render_dev_service_restored(
-                        &meta,
-                        &self.command_example(),
-                        self.dev_stdout_profile(),
+            let restore_result =
+                if watch_takes_over_service && source_watch_allows_service_restore(&watch_result) {
+                    self.stderr_lines(render_dev_run_step(
+                        "Restore",
+                        format!("Starting background service for {}", meta.name),
+                        stderr_profile,
                     ));
-                })
-            } else {
-                Ok(())
-            };
+                    self.service_service().start(&meta.name).map(|_| {
+                        self.stdout_lines(render_dev_service_restored(
+                            &meta,
+                            &self.command_example(),
+                            self.dev_stdout_profile(),
+                        ));
+                    })
+                } else {
+                    Ok(())
+                };
             return combine_watch_and_restore_results(watch_result, restore_result, &meta.name);
         }
 
@@ -368,23 +373,24 @@ impl Cli {
         let watch_result =
             self.run_source_gateway_watch(&meta, &repo_root, true, &source_watch_lease);
 
-        let restore_result = if restore_service {
-            self.stderr_lines(render_dev_run_step(
-                "Restore",
-                format!("Starting background service for {}", meta.name),
-                stderr_profile,
-            ));
-            self.service_service().start(&meta.name).map(|_| {
-                self.stdout_lines(render_source_watch_service_restored(
-                    &meta,
-                    &repo_root,
-                    &self.command_example(),
-                    self.dev_stdout_profile(),
+        let restore_result =
+            if restore_service && source_watch_allows_service_restore(&watch_result) {
+                self.stderr_lines(render_dev_run_step(
+                    "Restore",
+                    format!("Starting background service for {}", meta.name),
+                    stderr_profile,
                 ));
-            })
-        } else {
-            Ok(())
-        };
+                self.service_service().start(&meta.name).map(|_| {
+                    self.stdout_lines(render_source_watch_service_restored(
+                        &meta,
+                        &repo_root,
+                        &self.command_example(),
+                        self.dev_stdout_profile(),
+                    ));
+                })
+            } else {
+                Ok(())
+            };
 
         combine_watch_and_restore_results(watch_result, restore_result, &meta.name)
     }
@@ -713,6 +719,7 @@ impl Cli {
             .env_clear()
             .envs(build_openclaw_dev_source_env(meta, &self.env, repo_root))
             .current_dir(repo_root);
+        _source_watch_lease.configure_child(&mut command);
 
         let mut log_files = if tee_to_env_logs {
             Some(open_source_watch_log_files(meta)?)
@@ -726,9 +733,14 @@ impl Cli {
             command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
         }
 
+        let process_guard = SourceWatchProcessGuard::new()?;
         let mut child = command
             .spawn()
             .map_err(|error| format!("failed to run \"node\": {error}"))?;
+        if let Err(error) = process_guard.assign(&child) {
+            let _ = stop_source_watch_child(&mut child);
+            return Err(error);
+        }
         let source_watch = match self
             .environment_service()
             .create_source_watch_override_with_lease(
@@ -787,11 +799,10 @@ impl Cli {
             .map(|_| ());
 
         let status = combine_source_watch_cleanup_results(status_result, tee_result, clear_result)?;
-        Ok(match status.code() {
-            Some(code) => code,
-            None if stop_requested.load(Ordering::SeqCst) => 130,
-            None => 1,
-        })
+        Ok(source_watch_exit_code(
+            status.code(),
+            stop_requested.load(Ordering::SeqCst),
+        ))
     }
 
     fn build_dev_status_summary(&self, meta: EnvMeta) -> Result<Option<DevStatusSummary>, String> {
@@ -893,11 +904,92 @@ fn wait_for_source_watch_child(
     }
 }
 
+struct SourceWatchProcessGuard {
+    #[cfg(windows)]
+    job: windows_sys::Win32::Foundation::HANDLE,
+}
+
+impl SourceWatchProcessGuard {
+    fn new() -> Result<Self, String> {
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::System::JobObjects::{
+                CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+                SetInformationJobObject,
+            };
+
+            let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+            if job.is_null() {
+                return Err(format!(
+                    "failed creating source watch process job: {}",
+                    io::Error::last_os_error()
+                ));
+            }
+            let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            let configured = unsafe {
+                SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    std::ptr::from_ref(&info).cast(),
+                    std::mem::size_of_val(&info) as u32,
+                )
+            };
+            if configured == 0 {
+                unsafe {
+                    windows_sys::Win32::Foundation::CloseHandle(job);
+                }
+                return Err(format!(
+                    "failed configuring source watch process job: {}",
+                    io::Error::last_os_error()
+                ));
+            }
+            Ok(Self { job })
+        }
+        #[cfg(not(windows))]
+        {
+            Ok(Self {})
+        }
+    }
+
+    fn assign(&self, child: &std::process::Child) -> Result<(), String> {
+        #[cfg(windows)]
+        {
+            let assigned = unsafe {
+                windows_sys::Win32::System::JobObjects::AssignProcessToJobObject(
+                    self.job,
+                    child.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE,
+                )
+            };
+            if assigned == 0 {
+                return Err(format!(
+                    "failed assigning source watch to process job: {}",
+                    io::Error::last_os_error()
+                ));
+            }
+        }
+        #[cfg(not(windows))]
+        let _ = child;
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for SourceWatchProcessGuard {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.job);
+        }
+    }
+}
+
 fn stop_source_watch_child(
     child: &mut std::process::Child,
 ) -> Result<std::process::ExitStatus, String> {
     #[cfg(unix)]
     {
+        let tracked_processes = unix_descendant_processes(child.id()).unwrap_or_default();
         let pid = child.id().to_string();
         // OpenClaw's watch-node handler forwards TERM to its detached gateway
         // process group; allow its shutdown grace before forcing the wrapper down.
@@ -914,19 +1006,218 @@ fn stop_source_watch_child(
                     .try_wait()
                     .map_err(|error| format!("failed waiting for source watch shutdown: {error}"))?
                 {
+                    stop_tracked_unix_processes(&tracked_processes)?;
                     return Ok(status);
                 }
                 thread::sleep(Duration::from_millis(50));
             }
         }
+        force_stop_unix_process_tree(child.id(), &tracked_processes)?;
+        return child
+            .wait()
+            .map_err(|error| format!("failed waiting for stopped source watch: {error}"));
     }
 
-    child
-        .kill()
-        .map_err(|error| format!("failed stopping source watch: {error}"))?;
-    child
-        .wait()
-        .map_err(|error| format!("failed waiting for stopped source watch: {error}"))
+    #[cfg(windows)]
+    {
+        let pid = child.id().to_string();
+        let result = Command::new("taskkill")
+            .args(["/PID", &pid, "/T", "/F"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        if !result.as_ref().is_ok_and(|status| status.success())
+            && child
+                .try_wait()
+                .map_err(|error| format!("failed checking source watch shutdown: {error}"))?
+                .is_none()
+        {
+            return Err(match result {
+                Ok(status) => format!(
+                    "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; taskkill failed with {status}, so the background service was not restored"
+                ),
+                Err(error) => format!(
+                    "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; taskkill failed: {error}; the background service was not restored"
+                ),
+            });
+        }
+        return child
+            .wait()
+            .map_err(|error| format!("failed waiting for stopped source watch: {error}"));
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        child
+            .kill()
+            .map_err(|error| format!("failed stopping source watch: {error}"))?;
+        child
+            .wait()
+            .map_err(|error| format!("failed waiting for stopped source watch: {error}"))
+    }
+}
+
+#[cfg(unix)]
+fn unix_descendant_processes(root_pid: u32) -> Result<Vec<(u32, u32)>, String> {
+    let output = Command::new("ps")
+        .args(["-axo", "pid=,ppid=,pgid="])
+        .output()
+        .map_err(|error| format!("failed listing source watch process tree: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed listing source watch process tree: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let processes = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let pid = fields.next()?.parse::<u32>().ok()?;
+            let parent_pid = fields.next()?.parse::<u32>().ok()?;
+            let process_group = fields.next()?.parse::<u32>().ok()?;
+            Some((pid, parent_pid, process_group))
+        })
+        .collect::<Vec<_>>();
+    let mut tree = BTreeSet::from([root_pid]);
+    loop {
+        let before = tree.len();
+        for (pid, parent_pid, _) in &processes {
+            if tree.contains(parent_pid) {
+                tree.insert(*pid);
+            }
+        }
+        if tree.len() == before {
+            break;
+        }
+    }
+    Ok(processes
+        .into_iter()
+        .filter_map(|(pid, _, process_group)| {
+            (pid != root_pid && tree.contains(&pid)).then_some((pid, process_group))
+        })
+        .collect())
+}
+
+#[cfg(unix)]
+fn force_stop_unix_process_tree(
+    root_pid: u32,
+    tracked_processes: &[(u32, u32)],
+) -> Result<(), String> {
+    let _ = signal_unix_process(root_pid, "STOP");
+    let mut processes = tracked_processes.to_vec();
+    if let Ok(current_processes) = unix_descendant_processes(root_pid) {
+        for process in current_processes {
+            if !processes.contains(&process) {
+                processes.push(process);
+            }
+        }
+    }
+    let mut process_groups = processes
+        .iter()
+        .map(|(_, process_group)| *process_group)
+        .collect::<BTreeSet<_>>();
+    process_groups.insert(root_pid);
+    for process_group in process_groups {
+        let _ = signal_unix_process_group(process_group, "KILL");
+    }
+    for (pid, _) in &processes {
+        let _ = signal_unix_process(*pid, "KILL");
+    }
+    let _ = signal_unix_process(root_pid, "KILL");
+    wait_for_unix_processes_to_stop(&processes)
+}
+
+#[cfg(unix)]
+fn stop_tracked_unix_processes(processes: &[(u32, u32)]) -> Result<(), String> {
+    let alive = processes
+        .iter()
+        .copied()
+        .filter(|(pid, _)| unix_process_is_alive(*pid))
+        .collect::<Vec<_>>();
+    if alive.is_empty() {
+        return Ok(());
+    }
+    for process_group in alive
+        .iter()
+        .map(|(_, process_group)| *process_group)
+        .collect::<BTreeSet<_>>()
+    {
+        let _ = signal_unix_process_group(process_group, "KILL");
+    }
+    for (pid, _) in &alive {
+        let _ = signal_unix_process(*pid, "KILL");
+    }
+    wait_for_unix_processes_to_stop(&alive)
+}
+
+#[cfg(unix)]
+fn wait_for_unix_processes_to_stop(processes: &[(u32, u32)]) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let alive = processes
+            .iter()
+            .map(|(pid, _)| *pid)
+            .filter(|pid| unix_process_is_alive(*pid))
+            .collect::<Vec<_>>();
+        if alive.is_empty() {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(format!(
+                "{SOURCE_WATCH_TREE_ACTIVE_ERROR}: {}; the background service was not restored",
+                alive
+                    .iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(unix)]
+fn signal_unix_process(pid: u32, signal: &str) -> bool {
+    Command::new("kill")
+        .args([&format!("-{signal}"), &pid.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(unix)]
+fn signal_unix_process_group(process_group: u32, signal: &str) -> bool {
+    Command::new("kill")
+        .args([&format!("-{signal}"), &format!("-{process_group}")])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(unix)]
+fn unix_process_is_alive(pid: u32) -> bool {
+    signal_unix_process(pid, "0")
+}
+
+fn source_watch_exit_code(status_code: Option<i32>, stop_requested: bool) -> i32 {
+    if stop_requested {
+        130
+    } else {
+        status_code.unwrap_or(1)
+    }
+}
+
+fn source_watch_allows_service_restore(watch_result: &Result<i32, String>) -> bool {
+    !matches!(
+        watch_result,
+        Err(error) if error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR)
+    )
 }
 
 fn render_dev_status(summary: &DevStatusSummary, profile: RenderProfile) -> Vec<String> {
@@ -1582,6 +1873,7 @@ fn render_dev_status_list(summaries: &[DevStatusSummary], profile: RenderProfile
 mod tests {
     use super::{
         DevStatusSummary, RenderProfile, combine_watch_and_restore_results, render_dev_status,
+        source_watch_allows_service_restore, source_watch_exit_code,
         source_watch_stop_timeout_error,
     };
     use crate::service::ServiceActionSummary;
@@ -1668,5 +1960,23 @@ mod tests {
                     .to_string()
             )
         );
+    }
+
+    #[test]
+    fn source_watch_preserves_the_original_interrupt_exit_code() {
+        assert_eq!(source_watch_exit_code(Some(143), true), 130);
+        assert_eq!(source_watch_exit_code(Some(23), false), 23);
+        assert_eq!(source_watch_exit_code(None, false), 1);
+    }
+
+    #[test]
+    fn source_watch_does_not_restore_over_a_live_process_tree() {
+        assert!(source_watch_allows_service_restore(&Ok(0)));
+        assert!(source_watch_allows_service_restore(&Err(
+            "source watch failed".to_string()
+        )));
+        assert!(!source_watch_allows_service_restore(&Err(
+            "source watch process tree is still active: 123".to_string()
+        )));
     }
 }

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -10,6 +10,12 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+#[cfg(unix)]
+use std::os::unix::process::{CommandExt as _, ExitStatusExt as _};
 #[cfg(windows)]
 use std::os::windows::{io::AsRawHandle, process::CommandExt as _};
 
@@ -37,11 +43,20 @@ use crate::store::{
 const DEV_PREFERENCES_KIND: &str = "ocm-dev-preferences";
 const SOURCE_WATCH_TREE_ACTIVE_ERROR: &str = "source watch process tree is still active";
 #[cfg(unix)]
-const SOURCE_WATCH_NODE_STDIN_SHIM: &str = r#"import path from "node:path";
+const SOURCE_WATCH_NODE_SHIM: &str = r#"import fs from "node:fs";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
+const startFd = Number(process.env.OCM_SOURCE_WATCH_START_FD);
+delete process.env.OCM_SOURCE_WATCH_START_FD;
+if (Number.isInteger(startFd) && fs.readSync(startFd, Buffer.alloc(1), 0, 1, null) !== 1) {
+  process.exit(1);
+}
 const script = path.resolve("scripts/watch-node.mjs");
 process.argv = [process.execPath, script, ...process.argv.slice(1)];
-Object.defineProperty(process.stdin, "isTTY", { value: true });
+if (process.env.OCM_SOURCE_WATCH_FORCE_TTY === "1") {
+  delete process.env.OCM_SOURCE_WATCH_FORCE_TTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: true });
+}
 await import(pathToFileURL(script).href);"#;
 
 type SourceWatchResult<T> = Result<T, SourceWatchError>;
@@ -800,18 +815,12 @@ impl Cli {
 
         let mut command = Command::new("node");
         #[cfg(unix)]
-        if unsafe { libc::isatty(libc::STDIN_FILENO) } != 1 {
-            // watch-node detaches its runner solely from stdin.isTTY. Override that decision
-            // while preserving the real noninteractive stdin and EOF inherited by the runner.
-            command.args([
-                "--input-type=module",
-                "--eval",
-                SOURCE_WATCH_NODE_STDIN_SHIM,
-            ]);
+        {
+            command.args(["--input-type=module", "--eval", SOURCE_WATCH_NODE_SHIM]);
             command.args(&args[1..]);
-        } else {
-            command.args(&args);
         }
+        #[cfg(unix)]
+        let source_watch_force_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } != 1;
         #[cfg(windows)]
         // watch-node never detaches runners on win32; the Job Object owns the full tree.
         command.args(&args);
@@ -822,6 +831,12 @@ impl Cli {
             .env_clear()
             .envs(build_openclaw_dev_source_env(meta, &self.env, repo_root))
             .current_dir(repo_root);
+        #[cfg(unix)]
+        if source_watch_force_tty {
+            // watch-node detaches its runner solely from stdin.isTTY. Override that decision
+            // while preserving the real noninteractive stdin and EOF inherited by the runner.
+            command.env("OCM_SOURCE_WATCH_FORCE_TTY", "1");
+        }
         _source_watch_lease.configure_child(&mut command);
 
         let mut log_files = if tee_to_env_logs {
@@ -935,6 +950,14 @@ impl Cli {
                     error.message,
                 )),
             };
+        let status_result = match (status_result, process_guard.restore_terminal()) {
+            (result, Ok(())) => result,
+            (Ok(_), Err(error)) => Err(SourceWatchError::from(error)),
+            (Err(error), Err(restore_error)) => Err(SourceWatchError {
+                message: format!("{}; {restore_error}", error.message),
+                cleanup_verified: error.cleanup_verified,
+            }),
+        };
         let tee_result = if !source_watch_allows_service_restore(&status_result) {
             drop(tee_threads);
             Ok(())
@@ -950,8 +973,13 @@ impl Cli {
         };
 
         let status = combine_source_watch_cleanup_results(status_result, tee_result, clear_result)?;
+        let mut status_code = status.code();
+        #[cfg(unix)]
+        if status_code.is_none() {
+            status_code = status.signal().map(|signal| 128 + signal);
+        }
         Ok(source_watch_exit_code(
-            status.code(),
+            status_code,
             stop_requested.load(Ordering::SeqCst),
         ))
     }
@@ -1067,12 +1095,46 @@ fn wait_for_source_watch_child(
 }
 
 struct SourceWatchProcessGuard {
+    #[cfg(unix)]
+    terminal: Option<SourceWatchTerminalGuard>,
     #[cfg(windows)]
     job: windows_sys::Win32::Foundation::HANDLE,
 }
 
+#[cfg(unix)]
+struct SourceWatchTerminalGuard {
+    original_process_group: libc::pid_t,
+    startup_reader: UnixStream,
+    startup_writer: UnixStream,
+    foreground_assigned: AtomicBool,
+}
+
 impl SourceWatchProcessGuard {
     fn new() -> Result<Self, String> {
+        #[cfg(unix)]
+        {
+            let terminal = if unsafe { libc::isatty(libc::STDIN_FILENO) } == 1 {
+                let original_process_group = unsafe { libc::tcgetpgrp(libc::STDIN_FILENO) };
+                if original_process_group == -1 {
+                    return Err(format!(
+                        "failed reading source watch terminal ownership: {}",
+                        io::Error::last_os_error()
+                    ));
+                }
+                let (startup_reader, startup_writer) = UnixStream::pair().map_err(|error| {
+                    format!("failed creating source watch startup gate: {error}")
+                })?;
+                Some(SourceWatchTerminalGuard {
+                    original_process_group,
+                    startup_reader,
+                    startup_writer,
+                    foreground_assigned: AtomicBool::new(false),
+                })
+            } else {
+                None
+            };
+            return Ok(Self { terminal });
+        }
         #[cfg(windows)]
         {
             use windows_sys::Win32::System::JobObjects::{
@@ -1109,18 +1171,35 @@ impl SourceWatchProcessGuard {
             }
             return Ok(Self { job });
         }
-        #[cfg(not(windows))]
+        #[cfg(not(any(unix, windows)))]
         {
             Ok(Self {})
         }
     }
 
     fn configure_command(&mut self, command: &mut Command) -> Result<(), String> {
+        #[cfg(unix)]
+        if let Some(terminal) = &self.terminal {
+            let startup_fd = terminal.startup_reader.as_raw_fd();
+            command.env("OCM_SOURCE_WATCH_START_FD", startup_fd.to_string());
+            unsafe {
+                command.pre_exec(move || {
+                    let flags = libc::fcntl(startup_fd, libc::F_GETFD);
+                    if flags == -1 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if libc::fcntl(startup_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+        }
         #[cfg(windows)]
         {
             command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
         }
-        #[cfg(not(windows))]
+        #[cfg(not(any(unix, windows)))]
         let _ = command;
         Ok(())
     }
@@ -1141,16 +1220,36 @@ impl SourceWatchProcessGuard {
                 ));
             }
         }
-        #[cfg(not(windows))]
+        #[cfg(unix)]
+        if let Some(terminal) = &self.terminal {
+            set_terminal_foreground_process_group(child.id() as libc::pid_t)?;
+            terminal.foreground_assigned.store(true, Ordering::SeqCst);
+        }
+        #[cfg(not(any(unix, windows)))]
         let _ = child;
         Ok(())
     }
 
-    fn start_child(&self, child: &std::process::Child) -> Result<(), String> {
+    fn start_child(&self, _child: &std::process::Child) -> Result<(), String> {
+        #[cfg(unix)]
+        if let Some(terminal) = &self.terminal {
+            let mut writer = &terminal.startup_writer;
+            writer
+                .write_all(&[1])
+                .map_err(|error| format!("failed releasing source watch startup gate: {error}"))?;
+        }
         #[cfg(windows)]
-        resume_windows_process(child.id())?;
-        #[cfg(not(windows))]
-        let _ = child;
+        resume_windows_process(_child.id())?;
+        Ok(())
+    }
+
+    fn restore_terminal(&self) -> Result<(), String> {
+        #[cfg(unix)]
+        if let Some(terminal) = &self.terminal
+            && terminal.foreground_assigned.swap(false, Ordering::SeqCst)
+        {
+            set_terminal_foreground_process_group(terminal.original_process_group)?;
+        }
         Ok(())
     }
 
@@ -1217,6 +1316,13 @@ impl SourceWatchProcessGuard {
     }
 }
 
+#[cfg(unix)]
+impl Drop for SourceWatchProcessGuard {
+    fn drop(&mut self) {
+        let _ = self.restore_terminal();
+    }
+}
+
 #[cfg(windows)]
 impl Drop for SourceWatchProcessGuard {
     fn drop(&mut self) {
@@ -1224,6 +1330,40 @@ impl Drop for SourceWatchProcessGuard {
             windows_sys::Win32::Foundation::CloseHandle(self.job);
         }
     }
+}
+
+#[cfg(unix)]
+fn set_terminal_foreground_process_group(process_group: libc::pid_t) -> Result<(), String> {
+    let mut previous_mask = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+    let mut blocked_mask = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+    unsafe {
+        libc::sigemptyset(&mut blocked_mask);
+        libc::sigaddset(&mut blocked_mask, libc::SIGTTOU);
+    }
+    let mask_result =
+        unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, &blocked_mask, &mut previous_mask) };
+    if mask_result != 0 {
+        return Err(format!(
+            "failed blocking terminal ownership signal: {}",
+            io::Error::from_raw_os_error(mask_result)
+        ));
+    }
+    let terminal_result = unsafe { libc::tcsetpgrp(libc::STDIN_FILENO, process_group) };
+    let terminal_error = (terminal_result == -1).then(io::Error::last_os_error);
+    let restore_mask_result =
+        unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, &previous_mask, std::ptr::null_mut()) };
+    if restore_mask_result != 0 {
+        return Err(format!(
+            "failed restoring terminal ownership signal mask: {}",
+            io::Error::from_raw_os_error(restore_mask_result)
+        ));
+    }
+    if let Some(error) = terminal_error {
+        return Err(format!(
+            "failed assigning source watch terminal ownership: {error}"
+        ));
+    }
+    Ok(())
 }
 
 fn stop_source_watch_child(

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -272,10 +272,12 @@ impl Cli {
                     stderr_profile,
                 ));
                 if let Err(stop_error) = self.stop_service_for_source_watch(&meta.name) {
-                    drop(source_watch_lease.take());
-                    return Err(
-                        self.restore_service_policy_after_failed_takeover(&meta.name, stop_error)
-                    );
+                    let lease = source_watch_lease
+                        .as_mut()
+                        .ok_or_else(|| "source watch lease is missing".to_string())?;
+                    return Err(self.restore_service_policy_after_failed_takeover(
+                        &meta.name, stop_error, lease,
+                    ));
                 }
             }
             self.stderr_lines(render_dev_run_step(
@@ -293,9 +295,12 @@ impl Cli {
                     .as_ref()
                     .ok_or_else(|| "source watch lease is missing".to_string())?,
             );
-            drop(source_watch_lease.take());
             let restore_result =
                 if watch_takes_over_service && source_watch_allows_service_restore(&watch_result) {
+                    source_watch_lease
+                        .as_mut()
+                        .ok_or_else(|| "source watch lease is missing".to_string())?
+                        .begin_service_restore()?;
                     self.stderr_lines(render_dev_run_step(
                         "Restore",
                         format!("Starting background service for {}", meta.name),
@@ -311,6 +316,7 @@ impl Cli {
                 } else {
                     Ok(())
                 };
+            drop(source_watch_lease.take());
             return combine_watch_and_restore_results(watch_result, restore_result, &meta.name);
         }
 
@@ -398,10 +404,11 @@ impl Cli {
                 stderr_profile,
             ));
             if let Err(stop_error) = self.stop_service_for_source_watch(&meta.name) {
-                drop(source_watch_lease.take());
-                return Err(
-                    self.restore_service_policy_after_failed_takeover(&meta.name, stop_error)
-                );
+                let lease = source_watch_lease
+                    .as_mut()
+                    .ok_or_else(|| "source watch lease is missing".to_string())?;
+                return Err(self
+                    .restore_service_policy_after_failed_takeover(&meta.name, stop_error, lease));
             }
         }
 
@@ -423,10 +430,13 @@ impl Cli {
                 .as_ref()
                 .ok_or_else(|| "source watch lease is missing".to_string())?,
         );
-        drop(source_watch_lease.take());
 
         let restore_result =
             if restore_service && source_watch_allows_service_restore(&watch_result) {
+                source_watch_lease
+                    .as_mut()
+                    .ok_or_else(|| "source watch lease is missing".to_string())?
+                    .begin_service_restore()?;
                 self.stderr_lines(render_dev_run_step(
                     "Restore",
                     format!("Starting background service for {}", meta.name),
@@ -443,6 +453,7 @@ impl Cli {
             } else {
                 Ok(())
             };
+        drop(source_watch_lease.take());
 
         combine_watch_and_restore_results(watch_result, restore_result, &meta.name)
     }
@@ -462,7 +473,13 @@ impl Cli {
         &self,
         env_name: &str,
         stop_error: String,
+        source_watch_lease: &mut SourceWatchLease,
     ) -> String {
+        if let Err(restore_state_error) = source_watch_lease.begin_service_restore() {
+            return format!(
+                "{stop_error}; also failed preparing background service restoration: {restore_state_error}"
+            );
+        }
         match self.service_service().start(env_name) {
             Ok(_) => format!(
                 "{stop_error}; restored the background service policy and did not start source watch"

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -741,6 +741,9 @@ impl Cli {
             .spawn()
             .map_err(|error| format!("failed to run \"node\": {error}"))?;
         if let Err(error) = process_guard.assign_and_start(&child) {
+            #[cfg(windows)]
+            return Err(stop_suspended_source_watch_after_error(&mut child, error));
+            #[cfg(not(windows))]
             return Err(stop_source_watch_after_error(
                 &mut child,
                 &process_guard,
@@ -814,10 +817,13 @@ impl Cli {
         } else {
             wait_for_tee_threads(tee_threads)
         };
-        let clear_result = self
-            .environment_service()
-            .clear_source_watch_override(&meta.name, &source_watch.token)
-            .map(|_| ());
+        let clear_result = if source_watch_allows_override_clear(&status_result) {
+            self.environment_service()
+                .clear_source_watch_override(&meta.name, &source_watch.token)
+                .map(|_| ())
+        } else {
+            Ok(())
+        };
 
         let status = combine_source_watch_cleanup_results(status_result, tee_result, clear_result)?;
         Ok(source_watch_exit_code(
@@ -1149,10 +1155,12 @@ fn stop_source_watch_child(
             }
         }
         let _ = signal_unix_process_group(child.id(), "STOP");
-        process_guard.stop_remaining(child.id())?;
-        return child
+        let _ = signal_unix_process_group(child.id(), "KILL");
+        let status = child
             .wait()
-            .map_err(|error| format!("failed waiting for stopped source watch: {error}"));
+            .map_err(|error| format!("failed waiting for stopped source watch: {error}"))?;
+        wait_for_unix_process_group_to_stop(child.id())?;
+        return Ok(status);
     }
 
     #[cfg(windows)]
@@ -1270,6 +1278,24 @@ fn stop_source_watch_after_error(
     }
 }
 
+#[cfg(windows)]
+fn stop_suspended_source_watch_after_error(
+    child: &mut std::process::Child,
+    primary_error: String,
+) -> String {
+    if let Err(error) = child.kill() {
+        return format!(
+            "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; failed terminating a suspended watcher: {error}; setup also failed: {primary_error}"
+        );
+    }
+    match child.wait() {
+        Ok(_) => primary_error,
+        Err(error) => format!(
+            "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; failed reaping a suspended watcher: {error}; setup also failed: {primary_error}"
+        ),
+    }
+}
+
 fn source_watch_exit_code(status_code: Option<i32>, stop_requested: bool) -> i32 {
     if stop_requested {
         130
@@ -1279,6 +1305,15 @@ fn source_watch_exit_code(status_code: Option<i32>, stop_requested: bool) -> i32
 }
 
 fn source_watch_allows_service_restore(watch_result: &Result<i32, String>) -> bool {
+    !matches!(
+        watch_result,
+        Err(error) if error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR)
+    )
+}
+
+fn source_watch_allows_override_clear(
+    watch_result: &Result<std::process::ExitStatus, String>,
+) -> bool {
     !matches!(
         watch_result,
         Err(error) if error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR)

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -10,8 +10,6 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-#[cfg(unix)]
-use std::os::fd::FromRawFd;
 #[cfg(windows)]
 use std::os::windows::{io::AsRawHandle, process::CommandExt as _};
 
@@ -928,56 +926,40 @@ fn wait_for_source_watch_child(
     stop_requested: &AtomicBool,
     process_guard: &SourceWatchProcessGuard,
 ) -> Result<std::process::ExitStatus, String> {
+    let mut tracked_processes = Vec::new();
+    #[cfg(unix)]
+    let track_descendants = source_watch_needs_descendant_tracking();
     loop {
+        #[cfg(unix)]
+        if track_descendants {
+            merge_unix_processes(
+                &mut tracked_processes,
+                unix_descendant_processes(child.id()).map_err(source_watch_tree_discovery_error)?,
+            );
+        }
         if let Some(status) = child
             .try_wait()
             .map_err(|error| format!("failed waiting for source watch: {error}"))?
         {
+            #[cfg(unix)]
+            stop_tracked_unix_processes(child.id(), &tracked_processes)?;
             process_guard.stop_remaining(child.id())?;
             return Ok(status);
         }
         if stop_requested.load(Ordering::SeqCst) {
-            return stop_source_watch_child(child, process_guard);
+            return stop_source_watch_child(child, process_guard, &tracked_processes);
         }
         thread::sleep(Duration::from_millis(50));
     }
 }
 
 struct SourceWatchProcessGuard {
-    #[cfg(unix)]
-    _pty_master: File,
-    #[cfg(unix)]
-    pty_slave: Option<File>,
     #[cfg(windows)]
     job: windows_sys::Win32::Foundation::HANDLE,
 }
 
 impl SourceWatchProcessGuard {
     fn new() -> Result<Self, String> {
-        #[cfg(unix)]
-        {
-            let mut master = -1;
-            let mut slave = -1;
-            let opened = unsafe {
-                libc::openpty(
-                    &mut master,
-                    &mut slave,
-                    std::ptr::null_mut(),
-                    std::ptr::null_mut(),
-                    std::ptr::null_mut(),
-                )
-            };
-            if opened == -1 {
-                return Err(format!(
-                    "failed creating source watch terminal: {}",
-                    io::Error::last_os_error()
-                ));
-            }
-            return Ok(Self {
-                _pty_master: unsafe { File::from_raw_fd(master) },
-                pty_slave: Some(unsafe { File::from_raw_fd(slave) }),
-            });
-        }
         #[cfg(windows)]
         {
             use windows_sys::Win32::System::JobObjects::{
@@ -1014,26 +996,16 @@ impl SourceWatchProcessGuard {
             }
             return Ok(Self { job });
         }
-        #[cfg(not(any(unix, windows)))]
+        #[cfg(not(windows))]
         {
             Ok(Self {})
         }
     }
 
     fn configure_command(&mut self, command: &mut Command) -> Result<(), String> {
-        #[cfg(unix)]
-        {
-            let slave = self
-                .pty_slave
-                .take()
-                .ok_or_else(|| "source watch terminal was already assigned".to_string())?;
-            // watch-node keeps its runner in the same process group when stdin
-            // is a TTY, so the group remains an enforceable ownership boundary.
-            command.stdin(Stdio::from(slave));
-        }
         #[cfg(windows)]
         command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
-        #[cfg(not(any(unix, windows)))]
+        #[cfg(not(windows))]
         let _ = command;
         Ok(())
     }
@@ -1061,14 +1033,6 @@ impl SourceWatchProcessGuard {
     }
 
     fn stop_remaining(&self, root_pid: u32) -> Result<(), String> {
-        #[cfg(unix)]
-        {
-            if !unix_process_group_is_alive(root_pid) {
-                return Ok(());
-            }
-            let _ = signal_unix_process_group(root_pid, "KILL");
-            return wait_for_unix_process_group_to_stop(root_pid);
-        }
         #[cfg(windows)]
         {
             use windows_sys::Win32::System::JobObjects::TerminateJobObject;
@@ -1081,7 +1045,7 @@ impl SourceWatchProcessGuard {
             }
             return self.wait_for_windows_job_to_stop();
         }
-        #[cfg(not(any(unix, windows)))]
+        #[cfg(not(windows))]
         {
             let _ = root_pid;
             Ok(())
@@ -1139,37 +1103,54 @@ impl Drop for SourceWatchProcessGuard {
 fn stop_source_watch_child(
     child: &mut std::process::Child,
     process_guard: &SourceWatchProcessGuard,
+    tracked_processes: &[(u32, u32)],
 ) -> Result<std::process::ExitStatus, String> {
+    #[cfg(not(windows))]
+    let _ = process_guard;
     #[cfg(unix)]
     {
-        let pid = child.id().to_string();
+        let mut tracked_processes = tracked_processes.to_vec();
+        let track_descendants = source_watch_needs_descendant_tracking();
+        if track_descendants {
+            merge_unix_processes(
+                &mut tracked_processes,
+                unix_descendant_processes(child.id()).map_err(source_watch_tree_discovery_error)?,
+            );
+        }
         // watch-node forwards TERM to its runner; allow that grace before
         // enforcing the process-group ownership boundary.
-        let signal = Command::new("kill")
-            .args(["-TERM", &pid])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-        if signal.as_ref().is_ok_and(|status| status.success()) {
+        if signal_unix_process(child.id(), libc::SIGTERM)? {
             let deadline = std::time::Instant::now() + Duration::from_secs(7);
             while std::time::Instant::now() < deadline {
                 if let Some(status) = child
                     .try_wait()
                     .map_err(|error| format!("failed waiting for source watch shutdown: {error}"))?
                 {
-                    process_guard.stop_remaining(child.id())?;
+                    stop_tracked_unix_processes(child.id(), &tracked_processes)?;
                     return Ok(status);
+                }
+                if track_descendants {
+                    merge_unix_processes(
+                        &mut tracked_processes,
+                        unix_descendant_processes(child.id())
+                            .map_err(source_watch_tree_discovery_error)?,
+                    );
                 }
                 thread::sleep(Duration::from_millis(50));
             }
         }
-        let _ = signal_unix_process_group(child.id(), "STOP");
-        let _ = signal_unix_process_group(child.id(), "KILL");
+        signal_unix_process_group(child.id(), libc::SIGSTOP)?;
+        if track_descendants {
+            merge_unix_processes(
+                &mut tracked_processes,
+                unix_descendant_processes(child.id()).map_err(source_watch_tree_discovery_error)?,
+            );
+        }
+        kill_tracked_unix_processes(child.id(), &tracked_processes)?;
         let status = child
             .wait()
             .map_err(|error| format!("failed waiting for stopped source watch: {error}"))?;
-        wait_for_unix_process_group_to_stop(child.id())?;
+        wait_for_unix_processes_to_stop(&tracked_processes)?;
         return Ok(status);
     }
 
@@ -1193,15 +1174,170 @@ fn stop_source_watch_child(
 }
 
 #[cfg(unix)]
-fn wait_for_unix_process_group_to_stop(process_group: u32) -> Result<(), String> {
+fn unix_descendant_processes(root_pid: u32) -> Result<Vec<(u32, u32)>, String> {
+    let processes = unix_process_snapshot()?;
+    let mut tree = BTreeSet::from([root_pid]);
+    loop {
+        let before = tree.len();
+        for (pid, parent_pid, _) in &processes {
+            if tree.contains(parent_pid) {
+                tree.insert(*pid);
+            }
+        }
+        if tree.len() == before {
+            break;
+        }
+    }
+    Ok(processes
+        .into_iter()
+        .filter_map(|(pid, _, process_group)| {
+            (pid != root_pid && tree.contains(&pid)).then_some((pid, process_group))
+        })
+        .collect())
+}
+
+#[cfg(unix)]
+fn source_watch_needs_descendant_tracking() -> bool {
+    unsafe { libc::isatty(libc::STDIN_FILENO) != 1 }
+}
+
+#[cfg(target_os = "linux")]
+fn unix_process_snapshot() -> Result<Vec<(u32, u32, u32)>, String> {
+    let mut processes = Vec::new();
+    for entry in fs::read_dir("/proc")
+        .map_err(|error| format!("failed reading /proc for source watch processes: {error}"))?
+    {
+        let entry = entry.map_err(|error| {
+            format!("failed reading /proc entry for source watch processes: {error}")
+        })?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Ok(stat) = fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        let Some((_, fields)) = stat.rsplit_once(") ") else {
+            continue;
+        };
+        let mut fields = fields.split_whitespace();
+        let _state = fields.next();
+        let Some(parent_pid) = fields.next().and_then(|value| value.parse::<u32>().ok()) else {
+            continue;
+        };
+        let Some(process_group) = fields.next().and_then(|value| value.parse::<u32>().ok()) else {
+            continue;
+        };
+        processes.push((pid, parent_pid, process_group));
+    }
+    Ok(processes)
+}
+
+#[cfg(target_os = "macos")]
+fn unix_process_snapshot() -> Result<Vec<(u32, u32, u32)>, String> {
+    let capacity = unsafe { libc::proc_listallpids(std::ptr::null_mut(), 0) };
+    if capacity <= 0 {
+        return Err(format!(
+            "failed listing source watch processes: {}",
+            io::Error::last_os_error()
+        ));
+    }
+    let mut pids = vec![0_i32; capacity as usize];
+    let count = unsafe {
+        libc::proc_listallpids(
+            pids.as_mut_ptr().cast(),
+            (pids.len() * std::mem::size_of::<i32>()) as i32,
+        )
+    };
+    if count < 0 {
+        return Err(format!(
+            "failed reading source watch process list: {}",
+            io::Error::last_os_error()
+        ));
+    }
+    let mut processes = Vec::new();
+    for pid in pids.into_iter().take(count as usize).filter(|pid| *pid > 0) {
+        let mut info = unsafe { std::mem::zeroed::<libc::proc_bsdinfo>() };
+        let read = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                std::ptr::from_mut(&mut info).cast(),
+                std::mem::size_of_val(&info) as i32,
+            )
+        };
+        if read == std::mem::size_of_val(&info) as i32 {
+            processes.push((info.pbi_pid, info.pbi_ppid, info.pbi_pgid));
+        }
+    }
+    Ok(processes)
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+fn unix_process_snapshot() -> Result<Vec<(u32, u32, u32)>, String> {
+    Err("source watch process discovery is unsupported on this Unix platform".to_string())
+}
+
+#[cfg(unix)]
+fn merge_unix_processes(target: &mut Vec<(u32, u32)>, processes: Vec<(u32, u32)>) {
+    for process in processes {
+        if !target.contains(&process) {
+            target.push(process);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn kill_tracked_unix_processes(root_pid: u32, processes: &[(u32, u32)]) -> Result<(), String> {
+    let mut process_groups = processes
+        .iter()
+        .map(|(_, process_group)| *process_group)
+        .collect::<BTreeSet<_>>();
+    process_groups.insert(root_pid);
+    for process_group in process_groups {
+        let _ = signal_unix_process_group(process_group, libc::SIGKILL)?;
+    }
+    for (pid, _) in processes {
+        let _ = signal_unix_process(*pid, libc::SIGKILL)?;
+    }
+    let _ = signal_unix_process(root_pid, libc::SIGKILL)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn stop_tracked_unix_processes(root_pid: u32, processes: &[(u32, u32)]) -> Result<(), String> {
+    kill_tracked_unix_processes(root_pid, processes)?;
+    wait_for_unix_processes_to_stop(processes)
+}
+
+#[cfg(unix)]
+fn wait_for_unix_processes_to_stop(processes: &[(u32, u32)]) -> Result<(), String> {
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
     loop {
-        if !unix_process_group_is_alive(process_group) {
+        let alive = processes
+            .iter()
+            .map(|(pid, _)| *pid)
+            .filter_map(|pid| match unix_process_is_alive(pid) {
+                Ok(true) => Some(Ok(pid)),
+                Ok(false) => None,
+                Err(error) => Some(Err(error)),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if alive.is_empty() {
             return Ok(());
         }
         if std::time::Instant::now() >= deadline {
             return Err(format!(
-                "{SOURCE_WATCH_TREE_ACTIVE_ERROR}: process group {process_group}; the background service was not restored"
+                "{SOURCE_WATCH_TREE_ACTIVE_ERROR}: {}; the background service was not restored",
+                alive
+                    .iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
         }
         thread::sleep(Duration::from_millis(25));
@@ -1209,19 +1345,39 @@ fn wait_for_unix_process_group_to_stop(process_group: u32) -> Result<(), String>
 }
 
 #[cfg(unix)]
-fn signal_unix_process_group(process_group: u32, signal: &str) -> bool {
-    Command::new("kill")
-        .args([&format!("-{signal}"), &format!("-{process_group}")])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
+fn signal_unix_process(pid: u32, signal: i32) -> Result<bool, String> {
+    signal_unix_target(pid as i32, signal)
 }
 
 #[cfg(unix)]
-fn unix_process_group_is_alive(process_group: u32) -> bool {
-    signal_unix_process_group(process_group, "0")
+fn signal_unix_process_group(process_group: u32, signal: i32) -> Result<bool, String> {
+    signal_unix_target(-(process_group as i32), signal)
+}
+
+#[cfg(unix)]
+fn unix_process_is_alive(pid: u32) -> Result<bool, String> {
+    signal_unix_process(pid, 0)
+}
+
+#[cfg(unix)]
+fn signal_unix_target(target: i32, signal: i32) -> Result<bool, String> {
+    if unsafe { libc::kill(target, signal) } == 0 {
+        return Ok(true);
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(false)
+    } else {
+        Err(format!(
+            "failed signaling source watch process target {target}: {error}"
+        ))
+    }
+}
+
+fn source_watch_tree_discovery_error(error: String) -> String {
+    format!(
+        "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; unable to verify the process tree: {error}; the background service was not restored"
+    )
 }
 
 #[cfg(windows)]
@@ -1277,7 +1433,7 @@ fn stop_source_watch_after_error(
     process_guard: &SourceWatchProcessGuard,
     primary_error: String,
 ) -> String {
-    match stop_source_watch_child(child, process_guard) {
+    match stop_source_watch_child(child, process_guard, &[]) {
         Ok(_) => primary_error,
         Err(cleanup_error) if cleanup_error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR) => {
             format!("{cleanup_error}; setup also failed: {primary_error}")

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -10,8 +10,10 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
 #[cfg(windows)]
-use std::os::windows::io::AsRawHandle;
+use std::os::windows::{io::AsRawHandle, process::CommandExt as _};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -733,13 +735,17 @@ impl Cli {
             command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
         }
 
-        let process_guard = SourceWatchProcessGuard::new()?;
+        let mut process_guard = SourceWatchProcessGuard::new()?;
+        process_guard.configure_command(&mut command)?;
         let mut child = command
             .spawn()
             .map_err(|error| format!("failed to run \"node\": {error}"))?;
-        if let Err(error) = process_guard.assign(&child) {
-            let _ = stop_source_watch_child(&mut child);
-            return Err(error);
+        if let Err(error) = process_guard.assign_and_start(&child) {
+            return Err(stop_source_watch_after_error(
+                &mut child,
+                &process_guard,
+                error,
+            ));
         }
         let source_watch = match self
             .environment_service()
@@ -753,25 +759,34 @@ impl Cli {
             ) {
             Ok(source_watch) => source_watch,
             Err(error) => {
-                let _ = stop_source_watch_child(&mut child);
-                return Err(error);
+                return Err(stop_source_watch_after_error(
+                    &mut child,
+                    &process_guard,
+                    error,
+                ));
             }
         };
         let mut tee_threads = Vec::new();
         if let Some(log_files) = log_files.take() {
             let Some(stdout) = child.stdout.take() else {
-                let _ = stop_source_watch_child(&mut child);
                 let _ = self
                     .environment_service()
                     .clear_source_watch_override(&meta.name, &source_watch.token);
-                return Err("failed to capture source watch stdout".to_string());
+                return Err(stop_source_watch_after_error(
+                    &mut child,
+                    &process_guard,
+                    "failed to capture source watch stdout".to_string(),
+                ));
             };
             let Some(stderr) = child.stderr.take() else {
-                let _ = stop_source_watch_child(&mut child);
                 let _ = self
                     .environment_service()
                     .clear_source_watch_override(&meta.name, &source_watch.token);
-                return Err("failed to capture source watch stderr".to_string());
+                return Err(stop_source_watch_after_error(
+                    &mut child,
+                    &process_guard,
+                    "failed to capture source watch stderr".to_string(),
+                ));
             };
             tee_threads.push(spawn_tee_thread(
                 stdout,
@@ -788,11 +803,17 @@ impl Cli {
         }
 
         let status_result =
-            wait_for_source_watch_child(&mut child, &stop_requested).map_err(|error| {
-                let _ = stop_source_watch_child(&mut child);
-                error
-            });
-        let tee_result = wait_for_tee_threads(tee_threads);
+            wait_for_source_watch_child(&mut child, &stop_requested, &process_guard)
+                .map_err(|error| stop_source_watch_after_error(&mut child, &process_guard, error));
+        let tee_result = if status_result
+            .as_ref()
+            .is_err_and(|error| error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR))
+        {
+            drop(tee_threads);
+            Ok(())
+        } else {
+            wait_for_tee_threads(tee_threads)
+        };
         let clear_result = self
             .environment_service()
             .clear_source_watch_override(&meta.name, &source_watch.token)
@@ -889,28 +910,58 @@ fn combine_source_watch_cleanup_results(
 fn wait_for_source_watch_child(
     child: &mut std::process::Child,
     stop_requested: &AtomicBool,
+    process_guard: &SourceWatchProcessGuard,
 ) -> Result<std::process::ExitStatus, String> {
     loop {
         if let Some(status) = child
             .try_wait()
             .map_err(|error| format!("failed waiting for source watch: {error}"))?
         {
+            process_guard.stop_remaining(child.id())?;
             return Ok(status);
         }
         if stop_requested.load(Ordering::SeqCst) {
-            return stop_source_watch_child(child);
+            return stop_source_watch_child(child, process_guard);
         }
         thread::sleep(Duration::from_millis(50));
     }
 }
 
 struct SourceWatchProcessGuard {
+    #[cfg(unix)]
+    _pty_master: File,
+    #[cfg(unix)]
+    pty_slave: Option<File>,
     #[cfg(windows)]
     job: windows_sys::Win32::Foundation::HANDLE,
 }
 
 impl SourceWatchProcessGuard {
     fn new() -> Result<Self, String> {
+        #[cfg(unix)]
+        {
+            let mut master = -1;
+            let mut slave = -1;
+            let opened = unsafe {
+                libc::openpty(
+                    &mut master,
+                    &mut slave,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                )
+            };
+            if opened == -1 {
+                return Err(format!(
+                    "failed creating source watch terminal: {}",
+                    io::Error::last_os_error()
+                ));
+            }
+            return Ok(Self {
+                _pty_master: unsafe { File::from_raw_fd(master) },
+                pty_slave: Some(unsafe { File::from_raw_fd(slave) }),
+            });
+        }
         #[cfg(windows)]
         {
             use windows_sys::Win32::System::JobObjects::{
@@ -945,15 +996,33 @@ impl SourceWatchProcessGuard {
                     io::Error::last_os_error()
                 ));
             }
-            Ok(Self { job })
+            return Ok(Self { job });
         }
-        #[cfg(not(windows))]
+        #[cfg(not(any(unix, windows)))]
         {
             Ok(Self {})
         }
     }
 
-    fn assign(&self, child: &std::process::Child) -> Result<(), String> {
+    fn configure_command(&mut self, command: &mut Command) -> Result<(), String> {
+        #[cfg(unix)]
+        {
+            let slave = self
+                .pty_slave
+                .take()
+                .ok_or_else(|| "source watch terminal was already assigned".to_string())?;
+            // watch-node keeps its runner in the same process group when stdin
+            // is a TTY, so the group remains an enforceable ownership boundary.
+            command.stdin(Stdio::from(slave));
+        }
+        #[cfg(windows)]
+        command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
+        #[cfg(not(any(unix, windows)))]
+        let _ = command;
+        Ok(())
+    }
+
+    fn assign_and_start(&self, child: &std::process::Child) -> Result<(), String> {
         #[cfg(windows)]
         {
             let assigned = unsafe {
@@ -968,10 +1037,77 @@ impl SourceWatchProcessGuard {
                     io::Error::last_os_error()
                 ));
             }
+            resume_windows_process(child.id())?;
         }
         #[cfg(not(windows))]
         let _ = child;
         Ok(())
+    }
+
+    fn stop_remaining(&self, root_pid: u32) -> Result<(), String> {
+        #[cfg(unix)]
+        {
+            if !unix_process_group_is_alive(root_pid) {
+                return Ok(());
+            }
+            let _ = signal_unix_process_group(root_pid, "KILL");
+            return wait_for_unix_process_group_to_stop(root_pid);
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::System::JobObjects::TerminateJobObject;
+
+            if unsafe { TerminateJobObject(self.job, 1) } == 0 {
+                return Err(format!(
+                    "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; failed terminating the process job: {}; the background service was not restored",
+                    io::Error::last_os_error()
+                ));
+            }
+            return self.wait_for_windows_job_to_stop();
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = root_pid;
+            Ok(())
+        }
+    }
+
+    #[cfg(windows)]
+    fn wait_for_windows_job_to_stop(&self) -> Result<(), String> {
+        use windows_sys::Win32::System::JobObjects::{
+            JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, JobObjectBasicAccountingInformation,
+            QueryInformationJobObject,
+        };
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let mut info = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
+            let queried = unsafe {
+                QueryInformationJobObject(
+                    self.job,
+                    JobObjectBasicAccountingInformation,
+                    std::ptr::from_mut(&mut info).cast(),
+                    std::mem::size_of_val(&info) as u32,
+                    std::ptr::null_mut(),
+                )
+            };
+            if queried == 0 {
+                return Err(format!(
+                    "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; failed querying the process job: {}; the background service was not restored",
+                    io::Error::last_os_error()
+                ));
+            }
+            if info.ActiveProcesses == 0 {
+                return Ok(());
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; the Windows process job still has {} active processes; the background service was not restored",
+                    info.ActiveProcesses
+                ));
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
     }
 }
 
@@ -986,13 +1122,13 @@ impl Drop for SourceWatchProcessGuard {
 
 fn stop_source_watch_child(
     child: &mut std::process::Child,
+    process_guard: &SourceWatchProcessGuard,
 ) -> Result<std::process::ExitStatus, String> {
     #[cfg(unix)]
     {
-        let tracked_processes = unix_descendant_processes(child.id()).unwrap_or_default();
         let pid = child.id().to_string();
-        // OpenClaw's watch-node handler forwards TERM to its detached gateway
-        // process group; allow its shutdown grace before forcing the wrapper down.
+        // watch-node forwards TERM to its runner; allow that grace before
+        // enforcing the process-group ownership boundary.
         let signal = Command::new("kill")
             .args(["-TERM", &pid])
             .stdin(Stdio::null())
@@ -1006,13 +1142,14 @@ fn stop_source_watch_child(
                     .try_wait()
                     .map_err(|error| format!("failed waiting for source watch shutdown: {error}"))?
                 {
-                    stop_tracked_unix_processes(&tracked_processes)?;
+                    process_guard.stop_remaining(child.id())?;
                     return Ok(status);
                 }
                 thread::sleep(Duration::from_millis(50));
             }
         }
-        force_stop_unix_process_tree(child.id(), &tracked_processes)?;
+        let _ = signal_unix_process_group(child.id(), "STOP");
+        process_guard.stop_remaining(child.id())?;
         return child
             .wait()
             .map_err(|error| format!("failed waiting for stopped source watch: {error}"));
@@ -1020,28 +1157,7 @@ fn stop_source_watch_child(
 
     #[cfg(windows)]
     {
-        let pid = child.id().to_string();
-        let result = Command::new("taskkill")
-            .args(["/PID", &pid, "/T", "/F"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-        if !result.as_ref().is_ok_and(|status| status.success())
-            && child
-                .try_wait()
-                .map_err(|error| format!("failed checking source watch shutdown: {error}"))?
-                .is_none()
-        {
-            return Err(match result {
-                Ok(status) => format!(
-                    "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; taskkill failed with {status}, so the background service was not restored"
-                ),
-                Err(error) => format!(
-                    "{SOURCE_WATCH_TREE_ACTIVE_ERROR}; taskkill failed: {error}; the background service was not restored"
-                ),
-            });
-        }
+        process_guard.stop_remaining(child.id())?;
         return child
             .wait()
             .map_err(|error| format!("failed waiting for stopped source watch: {error}"));
@@ -1059,134 +1175,19 @@ fn stop_source_watch_child(
 }
 
 #[cfg(unix)]
-fn unix_descendant_processes(root_pid: u32) -> Result<Vec<(u32, u32)>, String> {
-    let output = Command::new("ps")
-        .args(["-axo", "pid=,ppid=,pgid="])
-        .output()
-        .map_err(|error| format!("failed listing source watch process tree: {error}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "failed listing source watch process tree: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    let processes = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let mut fields = line.split_whitespace();
-            let pid = fields.next()?.parse::<u32>().ok()?;
-            let parent_pid = fields.next()?.parse::<u32>().ok()?;
-            let process_group = fields.next()?.parse::<u32>().ok()?;
-            Some((pid, parent_pid, process_group))
-        })
-        .collect::<Vec<_>>();
-    let mut tree = BTreeSet::from([root_pid]);
-    loop {
-        let before = tree.len();
-        for (pid, parent_pid, _) in &processes {
-            if tree.contains(parent_pid) {
-                tree.insert(*pid);
-            }
-        }
-        if tree.len() == before {
-            break;
-        }
-    }
-    Ok(processes
-        .into_iter()
-        .filter_map(|(pid, _, process_group)| {
-            (pid != root_pid && tree.contains(&pid)).then_some((pid, process_group))
-        })
-        .collect())
-}
-
-#[cfg(unix)]
-fn force_stop_unix_process_tree(
-    root_pid: u32,
-    tracked_processes: &[(u32, u32)],
-) -> Result<(), String> {
-    let _ = signal_unix_process(root_pid, "STOP");
-    let mut processes = tracked_processes.to_vec();
-    if let Ok(current_processes) = unix_descendant_processes(root_pid) {
-        for process in current_processes {
-            if !processes.contains(&process) {
-                processes.push(process);
-            }
-        }
-    }
-    let mut process_groups = processes
-        .iter()
-        .map(|(_, process_group)| *process_group)
-        .collect::<BTreeSet<_>>();
-    process_groups.insert(root_pid);
-    for process_group in process_groups {
-        let _ = signal_unix_process_group(process_group, "KILL");
-    }
-    for (pid, _) in &processes {
-        let _ = signal_unix_process(*pid, "KILL");
-    }
-    let _ = signal_unix_process(root_pid, "KILL");
-    wait_for_unix_processes_to_stop(&processes)
-}
-
-#[cfg(unix)]
-fn stop_tracked_unix_processes(processes: &[(u32, u32)]) -> Result<(), String> {
-    let alive = processes
-        .iter()
-        .copied()
-        .filter(|(pid, _)| unix_process_is_alive(*pid))
-        .collect::<Vec<_>>();
-    if alive.is_empty() {
-        return Ok(());
-    }
-    for process_group in alive
-        .iter()
-        .map(|(_, process_group)| *process_group)
-        .collect::<BTreeSet<_>>()
-    {
-        let _ = signal_unix_process_group(process_group, "KILL");
-    }
-    for (pid, _) in &alive {
-        let _ = signal_unix_process(*pid, "KILL");
-    }
-    wait_for_unix_processes_to_stop(&alive)
-}
-
-#[cfg(unix)]
-fn wait_for_unix_processes_to_stop(processes: &[(u32, u32)]) -> Result<(), String> {
+fn wait_for_unix_process_group_to_stop(process_group: u32) -> Result<(), String> {
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
     loop {
-        let alive = processes
-            .iter()
-            .map(|(pid, _)| *pid)
-            .filter(|pid| unix_process_is_alive(*pid))
-            .collect::<Vec<_>>();
-        if alive.is_empty() {
+        if !unix_process_group_is_alive(process_group) {
             return Ok(());
         }
         if std::time::Instant::now() >= deadline {
             return Err(format!(
-                "{SOURCE_WATCH_TREE_ACTIVE_ERROR}: {}; the background service was not restored",
-                alive
-                    .iter()
-                    .map(u32::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                "{SOURCE_WATCH_TREE_ACTIVE_ERROR}: process group {process_group}; the background service was not restored"
             ));
         }
         thread::sleep(Duration::from_millis(25));
     }
-}
-
-#[cfg(unix)]
-fn signal_unix_process(pid: u32, signal: &str) -> bool {
-    Command::new("kill")
-        .args([&format!("-{signal}"), &pid.to_string()])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
 }
 
 #[cfg(unix)]
@@ -1201,8 +1202,72 @@ fn signal_unix_process_group(process_group: u32, signal: &str) -> bool {
 }
 
 #[cfg(unix)]
-fn unix_process_is_alive(pid: u32) -> bool {
-    signal_unix_process(pid, "0")
+fn unix_process_group_is_alive(process_group: u32) -> bool {
+    signal_unix_process_group(process_group, "0")
+}
+
+#[cfg(windows)]
+fn resume_windows_process(pid: u32) -> Result<(), String> {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+    };
+    use windows_sys::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(format!(
+            "failed listing suspended source watch threads: {}",
+            io::Error::last_os_error()
+        ));
+    }
+    let mut entry = THREADENTRY32 {
+        dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+        ..Default::default()
+    };
+    let mut found = unsafe { Thread32First(snapshot, &mut entry) } != 0;
+    let mut resumed = false;
+    while found {
+        if entry.th32OwnerProcessID == pid {
+            let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID) };
+            if !thread.is_null() {
+                let result = unsafe { ResumeThread(thread) };
+                unsafe {
+                    CloseHandle(thread);
+                }
+                resumed = result != u32::MAX;
+                break;
+            }
+        }
+        found = unsafe { Thread32Next(snapshot, &mut entry) } != 0;
+    }
+    unsafe {
+        CloseHandle(snapshot);
+    }
+    if resumed {
+        Ok(())
+    } else {
+        Err(format!(
+            "failed resuming suspended source watch process {pid}: {}",
+            io::Error::last_os_error()
+        ))
+    }
+}
+
+fn stop_source_watch_after_error(
+    child: &mut std::process::Child,
+    process_guard: &SourceWatchProcessGuard,
+    primary_error: String,
+) -> String {
+    match stop_source_watch_child(child, process_guard) {
+        Ok(_) => primary_error,
+        Err(cleanup_error) if cleanup_error.starts_with(SOURCE_WATCH_TREE_ACTIVE_ERROR) => {
+            format!("{cleanup_error}; setup also failed: {primary_error}")
+        }
+        Err(cleanup_error) => {
+            format!("{primary_error}; also failed stopping source watch: {cleanup_error}")
+        }
+    }
 }
 
 fn source_watch_exit_code(status_code: Option<i32>, stop_requested: bool) -> i32 {

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -740,6 +740,16 @@ impl Cli {
         let mut child = command
             .spawn()
             .map_err(|error| format!("failed to run \"node\": {error}"))?;
+        if let Err(error) = _source_watch_lease.attach_to_child(&child) {
+            #[cfg(windows)]
+            return Err(stop_suspended_source_watch_after_error(&mut child, error));
+            #[cfg(not(windows))]
+            return Err(stop_source_watch_after_error(
+                &mut child,
+                &process_guard,
+                error,
+            ));
+        }
         if let Err(error) = process_guard.assign_and_start(&child) {
             #[cfg(windows)]
             return Err(stop_suspended_source_watch_after_error(&mut child, error));

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -28,8 +28,8 @@ pub use snapshots::{
     EnvSnapshotSummary, RemoveEnvSnapshotOptions, RestoreEnvSnapshotOptions,
     select_snapshot_prune_candidates,
 };
-pub(crate) use source_watch::SourceWatchLease;
-pub use source_watch::{CreateSourceWatchOverrideOptions, SourceWatchOverride};
+pub use source_watch::SourceWatchOverride;
+pub(crate) use source_watch::{CreateSourceWatchOverrideOptions, SourceWatchLease};
 
 pub struct EnvironmentService<'a> {
     env: &'a BTreeMap<String, String>,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -29,7 +29,7 @@ pub use snapshots::{
     select_snapshot_prune_candidates,
 };
 pub(crate) use source_watch::SourceWatchLease;
-pub use source_watch::SourceWatchOverride;
+pub use source_watch::{CreateSourceWatchOverrideOptions, SourceWatchOverride};
 
 pub struct EnvironmentService<'a> {
     env: &'a BTreeMap<String, String>,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -28,7 +28,8 @@ pub use snapshots::{
     EnvSnapshotSummary, RemoveEnvSnapshotOptions, RestoreEnvSnapshotOptions,
     select_snapshot_prune_candidates,
 };
-pub use source_watch::{CreateSourceWatchOverrideOptions, SourceWatchOverride};
+pub(crate) use source_watch::SourceWatchLease;
+pub use source_watch::SourceWatchOverride;
 
 pub struct EnvironmentService<'a> {
     env: &'a BTreeMap<String, String>,

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -62,6 +62,10 @@ impl Drop for SourceWatchLease {
 }
 
 impl SourceWatchLease {
+    pub(crate) fn begin_service_restore(&mut self) -> Result<(), String> {
+        write_source_watch_lock(&mut self.lock_file, &format!("restoring:{}", self.lease_id))
+    }
+
     #[cfg(unix)]
     pub(crate) fn configure_child(&self, command: &mut Command) {
         let lock_fd = self.lock_file.as_raw_fd();
@@ -196,15 +200,7 @@ impl<'a> EnvironmentService<'a> {
             std::process::id(),
             now_utc().unix_timestamp_nanos()
         );
-        lock_file
-            .set_len(0)
-            .and_then(|()| writeln!(lock_file, "{lease_id}"))
-            .map_err(|error| {
-                format!(
-                    "failed recording source watch lock {}: {error}",
-                    display_path(&lock_path)
-                )
-            })?;
+        write_source_watch_lock(&mut lock_file, &lease_id)?;
         Ok(SourceWatchLease {
             env_name,
             lease_id,
@@ -315,6 +311,10 @@ impl<'a> EnvironmentService<'a> {
                 })?
                 .trim()
                 .to_string();
+            if source_watch_lock_is_restoring(&lock_lease_id) {
+                remove_file_if_present(&path)?;
+                return Ok(None);
+            }
             let meta = read_json::<SourceWatchOverride>(&path).map_err(|error| {
                 format!(
                     "source watch for env \"{env_name}\" is active or starting, but its metadata is unavailable: {error}"
@@ -352,6 +352,10 @@ impl<'a> EnvironmentService<'a> {
                     })?
                     .trim()
                     .to_string();
+                if source_watch_lock_is_restoring(&lock_lease_id) {
+                    remove_file_if_present(&path)?;
+                    return Ok(None);
+                }
                 let meta = read_json::<SourceWatchOverride>(&path).map_err(|error| {
                     format!(
                         "source watch for env \"{env_name}\" is active or starting, but its metadata is unavailable: {error}"
@@ -373,6 +377,18 @@ impl<'a> EnvironmentService<'a> {
             )),
         }
     }
+}
+
+fn write_source_watch_lock(lock_file: &mut File, value: &str) -> Result<(), String> {
+    lock_file
+        .set_len(0)
+        .and_then(|()| lock_file.seek(SeekFrom::Start(0)).map(|_| ()))
+        .and_then(|()| writeln!(lock_file, "{value}"))
+        .map_err(|error| format!("failed recording source watch lock: {error}"))
+}
+
+fn source_watch_lock_is_restoring(lock_value: &str) -> bool {
+    lock_value.starts_with("restoring:")
 }
 
 fn is_leased_source_watch(meta: &SourceWatchOverride) -> bool {

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -12,6 +12,8 @@ use std::os::windows::io::AsRawHandle;
 
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+#[cfg(windows)]
+use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 
 use super::EnvironmentService;
@@ -46,6 +48,17 @@ pub(crate) struct SourceWatchLease {
     env_name: String,
     lease_id: String,
     lock_file: File,
+    #[cfg(windows)]
+    lease_event: windows_sys::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+impl Drop for SourceWatchLease {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.lease_event);
+        }
+    }
 }
 
 impl SourceWatchLease {
@@ -81,7 +94,7 @@ impl SourceWatchLease {
         let duplicated = unsafe {
             DuplicateHandle(
                 GetCurrentProcess(),
-                self.lock_file.as_raw_handle() as HANDLE,
+                self.lease_event,
                 child.as_raw_handle() as HANDLE,
                 &mut child_handle,
                 0,
@@ -150,14 +163,24 @@ impl<'a> EnvironmentService<'a> {
                     display_path(&lock_path)
                 )
             })?;
+        #[cfg(windows)]
+        let lease_event = acquire_windows_source_watch_event(&lock_path, &env_name)?;
         match FileExt::try_lock_exclusive(&lock_file) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                #[cfg(windows)]
+                unsafe {
+                    windows_sys::Win32::Foundation::CloseHandle(lease_event);
+                }
                 return Err(format!(
                     "source watch for env \"{env_name}\" is already active or starting"
                 ));
             }
             Err(error) => {
+                #[cfg(windows)]
+                unsafe {
+                    windows_sys::Win32::Foundation::CloseHandle(lease_event);
+                }
                 return Err(format!(
                     "failed locking source watch for env \"{env_name}\": {error}"
                 ));
@@ -186,6 +209,8 @@ impl<'a> EnvironmentService<'a> {
             env_name,
             lease_id,
             lock_file,
+            #[cfg(windows)]
+            lease_event,
         })
     }
 
@@ -288,6 +313,28 @@ impl<'a> EnvironmentService<'a> {
             return Ok(None);
         }
 
+        #[cfg(windows)]
+        if let Some(_lease_event) = open_windows_source_watch_event(&lock_path)? {
+            let lock_lease_id = fs::read_to_string(&lock_path)
+                .map_err(|error| {
+                    format!(
+                        "failed reading active source watch lock {}: {error}",
+                        display_path(&lock_path)
+                    )
+                })?
+                .trim()
+                .to_string();
+            let meta = read_json::<SourceWatchOverride>(&path).map_err(|error| {
+                format!(
+                    "failed reading active source watch override {}: {error}",
+                    display_path(&path)
+                )
+            })?;
+            return Ok((source_watch_matches_lease(&meta, &lock_lease_id)
+                && is_valid_source_watch_structure(&meta, &env_name))
+            .then_some(meta));
+        }
+
         let lock_file = open_source_watch_lock(&lock_path)?;
         match FileExt::try_lock_exclusive(&lock_file) {
             Ok(()) => {
@@ -358,6 +405,84 @@ fn is_valid_source_watch_structure(meta: &SourceWatchOverride, env_name: &str) -
         && meta.watch_pid > 0
         && Path::new(&meta.repo_root).join("openclaw.mjs").is_file()
         && Path::new(&meta.repo_root).join("extensions").is_dir()
+}
+
+#[cfg(windows)]
+struct WindowsSourceWatchEvent {
+    handle: windows_sys::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+impl Drop for WindowsSourceWatchEvent {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn acquire_windows_source_watch_event(
+    lock_path: &Path,
+    env_name: &str,
+) -> Result<windows_sys::Win32::Foundation::HANDLE, String> {
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_ALREADY_EXISTS, GetLastError};
+    use windows_sys::Win32::System::Threading::CreateEventW;
+
+    let event_name = windows_source_watch_event_name(lock_path);
+    let event = unsafe { CreateEventW(std::ptr::null(), 1, 0, event_name.as_ptr()) };
+    if event.is_null() {
+        return Err(format!(
+            "failed creating source watch lease for env \"{env_name}\": {}",
+            io::Error::last_os_error()
+        ));
+    }
+    if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+        unsafe {
+            CloseHandle(event);
+        }
+        return Err(format!(
+            "source watch for env \"{env_name}\" is already active or starting"
+        ));
+    }
+    Ok(event)
+}
+
+#[cfg(windows)]
+fn open_windows_source_watch_event(
+    lock_path: &Path,
+) -> Result<Option<WindowsSourceWatchEvent>, String> {
+    use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, GetLastError};
+    use windows_sys::Win32::System::Threading::{OpenEventW, SYNCHRONIZATION_SYNCHRONIZE};
+
+    let event_name = windows_source_watch_event_name(lock_path);
+    let event = unsafe { OpenEventW(SYNCHRONIZATION_SYNCHRONIZE, 0, event_name.as_ptr()) };
+    if !event.is_null() {
+        return Ok(Some(WindowsSourceWatchEvent { handle: event }));
+    }
+    let error = unsafe { GetLastError() };
+    if error == ERROR_FILE_NOT_FOUND {
+        Ok(None)
+    } else {
+        Err(format!(
+            "failed checking source watch lease {}: {}",
+            display_path(lock_path),
+            io::Error::from_raw_os_error(error as i32)
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn windows_source_watch_event_name(lock_path: &Path) -> Vec<u16> {
+    let digest = Sha256::digest(display_path(lock_path).as_bytes());
+    let suffix = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("Local\\OCM-source-watch-{suffix}")
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect()
 }
 
 fn open_source_watch_lock(lock_path: &Path) -> Result<File, String> {

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -331,8 +331,10 @@ impl<'a> EnvironmentService<'a> {
         }
 
         let lock_file = open_source_watch_lock(&lock_path)?;
-        match FileExt::try_lock_exclusive(&lock_file) {
+        match FileExt::try_lock_shared(&lock_file) {
             Ok(()) => {
+                // Shared readers prove no watcher owns the exclusive lease. They may clean the
+                // same stale metadata concurrently without impersonating an active watcher.
                 remove_file_if_present(&path)?;
                 FileExt::unlock(&lock_file).map_err(|error| {
                     format!(

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -37,10 +37,10 @@ pub struct SourceWatchOverride {
 }
 
 #[derive(Clone, Debug)]
-pub struct CreateSourceWatchOverrideOptions {
-    pub env_name: String,
-    pub repo_root: PathBuf,
-    pub watch_pid: u32,
+pub(crate) struct CreateSourceWatchOverrideOptions {
+    pub(crate) env_name: String,
+    pub(crate) repo_root: PathBuf,
+    pub(crate) watch_pid: u32,
 }
 
 #[derive(Debug)]
@@ -212,13 +212,6 @@ impl<'a> EnvironmentService<'a> {
         })
     }
 
-    pub fn create_source_watch_override(
-        &self,
-        options: CreateSourceWatchOverrideOptions,
-    ) -> Result<SourceWatchOverride, String> {
-        self.write_source_watch_override(options, None)
-    }
-
     pub(crate) fn create_source_watch_override_with_lease(
         &self,
         options: CreateSourceWatchOverrideOptions,
@@ -230,27 +223,24 @@ impl<'a> EnvironmentService<'a> {
                 lease.env_name, options.env_name
             ));
         }
-        self.write_source_watch_override(options, Some(&lease.lease_id))
+        self.write_source_watch_override(options, &lease.lease_id)
     }
 
     fn write_source_watch_override(
         &self,
         options: CreateSourceWatchOverrideOptions,
-        lease_id: Option<&str>,
+        lease_id: &str,
     ) -> Result<SourceWatchOverride, String> {
         let env_name = validate_name(&options.env_name, "Environment name")?;
         let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         if let Some(parent) = path.parent() {
             ensure_dir(parent)?;
         }
-        let token = match lease_id {
-            Some(lease_id) => format!(
-                "lease:{lease_id}:{}-{}",
-                options.watch_pid,
-                now_utc().unix_timestamp_nanos()
-            ),
-            None => format!("{}-{}", options.watch_pid, now_utc().unix_timestamp_nanos()),
-        };
+        let token = format!(
+            "lease:{lease_id}:{}-{}",
+            options.watch_pid,
+            now_utc().unix_timestamp_nanos()
+        );
         let meta = SourceWatchOverride {
             kind: SOURCE_WATCH_OVERRIDE_KIND.to_string(),
             env_name,

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -1,7 +1,12 @@
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
@@ -40,10 +45,29 @@ pub(crate) struct SourceWatchLease {
     lock_file: File,
 }
 
-impl Drop for SourceWatchLease {
-    fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.lock_file);
+impl SourceWatchLease {
+    #[cfg(unix)]
+    pub(crate) fn configure_child(&self, command: &mut Command) {
+        let lock_fd = self.lock_file.as_raw_fd();
+        command.process_group(0);
+        // The watcher inherits the lease so an OCM crash cannot release
+        // exclusivity while the source gateway remains alive.
+        unsafe {
+            command.pre_exec(move || {
+                let flags = libc::fcntl(lock_fd, libc::F_GETFD);
+                if flags == -1 {
+                    return Err(io::Error::last_os_error());
+                }
+                if libc::fcntl(lock_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1 {
+                    return Err(io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
     }
+
+    #[cfg(not(unix))]
+    pub(crate) fn configure_child(&self, _command: &mut Command) {}
 }
 
 impl SourceWatchOverride {
@@ -68,8 +92,8 @@ impl<'a> EnvironmentService<'a> {
         let env_name = validate_name(env_name, "Environment name")?;
         let override_path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         let lock_path = override_path.with_extension("lock");
-        if !lock_path.exists()
-            && let Ok(meta) = read_json::<SourceWatchOverride>(&override_path)
+        if let Ok(meta) = read_json::<SourceWatchOverride>(&override_path)
+            && !is_leased_source_watch(&meta)
             && is_valid_source_watch_metadata(&meta, &env_name)
             && is_legacy_source_watch_process(&meta)
         {
@@ -129,7 +153,7 @@ impl<'a> EnvironmentService<'a> {
         &self,
         options: CreateSourceWatchOverrideOptions,
     ) -> Result<SourceWatchOverride, String> {
-        self.write_source_watch_override(options)
+        self.write_source_watch_override(options, false)
     }
 
     pub(crate) fn create_source_watch_override_with_lease(
@@ -143,19 +167,25 @@ impl<'a> EnvironmentService<'a> {
                 lease.env_name, options.env_name
             ));
         }
-        self.write_source_watch_override(options)
+        self.write_source_watch_override(options, true)
     }
 
     fn write_source_watch_override(
         &self,
         options: CreateSourceWatchOverrideOptions,
+        leased: bool,
     ) -> Result<SourceWatchOverride, String> {
         let env_name = validate_name(&options.env_name, "Environment name")?;
         let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         if let Some(parent) = path.parent() {
             ensure_dir(parent)?;
         }
-        let token = format!("{}-{}", options.watch_pid, now_utc().unix_timestamp_nanos());
+        let token_prefix = if leased { "lease-" } else { "" };
+        let token = format!(
+            "{token_prefix}{}-{}",
+            options.watch_pid,
+            now_utc().unix_timestamp_nanos()
+        );
         let meta = SourceWatchOverride {
             kind: SOURCE_WATCH_OVERRIDE_KIND.to_string(),
             env_name,
@@ -198,19 +228,20 @@ impl<'a> EnvironmentService<'a> {
         if !path.exists() {
             return Ok(None);
         }
-        if !lock_path.exists() {
-            let meta = match read_json::<SourceWatchOverride>(&path) {
-                Ok(meta) => meta,
-                Err(_) => {
-                    remove_file_if_present(&path)?;
-                    return Ok(None);
-                }
-            };
-            if is_valid_source_watch_metadata(&meta, &env_name)
-                && is_legacy_source_watch_process(&meta)
-            {
-                return Ok(Some(meta));
+        let meta = match read_json::<SourceWatchOverride>(&path) {
+            Ok(meta) => meta,
+            Err(_) => {
+                remove_file_if_present(&path)?;
+                return Ok(None);
             }
+        };
+        if !is_leased_source_watch(&meta)
+            && is_valid_source_watch_metadata(&meta, &env_name)
+            && is_legacy_source_watch_process(&meta)
+        {
+            return Ok(Some(meta));
+        }
+        if !lock_path.exists() {
             remove_file_if_present(&path)?;
             return Ok(None);
         }
@@ -228,12 +259,6 @@ impl<'a> EnvironmentService<'a> {
                 Ok(None)
             }
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                let meta = read_json::<SourceWatchOverride>(&path).map_err(|error| {
-                    format!(
-                        "failed reading active source watch override {}: {error}",
-                        display_path(&path)
-                    )
-                })?;
                 if is_valid_source_watch_metadata(&meta, &env_name) {
                     Ok(Some(meta))
                 } else {
@@ -246,6 +271,10 @@ impl<'a> EnvironmentService<'a> {
             )),
         }
     }
+}
+
+fn is_leased_source_watch(meta: &SourceWatchOverride) -> bool {
+    meta.token.starts_with("lease-")
 }
 
 fn is_valid_source_watch_metadata(meta: &SourceWatchOverride, env_name: &str) -> bool {

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -292,17 +292,8 @@ impl<'a> EnvironmentService<'a> {
         let env_name = validate_name(env_name, "Environment name")?;
         let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         let lock_path = path.with_extension("lock");
-        if !path.exists() {
-            return Ok(None);
-        }
-        let meta = match read_json::<SourceWatchOverride>(&path) {
-            Ok(meta) => meta,
-            Err(_) => {
-                remove_file_if_present(&path)?;
-                return Ok(None);
-            }
-        };
-        if !is_leased_source_watch(&meta)
+        if let Ok(meta) = read_json::<SourceWatchOverride>(&path)
+            && !is_leased_source_watch(&meta)
             && is_valid_source_watch_metadata(&meta, &env_name)
             && is_legacy_source_watch_process(&meta)
         {
@@ -326,13 +317,17 @@ impl<'a> EnvironmentService<'a> {
                 .to_string();
             let meta = read_json::<SourceWatchOverride>(&path).map_err(|error| {
                 format!(
-                    "failed reading active source watch override {}: {error}",
-                    display_path(&path)
+                    "source watch for env \"{env_name}\" is active or starting, but its metadata is unavailable: {error}"
                 )
             })?;
-            return Ok((source_watch_matches_lease(&meta, &lock_lease_id)
-                && is_valid_source_watch_structure(&meta, &env_name))
-            .then_some(meta));
+            if source_watch_matches_lease(&meta, &lock_lease_id)
+                && is_valid_source_watch_structure(&meta, &env_name)
+            {
+                return Ok(Some(meta));
+            }
+            return Err(format!(
+                "source watch for env \"{env_name}\" is active or starting, but its metadata does not match the active lease"
+            ));
         }
 
         let lock_file = open_source_watch_lock(&lock_path)?;
@@ -359,8 +354,7 @@ impl<'a> EnvironmentService<'a> {
                     .to_string();
                 let meta = read_json::<SourceWatchOverride>(&path).map_err(|error| {
                     format!(
-                        "failed reading active source watch override {}: {error}",
-                        display_path(&path)
+                        "source watch for env \"{env_name}\" is active or starting, but its metadata is unavailable: {error}"
                     )
                 })?;
                 let metadata_valid = source_watch_matches_lease(&meta, &lock_lease_id)
@@ -368,7 +362,9 @@ impl<'a> EnvironmentService<'a> {
                 if metadata_valid {
                     Ok(Some(meta))
                 } else {
-                    Ok(None)
+                    Err(format!(
+                        "source watch for env \"{env_name}\" is active or starting, but its metadata does not match the active lease"
+                    ))
                 }
             }
             Err(error) => Err(format!(

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -7,6 +7,8 @@ use std::process::Command;
 use std::os::fd::AsRawFd;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
@@ -42,6 +44,7 @@ pub struct CreateSourceWatchOverrideOptions {
 #[derive(Debug)]
 pub(crate) struct SourceWatchLease {
     env_name: String,
+    lease_id: String,
     lock_file: File,
 }
 
@@ -68,6 +71,37 @@ impl SourceWatchLease {
 
     #[cfg(not(unix))]
     pub(crate) fn configure_child(&self, _command: &mut Command) {}
+
+    #[cfg(windows)]
+    pub(crate) fn attach_to_child(&self, child: &std::process::Child) -> Result<(), String> {
+        use windows_sys::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
+        use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+        let mut child_handle: HANDLE = std::ptr::null_mut();
+        let duplicated = unsafe {
+            DuplicateHandle(
+                GetCurrentProcess(),
+                self.lock_file.as_raw_handle() as HANDLE,
+                child.as_raw_handle() as HANDLE,
+                &mut child_handle,
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            )
+        };
+        if duplicated == 0 {
+            return Err(format!(
+                "failed attaching source watch lease to child: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(windows))]
+    pub(crate) fn attach_to_child(&self, _child: &std::process::Child) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 impl SourceWatchOverride {
@@ -134,9 +168,14 @@ impl<'a> EnvironmentService<'a> {
         // lease, even if its child PID has since been reused by another process.
         remove_file_if_present(&override_path)?;
 
+        let lease_id = format!(
+            "{}-{}",
+            std::process::id(),
+            now_utc().unix_timestamp_nanos()
+        );
         lock_file
             .set_len(0)
-            .and_then(|()| writeln!(lock_file, "{}", std::process::id()))
+            .and_then(|()| writeln!(lock_file, "{lease_id}"))
             .map_err(|error| {
                 format!(
                     "failed recording source watch lock {}: {error}",
@@ -145,6 +184,7 @@ impl<'a> EnvironmentService<'a> {
             })?;
         Ok(SourceWatchLease {
             env_name,
+            lease_id,
             lock_file,
         })
     }
@@ -153,7 +193,7 @@ impl<'a> EnvironmentService<'a> {
         &self,
         options: CreateSourceWatchOverrideOptions,
     ) -> Result<SourceWatchOverride, String> {
-        self.write_source_watch_override(options, false)
+        self.write_source_watch_override(options, None)
     }
 
     pub(crate) fn create_source_watch_override_with_lease(
@@ -167,25 +207,27 @@ impl<'a> EnvironmentService<'a> {
                 lease.env_name, options.env_name
             ));
         }
-        self.write_source_watch_override(options, true)
+        self.write_source_watch_override(options, Some(&lease.lease_id))
     }
 
     fn write_source_watch_override(
         &self,
         options: CreateSourceWatchOverrideOptions,
-        leased: bool,
+        lease_id: Option<&str>,
     ) -> Result<SourceWatchOverride, String> {
         let env_name = validate_name(&options.env_name, "Environment name")?;
         let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         if let Some(parent) = path.parent() {
             ensure_dir(parent)?;
         }
-        let token_prefix = if leased { "lease-" } else { "" };
-        let token = format!(
-            "{token_prefix}{}-{}",
-            options.watch_pid,
-            now_utc().unix_timestamp_nanos()
-        );
+        let token = match lease_id {
+            Some(lease_id) => format!(
+                "lease:{lease_id}:{}-{}",
+                options.watch_pid,
+                now_utc().unix_timestamp_nanos()
+            ),
+            None => format!("{}-{}", options.watch_pid, now_utc().unix_timestamp_nanos()),
+        };
         let meta = SourceWatchOverride {
             kind: SOURCE_WATCH_OVERRIDE_KIND.to_string(),
             env_name,
@@ -259,11 +301,23 @@ impl<'a> EnvironmentService<'a> {
                 Ok(None)
             }
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                let metadata_valid = if is_leased_source_watch(&meta) {
-                    is_valid_source_watch_structure(&meta, &env_name)
-                } else {
-                    is_valid_source_watch_metadata(&meta, &env_name)
-                };
+                let lock_lease_id = fs::read_to_string(&lock_path)
+                    .map_err(|error| {
+                        format!(
+                            "failed reading active source watch lock {}: {error}",
+                            display_path(&lock_path)
+                        )
+                    })?
+                    .trim()
+                    .to_string();
+                let meta = read_json::<SourceWatchOverride>(&path).map_err(|error| {
+                    format!(
+                        "failed reading active source watch override {}: {error}",
+                        display_path(&path)
+                    )
+                })?;
+                let metadata_valid = source_watch_matches_lease(&meta, &lock_lease_id)
+                    && is_valid_source_watch_structure(&meta, &env_name);
                 if metadata_valid {
                     Ok(Some(meta))
                 } else {
@@ -279,7 +333,17 @@ impl<'a> EnvironmentService<'a> {
 }
 
 fn is_leased_source_watch(meta: &SourceWatchOverride) -> bool {
-    meta.token.starts_with("lease-")
+    meta.token.starts_with("lease:")
+}
+
+fn source_watch_matches_lease(meta: &SourceWatchOverride, lease_id: &str) -> bool {
+    if lease_id.is_empty() {
+        return !is_leased_source_watch(meta) && is_process_alive(meta.watch_pid);
+    }
+    meta.token
+        .strip_prefix("lease:")
+        .and_then(|token| token.split_once(':'))
+        .is_some_and(|(metadata_lease_id, _)| metadata_lease_id == lease_id)
 }
 
 fn is_valid_source_watch_metadata(meta: &SourceWatchOverride, env_name: &str) -> bool {

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -548,16 +548,28 @@ fn is_process_alive(pid: u32) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn process_command_line(pid: u32) -> Option<String> {
     let output = Command::new("ps")
-        .args(["-p", &pid.to_string(), "-o", "command="])
+        .args(["-ww", "-p", &pid.to_string(), "-o", "command="])
         .output()
         .ok()?;
     output
         .status
         .success()
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn process_command_line(pid: u32) -> Option<String> {
+    let command = fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    let command = command
+        .split(|byte| *byte == 0)
+        .filter(|argument| !argument.is_empty())
+        .map(String::from_utf8_lossy)
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!command.is_empty()).then_some(command)
 }
 
 #[cfg(target_os = "linux")]

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -2,6 +2,8 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
@@ -23,6 +25,8 @@ use crate::store::{
 };
 
 const SOURCE_WATCH_OVERRIDE_KIND: &str = "ocm-source-watch-override";
+const SOURCE_WATCH_LOCK_RETRY_ATTEMPTS: usize = 20;
+const SOURCE_WATCH_LOCK_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -169,7 +173,7 @@ impl<'a> EnvironmentService<'a> {
             })?;
         #[cfg(windows)]
         let lease_event = acquire_windows_source_watch_event(&lock_path, &env_name)?;
-        match FileExt::try_lock_exclusive(&lock_file) {
+        match try_lock_source_watch_exclusive(&lock_file) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 #[cfg(windows)]
@@ -394,6 +398,21 @@ fn write_source_watch_lock(lock_file: &mut File, value: &str) -> Result<(), Stri
         .and_then(|()| lock_file.seek(SeekFrom::Start(0)).map(|_| ()))
         .and_then(|()| writeln!(lock_file, "{value}"))
         .map_err(|error| format!("failed recording source watch lock: {error}"))
+}
+
+fn try_lock_source_watch_exclusive(lock_file: &File) -> io::Result<()> {
+    for attempt in 0..=SOURCE_WATCH_LOCK_RETRY_ATTEMPTS {
+        match FileExt::try_lock_exclusive(lock_file) {
+            Err(error)
+                if error.kind() == io::ErrorKind::WouldBlock
+                    && attempt < SOURCE_WATCH_LOCK_RETRY_ATTEMPTS =>
+            {
+                thread::sleep(SOURCE_WATCH_LOCK_RETRY_DELAY);
+            }
+            result => return result,
+        }
+    }
+    unreachable!("bounded source watch lock retry must return")
 }
 
 fn source_watch_lock_is_restoring(lock_value: &str) -> bool {
@@ -683,5 +702,41 @@ mod tests {
         assert!(!legacy_source_watch_command_matches(
             "cargo test source_watch"
         ));
+    }
+
+    #[test]
+    fn exclusive_source_watch_lock_retries_transient_shared_readers() {
+        let path = std::env::temp_dir().join(format!(
+            "ocm-source-watch-lock-retry-{}-{}",
+            std::process::id(),
+            now_utc().unix_timestamp_nanos()
+        ));
+        let reader = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        let contender = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        FileExt::lock_shared(&reader).unwrap();
+        let released = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let release_flag = std::sync::Arc::clone(&released);
+        let release = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(30));
+            FileExt::unlock(&reader).unwrap();
+            release_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        try_lock_source_watch_exclusive(&contender).unwrap();
+
+        assert!(released.load(std::sync::atomic::Ordering::SeqCst));
+        FileExt::unlock(&contender).unwrap();
+        release.join().unwrap();
+        fs::remove_file(path).unwrap();
     }
 }

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -259,7 +259,12 @@ impl<'a> EnvironmentService<'a> {
                 Ok(None)
             }
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                if is_valid_source_watch_metadata(&meta, &env_name) {
+                let metadata_valid = if is_leased_source_watch(&meta) {
+                    is_valid_source_watch_structure(&meta, &env_name)
+                } else {
+                    is_valid_source_watch_metadata(&meta, &env_name)
+                };
+                if metadata_valid {
                     Ok(Some(meta))
                 } else {
                     Ok(None)
@@ -278,6 +283,10 @@ fn is_leased_source_watch(meta: &SourceWatchOverride) -> bool {
 }
 
 fn is_valid_source_watch_metadata(meta: &SourceWatchOverride, env_name: &str) -> bool {
+    is_valid_source_watch_structure(meta, env_name) && is_process_alive(meta.watch_pid)
+}
+
+fn is_valid_source_watch_structure(meta: &SourceWatchOverride, env_name: &str) -> bool {
     meta.kind == SOURCE_WATCH_OVERRIDE_KIND
         && meta.env_name == env_name
         && !meta.repo_root.trim().is_empty()
@@ -285,7 +294,6 @@ fn is_valid_source_watch_metadata(meta: &SourceWatchOverride, env_name: &str) ->
         && meta.watch_pid > 0
         && Path::new(&meta.repo_root).join("openclaw.mjs").is_file()
         && Path::new(&meta.repo_root).join("extensions").is_dir()
-        && is_process_alive(meta.watch_pid)
 }
 
 fn open_source_watch_lock(lock_path: &Path) -> Result<File, String> {

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -36,6 +36,7 @@ pub struct CreateSourceWatchOverrideOptions {
 
 #[derive(Debug)]
 pub(crate) struct SourceWatchLease {
+    env_name: String,
     lock_file: File,
 }
 
@@ -67,6 +68,16 @@ impl<'a> EnvironmentService<'a> {
         let env_name = validate_name(env_name, "Environment name")?;
         let override_path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         let lock_path = override_path.with_extension("lock");
+        if !lock_path.exists()
+            && let Ok(meta) = read_json::<SourceWatchOverride>(&override_path)
+            && is_valid_source_watch_metadata(&meta, &env_name)
+            && is_legacy_source_watch_process(&meta)
+        {
+            return Err(format!(
+                "source watch for env \"{env_name}\" is already active with legacy pid {}",
+                meta.watch_pid
+            ));
+        }
         if let Some(parent) = lock_path.parent() {
             ensure_dir(parent)?;
         }
@@ -108,10 +119,34 @@ impl<'a> EnvironmentService<'a> {
                     display_path(&lock_path)
                 )
             })?;
-        Ok(SourceWatchLease { lock_file })
+        Ok(SourceWatchLease {
+            env_name,
+            lock_file,
+        })
     }
 
     pub fn create_source_watch_override(
+        &self,
+        options: CreateSourceWatchOverrideOptions,
+    ) -> Result<SourceWatchOverride, String> {
+        self.write_source_watch_override(options)
+    }
+
+    pub(crate) fn create_source_watch_override_with_lease(
+        &self,
+        options: CreateSourceWatchOverrideOptions,
+        lease: &SourceWatchLease,
+    ) -> Result<SourceWatchOverride, String> {
+        if options.env_name != lease.env_name {
+            return Err(format!(
+                "source watch lease for env \"{}\" cannot create an override for env \"{}\"",
+                lease.env_name, options.env_name
+            ));
+        }
+        self.write_source_watch_override(options)
+    }
+
+    fn write_source_watch_override(
         &self,
         options: CreateSourceWatchOverrideOptions,
     ) -> Result<SourceWatchOverride, String> {
@@ -163,67 +198,96 @@ impl<'a> EnvironmentService<'a> {
         if !path.exists() {
             return Ok(None);
         }
-        let meta = match read_json::<SourceWatchOverride>(&path) {
-            Ok(meta) => meta,
-            Err(_) => {
-                remove_file_if_present(&path)?;
-                return Ok(None);
+        if !lock_path.exists() {
+            let meta = match read_json::<SourceWatchOverride>(&path) {
+                Ok(meta) => meta,
+                Err(_) => {
+                    remove_file_if_present(&path)?;
+                    return Ok(None);
+                }
+            };
+            if is_valid_source_watch_metadata(&meta, &env_name)
+                && is_legacy_source_watch_process(&meta)
+            {
+                return Ok(Some(meta));
             }
-        };
-        if !is_valid_source_watch_override(&meta, &env_name, &lock_path)? {
             remove_file_if_present(&path)?;
             return Ok(None);
         }
-        Ok(Some(meta))
+
+        let lock_file = open_source_watch_lock(&lock_path)?;
+        match FileExt::try_lock_exclusive(&lock_file) {
+            Ok(()) => {
+                remove_file_if_present(&path)?;
+                FileExt::unlock(&lock_file).map_err(|error| {
+                    format!(
+                        "failed unlocking stale source watch lock {}: {error}",
+                        display_path(&lock_path)
+                    )
+                })?;
+                Ok(None)
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                let meta = read_json::<SourceWatchOverride>(&path).map_err(|error| {
+                    format!(
+                        "failed reading active source watch override {}: {error}",
+                        display_path(&path)
+                    )
+                })?;
+                if is_valid_source_watch_metadata(&meta, &env_name) {
+                    Ok(Some(meta))
+                } else {
+                    Ok(None)
+                }
+            }
+            Err(error) => Err(format!(
+                "failed checking source watch lock {}: {error}",
+                display_path(&lock_path)
+            )),
+        }
     }
 }
 
-fn is_valid_source_watch_override(
-    meta: &SourceWatchOverride,
-    env_name: &str,
-    lock_path: &Path,
-) -> Result<bool, String> {
-    let metadata_valid = meta.kind == SOURCE_WATCH_OVERRIDE_KIND
+fn is_valid_source_watch_metadata(meta: &SourceWatchOverride, env_name: &str) -> bool {
+    meta.kind == SOURCE_WATCH_OVERRIDE_KIND
         && meta.env_name == env_name
         && !meta.repo_root.trim().is_empty()
         && !meta.token.trim().is_empty()
         && meta.watch_pid > 0
         && Path::new(&meta.repo_root).join("openclaw.mjs").is_file()
         && Path::new(&meta.repo_root).join("extensions").is_dir()
-        && is_process_alive(meta.watch_pid);
-    if !metadata_valid {
-        return Ok(false);
-    }
-    source_watch_lease_is_active(lock_path)
+        && is_process_alive(meta.watch_pid)
 }
 
-fn source_watch_lease_is_active(lock_path: &Path) -> Result<bool, String> {
-    let lock_file = match OpenOptions::new().read(true).write(true).open(lock_path) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => {
-            return Err(format!(
+fn open_source_watch_lock(lock_path: &Path) -> Result<File, String> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(lock_path)
+        .map_err(|error| {
+            format!(
                 "failed opening source watch lock {}: {error}",
                 display_path(lock_path)
-            ));
-        }
-    };
-    match FileExt::try_lock_exclusive(&lock_file) {
-        Ok(()) => {
-            FileExt::unlock(&lock_file).map_err(|error| {
-                format!(
-                    "failed unlocking stale source watch lock {}: {error}",
-                    display_path(lock_path)
-                )
-            })?;
-            Ok(false)
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(true),
-        Err(error) => Err(format!(
-            "failed checking source watch lock {}: {error}",
-            display_path(lock_path)
-        )),
+            )
+        })
+}
+
+fn is_legacy_source_watch_process(meta: &SourceWatchOverride) -> bool {
+    let command_matches = process_command_line(meta.watch_pid)
+        .is_some_and(|command| legacy_source_watch_command_matches(&command));
+    if !command_matches {
+        return false;
     }
+    legacy_source_watch_cwd_matches(meta)
+}
+
+fn legacy_source_watch_command_matches(command: &str) -> bool {
+    let command = command.replace('\\', "/");
+    command.contains("node")
+        && command.contains("scripts/watch-node.mjs")
+        && command.contains("gateway")
+        && command.contains("run")
 }
 
 fn remove_file_if_present(path: &Path) -> Result<(), String> {
@@ -244,6 +308,62 @@ fn is_process_alive(pid: u32) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(unix)]
+fn process_command_line(pid: u32) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn legacy_source_watch_cwd_matches(meta: &SourceWatchOverride) -> bool {
+    fs::read_link(format!("/proc/{}/cwd", meta.watch_pid))
+        .ok()
+        .is_some_and(|cwd| same_path(&cwd, Path::new(&meta.repo_root)))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn legacy_source_watch_cwd_matches(meta: &SourceWatchOverride) -> bool {
+    let output = Command::new("lsof")
+        .args([
+            "-b",
+            "-w",
+            "-a",
+            "-p",
+            &meta.watch_pid.to_string(),
+            "-d",
+            "cwd",
+            "-Fn",
+        ])
+        .output();
+    let Ok(output) = output else {
+        return false;
+    };
+    output.status.success()
+        && String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .find_map(|line| line.strip_prefix('n'))
+            .is_some_and(|cwd| same_path(Path::new(cwd), Path::new(&meta.repo_root)))
+}
+
+#[cfg(windows)]
+fn legacy_source_watch_cwd_matches(_meta: &SourceWatchOverride) -> bool {
+    true
+}
+
+#[cfg(unix)]
+fn same_path(left: &Path, right: &Path) -> bool {
+    match (fs::canonicalize(left), fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
 #[cfg(windows)]
 fn is_process_alive(pid: u32) -> bool {
     let filter = format!("PID eq {pid}");
@@ -255,6 +375,19 @@ fn is_process_alive(pid: u32) -> bool {
                 && String::from_utf8_lossy(&output.stdout).contains(&pid.to_string())
         })
         .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn process_command_line(pid: u32) -> Option<String> {
+    let script = format!("(Get-CimInstance Win32_Process -Filter 'ProcessId = {pid}').CommandLine");
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 #[cfg(test)]
@@ -281,5 +414,15 @@ mod tests {
             PathBuf::from("/repo/openclaw/extensions")
         );
         assert_eq!(meta.command_label(), "node /repo/openclaw/openclaw.mjs");
+    }
+
+    #[test]
+    fn legacy_source_watch_identity_requires_the_watch_command() {
+        assert!(legacy_source_watch_command_matches(
+            "node scripts/watch-node.mjs gateway run --port 18789"
+        ));
+        assert!(!legacy_source_watch_command_matches(
+            "cargo test source_watch"
+        ));
     }
 }

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -1,7 +1,9 @@
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -25,11 +27,16 @@ pub struct SourceWatchOverride {
     pub started_at: OffsetDateTime,
 }
 
-#[derive(Clone, Debug)]
-pub struct CreateSourceWatchOverrideOptions {
-    pub env_name: String,
-    pub repo_root: PathBuf,
-    pub watch_pid: u32,
+#[derive(Debug)]
+pub(crate) struct SourceWatchLease {
+    env_name: String,
+    lock_file: File,
+}
+
+impl Drop for SourceWatchLease {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.lock_file);
+    }
 }
 
 impl SourceWatchOverride {
@@ -47,21 +54,76 @@ impl SourceWatchOverride {
 }
 
 impl<'a> EnvironmentService<'a> {
-    pub fn create_source_watch_override(
+    pub(crate) fn acquire_source_watch_lease(
         &self,
-        options: CreateSourceWatchOverrideOptions,
+        env_name: &str,
+    ) -> Result<SourceWatchLease, String> {
+        let env_name = validate_name(env_name, "Environment name")?;
+        let override_path = source_watch_override_path(&env_name, self.env, self.cwd)?;
+        let lock_path = override_path.with_extension("lock");
+        if let Some(parent) = lock_path.parent() {
+            ensure_dir(parent)?;
+        }
+        let mut lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&lock_path)
+            .map_err(|error| {
+                format!(
+                    "failed opening source watch lock {}: {error}",
+                    display_path(&lock_path)
+                )
+            })?;
+        match FileExt::try_lock_exclusive(&lock_file) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                return Err(format!(
+                    "source watch for env \"{env_name}\" is already active or starting"
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed locking source watch for env \"{env_name}\": {error}"
+                ));
+            }
+        }
+
+        // Owning the OS lock proves any surviving metadata belongs to a dead
+        // lease, even if its child PID has since been reused by another process.
+        remove_file_if_present(&override_path)?;
+
+        lock_file
+            .set_len(0)
+            .and_then(|()| writeln!(lock_file, "{}", std::process::id()))
+            .map_err(|error| {
+                format!(
+                    "failed recording source watch lock {}: {error}",
+                    display_path(&lock_path)
+                )
+            })?;
+        Ok(SourceWatchLease {
+            env_name,
+            lock_file,
+        })
+    }
+
+    pub(crate) fn create_source_watch_override(
+        &self,
+        lease: &SourceWatchLease,
+        repo_root: &Path,
+        watch_pid: u32,
     ) -> Result<SourceWatchOverride, String> {
-        let env_name = validate_name(&options.env_name, "Environment name")?;
-        let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
+        let path = source_watch_override_path(&lease.env_name, self.env, self.cwd)?;
         if let Some(parent) = path.parent() {
             ensure_dir(parent)?;
         }
-        let token = format!("{}-{}", options.watch_pid, now_utc().unix_timestamp_nanos());
+        let token = format!("{watch_pid}-{}", now_utc().unix_timestamp_nanos());
         let meta = SourceWatchOverride {
             kind: SOURCE_WATCH_OVERRIDE_KIND.to_string(),
-            env_name,
-            repo_root: display_path(&options.repo_root),
-            watch_pid: options.watch_pid,
+            env_name: lease.env_name.clone(),
+            repo_root: display_path(repo_root),
+            watch_pid,
             token,
             started_at: now_utc(),
         };
@@ -95,6 +157,7 @@ impl<'a> EnvironmentService<'a> {
     ) -> Result<Option<SourceWatchOverride>, String> {
         let env_name = validate_name(env_name, "Environment name")?;
         let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
+        let lock_path = path.with_extension("lock");
         if !path.exists() {
             return Ok(None);
         }
@@ -105,7 +168,7 @@ impl<'a> EnvironmentService<'a> {
                 return Ok(None);
             }
         };
-        if !is_valid_source_watch_override(&meta, &env_name) {
+        if !is_valid_source_watch_override(&meta, &env_name, &lock_path)? {
             remove_file_if_present(&path)?;
             return Ok(None);
         }
@@ -113,15 +176,52 @@ impl<'a> EnvironmentService<'a> {
     }
 }
 
-fn is_valid_source_watch_override(meta: &SourceWatchOverride, env_name: &str) -> bool {
-    meta.kind == SOURCE_WATCH_OVERRIDE_KIND
+fn is_valid_source_watch_override(
+    meta: &SourceWatchOverride,
+    env_name: &str,
+    lock_path: &Path,
+) -> Result<bool, String> {
+    let metadata_valid = meta.kind == SOURCE_WATCH_OVERRIDE_KIND
         && meta.env_name == env_name
         && !meta.repo_root.trim().is_empty()
         && !meta.token.trim().is_empty()
         && meta.watch_pid > 0
         && Path::new(&meta.repo_root).join("openclaw.mjs").is_file()
         && Path::new(&meta.repo_root).join("extensions").is_dir()
-        && is_process_alive(meta.watch_pid)
+        && is_process_alive(meta.watch_pid);
+    if !metadata_valid {
+        return Ok(false);
+    }
+    source_watch_lease_is_active(lock_path)
+}
+
+fn source_watch_lease_is_active(lock_path: &Path) -> Result<bool, String> {
+    let lock_file = match OpenOptions::new().read(true).write(true).open(lock_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "failed opening source watch lock {}: {error}",
+                display_path(lock_path)
+            ));
+        }
+    };
+    match FileExt::try_lock_exclusive(&lock_file) {
+        Ok(()) => {
+            FileExt::unlock(&lock_file).map_err(|error| {
+                format!(
+                    "failed unlocking stale source watch lock {}: {error}",
+                    display_path(lock_path)
+                )
+            })?;
+            Ok(false)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(true),
+        Err(error) => Err(format!(
+            "failed checking source watch lock {}: {error}",
+            display_path(lock_path)
+        )),
+    }
 }
 
 fn remove_file_if_present(path: &Path) -> Result<(), String> {

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -191,16 +191,18 @@ impl<'a> EnvironmentService<'a> {
             }
         }
 
-        // Owning the OS lock proves any surviving metadata belongs to a dead
-        // lease, even if its child PID has since been reused by another process.
-        remove_file_if_present(&override_path)?;
-
         let lease_id = format!(
             "{}-{}",
             std::process::id(),
             now_utc().unix_timestamp_nanos()
         );
+        // Publish the new generation before touching stale metadata. Readers that
+        // observe this exclusive owner must never correlate an old token with it.
         write_source_watch_lock(&mut lock_file, &lease_id)?;
+
+        // Owning the OS lock proves any surviving metadata belongs to a dead
+        // lease, even if its child PID has since been reused by another process.
+        remove_file_if_present(&override_path)?;
         Ok(SourceWatchLease {
             env_name,
             lease_id,
@@ -288,12 +290,26 @@ impl<'a> EnvironmentService<'a> {
         let env_name = validate_name(env_name, "Environment name")?;
         let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         let lock_path = path.with_extension("lock");
-        if let Some(parent) = lock_path.parent() {
-            ensure_dir(parent)?;
-        }
-        // Open/create before inspecting metadata so first-watch lease creation cannot
-        // interleave between a missing-lock check and stale override cleanup.
-        let lock_file = open_source_watch_lock(&lock_path)?;
+        let lock_file = match OpenOptions::new().read(true).open(&lock_path) {
+            Ok(lock_file) => lock_file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                // A lookup with no watch state remains read-only. If an override exists,
+                // create the lock before cleanup so lease creation cannot interleave.
+                if !path.exists() {
+                    return Ok(None);
+                }
+                if let Some(parent) = lock_path.parent() {
+                    ensure_dir(parent)?;
+                }
+                open_source_watch_lock(&lock_path)?
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed opening source watch lock {}: {error}",
+                    display_path(&lock_path)
+                ));
+            }
+        };
 
         #[cfg(windows)]
         if let Some(_lease_event) = open_windows_source_watch_event(&lock_path)? {

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -288,17 +288,12 @@ impl<'a> EnvironmentService<'a> {
         let env_name = validate_name(env_name, "Environment name")?;
         let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         let lock_path = path.with_extension("lock");
-        if let Ok(meta) = read_json::<SourceWatchOverride>(&path)
-            && !is_leased_source_watch(&meta)
-            && is_valid_source_watch_metadata(&meta, &env_name)
-            && is_legacy_source_watch_process(&meta)
-        {
-            return Ok(Some(meta));
+        if let Some(parent) = lock_path.parent() {
+            ensure_dir(parent)?;
         }
-        if !lock_path.exists() {
-            remove_file_if_present(&path)?;
-            return Ok(None);
-        }
+        // Open/create before inspecting metadata so first-watch lease creation cannot
+        // interleave between a missing-lock check and stale override cleanup.
+        let lock_file = open_source_watch_lock(&lock_path)?;
 
         #[cfg(windows)]
         if let Some(_lease_event) = open_windows_source_watch_event(&lock_path)? {
@@ -330,19 +325,25 @@ impl<'a> EnvironmentService<'a> {
             ));
         }
 
-        let lock_file = open_source_watch_lock(&lock_path)?;
         match FileExt::try_lock_shared(&lock_file) {
             Ok(()) => {
                 // Shared readers prove no watcher owns the exclusive lease. They may clean the
                 // same stale metadata concurrently without impersonating an active watcher.
-                remove_file_if_present(&path)?;
+                let active_legacy = read_json::<SourceWatchOverride>(&path).ok().filter(|meta| {
+                    !is_leased_source_watch(meta)
+                        && is_valid_source_watch_metadata(meta, &env_name)
+                        && is_legacy_source_watch_process(meta)
+                });
+                if active_legacy.is_none() {
+                    remove_file_if_present(&path)?;
+                }
                 FileExt::unlock(&lock_file).map_err(|error| {
                     format!(
                         "failed unlocking stale source watch lock {}: {error}",
                         display_path(&lock_path)
                     )
                 })?;
-                Ok(None)
+                Ok(active_legacy)
             }
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 let lock_lease_id = fs::read_to_string(&lock_path)

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -27,9 +27,15 @@ pub struct SourceWatchOverride {
     pub started_at: OffsetDateTime,
 }
 
+#[derive(Clone, Debug)]
+pub struct CreateSourceWatchOverrideOptions {
+    pub env_name: String,
+    pub repo_root: PathBuf,
+    pub watch_pid: u32,
+}
+
 #[derive(Debug)]
 pub(crate) struct SourceWatchLease {
-    env_name: String,
     lock_file: File,
 }
 
@@ -102,28 +108,24 @@ impl<'a> EnvironmentService<'a> {
                     display_path(&lock_path)
                 )
             })?;
-        Ok(SourceWatchLease {
-            env_name,
-            lock_file,
-        })
+        Ok(SourceWatchLease { lock_file })
     }
 
-    pub(crate) fn create_source_watch_override(
+    pub fn create_source_watch_override(
         &self,
-        lease: &SourceWatchLease,
-        repo_root: &Path,
-        watch_pid: u32,
+        options: CreateSourceWatchOverrideOptions,
     ) -> Result<SourceWatchOverride, String> {
-        let path = source_watch_override_path(&lease.env_name, self.env, self.cwd)?;
+        let env_name = validate_name(&options.env_name, "Environment name")?;
+        let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         if let Some(parent) = path.parent() {
             ensure_dir(parent)?;
         }
-        let token = format!("{watch_pid}-{}", now_utc().unix_timestamp_nanos());
+        let token = format!("{}-{}", options.watch_pid, now_utc().unix_timestamp_nanos());
         let meta = SourceWatchOverride {
             kind: SOURCE_WATCH_OVERRIDE_KIND.to_string(),
-            env_name: lease.env_name.clone(),
-            repo_root: display_path(repo_root),
-            watch_pid,
+            env_name,
+            repo_root: display_path(&options.repo_root),
+            watch_pid: options.watch_pid,
             token,
             started_at: now_utc(),
         };

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -2,8 +2,12 @@ mod support;
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
+use ocm::store::{now_utc, supervisor_runtime_path};
+use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
 use serde_json::Value;
 
 use crate::support::{
@@ -283,6 +287,55 @@ fn install_fake_dev_runners(root: &TestDir, env: &mut std::collections::BTreeMap
 
 fn source_watch_override_path(root: &TestDir, name: &str) -> PathBuf {
     root.child(format!("ocm-home/source-watch/{name}.json"))
+}
+
+fn source_watch_lock_path(root: &TestDir, name: &str) -> PathBuf {
+    root.child(format!("ocm-home/source-watch/{name}.lock"))
+}
+
+#[cfg(unix)]
+fn install_blocking_fake_dev_runners(
+    root: &TestDir,
+    env: &mut std::collections::BTreeMap<String, String>,
+) -> (PathBuf, PathBuf, PathBuf) {
+    install_fake_dev_runners(root, env);
+    let started = root.child("source-watch.started");
+    let release = root.child("source-watch.release");
+    let log = root.child("source-watch.log");
+    let node = format!(
+        "#!/bin/sh\nprintf 'started\\n' >> \"{}\"\nprintf 'ready\\n' > \"{}\"\nwhile [ ! -f \"{}\" ]; do /bin/sleep 0.05; done\n",
+        path_string(&log),
+        path_string(&started),
+        path_string(&release),
+    );
+    write_executable_script(&root.child("fake-dev-bin/node"), &node);
+    (started, release, log)
+}
+
+#[cfg(unix)]
+fn install_failing_fake_dev_runners(
+    root: &TestDir,
+    env: &mut std::collections::BTreeMap<String, String>,
+) -> PathBuf {
+    install_fake_dev_runners(root, env);
+    let started = root.child("source-watch.started");
+    let node = format!(
+        "#!/bin/sh\nprintf 'ready\\n' > \"{}\"\nexit 23\n",
+        path_string(&started),
+    );
+    write_executable_script(&root.child("fake-dev-bin/node"), &node);
+    started
+}
+
+fn wait_for_path(path: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    path.exists()
 }
 
 fn service_env(root: &TestDir) -> std::collections::BTreeMap<String, String> {
@@ -1273,6 +1326,233 @@ fn dev_watch_force_restores_runtime_service_when_source_watch_cannot_spawn() {
     assert_eq!(show_json["defaultRuntime"], "stable");
     assert_eq!(show_json["serviceEnabled"], true);
     assert_eq!(show_json["serviceRunning"], true);
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_rejects_overlap_and_reclaims_the_released_lock() {
+    let root = TestDir::new("dev-command-watch-overlap");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    let (started, release, watch_log) = install_blocking_fake_dev_runners(&root, &mut env);
+
+    let mut first = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    first
+        .current_dir(&cwd)
+        .args(["dev", "demo", "--repo", &path_string(&repo), "--watch"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let first = first.spawn().unwrap();
+    let did_start = wait_for_path(&started, Duration::from_secs(30));
+
+    let overlap = run_ocm(&cwd, &env, &["dev", "demo", "--watch"]);
+    fs::write(&release, "release\n").unwrap();
+    let first_output = first.wait_with_output().unwrap();
+
+    assert!(
+        did_start,
+        "first source watch did not start: {}",
+        stderr(&first_output)
+    );
+    assert!(
+        !overlap.status.success(),
+        "overlapping source watch unexpectedly succeeded"
+    );
+    assert!(
+        stderr(&overlap).contains("source watch for env \"demo\" is already active or starting"),
+        "{}",
+        stderr(&overlap)
+    );
+    assert!(first_output.status.success(), "{}", stderr(&first_output));
+    assert!(source_watch_lock_path(&root, "demo").exists());
+    assert!(!source_watch_override_path(&root, "demo").exists());
+
+    let after_release = run_ocm(&cwd, &env, &["dev", "demo", "--watch"]);
+    assert!(after_release.status.success(), "{}", stderr(&after_release));
+    let starts = fs::read_to_string(watch_log).unwrap();
+    assert_eq!(starts.lines().count(), 2);
+}
+
+#[test]
+fn dev_watch_aborts_and_restores_policy_when_service_stop_times_out() {
+    let root = TestDir::new("dev-command-watch-stop-timeout");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = service_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+    create_runtime_backed_env(&cwd, &env);
+
+    let start = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let stdout_path = path_string(&root.child("demo.stdout.log"));
+    let stderr_path = path_string(&root.child("demo.stderr.log"));
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: path_string(&root.child("ocm-home")),
+        updated_at: now_utc(),
+        services: vec![SupervisorRuntimeService {
+            env_name: "demo".to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: "stable".to_string(),
+            gateway_state: "running".to_string(),
+            restart_count: 0,
+            child_port: 21901,
+            pid: Some(std::process::id()),
+            stdout_path: stdout_path.clone(),
+            stderr_path: stderr_path.clone(),
+            last_exit_code: None,
+            last_error: None,
+            last_event_at: None,
+            next_retry_at: None,
+        }],
+        children: vec![SupervisorRuntimeChild {
+            env_name: "demo".to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: "stable".to_string(),
+            pid: std::process::id(),
+            restart_count: 0,
+            child_port: 21901,
+            stdout_path,
+            stderr_path,
+        }],
+    };
+    fs::write(&runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+
+    let watch = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "dev",
+            "demo",
+            "--repo",
+            &path_string(&repo),
+            "--watch",
+            "--force",
+        ],
+    );
+    assert!(!watch.status.success());
+    assert!(
+        stderr(&watch)
+            .contains("background service for demo is still running after the stop request"),
+        "{}",
+        stderr(&watch)
+    );
+    assert!(
+        stderr(&watch)
+            .contains("restored the background service policy and did not start source watch"),
+        "{}",
+        stderr(&watch)
+    );
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(show_json["serviceRunning"], true);
+    assert!(!root.child("node.log").exists());
+    assert!(!source_watch_override_path(&root, "demo").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_signal_stops_the_child_and_restores_the_service() {
+    let root = TestDir::new("dev-command-watch-signal");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = service_env(&root);
+    let (started, release, _) = install_blocking_fake_dev_runners(&root, &mut env);
+    create_runtime_backed_env(&cwd, &env);
+
+    let start = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let mut watch = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    watch
+        .current_dir(&cwd)
+        .args([
+            "dev",
+            "demo",
+            "--repo",
+            &path_string(&repo),
+            "--watch",
+            "--force",
+        ])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut watch = watch.spawn().unwrap();
+    let did_start = wait_for_path(&started, Duration::from_secs(30));
+    let signal = Command::new("kill")
+        .args(["-INT", &watch.id().to_string()])
+        .output()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut stopped_from_signal = false;
+    while Instant::now() < deadline {
+        if watch.try_wait().unwrap().is_some() {
+            stopped_from_signal = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    if !stopped_from_signal {
+        fs::write(&release, "release\n").unwrap();
+    }
+    let watch = watch.wait_with_output().unwrap();
+
+    assert!(did_start, "source watch did not start: {}", stderr(&watch));
+    assert!(signal.status.success(), "{}", stderr(&signal));
+    assert!(stopped_from_signal, "source watch ignored SIGINT");
+    assert_eq!(watch.status.code(), Some(130), "{}", stderr(&watch));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(show_json["serviceRunning"], true);
+    assert!(!source_watch_override_path(&root, "demo").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_nonzero_child_exit_restores_the_service() {
+    let root = TestDir::new("dev-command-watch-child-failure");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = service_env(&root);
+    let started = install_failing_fake_dev_runners(&root, &mut env);
+    create_runtime_backed_env(&cwd, &env);
+
+    let start = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let watch = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "dev",
+            "demo",
+            "--repo",
+            &path_string(&repo),
+            "--watch",
+            "--force",
+        ],
+    );
+    assert!(started.exists());
+    assert_eq!(watch.status.code(), Some(23), "{}", stderr(&watch));
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(show_json["serviceRunning"], true);
+    assert!(!source_watch_override_path(&root, "demo").exists());
 }
 
 #[test]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -348,19 +348,21 @@ fn install_stubborn_fake_dev_runners(
 fn install_orphaning_fake_dev_runners(
     root: &TestDir,
     env: &mut std::collections::BTreeMap<String, String>,
-) -> (PathBuf, PathBuf, PathBuf) {
+) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
     install_fake_dev_runners(root, env);
     let started = root.child("source-watch.started");
     let descendant_pid = root.child("source-watch-descendant.pid");
     let stdin_kind = root.child("source-watch.stdin-kind");
+    let node_args = root.child("source-watch.node-args");
     let node = format!(
-        "#!/bin/sh\nif [ -t 0 ]; then printf 'tty\\n'; else printf 'pipe\\n'; fi > \"{}\"\n/bin/sleep 300 &\nprintf '%s\\n' \"$!\" > \"{}\"\nprintf 'ready\\n' > \"{}\"\nexit 23\n",
+        "#!/bin/sh\nif [ -t 0 ]; then printf 'tty\\n'; else printf 'pipe\\n'; fi > \"{}\"\nprintf '%s\\n' \"$*\" > \"{}\"\n/bin/sleep 300 &\nprintf '%s\\n' \"$!\" > \"{}\"\nprintf 'ready\\n' > \"{}\"\nexit 23\n",
         path_string(&stdin_kind),
+        path_string(&node_args),
         path_string(&descendant_pid),
         path_string(&started),
     );
     write_executable_script(&root.child("fake-dev-bin/node"), &node);
-    (started, descendant_pid, stdin_kind)
+    (started, descendant_pid, stdin_kind, node_args)
 }
 
 fn wait_for_path(path: &Path, timeout: Duration) -> bool {
@@ -1584,7 +1586,7 @@ fn dev_watch_stops_descendants_when_the_wrapper_exits_first() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
-    let (started, descendant_pid_path, stdin_kind) =
+    let (started, descendant_pid_path, stdin_kind, node_args) =
         install_orphaning_fake_dev_runners(&root, &mut env);
 
     let watch = run_ocm(
@@ -1607,7 +1609,13 @@ fn dev_watch_stops_descendants_when_the_wrapper_exits_first() {
         .unwrap();
 
     assert_eq!(watch.status.code(), Some(23), "{}", stderr(&watch));
-    assert_eq!(fs::read_to_string(stdin_kind).unwrap().trim(), "tty");
+    assert_eq!(fs::read_to_string(stdin_kind).unwrap().trim(), "pipe");
+    let node_args = fs::read_to_string(node_args).unwrap();
+    assert!(node_args.contains("--input-type=module"), "{node_args}");
+    assert!(
+        node_args.contains("Object.defineProperty(process.stdin"),
+        "{node_args}"
+    );
     assert!(
         wait_for_process_exit(descendant_pid, Duration::from_secs(3)),
         "source watch descendant {descendant_pid} survived wrapper exit"

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -475,6 +475,31 @@ fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
     !process_is_alive(pid)
 }
 
+#[cfg(unix)]
+fn wait_for_process_stop(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let mut status = 0;
+        let waited = unsafe {
+            libc::waitpid(
+                pid as libc::pid_t,
+                &mut status,
+                libc::WNOHANG | libc::WUNTRACED,
+            )
+        };
+        if waited == pid as libc::pid_t && libc::WIFSTOPPED(status) {
+            return true;
+        }
+        assert!(
+            waited >= 0,
+            "failed waiting for process stop: {}",
+            std::io::Error::last_os_error()
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    false
+}
+
 fn service_env(root: &TestDir) -> std::collections::BTreeMap<String, String> {
     let mut env = ocm_env(root);
     install_fake_service_manager(root, &mut env);
@@ -1721,6 +1746,18 @@ fn dev_watch_gives_interactive_child_terminal_foreground_ownership() {
     assert!(
         wait_for_path(&started, Duration::from_secs(30)),
         "source watch did not reach its interactive stdin read"
+    );
+    terminal.write_all(&[0x1a]).unwrap();
+    assert!(
+        wait_for_process_stop(watch.id(), Duration::from_secs(10)),
+        "OCM did not suspend with its foreground source watch"
+    );
+    let resumed = unsafe { libc::kill(watch.id() as libc::pid_t, libc::SIGCONT) };
+    assert_eq!(
+        resumed,
+        0,
+        "failed resuming OCM: {}",
+        std::io::Error::last_os_error()
     );
     terminal.write_all(b"terminal-input\n").unwrap();
     assert!(

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1348,8 +1348,12 @@ fn dev_watch_rejects_overlap_and_reclaims_the_released_lock() {
         .stderr(Stdio::piped());
     let first = first.spawn().unwrap();
     let did_start = wait_for_path(&started, Duration::from_secs(30));
+    let override_path = source_watch_override_path(&root, "demo");
+    let did_write_override = wait_for_path(&override_path, Duration::from_secs(30));
+    let override_before_overlap = fs::read_to_string(&override_path).unwrap_or_default();
 
     let overlap = run_ocm(&cwd, &env, &["dev", "demo", "--watch"]);
+    let override_after_overlap = fs::read_to_string(&override_path).unwrap_or_default();
     fs::write(&release, "release\n").unwrap();
     let first_output = first.wait_with_output().unwrap();
 
@@ -1357,6 +1361,10 @@ fn dev_watch_rejects_overlap_and_reclaims_the_released_lock() {
         did_start,
         "first source watch did not start: {}",
         stderr(&first_output)
+    );
+    assert!(
+        did_write_override,
+        "first source watch did not publish its override"
     );
     assert!(
         !overlap.status.success(),
@@ -1367,6 +1375,7 @@ fn dev_watch_rejects_overlap_and_reclaims_the_released_lock() {
         "{}",
         stderr(&overlap)
     );
+    assert_eq!(override_after_overlap, override_before_overlap);
     assert!(first_output.status.success(), "{}", stderr(&first_output));
     assert!(source_watch_lock_path(&root, "demo").exists());
     assert!(!source_watch_override_path(&root, "demo").exists());

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -327,6 +327,23 @@ fn install_failing_fake_dev_runners(
     started
 }
 
+#[cfg(unix)]
+fn install_stubborn_fake_dev_runners(
+    root: &TestDir,
+    env: &mut std::collections::BTreeMap<String, String>,
+) -> (PathBuf, PathBuf) {
+    install_fake_dev_runners(root, env);
+    let started = root.child("source-watch.started");
+    let descendant_pid = root.child("source-watch-descendant.pid");
+    let node = format!(
+        "#!/bin/sh\ntrap '' TERM\n/bin/sleep 300 &\nprintf '%s\\n' \"$!\" > \"{}\"\nprintf 'ready\\n' > \"{}\"\nwhile :; do /bin/sleep 1; done\n",
+        path_string(&descendant_pid),
+        path_string(&started),
+    );
+    write_executable_script(&root.child("fake-dev-bin/node"), &node);
+    (started, descendant_pid)
+}
+
 fn wait_for_path(path: &Path, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
@@ -336,6 +353,28 @@ fn wait_for_path(path: &Path, timeout: Duration) -> bool {
         thread::sleep(Duration::from_millis(25));
     }
     path.exists()
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(unix)]
+fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !process_is_alive(pid) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    !process_is_alive(pid)
 }
 
 fn service_env(root: &TestDir) -> std::collections::BTreeMap<String, String> {
@@ -1384,6 +1423,138 @@ fn dev_watch_rejects_overlap_and_reclaims_the_released_lock() {
     assert!(after_release.status.success(), "{}", stderr(&after_release));
     let starts = fs::read_to_string(watch_log).unwrap();
     assert_eq!(starts.lines().count(), 2);
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_lease_survives_parent_crash_until_the_watcher_exits() {
+    let root = TestDir::new("dev-command-watch-parent-crash");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    let (started, release, watch_log) = install_blocking_fake_dev_runners(&root, &mut env);
+
+    let mut first = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    first
+        .current_dir(&cwd)
+        .args(["dev", "demo", "--repo", &path_string(&repo), "--watch"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut first = first.spawn().unwrap();
+    assert!(
+        wait_for_path(&started, Duration::from_secs(30)),
+        "source watch did not start"
+    );
+    let override_path = source_watch_override_path(&root, "demo");
+    assert!(
+        wait_for_path(&override_path, Duration::from_secs(30)),
+        "source watch did not publish its override"
+    );
+    let source_watch: Value =
+        serde_json::from_str(&fs::read_to_string(&override_path).unwrap()).unwrap();
+    let watcher_pid = source_watch["watchPid"].as_u64().unwrap() as u32;
+
+    let killed = Command::new("kill")
+        .args(["-KILL", &first.id().to_string()])
+        .output()
+        .unwrap();
+    assert!(killed.status.success(), "{}", stderr(&killed));
+    assert!(!first.wait().unwrap().success());
+    assert!(process_is_alive(watcher_pid));
+
+    let mut overlap = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    overlap
+        .current_dir(&cwd)
+        .args(["dev", "demo", "--watch"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut overlap = overlap.spawn().unwrap();
+    let overlap_deadline = Instant::now() + Duration::from_secs(5);
+    let overlap_exited = loop {
+        if overlap.try_wait().unwrap().is_some() {
+            break true;
+        }
+        if Instant::now() >= overlap_deadline {
+            break false;
+        }
+        thread::sleep(Duration::from_millis(25));
+    };
+    if !overlap_exited {
+        fs::write(&release, "release\n").unwrap();
+        let _ = overlap.kill();
+    }
+    let overlap = overlap.wait_with_output().unwrap();
+    assert!(
+        overlap_exited,
+        "overlapping source watch blocked instead of rejecting the live lease"
+    );
+    assert!(!overlap.status.success());
+    assert!(
+        stderr(&overlap).contains("source watch for env \"demo\" is already active or starting"),
+        "{}",
+        stderr(&overlap)
+    );
+
+    fs::write(&release, "release\n").unwrap();
+    assert!(wait_for_process_exit(watcher_pid, Duration::from_secs(10)));
+
+    let after_release = run_ocm(&cwd, &env, &["dev", "demo", "--watch"]);
+    assert!(after_release.status.success(), "{}", stderr(&after_release));
+    let starts = fs::read_to_string(watch_log).unwrap();
+    assert_eq!(starts.lines().count(), 2);
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_force_stops_the_entire_stubborn_process_tree() {
+    let root = TestDir::new("dev-command-watch-force-tree");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    let (started, descendant_pid_path) = install_stubborn_fake_dev_runners(&root, &mut env);
+
+    let mut watch = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    watch
+        .current_dir(&cwd)
+        .args(["dev", "demo", "--repo", &path_string(&repo), "--watch"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let watch = watch.spawn().unwrap();
+    assert!(
+        wait_for_path(&started, Duration::from_secs(30)),
+        "source watch did not start"
+    );
+    assert!(
+        wait_for_path(&descendant_pid_path, Duration::from_secs(30)),
+        "source watch descendant did not start"
+    );
+    let descendant_pid = fs::read_to_string(&descendant_pid_path)
+        .unwrap()
+        .trim()
+        .parse::<u32>()
+        .unwrap();
+
+    let signal = Command::new("kill")
+        .args(["-INT", &watch.id().to_string()])
+        .output()
+        .unwrap();
+    assert!(signal.status.success(), "{}", stderr(&signal));
+    let watch = watch.wait_with_output().unwrap();
+
+    assert_eq!(watch.status.code(), Some(130), "{}", stderr(&watch));
+    assert!(
+        wait_for_process_exit(descendant_pid, Duration::from_secs(3)),
+        "source watch descendant {descendant_pid} survived forced shutdown"
+    );
+    assert!(!source_watch_override_path(&root, "demo").exists());
 }
 
 #[test]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1,6 +1,14 @@
 mod support;
 
 use std::fs;
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::io::Write;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
@@ -363,6 +371,75 @@ fn install_orphaning_fake_dev_runners(
     );
     write_executable_script(&root.child("fake-dev-bin/node"), &node);
     (started, descendant_pid, stdin_kind, node_args)
+}
+
+#[cfg(unix)]
+fn install_interactive_fake_dev_runners(
+    root: &TestDir,
+    env: &mut std::collections::BTreeMap<String, String>,
+) -> (PathBuf, PathBuf) {
+    install_fake_dev_runners(root, env);
+    let started = root.child("source-watch.started");
+    let received = root.child("source-watch.received");
+    let node = format!(
+        "#!/bin/sh\nprintf 'ready\\n' > \"{}\"\nIFS= read -r line\nprintf '%s\\n' \"$line\" > \"{}\"\n",
+        path_string(&started),
+        path_string(&received),
+    );
+    write_executable_script(&root.child("fake-dev-bin/node"), &node);
+    (started, received)
+}
+
+#[cfg(unix)]
+fn spawn_ocm_with_controlling_pty(
+    cwd: &Path,
+    env: &std::collections::BTreeMap<String, String>,
+    args: &[&str],
+) -> (std::process::Child, File) {
+    let mut master_fd = -1;
+    let mut slave_fd = -1;
+    let opened = unsafe {
+        libc::openpty(
+            &mut master_fd,
+            &mut slave_fd,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(
+        opened,
+        0,
+        "failed opening test PTY: {}",
+        std::io::Error::last_os_error()
+    );
+    let master = unsafe { File::from_raw_fd(master_fd) };
+    let slave = unsafe { File::from_raw_fd(slave_fd) };
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    command
+        .current_dir(cwd)
+        .args(args)
+        .env_clear()
+        .envs(env)
+        .stdin(Stdio::from(slave))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY as _, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::tcsetpgrp(libc::STDIN_FILENO, libc::getpgrp()) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    (command.spawn().unwrap(), master)
 }
 
 fn wait_for_path(path: &Path, timeout: Duration) -> bool {
@@ -1621,6 +1698,42 @@ fn dev_watch_stops_descendants_when_the_wrapper_exits_first() {
     assert!(
         wait_for_process_exit(descendant_pid, Duration::from_secs(3)),
         "source watch descendant {descendant_pid} survived wrapper exit"
+    );
+    assert!(!source_watch_override_path(&root, "demo").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_gives_interactive_child_terminal_foreground_ownership() {
+    let root = TestDir::new("dev-command-watch-interactive-terminal");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    let (started, received) = install_interactive_fake_dev_runners(&root, &mut env);
+
+    let repo_path = path_string(&repo);
+    let (mut watch, mut terminal) = spawn_ocm_with_controlling_pty(
+        &cwd,
+        &env,
+        &["dev", "demo", "--repo", &repo_path, "--watch"],
+    );
+    assert!(
+        wait_for_path(&started, Duration::from_secs(30)),
+        "source watch did not reach its interactive stdin read"
+    );
+    terminal.write_all(b"terminal-input\n").unwrap();
+    assert!(
+        wait_for_path(&received, Duration::from_secs(10)),
+        "source watch was suspended while reading inherited terminal stdin"
+    );
+
+    drop(terminal);
+    let status = watch.wait().unwrap();
+    assert!(status.success(), "source watch exited with {status}");
+    assert_eq!(
+        fs::read_to_string(received).unwrap().trim(),
+        "terminal-input"
     );
     assert!(!source_watch_override_path(&root, "demo").exists());
 }

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -981,7 +981,8 @@ fn dev_command_can_onboard_then_watch() {
     assert!(pnpm_log.contains("openclaw onboard --mode local --no-install-daemon"));
 
     let node_log = fs::read_to_string(root.child("node.log")).unwrap();
-    assert!(node_log.contains("scripts/watch-node.mjs gateway run --port"));
+    assert!(node_log.contains("scripts/watch-node.mjs"));
+    assert!(node_log.contains("gateway run --port"));
     assert!(!source_watch_override_path(&root, "demo").exists());
 }
 
@@ -1284,7 +1285,8 @@ fn dev_watch_force_takes_over_runtime_env_without_rebinding() {
     let node_log = fs::read_to_string(root.child("node.log")).unwrap();
     assert!(node_log.contains(&path_string(&repo)));
     assert!(node_log.contains(show_json["configPath"].as_str().unwrap()));
-    assert!(node_log.contains("21901|scripts/watch-node.mjs gateway run --port 21901"));
+    assert!(node_log.contains("21901|--input-type=module"));
+    assert!(node_log.contains("gateway run --port 21901"));
     assert!(node_log.contains(&format!(
         "|bundled={}",
         path_string(&repo.join("extensions"))
@@ -1850,5 +1852,6 @@ fn dev_watch_force_temporarily_takes_over_and_restores_the_background_service() 
     assert!(!source_watch_override_path(&root, "demo").exists());
 
     let node_log = fs::read_to_string(root.child("node.log")).unwrap();
-    assert!(node_log.contains("scripts/watch-node.mjs gateway run --port"));
+    assert!(node_log.contains("scripts/watch-node.mjs"));
+    assert!(node_log.contains("gateway run --port"));
 }

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -348,17 +348,19 @@ fn install_stubborn_fake_dev_runners(
 fn install_orphaning_fake_dev_runners(
     root: &TestDir,
     env: &mut std::collections::BTreeMap<String, String>,
-) -> (PathBuf, PathBuf) {
+) -> (PathBuf, PathBuf, PathBuf) {
     install_fake_dev_runners(root, env);
     let started = root.child("source-watch.started");
     let descendant_pid = root.child("source-watch-descendant.pid");
+    let stdin_kind = root.child("source-watch.stdin-kind");
     let node = format!(
-        "#!/bin/sh\n/bin/sleep 300 &\nprintf '%s\\n' \"$!\" > \"{}\"\nprintf 'ready\\n' > \"{}\"\nexit 23\n",
+        "#!/bin/sh\nif [ -t 0 ]; then printf 'tty\\n'; else printf 'pipe\\n'; fi > \"{}\"\n/bin/sleep 300 &\nprintf '%s\\n' \"$!\" > \"{}\"\nprintf 'ready\\n' > \"{}\"\nexit 23\n",
+        path_string(&stdin_kind),
         path_string(&descendant_pid),
         path_string(&started),
     );
     write_executable_script(&root.child("fake-dev-bin/node"), &node);
-    (started, descendant_pid)
+    (started, descendant_pid, stdin_kind)
 }
 
 fn wait_for_path(path: &Path, timeout: Duration) -> bool {
@@ -1582,7 +1584,8 @@ fn dev_watch_stops_descendants_when_the_wrapper_exits_first() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
-    let (started, descendant_pid_path) = install_orphaning_fake_dev_runners(&root, &mut env);
+    let (started, descendant_pid_path, stdin_kind) =
+        install_orphaning_fake_dev_runners(&root, &mut env);
 
     let watch = run_ocm(
         &cwd,
@@ -1604,6 +1607,7 @@ fn dev_watch_stops_descendants_when_the_wrapper_exits_first() {
         .unwrap();
 
     assert_eq!(watch.status.code(), Some(23), "{}", stderr(&watch));
+    assert_eq!(fs::read_to_string(stdin_kind).unwrap().trim(), "tty");
     assert!(
         wait_for_process_exit(descendant_pid, Duration::from_secs(3)),
         "source watch descendant {descendant_pid} survived wrapper exit"

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -344,6 +344,23 @@ fn install_stubborn_fake_dev_runners(
     (started, descendant_pid)
 }
 
+#[cfg(unix)]
+fn install_orphaning_fake_dev_runners(
+    root: &TestDir,
+    env: &mut std::collections::BTreeMap<String, String>,
+) -> (PathBuf, PathBuf) {
+    install_fake_dev_runners(root, env);
+    let started = root.child("source-watch.started");
+    let descendant_pid = root.child("source-watch-descendant.pid");
+    let node = format!(
+        "#!/bin/sh\n/bin/sleep 300 &\nprintf '%s\\n' \"$!\" > \"{}\"\nprintf 'ready\\n' > \"{}\"\nexit 23\n",
+        path_string(&descendant_pid),
+        path_string(&started),
+    );
+    write_executable_script(&root.child("fake-dev-bin/node"), &node);
+    (started, descendant_pid)
+}
+
 fn wait_for_path(path: &Path, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
@@ -1553,6 +1570,43 @@ fn dev_watch_force_stops_the_entire_stubborn_process_tree() {
     assert!(
         wait_for_process_exit(descendant_pid, Duration::from_secs(3)),
         "source watch descendant {descendant_pid} survived forced shutdown"
+    );
+    assert!(!source_watch_override_path(&root, "demo").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_stops_descendants_when_the_wrapper_exits_first() {
+    let root = TestDir::new("dev-command-watch-wrapper-exit");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    let (started, descendant_pid_path) = install_orphaning_fake_dev_runners(&root, &mut env);
+
+    let watch = run_ocm(
+        &cwd,
+        &env,
+        &["dev", "demo", "--repo", &path_string(&repo), "--watch"],
+    );
+    assert!(
+        wait_for_path(&started, Duration::from_secs(30)),
+        "source watch did not start"
+    );
+    assert!(
+        wait_for_path(&descendant_pid_path, Duration::from_secs(30)),
+        "source watch descendant did not start"
+    );
+    let descendant_pid = fs::read_to_string(&descendant_pid_path)
+        .unwrap()
+        .trim()
+        .parse::<u32>()
+        .unwrap();
+
+    assert_eq!(watch.status.code(), Some(23), "{}", stderr(&watch));
+    assert!(
+        wait_for_process_exit(descendant_pid, Duration::from_secs(3)),
+        "source watch descendant {descendant_pid} survived wrapper exit"
     );
     assert!(!source_watch_override_path(&root, "demo").exists());
 }

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1859,9 +1859,8 @@ fn dev_watch_aborts_and_restores_policy_when_service_stop_times_out() {
 }
 
 #[cfg(unix)]
-#[test]
-fn dev_watch_signal_stops_the_child_and_restores_the_service() {
-    let root = TestDir::new("dev-command-watch-signal");
+fn assert_dev_watch_signal_restores_service(test_name: &str, signal_name: &str) {
+    let root = TestDir::new(test_name);
     let repo = init_openclaw_repo(&root);
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -1890,7 +1889,7 @@ fn dev_watch_signal_stops_the_child_and_restores_the_service() {
     let mut watch = watch.spawn().unwrap();
     let did_start = wait_for_path(&started, Duration::from_secs(30));
     let signal = Command::new("kill")
-        .args(["-INT", &watch.id().to_string()])
+        .args([signal_name, &watch.id().to_string()])
         .output()
         .unwrap();
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1916,6 +1915,18 @@ fn dev_watch_signal_stops_the_child_and_restores_the_service() {
     let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     assert_eq!(show_json["serviceRunning"], true);
     assert!(!source_watch_override_path(&root, "demo").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_interrupt_stops_the_child_and_restores_the_service() {
+    assert_dev_watch_signal_restores_service("dev-command-watch-interrupt", "-INT");
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_watch_termination_stops_the_child_and_restores_the_service() {
+    assert_dev_watch_signal_restores_service("dev-command-watch-termination", "-TERM");
 }
 
 #[cfg(unix)]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1775,6 +1775,130 @@ fn dev_watch_gives_interactive_child_terminal_foreground_ownership() {
     assert!(!source_watch_override_path(&root, "demo").exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn dev_watch_background_resume_waits_for_foreground_ownership() {
+    let root = TestDir::new("dev-command-watch-background-resume");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    let (started, received) = install_interactive_fake_dev_runners(&root, &mut env);
+    let override_path = source_watch_override_path(&root, "demo");
+    let script = r#"
+import fcntl
+import os
+import pty
+import signal
+import subprocess
+import termios
+import time
+
+def wait_path(path, label):
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if os.path.exists(path):
+            return
+        time.sleep(0.025)
+    raise RuntimeError(f"timed out waiting for {label}")
+
+def wait_stopped(pid, label):
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        waited, status = os.waitpid(pid, os.WNOHANG | os.WUNTRACED)
+        if waited == pid:
+            if os.WIFSTOPPED(status):
+                return
+            raise RuntimeError(f"OCM exited while waiting for {label}: status={status}")
+        time.sleep(0.025)
+    raise RuntimeError(f"timed out waiting for {label}")
+
+master, slave = pty.openpty()
+process = None
+succeeded = False
+try:
+    os.setsid()
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
+    fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+    shell_group = os.getpgrp()
+    os.tcsetpgrp(slave, shell_group)
+    process = subprocess.Popen(
+        [
+            os.environ["OCM_TEST_BINARY"],
+            "dev",
+            "demo",
+            "--repo",
+            os.environ["OCM_TEST_REPO"],
+            "--watch",
+        ],
+        cwd=os.environ["OCM_TEST_CWD"],
+        stdin=slave,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        preexec_fn=os.setpgrp,
+    )
+    wait_path(os.environ["OCM_TEST_STARTED"], "watcher startup")
+    wait_stopped(process.pid, "initial background stop")
+
+    os.killpg(process.pid, signal.SIGCONT)
+    wait_stopped(process.pid, "background resume stop")
+    if not os.path.exists(os.environ["OCM_TEST_OVERRIDE"]):
+        raise RuntimeError("background resume dropped the active watch lease")
+
+    os.tcsetpgrp(slave, process.pid)
+    os.killpg(process.pid, signal.SIGCONT)
+    os.write(master, b"terminal-input\n")
+    wait_path(os.environ["OCM_TEST_RECEIVED"], "foreground input")
+    time.sleep(0.2)
+    os.close(master)
+    master = -1
+    os.close(slave)
+    slave = -1
+    exit_code = process.wait(timeout=10)
+    if exit_code != 0:
+        error = process.stderr.read().decode(errors="replace")
+        raise RuntimeError(f"OCM exited with {exit_code}: {error}")
+    succeeded = True
+finally:
+    if not succeeded and process is not None:
+        for process_group in (process.pid,):
+            try:
+                os.killpg(process_group, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+    if master >= 0:
+        os.close(master)
+    if slave >= 0:
+        os.close(slave)
+"#;
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(script)
+        .env_clear()
+        .envs(&env)
+        .env("OCM_TEST_BINARY", env!("CARGO_BIN_EXE_ocm"))
+        .env("OCM_TEST_REPO", path_string(&repo))
+        .env("OCM_TEST_CWD", path_string(&cwd))
+        .env("OCM_TEST_STARTED", path_string(&started))
+        .env("OCM_TEST_RECEIVED", path_string(&received))
+        .env("OCM_TEST_OVERRIDE", path_string(&override_path))
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "python PTY scenario failed with {}:\nstdout={}\nstderr={}",
+        output.status,
+        stdout(&output),
+        stderr(&output)
+    );
+    assert_eq!(
+        fs::read_to_string(received).unwrap().trim(),
+        "terminal-input"
+    );
+    assert!(!override_path.exists());
+}
+
 #[test]
 fn dev_watch_aborts_and_restores_policy_when_service_stop_times_out() {
     let root = TestDir::new("dev-command-watch-stop-timeout");

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -313,13 +313,13 @@ fn leased_source_watch_remains_active_after_its_wrapper_pid_exits() {
 }
 
 #[test]
-fn leased_source_watch_rejects_metadata_from_an_older_lease() {
+fn leased_source_watch_blocks_fallback_for_metadata_from_an_older_lease() {
     let root = TestDir::new("source-watch-stale-generation");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let source_repo = create_source_repo(&root);
     let env = ocm_env(&root);
-    let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
+    create_runtime_backed_env(&root, &cwd, &env);
     let _source_watch = lock_source_watch_with_id(&root, "current-lease");
     let override_path = root.child("ocm-home/source-watch/demo.json");
     let lease_token = format!("lease:stale-lease:{}", "<redacted>");
@@ -342,10 +342,12 @@ fn leased_source_watch_rejects_metadata_from_an_older_lease() {
         &env,
         &["env", "resolve", "demo", "--json", "--", "status"],
     );
-    assert!(resolve.status.success(), "{}", stderr(&resolve));
-    let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
-    assert_eq!(resolved["bindingKind"], "runtime");
-    assert_eq!(resolved["binaryPath"], path_string(&runtime_path));
+    assert!(!resolve.status.success());
+    assert!(
+        stderr(&resolve).contains("metadata does not match the active lease"),
+        "{}",
+        stderr(&resolve)
+    );
     assert!(override_path.exists());
 }
 

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -2,12 +2,15 @@ mod support;
 
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use fs2::FileExt;
+use ocm::env::EnvironmentService;
 use serde_json::{Value, json};
 
 use crate::support::{
@@ -268,6 +271,24 @@ fn stale_source_watch_without_a_lock_is_cleaned_under_a_new_lock() {
     assert_eq!(resolved["binaryPath"], path_string(&runtime_path));
     assert!(!override_path.exists());
     assert!(lock_path.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn source_watch_lookup_without_state_keeps_a_read_only_home_unchanged() {
+    let root = TestDir::new("source-watch-read-only-home");
+    let cwd = root.child("workspace");
+    let ocm_home = root.child("ocm-home");
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(&ocm_home).unwrap();
+    let env = ocm_env(&root);
+    fs::set_permissions(&ocm_home, fs::Permissions::from_mode(0o500)).unwrap();
+
+    let result = EnvironmentService::new(&env, &cwd).active_source_watch_override("demo");
+
+    fs::set_permissions(&ocm_home, fs::Permissions::from_mode(0o700)).unwrap();
+    assert!(result.unwrap().is_none());
+    assert!(!ocm_home.join("source-watch").exists());
 }
 
 #[test]

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -465,7 +465,12 @@ fn live_legacy_source_watch_remains_active_until_its_process_exits() {
     let env = ocm_env(&root);
     let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
 
-    let legacy_bin = root.child("legacy-bin/node");
+    let long_legacy_dir = (0..10).fold(root.child("legacy-bin"), |path, index| {
+        path.join(format!(
+            "segment-{index:02}-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        ))
+    });
+    let legacy_bin = long_legacy_dir.join("node");
     let started = root.child("legacy-watch.started");
     let release = root.child("legacy-watch.release");
     write_executable_script(

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -3,6 +3,9 @@ mod support;
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use fs2::FileExt;
 use serde_json::{Value, json};
@@ -115,6 +118,7 @@ impl Drop for SourceWatchFixture {
 
 fn lock_source_watch(root: &TestDir) -> SourceWatchFixture {
     let lock_path = root.child("ocm-home/source-watch/demo.lock");
+    fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
     let lock_file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -123,6 +127,17 @@ fn lock_source_watch(root: &TestDir) -> SourceWatchFixture {
         .unwrap();
     FileExt::lock_exclusive(&lock_file).unwrap();
     SourceWatchFixture { lock_file }
+}
+
+fn wait_for_path(path: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    path.exists()
 }
 
 #[test]
@@ -224,6 +239,93 @@ fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
     let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
     assert_eq!(resolved["bindingKind"], "runtime");
     assert_eq!(resolved["binaryPath"], path_string(&runtime_path));
+    assert!(!override_path.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn live_legacy_source_watch_remains_active_until_its_process_exits() {
+    let root = TestDir::new("source-watch-live-legacy");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let source_repo = create_source_repo(&root);
+    fs::create_dir_all(source_repo.join("scripts")).unwrap();
+    fs::write(
+        source_repo.join("scripts/watch-node.mjs"),
+        "// legacy watch\n",
+    )
+    .unwrap();
+    let env = ocm_env(&root);
+    let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
+
+    let legacy_bin = root.child("legacy-bin/node");
+    let started = root.child("legacy-watch.started");
+    let release = root.child("legacy-watch.release");
+    write_executable_script(
+        &legacy_bin,
+        &format!(
+            "#!/bin/sh\nprintf 'ready\\n' > \"{}\"\nwhile [ ! -f \"{}\" ]; do /bin/sleep 0.05; done\n",
+            path_string(&started),
+            path_string(&release)
+        ),
+    );
+    let mut legacy_watch = Command::new(&legacy_bin);
+    legacy_watch
+        .args([
+            "scripts/watch-node.mjs",
+            "gateway",
+            "run",
+            "--port",
+            "21901",
+        ])
+        .current_dir(&source_repo)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut legacy_watch = legacy_watch.spawn().unwrap();
+    assert!(
+        wait_for_path(&started, Duration::from_secs(10)),
+        "legacy source watch did not start"
+    );
+
+    let override_path = root.child("ocm-home/source-watch/demo.json");
+    fs::create_dir_all(override_path.parent().unwrap()).unwrap();
+    fs::write(
+        &override_path,
+        json!({
+            "kind": "ocm-source-watch-override",
+            "envName": "demo",
+            "repoRoot": path_string(&source_repo),
+            "watchPid": legacy_watch.id(),
+            "token": "<redacted>",
+            "startedAt": "2026-06-17T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let active = run_ocm(
+        &cwd,
+        &env,
+        &["env", "resolve", "demo", "--json", "--", "status"],
+    );
+    assert!(active.status.success(), "{}", stderr(&active));
+    let active: Value = serde_json::from_str(&stdout(&active)).unwrap();
+    assert_eq!(active["bindingKind"], "source-watch");
+    assert!(override_path.exists());
+
+    fs::write(&release, "release\n").unwrap();
+    assert!(legacy_watch.wait().unwrap().success());
+
+    let stale = run_ocm(
+        &cwd,
+        &env,
+        &["env", "resolve", "demo", "--json", "--", "status"],
+    );
+    assert!(stale.status.success(), "{}", stderr(&stale));
+    let stale: Value = serde_json::from_str(&stdout(&stale)).unwrap();
+    assert_eq!(stale["bindingKind"], "runtime");
+    assert_eq!(stale["binaryPath"], path_string(&runtime_path));
     assert!(!override_path.exists());
 }
 

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -40,7 +40,10 @@ fn install_fake_node(root: &TestDir, env: &mut BTreeMap<String, String>) -> Path
 fn create_source_repo(root: &TestDir) -> PathBuf {
     let repo = root.child("source/openclaw");
     fs::create_dir_all(repo.join("extensions/codex")).unwrap();
+    fs::create_dir_all(repo.join("scripts")).unwrap();
+    fs::write(repo.join("package.json"), r#"{"name":"openclaw"}"#).unwrap();
     fs::write(repo.join("openclaw.mjs"), "console.log('openclaw');\n").unwrap();
+    fs::write(repo.join("scripts/run-node.mjs"), "").unwrap();
     fs::write(
         repo.join("extensions/codex/openclaw.plugin.json"),
         r#"{"id":"codex"}"#,
@@ -272,6 +275,47 @@ fn held_source_watch_lease_without_metadata_blocks_runtime_fallback() {
         ),
         "{}",
         stderr(&resolve)
+    );
+}
+
+#[test]
+fn restoring_source_watch_lease_allows_runtime_fallback() {
+    let root = TestDir::new("source-watch-restoring");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let source_repo = create_source_repo(&root);
+    let env = ocm_env(&root);
+    let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
+    let _source_watch = lock_source_watch_with_id(&root, "restoring:fixture-lease");
+
+    let resolve = run_ocm(
+        &cwd,
+        &env,
+        &["env", "resolve", "demo", "--json", "--", "status"],
+    );
+
+    assert!(resolve.status.success(), "{}", stderr(&resolve));
+    let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
+    assert_eq!(resolved["bindingKind"], "runtime");
+    assert_eq!(resolved["binaryPath"], path_string(&runtime_path));
+
+    let overlapping_watch = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "dev",
+            "demo",
+            "--repo",
+            &path_string(&source_repo),
+            "--watch",
+            "--force",
+        ],
+    );
+    assert!(!overlapping_watch.status.success());
+    assert!(
+        stderr(&overlapping_watch).contains("already active or starting"),
+        "{}",
+        stderr(&overlapping_watch)
     );
 }
 

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -139,6 +139,22 @@ fn lock_source_watch_with_id(root: &TestDir, lease_id: &str) -> SourceWatchFixtu
     SourceWatchFixture { lock_file }
 }
 
+fn share_source_watch_lock_with_id(root: &TestDir, lease_id: &str) -> SourceWatchFixture {
+    let lock_path = root.child("ocm-home/source-watch/demo.lock");
+    fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+    let mut lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(lock_path)
+        .unwrap();
+    FileExt::lock_shared(&lock_file).unwrap();
+    lock_file.set_len(0).unwrap();
+    use std::io::Write;
+    writeln!(lock_file, "{lease_id}").unwrap();
+    SourceWatchFixture { lock_file }
+}
+
 fn wait_for_path(path: &Path, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
@@ -246,6 +262,44 @@ fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
         &env,
         &["env", "resolve", "demo", "--json", "--", "status"],
     );
+    assert!(resolve.status.success(), "{}", stderr(&resolve));
+    let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
+    assert_eq!(resolved["bindingKind"], "runtime");
+    assert_eq!(resolved["binaryPath"], path_string(&runtime_path));
+    assert!(!override_path.exists());
+}
+
+#[test]
+fn concurrent_stale_lock_readers_do_not_revive_source_watch_metadata() {
+    let root = TestDir::new("source-watch-stale-reader");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let source_repo = create_source_repo(&root);
+    let env = ocm_env(&root);
+    let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
+    let lease_id = "stale-reader";
+    let _stale_reader = share_source_watch_lock_with_id(&root, lease_id);
+    let override_path = root.child("ocm-home/source-watch/demo.json");
+    fs::write(
+        &override_path,
+        json!({
+            "kind": "ocm-source-watch-override",
+            "envName": "demo",
+            "repoRoot": path_string(&source_repo),
+            "watchPid": std::process::id(),
+            "token": format!("lease:{lease_id}:{}", "<redacted>"),
+            "startedAt": "2026-06-17T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let resolve = run_ocm(
+        &cwd,
+        &env,
+        &["env", "resolve", "demo", "--json", "--", "status"],
+    );
+
     assert!(resolve.status.success(), "{}", stderr(&resolve));
     let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
     assert_eq!(resolved["bindingKind"], "runtime");

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -233,7 +233,7 @@ fn source_watch_override_takes_precedence_for_resolve_and_run() {
 }
 
 #[test]
-fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
+fn stale_source_watch_without_a_lock_is_cleaned_under_a_new_lock() {
     let root = TestDir::new("source-watch-stale-pid");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -241,8 +241,8 @@ fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
     let env = ocm_env(&root);
     let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
     let override_path = root.child("ocm-home/source-watch/demo.json");
+    let lock_path = root.child("ocm-home/source-watch/demo.lock");
     fs::create_dir_all(override_path.parent().unwrap()).unwrap();
-    fs::write(root.child("ocm-home/source-watch/demo.lock"), "stale\n").unwrap();
     fs::write(
         &override_path,
         json!({
@@ -267,6 +267,7 @@ fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
     assert_eq!(resolved["bindingKind"], "runtime");
     assert_eq!(resolved["binaryPath"], path_string(&runtime_path));
     assert!(!override_path.exists());
+    assert!(lock_path.exists());
 }
 
 #[test]

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -251,6 +251,31 @@ fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
 }
 
 #[test]
+fn held_source_watch_lease_without_metadata_blocks_runtime_fallback() {
+    let root = TestDir::new("source-watch-starting");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+    create_runtime_backed_env(&root, &cwd, &env);
+    let _source_watch = lock_source_watch_with_id(&root, "starting-lease");
+
+    let resolve = run_ocm(
+        &cwd,
+        &env,
+        &["env", "resolve", "demo", "--json", "--", "status"],
+    );
+
+    assert!(!resolve.status.success());
+    assert!(
+        stderr(&resolve).contains(
+            "source watch for env \"demo\" is active or starting, but its metadata is unavailable"
+        ),
+        "{}",
+        stderr(&resolve)
+    );
+}
+
+#[test]
 fn leased_source_watch_remains_active_after_its_wrapper_pid_exits() {
     let root = TestDir::new("source-watch-descendant-lease");
     let cwd = root.child("workspace");

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -216,6 +216,7 @@ fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
     let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
     let override_path = root.child("ocm-home/source-watch/demo.json");
     fs::create_dir_all(override_path.parent().unwrap()).unwrap();
+    fs::write(root.child("ocm-home/source-watch/demo.lock"), "stale\n").unwrap();
     fs::write(
         &override_path,
         json!({
@@ -290,6 +291,7 @@ fn live_legacy_source_watch_remains_active_until_its_process_exits() {
 
     let override_path = root.child("ocm-home/source-watch/demo.json");
     fs::create_dir_all(override_path.parent().unwrap()).unwrap();
+    fs::write(root.child("ocm-home/source-watch/demo.lock"), "stale\n").unwrap();
     fs::write(
         &override_path,
         json!({

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -1,9 +1,10 @@
 mod support;
 
 use std::collections::BTreeMap;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
+use fs2::FileExt;
 use serde_json::{Value, json};
 
 use crate::support::{
@@ -84,9 +85,27 @@ fn create_runtime_backed_env(
     runtime_path
 }
 
-fn write_active_source_watch_override(root: &TestDir, source_repo: &Path) {
+struct SourceWatchFixture {
+    lock_file: File,
+}
+
+impl Drop for SourceWatchFixture {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.lock_file);
+    }
+}
+
+fn write_active_source_watch_override(root: &TestDir, source_repo: &Path) -> SourceWatchFixture {
     let path = root.child("ocm-home/source-watch/demo.json");
+    let lock_path = root.child("ocm-home/source-watch/demo.lock");
     fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(lock_path)
+        .unwrap();
+    FileExt::lock_exclusive(&lock_file).unwrap();
     fs::write(
         path,
         json!({
@@ -94,12 +113,13 @@ fn write_active_source_watch_override(root: &TestDir, source_repo: &Path) {
             "envName": "demo",
             "repoRoot": path_string(source_repo),
             "watchPid": std::process::id(),
-            "token": "test-source-watch",
+            "token": "<redacted>",
             "startedAt": "2026-06-17T00:00:00Z"
         })
         .to_string(),
     )
     .unwrap();
+    SourceWatchFixture { lock_file }
 }
 
 #[test]
@@ -111,7 +131,7 @@ fn source_watch_override_takes_precedence_for_resolve_and_run() {
     let mut env = ocm_env(&root);
     let node_log = install_fake_node(&root, &mut env);
     let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
-    write_active_source_watch_override(&root, &source_repo);
+    let _source_watch = write_active_source_watch_override(&root, &source_repo);
 
     let entry = source_repo.join("openclaw.mjs");
     let resolve = run_ocm(
@@ -168,6 +188,42 @@ fn source_watch_override_takes_precedence_for_resolve_and_run() {
 }
 
 #[test]
+fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
+    let root = TestDir::new("source-watch-stale-pid");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let source_repo = create_source_repo(&root);
+    let env = ocm_env(&root);
+    let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
+    let override_path = root.child("ocm-home/source-watch/demo.json");
+    fs::create_dir_all(override_path.parent().unwrap()).unwrap();
+    fs::write(
+        &override_path,
+        json!({
+            "kind": "ocm-source-watch-override",
+            "envName": "demo",
+            "repoRoot": path_string(&source_repo),
+            "watchPid": std::process::id(),
+            "token": "<redacted>",
+            "startedAt": "2026-06-17T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let resolve = run_ocm(
+        &cwd,
+        &env,
+        &["env", "resolve", "demo", "--json", "--", "status"],
+    );
+    assert!(resolve.status.success(), "{}", stderr(&resolve));
+    let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
+    assert_eq!(resolved["bindingKind"], "runtime");
+    assert_eq!(resolved["binaryPath"], path_string(&runtime_path));
+    assert!(!override_path.exists());
+}
+
+#[test]
 fn source_watch_override_flows_to_env_exec_and_status_surfaces() {
     let root = TestDir::new("source-watch-exec-status");
     let cwd = root.child("workspace");
@@ -177,7 +233,7 @@ fn source_watch_override_flows_to_env_exec_and_status_surfaces() {
     install_fake_service_manager(&root, &mut env);
     let node_log = install_fake_node(&root, &mut env);
     create_runtime_backed_env(&root, &cwd, &env);
-    write_active_source_watch_override(&root, &source_repo);
+    let _source_watch = write_active_source_watch_override(&root, &source_repo);
 
     let entry = source_repo.join("openclaw.mjs");
     let exec = run_ocm(

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -85,6 +85,24 @@ fn create_runtime_backed_env(
     runtime_path
 }
 
+fn write_active_source_watch_override(root: &TestDir, source_repo: &Path) {
+    let path = root.child("ocm-home/source-watch/demo.json");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        path,
+        json!({
+            "kind": "ocm-source-watch-override",
+            "envName": "demo",
+            "repoRoot": path_string(source_repo),
+            "watchPid": std::process::id(),
+            "token": "test-source-watch",
+            "startedAt": "2026-06-17T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
 struct SourceWatchFixture {
     lock_file: File,
 }
@@ -95,10 +113,8 @@ impl Drop for SourceWatchFixture {
     }
 }
 
-fn write_active_source_watch_override(root: &TestDir, source_repo: &Path) -> SourceWatchFixture {
-    let path = root.child("ocm-home/source-watch/demo.json");
+fn lock_source_watch(root: &TestDir) -> SourceWatchFixture {
     let lock_path = root.child("ocm-home/source-watch/demo.lock");
-    fs::create_dir_all(path.parent().unwrap()).unwrap();
     let lock_file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -106,19 +122,6 @@ fn write_active_source_watch_override(root: &TestDir, source_repo: &Path) -> Sou
         .open(lock_path)
         .unwrap();
     FileExt::lock_exclusive(&lock_file).unwrap();
-    fs::write(
-        path,
-        json!({
-            "kind": "ocm-source-watch-override",
-            "envName": "demo",
-            "repoRoot": path_string(source_repo),
-            "watchPid": std::process::id(),
-            "token": "<redacted>",
-            "startedAt": "2026-06-17T00:00:00Z"
-        })
-        .to_string(),
-    )
-    .unwrap();
     SourceWatchFixture { lock_file }
 }
 
@@ -131,7 +134,8 @@ fn source_watch_override_takes_precedence_for_resolve_and_run() {
     let mut env = ocm_env(&root);
     let node_log = install_fake_node(&root, &mut env);
     let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
-    let _source_watch = write_active_source_watch_override(&root, &source_repo);
+    let _source_watch = lock_source_watch(&root);
+    write_active_source_watch_override(&root, &source_repo);
 
     let entry = source_repo.join("openclaw.mjs");
     let resolve = run_ocm(
@@ -233,7 +237,8 @@ fn source_watch_override_flows_to_env_exec_and_status_surfaces() {
     install_fake_service_manager(&root, &mut env);
     let node_log = install_fake_node(&root, &mut env);
     create_runtime_backed_env(&root, &cwd, &env);
-    let _source_watch = write_active_source_watch_override(&root, &source_repo);
+    let _source_watch = lock_source_watch(&root);
+    write_active_source_watch_override(&root, &source_repo);
 
     let entry = source_repo.join("openclaw.mjs");
     let exec = run_ocm(

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -117,15 +117,22 @@ impl Drop for SourceWatchFixture {
 }
 
 fn lock_source_watch(root: &TestDir) -> SourceWatchFixture {
+    lock_source_watch_with_id(root, "")
+}
+
+fn lock_source_watch_with_id(root: &TestDir, lease_id: &str) -> SourceWatchFixture {
     let lock_path = root.child("ocm-home/source-watch/demo.lock");
     fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
-    let lock_file = OpenOptions::new()
+    let mut lock_file = OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .open(lock_path)
         .unwrap();
     FileExt::lock_exclusive(&lock_file).unwrap();
+    lock_file.set_len(0).unwrap();
+    use std::io::Write;
+    writeln!(lock_file, "{lease_id}").unwrap();
     SourceWatchFixture { lock_file }
 }
 
@@ -251,9 +258,10 @@ fn leased_source_watch_remains_active_after_its_wrapper_pid_exits() {
     let source_repo = create_source_repo(&root);
     let env = ocm_env(&root);
     create_runtime_backed_env(&root, &cwd, &env);
-    let _source_watch = lock_source_watch(&root);
+    let lease_id = "fixture-lease";
+    let _source_watch = lock_source_watch_with_id(&root, lease_id);
     let override_path = root.child("ocm-home/source-watch/demo.json");
-    let lease_token = format!("lease-{}", "<redacted>");
+    let lease_token = format!("lease:{lease_id}:{}", "<redacted>");
     fs::write(
         &override_path,
         json!({
@@ -276,6 +284,43 @@ fn leased_source_watch_remains_active_after_its_wrapper_pid_exits() {
     assert!(resolve.status.success(), "{}", stderr(&resolve));
     let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
     assert_eq!(resolved["bindingKind"], "source-watch");
+    assert!(override_path.exists());
+}
+
+#[test]
+fn leased_source_watch_rejects_metadata_from_an_older_lease() {
+    let root = TestDir::new("source-watch-stale-generation");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let source_repo = create_source_repo(&root);
+    let env = ocm_env(&root);
+    let runtime_path = create_runtime_backed_env(&root, &cwd, &env);
+    let _source_watch = lock_source_watch_with_id(&root, "current-lease");
+    let override_path = root.child("ocm-home/source-watch/demo.json");
+    let lease_token = format!("lease:stale-lease:{}", "<redacted>");
+    fs::write(
+        &override_path,
+        json!({
+            "kind": "ocm-source-watch-override",
+            "envName": "demo",
+            "repoRoot": path_string(&source_repo),
+            "watchPid": std::process::id(),
+            "token": lease_token,
+            "startedAt": "2026-06-17T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let resolve = run_ocm(
+        &cwd,
+        &env,
+        &["env", "resolve", "demo", "--json", "--", "status"],
+    );
+    assert!(resolve.status.success(), "{}", stderr(&resolve));
+    let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
+    assert_eq!(resolved["bindingKind"], "runtime");
+    assert_eq!(resolved["binaryPath"], path_string(&runtime_path));
     assert!(override_path.exists());
 }
 

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -243,6 +243,42 @@ fn source_watch_override_with_a_live_reused_pid_is_removed_without_its_lease() {
     assert!(!override_path.exists());
 }
 
+#[test]
+fn leased_source_watch_remains_active_after_its_wrapper_pid_exits() {
+    let root = TestDir::new("source-watch-descendant-lease");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let source_repo = create_source_repo(&root);
+    let env = ocm_env(&root);
+    create_runtime_backed_env(&root, &cwd, &env);
+    let _source_watch = lock_source_watch(&root);
+    let override_path = root.child("ocm-home/source-watch/demo.json");
+    let lease_token = format!("lease-{}", "<redacted>");
+    fs::write(
+        &override_path,
+        json!({
+            "kind": "ocm-source-watch-override",
+            "envName": "demo",
+            "repoRoot": path_string(&source_repo),
+            "watchPid": u32::MAX,
+            "token": lease_token,
+            "startedAt": "2026-06-17T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let resolve = run_ocm(
+        &cwd,
+        &env,
+        &["env", "resolve", "demo", "--json", "--", "status"],
+    );
+    assert!(resolve.status.success(), "{}", stderr(&resolve));
+    let resolved: Value = serde_json::from_str(&stdout(&resolve)).unwrap();
+    assert_eq!(resolved["bindingKind"], "source-watch");
+    assert!(override_path.exists());
+}
+
 #[cfg(unix)]
 #[test]
 fn live_legacy_source_watch_remains_active_until_its_process_exits() {


### PR DESCRIPTION
## What Problem This Solves

`ocm dev --watch` could overlap another watch for the same environment, publish stale ownership metadata, or leave the background service and source process tree in the wrong state after failures, signals, job-control suspension, or wrapper exits.

That made repeated development and retesting unsafe: a second watch could race the first, detached descendants could survive cleanup, and service takeover could be restored by the wrong owner.

## Why This Change Was Made

- Serialize source-watch ownership with a per-environment lock and lease generation.
- Publish and validate process identity before treating metadata as authoritative.
- Own and terminate the full source-watch process tree on Unix and Windows.
- Assign Windows watchers to a Job Object before publishing the lease.
- Preserve interactive stdin, terminal foreground ownership, and `Ctrl-Z` / `fg` job control.
- Keep service restoration under the active lease and restore the previous policy on every failure or termination path.
- Remove the unleased source-watch override mutation API.
- Reclaim stale metadata without allowing concurrent readers to revive it.

## User Impact

Only one source watch can own an environment at a time. Stale watches are reclaimed, active watches cannot be displaced by stale metadata, terminal suspension/resume behaves like a normal foreground job, and forced service takeover is restored reliably when the watch exits or cannot start.

## Evidence

Reviewed head: `7b114254056022627f919ef27c61cd03cc524afa`

- `cargo fmt --check`
- `cargo check`
- `cargo test --test dev_command_tests --test source_watch_tests` (49 passed)
- `cargo test` (full suite passed)
- Windows API compile probe for the Job Object/process APIs passed; full Windows cross-check was unavailable locally because `x86_64-w64-mingw32-gcc` is not installed.
- Fresh whole-branch Sol/high autoreview: no findings; patch correct with 0.84 confidence.
