### PR TITLE
fix(runtime): harden managed installs and services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@ All notable changes to OCM are documented here.
 - Preserve uncommitted dev worktrees and reject unrelated checkout collisions by requiring exact Git worktree registration before reuse or removal.
 - Make single and merged log following rotation-safe and byte-safe, preserving split or invalid UTF-8, multiline record ordering, and boundaries around unterminated records.
 - Prevent overlapping source watches, remove the unleased override mutation path, reclaim stale watch locks, preserve terminal job control, handle termination signals, and restore background-service policy when takeover cannot stop or exits with an error.
+- Verify managed Node.js archives against pinned release checksums and serialize bootstrap so concurrent processes cannot delete a valid toolchain.
+- Preserve working runtimes until replacement artifacts, dependencies, and metadata are ready; require release integrity and reject unsafe artifact names.
+- Write private service definitions, preserve existing service-directory modes, escape systemd specifiers, reject directive injection, and fail closed on unknown launchd users or cross-store service ownership.
+- Serialize supervisor restart requests, restore service policy after failed reconciliation, preserve raw warnings, and fail upgrades when a gateway restart cannot be observed.

--- a/src/cli/render/service.rs
+++ b/src/cli/render/service.rs
@@ -460,7 +460,7 @@ fn service_action_next_steps(
 }
 
 fn service_action_raw(summary: &ServiceActionSummary, _command_example: &str) -> Vec<String> {
-    vec![
+    let mut lines = vec![
         format!("envName: {}", summary.env_name),
         format!("action: {}", summary.action),
         format!("installed: {}", summary.installed),
@@ -481,7 +481,14 @@ fn service_action_raw(summary: &ServiceActionSummary, _command_example: &str) ->
                 .clone()
                 .unwrap_or_else(|| "none".to_string())
         ),
-    ]
+    ];
+    lines.extend(
+        summary
+            .warnings
+            .iter()
+            .map(|warning| format!("warning: {warning}")),
+    );
+    lines
 }
 
 fn action_title(summary: &ServiceActionSummary) -> String {
@@ -620,5 +627,34 @@ mod tests {
         );
         assert!(!lines.iter().any(|line| line.contains("/tmp/stdout.log")));
         assert!(!lines.iter().any(|line| line.contains("/tmp/stderr.log")));
+    }
+
+    #[test]
+    fn service_action_raw_preserves_operational_warnings() {
+        let mut summary = ServiceActionSummary {
+            env_name: "demo".to_string(),
+            service_kind: "gateway".to_string(),
+            action: "stop".to_string(),
+            installed: true,
+            loaded: true,
+            desired_running: false,
+            running: true,
+            gateway_port: 18789,
+            binding_kind: Some("runtime".to_string()),
+            binding_name: Some("stable".to_string()),
+            stdout_path: None,
+            stderr_path: None,
+            warnings: vec!["gateway is still shutting down".to_string()],
+        };
+        let lines = service_action(&summary, RenderProfile::raw(), "ocm");
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == "warning: gateway is still shutting down")
+        );
+
+        summary.warnings.clear();
+        let lines = service_action(&summary, RenderProfile::raw(), "ocm");
+        assert!(!lines.iter().any(|line| line.starts_with("warning:")));
     }
 }

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -25,14 +25,14 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EnvDevMeta {
     pub repo_root: String,
     pub worktree_root: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EnvMeta {
     pub kind: String,

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -9,6 +9,7 @@ use crate::store::{
     get_environment, get_runtime_verified, import_environment, list_environments,
     lock_environment_operation, now_utc, remove_environment, resolve_config_gateway_port,
     resolve_effective_gateway_ports, resolve_env_gateway_port, save_environment,
+    set_environment_service_policy,
 };
 use crate::supervisor::sync_supervisor_if_present;
 
@@ -293,23 +294,13 @@ impl<'a> EnvironmentService<'a> {
         service_running: Option<bool>,
     ) -> Result<EnvMeta, String> {
         let _lock = self.lock_operation(name)?;
-        self.set_service_policy_locked(name, service_enabled, service_running)
-    }
-
-    pub(crate) fn set_service_policy_locked(
-        &self,
-        name: &str,
-        service_enabled: Option<bool>,
-        service_running: Option<bool>,
-    ) -> Result<EnvMeta, String> {
-        let mut meta = get_environment(name, self.env, self.cwd)?;
-        if let Some(service_enabled) = service_enabled {
-            meta.service_enabled = service_enabled;
-        }
-        if let Some(service_running) = service_running {
-            meta.service_running = service_running;
-        }
-        let saved = save_environment(meta, self.env, self.cwd)?;
+        let saved = set_environment_service_policy(
+            name,
+            service_enabled,
+            service_running,
+            self.env,
+            self.cwd,
+        )?;
         sync_supervisor_if_present(self.env, self.cwd)?;
         Ok(saved)
     }

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -25,14 +25,14 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EnvDevMeta {
     pub repo_root: String,
     pub worktree_root: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EnvMeta {
     pub kind: String,
@@ -294,7 +294,7 @@ impl<'a> EnvironmentService<'a> {
         service_running: Option<bool>,
     ) -> Result<EnvMeta, String> {
         let _lock = self.lock_operation(name)?;
-        let saved = set_environment_service_policy(
+        let change = set_environment_service_policy(
             name,
             service_enabled,
             service_running,
@@ -302,7 +302,7 @@ impl<'a> EnvironmentService<'a> {
             self.cwd,
         )?;
         sync_supervisor_if_present(self.env, self.cwd)?;
-        Ok(saved)
+        Ok(change.applied)
     }
 
     pub fn remove(&self, name: &str, force: bool) -> Result<EnvMeta, String> {

--- a/src/infra/download.rs
+++ b/src/infra/download.rs
@@ -28,7 +28,13 @@ pub fn artifact_file_name_from_url(url: &str) -> Result<String, String> {
         .filter(|value| !value.is_empty())
         .ok_or_else(|| format!("runtime URL must include a file name: {trimmed}"))?;
 
-    if segment == "." || segment == ".." {
+    if segment == "."
+        || segment == ".."
+        || segment.contains('\\')
+        || segment.contains(':')
+        || segment.contains('\0')
+        || Path::new(segment).components().count() != 1
+    {
         return Err(format!("runtime URL must include a file name: {trimmed}"));
     }
 
@@ -136,6 +142,18 @@ pub fn verify_file_sha256(path: &Path, expected: &str) -> Result<String, String>
 }
 
 pub fn verify_file_integrity(path: &Path, expected: &str) -> Result<(), String> {
+    let expected = normalize_file_integrity(expected)?;
+    let Some((algorithm, encoded)) = expected.split_once('-') else {
+        unreachable!("normalized integrity includes an algorithm");
+    };
+
+    match algorithm {
+        "sha512" => verify_file_sha512_base64(path, encoded, &expected),
+        _ => unreachable!("normalized integrity uses a supported algorithm"),
+    }
+}
+
+pub fn normalize_file_integrity(expected: &str) -> Result<String, String> {
     let expected = expected.trim();
     if expected.is_empty() {
         return Err("runtime artifact integrity is required".to_string());
@@ -149,7 +167,15 @@ pub fn verify_file_integrity(path: &Path, expected: &str) -> Result<(), String> 
     }
 
     match algorithm {
-        "sha512" => verify_file_sha512_base64(path, encoded.trim(), expected),
+        "sha512" => {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(encoded.trim())
+                .map_err(|_| format!("runtime artifact integrity is invalid: {expected}"))?;
+            if decoded.len() != 64 {
+                return Err(format!("runtime artifact integrity is invalid: {expected}"));
+            }
+            Ok(format!("sha512-{}", encoded.trim()))
+        }
         _ => Err(format!(
             "runtime artifact integrity algorithm is unsupported: {algorithm}"
         )),
@@ -181,4 +207,32 @@ fn verify_file_sha512_base64(
         return Err("runtime artifact integrity mismatch".to_string());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::artifact_file_name_from_url;
+
+    #[test]
+    fn artifact_file_name_rejects_cross_platform_path_components() {
+        for url in [
+            "https://example.test/releases/..",
+            "https://example.test/releases/C:\\temp\\openclaw.exe",
+            "https://example.test/releases/..\\..\\openclaw.exe",
+            "https://example.test/releases/share:openclaw",
+        ] {
+            assert!(artifact_file_name_from_url(url).is_err(), "{url}");
+        }
+    }
+
+    #[test]
+    fn artifact_file_name_accepts_one_portable_component() {
+        assert_eq!(
+            artifact_file_name_from_url(
+                "https://example.test/releases/openclaw.tar.gz?download=1#asset"
+            )
+            .unwrap(),
+            "openclaw.tar.gz"
+        );
+    }
 }

--- a/src/managed_node.rs
+++ b/src/managed_node.rs
@@ -3,12 +3,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::infra::archive::{extract_tar_gz, extract_zip};
-use crate::infra::download::download_to_file;
-use crate::store::{display_path, resolve_store_paths};
+use crate::infra::download::{download_to_file, normalize_sha256, verify_file_sha256};
+use crate::store::{display_path, lock_file, resolve_store_paths};
 
 pub const OPENCLAW_MIN_NODE_VERSION: &str = "22.14.0";
 
 const INTERNAL_MANAGED_NODE_ARCHIVE_URL_ENV: &str = "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_URL";
+const INTERNAL_MANAGED_NODE_ARCHIVE_SHA256_ENV: &str = "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_SHA256";
 const NODE_DIST_BASE_URL: &str = "https://nodejs.org/dist";
 
 #[derive(Clone, Debug)]
@@ -26,6 +27,7 @@ pub(crate) struct ManagedNodeDistribution {
     node_relative_path: &'static str,
     npm_cli_relative_path: &'static str,
     platform_label: &'static str,
+    archive_sha256: &'static str,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -71,6 +73,18 @@ pub(crate) fn ensure_managed_node_toolchain(
 ) -> Result<ManagedNodeToolchain, String> {
     let distribution = managed_node_distribution()?;
     let root = managed_node_root(&distribution, env, cwd)?;
+    let parent = root.parent().ok_or_else(|| {
+        format!(
+            "managed Node.js root has no parent: {}",
+            display_path(&root)
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let lock_path = parent.join(format!(".{}.lock", distribution.root_dir_name));
+    let _lock = lock_file(&lock_path, "managed Node.js installation")?;
+
+    // Another OCM process may have completed the same installation while this
+    // process waited for the lock, so validate the shared root again here.
     if let Some((node_bin, npm_cli)) = verify_managed_node_toolchain(&root, &distribution) {
         return Ok(ManagedNodeToolchain { node_bin, npm_cli });
     }
@@ -83,14 +97,6 @@ pub(crate) fn ensure_managed_node_toolchain(
             )
         })?;
     }
-
-    let parent = root.parent().ok_or_else(|| {
-        format!(
-            "managed Node.js root has no parent: {}",
-            display_path(&root)
-        )
-    })?;
-    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
 
     let stage_root = parent.join(format!(
         ".node-toolchain-{}-{}",
@@ -105,6 +111,10 @@ pub(crate) fn ensure_managed_node_toolchain(
         fs::create_dir_all(&stage_root).map_err(|error| error.to_string())?;
         let archive_path = stage_root.join(&distribution.asset_name);
         download_to_file(&managed_node_archive_url(&distribution, env), &archive_path)?;
+        verify_file_sha256(
+            &archive_path,
+            &managed_node_archive_sha256(&distribution, env)?,
+        )?;
 
         let extract_root = stage_root.join("extract");
         match distribution.archive_kind {
@@ -135,9 +145,6 @@ pub(crate) fn ensure_managed_node_toolchain(
     })();
 
     let _ = fs::remove_dir_all(&stage_root);
-    if result.is_err() {
-        let _ = fs::remove_dir_all(&root);
-    }
     result
 }
 
@@ -238,6 +245,31 @@ fn managed_node_distribution_for(
     node_relative_path: &'static str,
     npm_cli_relative_path: &'static str,
 ) -> Result<ManagedNodeDistribution, String> {
+    let archive_sha256 = match (version, suffix) {
+        ("22.14.0", "darwin-arm64") => {
+            "e9404633bc02a5162c5c573b1e2490f5fb44648345d64a958b17e325729a5e42"
+        }
+        ("22.14.0", "darwin-x64") => {
+            "6698587713ab565a94a360e091df9f6d91c8fadda6d00f0cf6526e9b40bed250"
+        }
+        ("22.14.0", "linux-arm64") => {
+            "8cf30ff7250f9463b53c18f89c6c606dfda70378215b2c905d0a9a8b08bd45e0"
+        }
+        ("22.14.0", "linux-x64") => {
+            "9d942932535988091034dc94cc5f42b6dc8784d6366df3a36c4c9ccb3996f0c2"
+        }
+        ("22.14.0", "win-arm64") => {
+            "2d71f5f9b2fffa33baa108c07d74b0d24e0c3dd8f441d567772ae0e3dd4b1a22"
+        }
+        ("22.14.0", "win-x64") => {
+            "55b639295920b219bb2acbcfa00f90393a2789095b7323f79475c9f34795f217"
+        }
+        _ => {
+            return Err(format!(
+                "unsupported managed Node.js distribution: v{version}-{suffix}"
+            ));
+        }
+    };
     let extension = match archive_kind {
         ManagedNodeArchiveKind::TarGz => "tar.gz",
         ManagedNodeArchiveKind::Zip => "zip",
@@ -251,6 +283,7 @@ fn managed_node_distribution_for(
         node_relative_path,
         npm_cli_relative_path,
         platform_label,
+        archive_sha256,
     })
 }
 
@@ -284,6 +317,28 @@ fn managed_node_archive_url(
         "{}/v{}/{}",
         NODE_DIST_BASE_URL, distribution.version, distribution.asset_name
     )
+}
+
+fn managed_node_archive_sha256(
+    distribution: &ManagedNodeDistribution,
+    env: &BTreeMap<String, String>,
+) -> Result<String, String> {
+    if env
+        .get(INTERNAL_MANAGED_NODE_ARCHIVE_URL_ENV)
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return env
+            .get(INTERNAL_MANAGED_NODE_ARCHIVE_SHA256_ENV)
+            .map(String::as_str)
+            .map(normalize_sha256)
+            .transpose()?
+            .ok_or_else(|| {
+                format!(
+                    "{INTERNAL_MANAGED_NODE_ARCHIVE_SHA256_ENV} is required when overriding the managed Node.js archive URL"
+                )
+            });
+    }
+    Ok(distribution.archive_sha256.to_string())
 }
 
 fn verify_managed_node_toolchain(

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use super::inspect::ServiceSummary;
 use super::service_backend_support_error;
 use crate::env::EnvironmentService;
+use crate::store::save_environment;
 use crate::supervisor::SupervisorService;
 
 #[derive(Clone, Debug, Serialize)]
@@ -129,26 +130,40 @@ pub fn restart_service(
     }
 
     let supervisor = SupervisorService::new(env, cwd);
-    let request_id = supervisor.request_child_restart(name)?;
+    let mut request_id = supervisor.request_child_restart(name)?;
     let restart_result = wait_for_restart_action_summary(name, before.child_pid, env, cwd);
     match restart_result {
         Ok(mut status) => {
-            if status.observed_restart {
-                if let Err(clear_error) = supervisor.clear_child_restart_request(name, &request_id)
-                {
-                    status.warnings.push(format!(
-                        "restart completed, but failed to clear restart request: {clear_error}"
-                    ));
+            if !status.observed_restart {
+                let (_, recovery_request_id) = supervisor
+                    .recover_child_restart_with_request_id(name)
+                    .map_err(|error| {
+                        format!(
+                            "gateway restart was not observed and targeted supervisor recovery failed: {error}"
+                        )
+                    })?;
+                request_id = recovery_request_id;
+                status = wait_for_restart_action_summary_with_timeout(
+                    name,
+                    before.child_pid,
+                    Duration::from_secs(5),
+                    env,
+                    cwd,
+                )?;
+                if !status.observed_restart {
+                    return Err(
+                        "gateway restart was not observed after targeted supervisor recovery"
+                            .to_string(),
+                    );
                 }
-            } else {
-                match supervisor.recover_child_restart(name) {
-                    Ok(_) => status.warnings.push(
-                        "gateway restart was not observed; the targeted restart request was requeued and the supervisor was rechecked".to_string(),
-                    ),
-                    Err(error) => status.warnings.push(format!(
-                        "gateway restart was not observed; targeted supervisor recovery failed: {error}"
-                    )),
-                }
+                status
+                    .warnings
+                    .push("gateway restart required targeted supervisor recovery".to_string());
+            }
+            if let Err(clear_error) = supervisor.clear_child_restart_request(name, &request_id) {
+                status.warnings.push(format!(
+                    "restart completed, but failed to clear restart request: {clear_error}"
+                ));
             }
             Ok(service_action_summary(
                 "restart",
@@ -209,13 +224,20 @@ fn update_service(
     if require_binding {
         ensure_gateway_binding(name, env, cwd)?;
     }
-    EnvironmentService::new(env, cwd).set_service_policy_locked(
-        name,
-        service_enabled,
-        service_running,
-    )?;
+    let env_service = EnvironmentService::new(env, cwd);
+    let previous = env_service.get(name)?;
     if let ServiceSupervisorPolicy::EnsureRunning = supervisor_policy {
         ensure_supervisor_running(env, cwd)?;
+    }
+    if let Err(error) = env_service.set_service_policy(name, service_enabled, service_running) {
+        let rollback = save_environment(previous, env, cwd)
+            .and_then(|_| SupervisorService::new(env, cwd).sync().map(|_| ()));
+        return match rollback {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(format!(
+                "{error}; failed to restore the previous service policy: {rollback_error}"
+            )),
+        };
     }
     let (summary, warnings) = wait_for_action_summary(name, action, env, cwd)?;
     Ok(service_action_summary(action, summary, warnings))
@@ -260,7 +282,23 @@ fn wait_for_restart_action_summary(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<RestartActionStatus, String> {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    wait_for_restart_action_summary_with_timeout(
+        name,
+        previous_pid,
+        Duration::from_secs(30),
+        env,
+        cwd,
+    )
+}
+
+fn wait_for_restart_action_summary_with_timeout(
+    name: &str,
+    previous_pid: Option<u32>,
+    timeout: Duration,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<RestartActionStatus, String> {
+    let deadline = Instant::now() + timeout;
     let mut latest = super::inspect::service_status_fast(name, env, cwd)?;
     while Instant::now() < deadline {
         if latest.running

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 use super::inspect::ServiceSummary;
 use super::service_backend_support_error;
 use crate::env::EnvironmentService;
-use crate::store::save_environment;
-use crate::supervisor::SupervisorService;
+use crate::store::{restore_environment_service_policy, set_environment_service_policy};
+use crate::supervisor::{SupervisorService, sync_supervisor_if_present};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -229,9 +229,18 @@ fn update_service(
     if let ServiceSupervisorPolicy::EnsureRunning = supervisor_policy {
         ensure_supervisor_running(env, cwd)?;
     }
-    if let Err(error) = env_service.set_service_policy(name, service_enabled, service_running) {
-        let rollback = save_environment(previous, env, cwd)
-            .and_then(|_| SupervisorService::new(env, cwd).sync().map(|_| ()));
+    set_environment_service_policy(name, service_enabled, service_running, env, cwd)?;
+    if let Err(error) = sync_supervisor_if_present(env, cwd) {
+        let rollback = restore_environment_service_policy(
+            name,
+            service_enabled,
+            service_running,
+            previous.service_enabled,
+            previous.service_running,
+            env,
+            cwd,
+        )
+        .and_then(|_| sync_supervisor_if_present(env, cwd).map(|_| ()));
         return match rollback {
             Ok(()) => Err(error),
             Err(rollback_error) => Err(format!(

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -224,23 +224,18 @@ fn update_service(
     if require_binding {
         ensure_gateway_binding(name, env, cwd)?;
     }
-    let env_service = EnvironmentService::new(env, cwd);
-    let previous = env_service.get(name)?;
     if let ServiceSupervisorPolicy::EnsureRunning = supervisor_policy {
         ensure_supervisor_running(env, cwd)?;
     }
-    set_environment_service_policy(name, service_enabled, service_running, env, cwd)?;
+    let change = set_environment_service_policy(name, service_enabled, service_running, env, cwd)?;
     if let Err(error) = sync_supervisor_if_present(env, cwd) {
-        let rollback = restore_environment_service_policy(
-            name,
-            service_enabled,
-            service_running,
-            previous.service_enabled,
-            previous.service_running,
-            env,
-            cwd,
-        )
-        .and_then(|_| sync_supervisor_if_present(env, cwd).map(|_| ()));
+        let rollback = restore_environment_service_policy(&change, env, cwd).and_then(|restored| {
+            if restored {
+                sync_supervisor_if_present(env, cwd).map(|_| ())
+            } else {
+                Ok(())
+            }
+        });
         return match rollback {
             Ok(()) => Err(error),
             Err(rollback_error) => Err(format!(

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -422,6 +422,21 @@ fn ensure_service_definition_dir(path: &Path) -> Result<(), String> {
     let existed = path.exists();
     fs::create_dir_all(path).map_err(|error| error.to_string())?;
     if existed {
+        #[cfg(unix)]
+        {
+            let mode = fs::metadata(path)
+                .map_err(|error| error.to_string())?
+                .permissions()
+                .mode();
+            let writable_by_others = mode & 0o022 != 0;
+            let sticky = mode & 0o1000 != 0;
+            if writable_by_others && !sticky {
+                return Err(format!(
+                    "service definition directory {} is group/world-writable; remove those write permissions before installing the service",
+                    display_path(path)
+                ));
+            }
+        }
         return Ok(());
     }
     set_mode(path, SERVICE_DIR_MODE)
@@ -966,6 +981,43 @@ mod tests {
                 & 0o777,
             0o700
         );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn service_definition_rejects_a_writable_existing_parent() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("ocm-platform-writable-parent-{unique}"));
+        let definition_parent = root.join("home/.config/systemd/user");
+        fs::create_dir_all(&definition_parent).unwrap();
+        fs::set_permissions(&definition_parent, fs::Permissions::from_mode(0o775)).unwrap();
+        let env = BTreeMap::from([
+            ("HOME".to_string(), display_path(&root.join("home"))),
+            ("OCM_HOME".to_string(), display_path(&root.join("store"))),
+            (
+                "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+                "systemd-user".to_string(),
+            ),
+        ]);
+        let definition = ManagedServiceDefinition {
+            label: OCM_SERVICE_LABEL.to_string(),
+            description: "test".to_string(),
+            definition_path: definition_parent.join("test.service"),
+            program_arguments: vec!["/bin/true".to_string()],
+            working_directory: root.join("store"),
+            stdout_path: root.join("logs/stdout.log"),
+            stderr_path: root.join("logs/stderr.log"),
+            environment: BTreeMap::new(),
+        };
+
+        let error = write_managed_service_definition(&definition, &env).unwrap_err();
+        assert!(error.contains("group/world-writable"));
+        assert!(!definition.definition_path.exists());
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -8,7 +8,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-use crate::store::{display_path, resolve_user_home};
+use crate::store::{display_path, lock_file, resolve_user_home};
 
 pub(crate) const OCM_SERVICE_LABEL: &str = "ai.openclaw.ocm";
 const SERVICE_MANAGER_OVERRIDE: &str = "OCM_INTERNAL_SERVICE_MANAGER";
@@ -227,6 +227,8 @@ pub(crate) fn write_managed_service_definition(
         ));
     };
     ensure_service_definition_dir(parent)?;
+    let lock_path = definition.definition_path.with_extension("lock");
+    let _lock = lock_file(&lock_path, "managed service definition")?;
     validate_existing_service_owner(definition, env)?;
 
     let raw = match service_manager_kind(env) {

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -248,6 +248,7 @@ pub(crate) fn write_managed_service_definition(
             &definition.stdout_path,
             &definition.stderr_path,
             &definition.environment,
+            systemd_supports_append_output(env),
         )?,
         ServiceManagerKind::Unsupported => {
             return Err(unsupported_service_manager_message().to_string());
@@ -358,6 +359,7 @@ fn build_systemd_unit(
     stdout_path: &Path,
     stderr_path: &Path,
     environment: &BTreeMap<String, String>,
+    append_output: bool,
 ) -> Result<String, String> {
     validate_systemd_value("Description", description)?;
     validate_systemd_value("WorkingDirectory", &display_path(working_directory))?;
@@ -399,9 +401,37 @@ fn build_systemd_unit(
         systemd_quote(&display_path(working_directory)),
         exec_start,
         environment_block,
-        systemd_quote(&format!("append:{}", display_path(stdout_path))),
-        systemd_quote(&format!("append:{}", display_path(stderr_path))),
+        systemd_quote(&systemd_output_target(stdout_path, append_output)),
+        systemd_quote(&systemd_output_target(stderr_path, append_output)),
     ))
+}
+
+fn systemd_supports_append_output(env: &BTreeMap<String, String>) -> bool {
+    let systemctl = env
+        .get(SYSTEMCTL_BIN_OVERRIDE)
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("systemctl");
+    Command::new(systemctl)
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .is_some_and(|output| systemd_version_supports_append(&output.stdout))
+}
+
+fn systemd_version_supports_append(stdout: &[u8]) -> bool {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|version| version.parse::<u32>().ok())
+        .is_some_and(|version| version >= 240)
+}
+
+fn systemd_output_target(path: &Path, append: bool) -> String {
+    let mode = if append { "append" } else { "file" };
+    format!("{mode}:{}", display_path(path))
 }
 
 fn plist_escape(value: &str) -> String {
@@ -671,7 +701,8 @@ mod tests {
     use super::{
         ManagedServiceDefinition, ManagedServiceIdentity, OCM_SERVICE_LABEL, ServiceManagerKind,
         gui_domain, managed_service_identity, managed_service_label, service_backend_support_error,
-        service_definition_dir, service_manager_kind, write_managed_service_definition,
+        service_definition_dir, service_manager_kind, systemd_version_supports_append,
+        write_managed_service_definition,
     };
 
     #[test]
@@ -682,6 +713,13 @@ mod tests {
             "systemd-user".to_string(),
         );
         assert_eq!(service_manager_kind(&env), ServiceManagerKind::SystemdUser);
+    }
+
+    #[test]
+    fn systemd_append_output_requires_version_240() {
+        assert!(!systemd_version_supports_append(b"systemd 239\n"));
+        assert!(systemd_version_supports_append(b"systemd 240 (240.1)\n"));
+        assert!(!systemd_version_supports_append(b""));
     }
 
     #[test]
@@ -894,6 +932,10 @@ mod tests {
             "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
             "systemd-user".to_string(),
         );
+        env.insert(
+            "OCM_INTERNAL_SYSTEMCTL_BIN".to_string(),
+            "/definitely/missing/systemctl".to_string(),
+        );
 
         let definition = ManagedServiceDefinition {
             label: OCM_SERVICE_LABEL.to_string(),
@@ -919,8 +961,8 @@ mod tests {
         assert!(unit.contains("ExecStart=/bin/sh -lc"));
         assert!(unit.contains("WorkingDirectory=/tmp/work"));
         assert!(unit.contains("Environment=\"OPENCLAW_HOME=/tmp/demo\""));
-        assert!(unit.contains("StandardOutput=append:"));
-        assert!(unit.contains("StandardError=append:"));
+        assert!(unit.contains("StandardOutput=file:"));
+        assert!(unit.contains("StandardError=file:"));
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -409,7 +409,6 @@ fn build_systemd_unit(
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SystemdOutputMode {
     Journal,
-    File,
     Append,
 }
 
@@ -439,7 +438,6 @@ fn systemd_version(stdout: &[u8]) -> Option<u32> {
 fn systemd_output_mode_for_version(version: Option<u32>) -> SystemdOutputMode {
     match version {
         Some(240..) => SystemdOutputMode::Append,
-        Some(236..=239) => SystemdOutputMode::File,
         _ => SystemdOutputMode::Journal,
     }
 }
@@ -447,7 +445,6 @@ fn systemd_output_mode_for_version(version: Option<u32>) -> SystemdOutputMode {
 fn systemd_output_target(path: &Path, mode: SystemdOutputMode) -> String {
     match mode {
         SystemdOutputMode::Journal => "journal".to_string(),
-        SystemdOutputMode::File => format!("file:{}", display_path(path)),
         SystemdOutputMode::Append => format!("append:{}", display_path(path)),
     }
 }
@@ -741,11 +738,11 @@ mod tests {
         );
         assert_eq!(
             systemd_output_mode_for_version(Some(236)),
-            super::SystemdOutputMode::File
+            super::SystemdOutputMode::Journal
         );
         assert_eq!(
             systemd_output_mode_for_version(Some(239)),
-            super::SystemdOutputMode::File
+            super::SystemdOutputMode::Journal
         );
         assert_eq!(
             systemd_output_mode_for_version(Some(240)),

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -248,7 +248,7 @@ pub(crate) fn write_managed_service_definition(
             &definition.stdout_path,
             &definition.stderr_path,
             &definition.environment,
-            systemd_supports_append_output(env),
+            systemd_output_mode(env),
         )?,
         ServiceManagerKind::Unsupported => {
             return Err(unsupported_service_manager_message().to_string());
@@ -359,7 +359,7 @@ fn build_systemd_unit(
     stdout_path: &Path,
     stderr_path: &Path,
     environment: &BTreeMap<String, String>,
-    append_output: bool,
+    output_mode: SystemdOutputMode,
 ) -> Result<String, String> {
     validate_systemd_value("Description", description)?;
     validate_systemd_value("WorkingDirectory", &display_path(working_directory))?;
@@ -401,37 +401,55 @@ fn build_systemd_unit(
         systemd_quote(&display_path(working_directory)),
         exec_start,
         environment_block,
-        systemd_quote(&systemd_output_target(stdout_path, append_output)),
-        systemd_quote(&systemd_output_target(stderr_path, append_output)),
+        systemd_quote(&systemd_output_target(stdout_path, output_mode)),
+        systemd_quote(&systemd_output_target(stderr_path, output_mode)),
     ))
 }
 
-fn systemd_supports_append_output(env: &BTreeMap<String, String>) -> bool {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SystemdOutputMode {
+    Journal,
+    File,
+    Append,
+}
+
+fn systemd_output_mode(env: &BTreeMap<String, String>) -> SystemdOutputMode {
     let systemctl = env
         .get(SYSTEMCTL_BIN_OVERRIDE)
         .map(String::as_str)
         .filter(|value| !value.trim().is_empty())
         .unwrap_or("systemctl");
-    Command::new(systemctl)
+    let version = Command::new(systemctl)
         .arg("--version")
         .output()
         .ok()
         .filter(|output| output.status.success())
-        .is_some_and(|output| systemd_version_supports_append(&output.stdout))
+        .and_then(|output| systemd_version(&output.stdout));
+    systemd_output_mode_for_version(version)
 }
 
-fn systemd_version_supports_append(stdout: &[u8]) -> bool {
+fn systemd_version(stdout: &[u8]) -> Option<u32> {
     String::from_utf8_lossy(stdout)
         .lines()
         .next()
         .and_then(|line| line.split_whitespace().nth(1))
         .and_then(|version| version.parse::<u32>().ok())
-        .is_some_and(|version| version >= 240)
 }
 
-fn systemd_output_target(path: &Path, append: bool) -> String {
-    let mode = if append { "append" } else { "file" };
-    format!("{mode}:{}", display_path(path))
+fn systemd_output_mode_for_version(version: Option<u32>) -> SystemdOutputMode {
+    match version {
+        Some(240..) => SystemdOutputMode::Append,
+        Some(236..=239) => SystemdOutputMode::File,
+        _ => SystemdOutputMode::Journal,
+    }
+}
+
+fn systemd_output_target(path: &Path, mode: SystemdOutputMode) -> String {
+    match mode {
+        SystemdOutputMode::Journal => "journal".to_string(),
+        SystemdOutputMode::File => format!("file:{}", display_path(path)),
+        SystemdOutputMode::Append => format!("append:{}", display_path(path)),
+    }
 }
 
 fn plist_escape(value: &str) -> String {
@@ -701,7 +719,7 @@ mod tests {
     use super::{
         ManagedServiceDefinition, ManagedServiceIdentity, OCM_SERVICE_LABEL, ServiceManagerKind,
         gui_domain, managed_service_identity, managed_service_label, service_backend_support_error,
-        service_definition_dir, service_manager_kind, systemd_version_supports_append,
+        service_definition_dir, service_manager_kind, systemd_output_mode_for_version,
         write_managed_service_definition,
     };
 
@@ -716,10 +734,27 @@ mod tests {
     }
 
     #[test]
-    fn systemd_append_output_requires_version_240() {
-        assert!(!systemd_version_supports_append(b"systemd 239\n"));
-        assert!(systemd_version_supports_append(b"systemd 240 (240.1)\n"));
-        assert!(!systemd_version_supports_append(b""));
+    fn systemd_output_modes_follow_supported_versions() {
+        assert_eq!(
+            systemd_output_mode_for_version(Some(235)),
+            super::SystemdOutputMode::Journal
+        );
+        assert_eq!(
+            systemd_output_mode_for_version(Some(236)),
+            super::SystemdOutputMode::File
+        );
+        assert_eq!(
+            systemd_output_mode_for_version(Some(239)),
+            super::SystemdOutputMode::File
+        );
+        assert_eq!(
+            systemd_output_mode_for_version(Some(240)),
+            super::SystemdOutputMode::Append
+        );
+        assert_eq!(
+            systemd_output_mode_for_version(None),
+            super::SystemdOutputMode::Journal
+        );
     }
 
     #[test]
@@ -961,8 +996,8 @@ mod tests {
         assert!(unit.contains("ExecStart=/bin/sh -lc"));
         assert!(unit.contains("WorkingDirectory=/tmp/work"));
         assert!(unit.contains("Environment=\"OPENCLAW_HOME=/tmp/demo\""));
-        assert!(unit.contains("StandardOutput=file:"));
-        assert!(unit.contains("StandardError=file:"));
+        assert!(unit.contains("StandardOutput=journal"));
+        assert!(unit.contains("StandardError=journal"));
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeMap;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -11,8 +14,9 @@ pub(crate) const OCM_SERVICE_LABEL: &str = "ai.openclaw.ocm";
 const SERVICE_MANAGER_OVERRIDE: &str = "OCM_INTERNAL_SERVICE_MANAGER";
 const LAUNCHCTL_BIN_OVERRIDE: &str = "OCM_INTERNAL_LAUNCHCTL_BIN";
 const SYSTEMCTL_BIN_OVERRIDE: &str = "OCM_INTERNAL_SYSTEMCTL_BIN";
-const SERVICE_DIR_MODE: u32 = 0o755;
-const SERVICE_FILE_MODE: u32 = 0o644;
+const ID_BIN_OVERRIDE: &str = "OCM_INTERNAL_ID_BIN";
+const SERVICE_DIR_MODE: u32 = 0o700;
+const SERVICE_FILE_MODE: u32 = 0o600;
 const LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS: u32 = 1;
 const LAUNCH_AGENT_UMASK_DECIMAL: u32 = 0o077;
 
@@ -192,7 +196,7 @@ pub(crate) fn write_managed_service_definition(
     definition: &ManagedServiceDefinition,
     env: &BTreeMap<String, String>,
 ) -> Result<(), String> {
-    ensure_secure_dir(
+    ensure_private_dir(
         &definition
             .stdout_path
             .parent()
@@ -204,7 +208,7 @@ pub(crate) fn write_managed_service_definition(
                 )
             })?,
     )?;
-    ensure_secure_dir(
+    ensure_private_dir(
         &definition
             .stderr_path
             .parent()
@@ -222,7 +226,8 @@ pub(crate) fn write_managed_service_definition(
             display_path(&definition.definition_path)
         ));
     };
-    ensure_secure_dir(parent)?;
+    ensure_service_definition_dir(parent)?;
+    validate_existing_service_owner(definition, env)?;
 
     let raw = match service_manager_kind(env) {
         ServiceManagerKind::Launchd => build_launch_agent_plist(
@@ -238,14 +243,50 @@ pub(crate) fn write_managed_service_definition(
             &definition.description,
             &definition.program_arguments,
             &definition.working_directory,
+            &definition.stdout_path,
+            &definition.stderr_path,
             &definition.environment,
-        ),
+        )?,
         ServiceManagerKind::Unsupported => {
             return Err(unsupported_service_manager_message().to_string());
         }
     };
-    fs::write(&definition.definition_path, raw).map_err(|error| error.to_string())?;
-    set_mode(&definition.definition_path, SERVICE_FILE_MODE)
+    write_private_service_file(&definition.definition_path, raw.as_bytes())
+}
+
+fn validate_existing_service_owner(
+    definition: &ManagedServiceDefinition,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    if !definition.definition_path.exists() {
+        return Ok(());
+    }
+    let Some(ocm_home) = definition.environment.get("OCM_HOME") else {
+        return Ok(());
+    };
+    let raw = fs::read_to_string(&definition.definition_path).map_err(|error| {
+        format!(
+            "failed to read existing service definition {}: {error}",
+            display_path(&definition.definition_path)
+        )
+    })?;
+    let owner_marker = match service_manager_kind(env) {
+        ServiceManagerKind::Launchd => format!(
+            "<key>OCM_HOME</key>\n      <string>{}</string>",
+            plist_escape(ocm_home)
+        ),
+        ServiceManagerKind::SystemdUser => {
+            format!("Environment=\"OCM_HOME={}\"", systemd_escape(ocm_home))
+        }
+        ServiceManagerKind::Unsupported => return Ok(()),
+    };
+    if raw.contains(&owner_marker) {
+        return Ok(());
+    }
+    Err(format!(
+        "the managed OCM service at {} is already bound to a different OCM_HOME; stop and uninstall that service before activating this store",
+        display_path(&definition.definition_path)
+    ))
 }
 
 pub(crate) fn activate_managed_service(
@@ -308,8 +349,21 @@ fn build_systemd_unit(
     description: &str,
     program_arguments: &[String],
     working_directory: &Path,
+    stdout_path: &Path,
+    stderr_path: &Path,
     environment: &BTreeMap<String, String>,
-) -> String {
+) -> Result<String, String> {
+    validate_systemd_value("Description", description)?;
+    validate_systemd_value("WorkingDirectory", &display_path(working_directory))?;
+    validate_systemd_value("StandardOutput", &display_path(stdout_path))?;
+    validate_systemd_value("StandardError", &display_path(stderr_path))?;
+    for argument in program_arguments {
+        validate_systemd_value("ExecStart", argument)?;
+    }
+    for (key, value) in environment {
+        validate_systemd_environment_key(key)?;
+        validate_systemd_value("Environment value", value)?;
+    }
     let exec_start = program_arguments
         .iter()
         .map(|arg| systemd_quote(arg))
@@ -333,13 +387,15 @@ fn build_systemd_unit(
         format!("{environment_lines}\n")
     };
 
-    format!(
-        "[Unit]\nDescription={}\nAfter=network.target\n\n[Service]\nType=simple\nWorkingDirectory={}\nExecStart={}\n{}Restart=always\nRestartSec=1\nUMask=0077\n\n[Install]\nWantedBy=default.target\n",
+    Ok(format!(
+        "[Unit]\nDescription={}\nAfter=network.target\n\n[Service]\nType=simple\nWorkingDirectory={}\nExecStart={}\n{}StandardOutput={}\nStandardError={}\nRestart=always\nRestartSec=1\nUMask=0077\n\n[Install]\nWantedBy=default.target\n",
         systemd_escape(description),
         systemd_quote(&display_path(working_directory)),
         exec_start,
         environment_block,
-    )
+        systemd_quote(&format!("append:{}", display_path(stdout_path))),
+        systemd_quote(&format!("append:{}", display_path(stderr_path))),
+    ))
 }
 
 fn plist_escape(value: &str) -> String {
@@ -351,9 +407,55 @@ fn plist_escape(value: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-fn ensure_secure_dir(path: &Path) -> Result<(), String> {
+fn ensure_private_dir(path: &Path) -> Result<(), String> {
     fs::create_dir_all(path).map_err(|error| error.to_string())?;
     set_mode(path, SERVICE_DIR_MODE)
+}
+
+fn ensure_service_definition_dir(path: &Path) -> Result<(), String> {
+    let existed = path.exists();
+    fs::create_dir_all(path).map_err(|error| error.to_string())?;
+    if existed {
+        return Ok(());
+    }
+    set_mode(path, SERVICE_DIR_MODE)
+}
+
+fn write_private_service_file(path: &Path, raw: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("service definition has no parent: {}", display_path(path)))?;
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            format!(
+                "service definition has no file name: {}",
+                display_path(path)
+            )
+        })?;
+    let temp_path = parent.join(format!(
+        ".{file_name}.tmp-{}-{}",
+        std::process::id(),
+        time::OffsetDateTime::now_utc().unix_timestamp_nanos()
+    ));
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    options.mode(SERVICE_FILE_MODE);
+    let mut file = options
+        .open(&temp_path)
+        .map_err(|error| error.to_string())?;
+    let result = (|| {
+        file.write_all(raw).map_err(|error| error.to_string())?;
+        file.sync_all().map_err(|error| error.to_string())?;
+        set_mode(&temp_path, SERVICE_FILE_MODE)?;
+        fs::rename(&temp_path, path).map_err(|error| error.to_string())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
 }
 
 fn set_mode(path: &Path, mode: u32) -> Result<(), String> {
@@ -377,7 +479,7 @@ fn activate_launchd_service(
     definition_path: &Path,
     env: &BTreeMap<String, String>,
 ) -> Result<(), String> {
-    let domain = gui_domain();
+    let domain = gui_domain(env)?;
     let definition_path = display_path(definition_path);
     let target = format!("{domain}/{label}");
     let _ = run_launchctl(env, ["bootout", target.as_str()]);
@@ -434,20 +536,30 @@ fn activate_systemd_user_service(
     Ok(())
 }
 
-fn gui_domain() -> String {
-    Command::new("id")
+fn gui_domain(env: &BTreeMap<String, String>) -> Result<String, String> {
+    let id_bin = env
+        .get(ID_BIN_OVERRIDE)
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("/usr/bin/id");
+    Command::new(id_bin)
         .arg("-u")
         .output()
-        .ok()
-        .filter(|output| output.status.success())
+        .map_err(|error| {
+            format!("failed to determine the current UID with \"{id_bin} -u\": {error}")
+        })
         .and_then(|output| {
+            if !output.status.success() {
+                return Err(format!(
+                    "\"{id_bin} -u\" failed while determining the launchd domain"
+                ));
+            }
             String::from_utf8_lossy(&output.stdout)
                 .trim()
                 .parse::<u32>()
-                .ok()
+                .map(|uid| format!("gui/{uid}"))
+                .map_err(|_| format!("\"{id_bin} -u\" returned an invalid UID"))
         })
-        .map(|uid| format!("gui/{uid}"))
-        .unwrap_or_else(|| "gui/501".to_string())
 }
 
 fn run_launchctl<const N: usize>(
@@ -499,13 +611,36 @@ fn systemd_quote(value: &str) -> String {
 }
 
 fn systemd_escape(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('%', "%%")
+}
+
+fn validate_systemd_value(label: &str, value: &str) -> Result<(), String> {
+    if value.contains(['\r', '\n']) {
+        return Err(format!("{label} cannot contain a line break"));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(format!("{label} cannot contain control characters"));
+    }
+    Ok(())
+}
+
+fn validate_systemd_environment_key(key: &str) -> Result<(), String> {
+    validate_systemd_value("Environment key", key)?;
+    if key.is_empty() || key.contains('=') {
+        return Err("Environment key must be non-empty and cannot contain '='".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -513,7 +648,7 @@ mod tests {
 
     use super::{
         ManagedServiceDefinition, ManagedServiceIdentity, OCM_SERVICE_LABEL, ServiceManagerKind,
-        managed_service_identity, managed_service_label, service_backend_support_error,
+        gui_domain, managed_service_identity, managed_service_label, service_backend_support_error,
         service_definition_dir, service_manager_kind, write_managed_service_definition,
     };
 
@@ -621,6 +756,16 @@ mod tests {
                     .to_string()
             )
         );
+    }
+
+    #[test]
+    fn launchd_domain_never_guesses_a_uid() {
+        let env = BTreeMap::from([(
+            "OCM_INTERNAL_ID_BIN".to_string(),
+            "/definitely/missing/id".to_string(),
+        )]);
+        let error = gui_domain(&env).unwrap_err();
+        assert!(error.contains("failed to determine the current UID"));
     }
 
     #[test]
@@ -752,6 +897,152 @@ mod tests {
         assert!(unit.contains("ExecStart=/bin/sh -lc"));
         assert!(unit.contains("WorkingDirectory=/tmp/work"));
         assert!(unit.contains("Environment=\"OPENCLAW_HOME=/tmp/demo\""));
+        assert!(unit.contains("StandardOutput=append:"));
+        assert!(unit.contains("StandardError=append:"));
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn service_definition_and_logs_are_private_without_widening_existing_parent() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("ocm-platform-private-{unique}"));
+        let definition_parent = root.join("home/.config/systemd/user");
+        fs::create_dir_all(&definition_parent).unwrap();
+        fs::set_permissions(&definition_parent, fs::Permissions::from_mode(0o750)).unwrap();
+
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), display_path(&root.join("home")));
+        env.insert("OCM_HOME".to_string(), display_path(&root.join("store")));
+        env.insert(
+            "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+            "systemd-user".to_string(),
+        );
+        let definition = ManagedServiceDefinition {
+            label: OCM_SERVICE_LABEL.to_string(),
+            description: "test".to_string(),
+            definition_path: definition_parent.join("test.service"),
+            program_arguments: vec!["/bin/true".to_string()],
+            working_directory: root.join("store"),
+            stdout_path: root.join("logs/stdout.log"),
+            stderr_path: root.join("logs/stderr.log"),
+            environment: BTreeMap::new(),
+        };
+
+        write_managed_service_definition(&definition, &env).unwrap();
+
+        assert_eq!(
+            fs::metadata(&definition_parent)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o750
+        );
+        assert_eq!(
+            fs::metadata(&definition.definition_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        assert_eq!(
+            fs::metadata(root.join("logs"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn systemd_definition_escapes_specifiers_and_rejects_line_breaks() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("ocm-platform-systemd-escape-{unique}"));
+        fs::create_dir_all(root.join("home")).unwrap();
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), display_path(&root.join("home")));
+        env.insert("OCM_HOME".to_string(), display_path(&root.join("store")));
+        env.insert(
+            "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+            "systemd-user".to_string(),
+        );
+        let mut definition = ManagedServiceDefinition {
+            label: OCM_SERVICE_LABEL.to_string(),
+            description: "OCM %p".to_string(),
+            definition_path: root.join("home/.config/systemd/user/test.service"),
+            program_arguments: vec!["/tmp/%p/ocm".to_string()],
+            working_directory: root.join("store-%p"),
+            stdout_path: root.join("logs/%p.stdout.log"),
+            stderr_path: root.join("logs/%p.stderr.log"),
+            environment: BTreeMap::from([("VALUE".to_string(), "%p".to_string())]),
+        };
+
+        write_managed_service_definition(&definition, &env).unwrap();
+        let unit = fs::read_to_string(&definition.definition_path).unwrap();
+        assert!(unit.contains("Description=OCM %%p"), "{unit}");
+        assert!(unit.contains("/tmp/%%p/ocm"), "{unit}");
+        assert!(unit.contains("VALUE=%%p"), "{unit}");
+
+        definition.description = "bad\nRestart=no".to_string();
+        let error = write_managed_service_definition(&definition, &env).unwrap_err();
+        assert!(error.contains("Description cannot contain a line break"));
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn stable_service_identity_rejects_a_different_store_owner() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("ocm-platform-owner-{unique}"));
+        fs::create_dir_all(root.join("home")).unwrap();
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), display_path(&root.join("home")));
+        env.insert("OCM_HOME".to_string(), display_path(&root.join("store-a")));
+        env.insert(
+            "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+            "systemd-user".to_string(),
+        );
+        let definition_path = root.join("home/.config/systemd/user/ai.openclaw.ocm.service");
+        let definition = ManagedServiceDefinition {
+            label: OCM_SERVICE_LABEL.to_string(),
+            description: "store a".to_string(),
+            definition_path: definition_path.clone(),
+            program_arguments: vec!["/bin/true".to_string()],
+            working_directory: root.join("store-a"),
+            stdout_path: root.join("store-a/logs/stdout.log"),
+            stderr_path: root.join("store-a/logs/stderr.log"),
+            environment: BTreeMap::from([(
+                "OCM_HOME".to_string(),
+                display_path(&root.join("store-a")),
+            )]),
+        };
+        write_managed_service_definition(&definition, &env).unwrap();
+        let original = fs::read_to_string(&definition_path).unwrap();
+
+        let mut other = definition;
+        other.description = "store b".to_string();
+        other.working_directory = root.join("store-b");
+        other
+            .environment
+            .insert("OCM_HOME".to_string(), display_path(&root.join("store-b")));
+        let error = write_managed_service_definition(&other, &env).unwrap_err();
+        assert!(error.contains("already bound to a different OCM_HOME"));
+        assert_eq!(fs::read_to_string(&definition_path).unwrap(), original);
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -270,17 +270,21 @@ fn validate_existing_service_owner(
             display_path(&definition.definition_path)
         )
     })?;
-    let owner_marker = match service_manager_kind(env) {
-        ServiceManagerKind::Launchd => format!(
+    let owner_markers = match service_manager_kind(env) {
+        ServiceManagerKind::Launchd => vec![format!(
             "<key>OCM_HOME</key>\n      <string>{}</string>",
             plist_escape(ocm_home)
-        ),
-        ServiceManagerKind::SystemdUser => {
-            format!("Environment=\"OCM_HOME={}\"", systemd_escape(ocm_home))
-        }
+        )],
+        ServiceManagerKind::SystemdUser => vec![
+            format!("Environment=\"OCM_HOME={}\"", systemd_escape(ocm_home)),
+            format!(
+                "Environment=\"OCM_HOME={}\"",
+                systemd_legacy_escape(ocm_home)
+            ),
+        ],
         ServiceManagerKind::Unsupported => return Ok(()),
     };
-    if raw.contains(&owner_marker) {
+    if owner_markers.iter().any(|marker| raw.contains(marker)) {
         return Ok(());
     }
     Err(format!(
@@ -611,10 +615,11 @@ fn systemd_quote(value: &str) -> String {
 }
 
 fn systemd_escape(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('%', "%%")
+    systemd_legacy_escape(value).replace('%', "%%")
+}
+
+fn systemd_legacy_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 fn validate_systemd_value(label: &str, value: &str) -> Result<(), String> {
@@ -1043,6 +1048,45 @@ mod tests {
         let error = write_managed_service_definition(&other, &env).unwrap_err();
         assert!(error.contains("already bound to a different OCM_HOME"));
         assert_eq!(fs::read_to_string(&definition_path).unwrap(), original);
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn stable_service_identity_accepts_legacy_systemd_percent_escaping() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("ocm-platform-owner-percent-{unique}"));
+        fs::create_dir_all(root.join("home")).unwrap();
+        let store = root.join("store%1");
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), display_path(&root.join("home")));
+        env.insert("OCM_HOME".to_string(), display_path(&store));
+        env.insert(
+            "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+            "systemd-user".to_string(),
+        );
+        let definition = ManagedServiceDefinition {
+            label: OCM_SERVICE_LABEL.to_string(),
+            description: "percent store".to_string(),
+            definition_path: root.join("home/.config/systemd/user/ai.openclaw.ocm.service"),
+            program_arguments: vec!["/bin/true".to_string()],
+            working_directory: store.clone(),
+            stdout_path: store.join("logs/stdout.log"),
+            stderr_path: store.join("logs/stderr.log"),
+            environment: BTreeMap::from([("OCM_HOME".to_string(), display_path(&store))]),
+        };
+
+        write_managed_service_definition(&definition, &env).unwrap();
+        let current = fs::read_to_string(&definition.definition_path).unwrap();
+        let legacy = current.replace("store%%1", "store%1");
+        fs::write(&definition.definition_path, legacy).unwrap();
+
+        write_managed_service_definition(&definition, &env).unwrap();
+        let rewritten = fs::read_to_string(&definition.definition_path).unwrap();
+        assert!(rewritten.contains("store%%1"));
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/src/store/common.rs
+++ b/src/store/common.rs
@@ -1,7 +1,8 @@
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use fs2::FileExt;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
@@ -11,6 +12,35 @@ pub(crate) fn path_exists(path: &Path) -> bool {
 
 pub(crate) fn ensure_dir(path: &Path) -> Result<(), String> {
     fs::create_dir_all(path).map_err(|error| error.to_string())
+}
+
+pub(crate) struct ExclusiveFileLock {
+    file: File,
+}
+
+impl Drop for ExclusiveFileLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+pub(crate) fn lock_file(path: &Path, label: &str) -> Result<ExclusiveFileLock, String> {
+    if let Some(parent) = path.parent() {
+        ensure_dir(parent)?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| format!("failed to open {label} lock at {}: {error}", path.display()))?;
+    file.lock_exclusive().map_err(|error| {
+        format!(
+            "failed to acquire {label} lock at {}: {error}",
+            path.display()
+        )
+    })?;
+    Ok(ExclusiveFileLock { file })
 }
 
 pub(crate) fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), String> {

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -36,10 +36,13 @@ static NEXT_IMPORT_ID: AtomicU64 = AtomicU64::new(0);
 struct EnvRegistry {
     kind: String,
     envs: Vec<EnvMeta>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    service_policy_revisions: BTreeMap<String, u64>,
 }
 
 pub(crate) struct EnvironmentServicePolicyChange {
     pub(crate) applied: EnvMeta,
+    applied_revision: u64,
     previous_service_enabled: bool,
     previous_service_running: bool,
 }
@@ -48,6 +51,7 @@ fn empty_env_registry() -> EnvRegistry {
     EnvRegistry {
         kind: "ocm-env-registry".to_string(),
         envs: Vec::new(),
+        service_policy_revisions: BTreeMap::new(),
     }
 }
 
@@ -195,6 +199,15 @@ fn find_environment(registry: &EnvRegistry, name: &str) -> Option<EnvMeta> {
     registry.envs.iter().find(|meta| meta.name == name).cloned()
 }
 
+fn bump_service_policy_revision(registry: &mut EnvRegistry, name: &str) -> u64 {
+    let revision = registry
+        .service_policy_revisions
+        .entry(name.to_string())
+        .or_default();
+    *revision = revision.saturating_add(1);
+    *revision
+}
+
 pub fn list_environments(
     env: &BTreeMap<String, String>,
     cwd: &Path,
@@ -222,7 +235,14 @@ pub fn save_environment(
 ) -> Result<EnvMeta, String> {
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
+    let policy_changed = find_environment(&registry, &meta.name).is_some_and(|current| {
+        current.service_enabled != meta.service_enabled
+            || current.service_running != meta.service_running
+    });
     meta = upsert_environment(&mut registry, meta)?;
+    if policy_changed {
+        bump_service_policy_revision(&mut registry, &meta.name);
+    }
     write_env_registry(&mut registry, env, cwd)?;
 
     Ok(meta)
@@ -252,24 +272,32 @@ pub(crate) fn set_environment_service_policy(
     let safe_name = validate_name(name, "Environment name")?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
-    let meta = registry
-        .envs
-        .iter_mut()
-        .find(|meta| meta.name == safe_name)
-        .ok_or_else(|| format!("environment \"{safe_name}\" does not exist"))?;
-    let previous_service_enabled = meta.service_enabled;
-    let previous_service_running = meta.service_running;
-    if let Some(service_enabled) = service_enabled {
-        meta.service_enabled = service_enabled;
-    }
-    if let Some(service_running) = service_running {
-        meta.service_running = service_running;
-    }
-    meta.updated_at = now_utc();
-    let applied = meta.clone();
+    let (applied, previous_service_enabled, previous_service_running) = {
+        let meta = registry
+            .envs
+            .iter_mut()
+            .find(|meta| meta.name == safe_name)
+            .ok_or_else(|| format!("environment \"{safe_name}\" does not exist"))?;
+        let previous_service_enabled = meta.service_enabled;
+        let previous_service_running = meta.service_running;
+        if let Some(service_enabled) = service_enabled {
+            meta.service_enabled = service_enabled;
+        }
+        if let Some(service_running) = service_running {
+            meta.service_running = service_running;
+        }
+        meta.updated_at = now_utc();
+        (
+            meta.clone(),
+            previous_service_enabled,
+            previous_service_running,
+        )
+    };
+    let applied_revision = bump_service_policy_revision(&mut registry, &safe_name);
     write_env_registry(&mut registry, env, cwd)?;
     Ok(EnvironmentServicePolicyChange {
         applied,
+        applied_revision,
         previous_service_enabled,
         previous_service_running,
     })
@@ -282,17 +310,23 @@ pub(crate) fn restore_environment_service_policy(
 ) -> Result<bool, String> {
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
+    let current_revision = registry
+        .service_policy_revisions
+        .get(&change.applied.name)
+        .copied()
+        .unwrap_or_default();
+    if current_revision != change.applied_revision {
+        return Ok(false);
+    }
     let meta = registry
         .envs
         .iter_mut()
         .find(|meta| meta.name == change.applied.name)
         .ok_or_else(|| format!("environment \"{}\" does not exist", change.applied.name))?;
-    if *meta != change.applied {
-        return Ok(false);
-    }
     meta.service_enabled = change.previous_service_enabled;
     meta.service_running = change.previous_service_running;
     meta.updated_at = now_utc();
+    bump_service_policy_revision(&mut registry, &change.applied.name);
     write_env_registry(&mut registry, env, cwd)?;
     Ok(true)
 }
@@ -671,6 +705,7 @@ pub fn remove_environment(
     }
 
     registry.envs.retain(|entry| entry.name != meta.name);
+    registry.service_policy_revisions.remove(&meta.name);
     write_env_registry(&mut registry, env, cwd)?;
 
     Ok(meta)
@@ -743,18 +778,20 @@ mod tests {
         concurrent.default_runtime = Some("stable".to_string());
         save_environment(concurrent, &env, &cwd).unwrap();
 
+        assert!(restore_environment_service_policy(&change, &env, &cwd).unwrap());
+        let current = get_environment("demo", &env, &cwd).unwrap();
+        assert!(!current.service_enabled);
+        assert!(!current.service_running);
+        assert_eq!(current.default_runtime.as_deref(), Some("stable"));
+
+        let change =
+            set_environment_service_policy("demo", Some(true), Some(true), &env, &cwd).unwrap();
+        let _same_policy =
+            set_environment_service_policy("demo", Some(true), Some(true), &env, &cwd).unwrap();
         assert!(!restore_environment_service_policy(&change, &env, &cwd).unwrap());
         let current = get_environment("demo", &env, &cwd).unwrap();
         assert!(current.service_enabled);
         assert!(current.service_running);
-        assert_eq!(current.default_runtime.as_deref(), Some("stable"));
-
-        let change =
-            set_environment_service_policy("demo", Some(false), Some(false), &env, &cwd).unwrap();
-        assert!(restore_environment_service_policy(&change, &env, &cwd).unwrap());
-        let restored = get_environment("demo", &env, &cwd).unwrap();
-        assert!(restored.service_enabled);
-        assert!(restored.service_running);
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -38,6 +38,12 @@ struct EnvRegistry {
     envs: Vec<EnvMeta>,
 }
 
+pub(crate) struct EnvironmentServicePolicyChange {
+    pub(crate) applied: EnvMeta,
+    previous_service_enabled: bool,
+    previous_service_running: bool,
+}
+
 fn empty_env_registry() -> EnvRegistry {
     EnvRegistry {
         kind: "ocm-env-registry".to_string(),
@@ -242,7 +248,7 @@ pub(crate) fn set_environment_service_policy(
     service_running: Option<bool>,
     env: &BTreeMap<String, String>,
     cwd: &Path,
-) -> Result<EnvMeta, String> {
+) -> Result<EnvironmentServicePolicyChange, String> {
     let safe_name = validate_name(name, "Environment name")?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
@@ -251,6 +257,8 @@ pub(crate) fn set_environment_service_policy(
         .iter_mut()
         .find(|meta| meta.name == safe_name)
         .ok_or_else(|| format!("environment \"{safe_name}\" does not exist"))?;
+    let previous_service_enabled = meta.service_enabled;
+    let previous_service_running = meta.service_running;
     if let Some(service_enabled) = service_enabled {
         meta.service_enabled = service_enabled;
     }
@@ -258,38 +266,35 @@ pub(crate) fn set_environment_service_policy(
         meta.service_running = service_running;
     }
     meta.updated_at = now_utc();
-    let saved = meta.clone();
+    let applied = meta.clone();
     write_env_registry(&mut registry, env, cwd)?;
-    Ok(saved)
+    Ok(EnvironmentServicePolicyChange {
+        applied,
+        previous_service_enabled,
+        previous_service_running,
+    })
 }
 
 pub(crate) fn restore_environment_service_policy(
-    name: &str,
-    attempted_service_enabled: Option<bool>,
-    attempted_service_running: Option<bool>,
-    previous_service_enabled: bool,
-    previous_service_running: bool,
+    change: &EnvironmentServicePolicyChange,
     env: &BTreeMap<String, String>,
     cwd: &Path,
-) -> Result<EnvMeta, String> {
-    let safe_name = validate_name(name, "Environment name")?;
+) -> Result<bool, String> {
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
     let meta = registry
         .envs
         .iter_mut()
-        .find(|meta| meta.name == safe_name)
-        .ok_or_else(|| format!("environment \"{safe_name}\" does not exist"))?;
-    if attempted_service_enabled.is_some_and(|attempted| meta.service_enabled == attempted) {
-        meta.service_enabled = previous_service_enabled;
+        .find(|meta| meta.name == change.applied.name)
+        .ok_or_else(|| format!("environment \"{}\" does not exist", change.applied.name))?;
+    if *meta != change.applied {
+        return Ok(false);
     }
-    if attempted_service_running.is_some_and(|attempted| meta.service_running == attempted) {
-        meta.service_running = previous_service_running;
-    }
+    meta.service_enabled = change.previous_service_enabled;
+    meta.service_running = change.previous_service_running;
     meta.updated_at = now_utc();
-    let restored = meta.clone();
     write_env_registry(&mut registry, env, cwd)?;
-    Ok(restored)
+    Ok(true)
 }
 
 pub fn create_environment(
@@ -686,4 +691,71 @@ fn import_staging_dir() -> PathBuf {
     std::env::temp_dir()
         .join("ocm-env-imports")
         .join(format!("{}-{id}", std::process::id()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+
+    use crate::env::CreateEnvironmentOptions;
+
+    use super::{
+        NEXT_IMPORT_ID, Ordering, create_environment, get_environment,
+        restore_environment_service_policy, save_environment, set_environment_service_policy,
+    };
+
+    #[test]
+    fn service_policy_rollback_requires_the_applied_snapshot_to_still_be_current() {
+        let id = NEXT_IMPORT_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join("ocm-env-policy-tests")
+            .join(format!("{}-{id}", std::process::id()));
+        let cwd = root.join("workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let env = BTreeMap::from([
+            ("HOME".to_string(), root.join("home").display().to_string()),
+            (
+                "OCM_HOME".to_string(),
+                root.join("ocm-home").display().to_string(),
+            ),
+        ]);
+        create_environment(
+            CreateEnvironmentOptions {
+                name: "demo".to_string(),
+                root: None,
+                gateway_port: None,
+                service_enabled: false,
+                service_running: false,
+                default_runtime: None,
+                default_launcher: None,
+                dev: None,
+                protected: false,
+            },
+            &env,
+            &cwd,
+        )
+        .unwrap();
+
+        let change =
+            set_environment_service_policy("demo", Some(true), Some(true), &env, &cwd).unwrap();
+        let mut concurrent = get_environment("demo", &env, &cwd).unwrap();
+        concurrent.default_runtime = Some("stable".to_string());
+        save_environment(concurrent, &env, &cwd).unwrap();
+
+        assert!(!restore_environment_service_policy(&change, &env, &cwd).unwrap());
+        let current = get_environment("demo", &env, &cwd).unwrap();
+        assert!(current.service_enabled);
+        assert!(current.service_running);
+        assert_eq!(current.default_runtime.as_deref(), Some("stable"));
+
+        let change =
+            set_environment_service_policy("demo", Some(false), Some(false), &env, &cwd).unwrap();
+        assert!(restore_environment_service_policy(&change, &env, &cwd).unwrap());
+        let restored = get_environment("demo", &env, &cwd).unwrap();
+        assert!(restored.service_enabled);
+        assert!(restored.service_running);
+
+        fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -705,7 +705,9 @@ pub fn remove_environment(
     }
 
     registry.envs.retain(|entry| entry.name != meta.name);
-    registry.service_policy_revisions.remove(&meta.name);
+    // Keep a monotonic tombstone so a stale rollback token cannot target a
+    // later environment that reuses the same name.
+    bump_service_policy_revision(&mut registry, &meta.name);
     write_env_registry(&mut registry, env, cwd)?;
 
     Ok(meta)
@@ -736,7 +738,7 @@ mod tests {
     use crate::env::CreateEnvironmentOptions;
 
     use super::{
-        NEXT_IMPORT_ID, Ordering, create_environment, get_environment,
+        NEXT_IMPORT_ID, Ordering, create_environment, get_environment, remove_environment,
         restore_environment_service_policy, save_environment, set_environment_service_policy,
     };
 
@@ -786,12 +788,34 @@ mod tests {
 
         let change =
             set_environment_service_policy("demo", Some(true), Some(true), &env, &cwd).unwrap();
-        let _same_policy =
+        let same_policy =
             set_environment_service_policy("demo", Some(true), Some(true), &env, &cwd).unwrap();
         assert!(!restore_environment_service_policy(&change, &env, &cwd).unwrap());
         let current = get_environment("demo", &env, &cwd).unwrap();
         assert!(current.service_enabled);
         assert!(current.service_running);
+
+        remove_environment("demo", false, &env, &cwd).unwrap();
+        create_environment(
+            CreateEnvironmentOptions {
+                name: "demo".to_string(),
+                root: None,
+                gateway_port: None,
+                service_enabled: false,
+                service_running: false,
+                default_runtime: None,
+                default_launcher: None,
+                dev: None,
+                protected: false,
+            },
+            &env,
+            &cwd,
+        )
+        .unwrap();
+        assert!(!restore_environment_service_policy(&same_policy, &env, &cwd).unwrap());
+        let recreated = get_environment("demo", &env, &cwd).unwrap();
+        assert!(!recreated.service_enabled);
+        assert!(!recreated.service_running);
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -236,6 +236,62 @@ pub(crate) fn save_environment_with_validated_launcher(
     Ok(meta)
 }
 
+pub(crate) fn set_environment_service_policy(
+    name: &str,
+    service_enabled: Option<bool>,
+    service_running: Option<bool>,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
+    let safe_name = validate_name(name, "Environment name")?;
+    let _lock = lock_env_registry(env, cwd)?;
+    let mut registry = load_env_registry(env, cwd)?;
+    let meta = registry
+        .envs
+        .iter_mut()
+        .find(|meta| meta.name == safe_name)
+        .ok_or_else(|| format!("environment \"{safe_name}\" does not exist"))?;
+    if let Some(service_enabled) = service_enabled {
+        meta.service_enabled = service_enabled;
+    }
+    if let Some(service_running) = service_running {
+        meta.service_running = service_running;
+    }
+    meta.updated_at = now_utc();
+    let saved = meta.clone();
+    write_env_registry(&mut registry, env, cwd)?;
+    Ok(saved)
+}
+
+pub(crate) fn restore_environment_service_policy(
+    name: &str,
+    attempted_service_enabled: Option<bool>,
+    attempted_service_running: Option<bool>,
+    previous_service_enabled: bool,
+    previous_service_running: bool,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
+    let safe_name = validate_name(name, "Environment name")?;
+    let _lock = lock_env_registry(env, cwd)?;
+    let mut registry = load_env_registry(env, cwd)?;
+    let meta = registry
+        .envs
+        .iter_mut()
+        .find(|meta| meta.name == safe_name)
+        .ok_or_else(|| format!("environment \"{safe_name}\" does not exist"))?;
+    if attempted_service_enabled.is_some_and(|attempted| meta.service_enabled == attempted) {
+        meta.service_enabled = previous_service_enabled;
+    }
+    if attempted_service_running.is_some_and(|attempted| meta.service_running == attempted) {
+        meta.service_running = previous_service_running;
+    }
+    meta.updated_at = now_utc();
+    let restored = meta.clone();
+    write_env_registry(&mut registry, env, cwd)?;
+    Ok(restored)
+}
+
 pub fn create_environment(
     options: CreateEnvironmentOptions,
     env: &BTreeMap<String, String>,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -15,7 +15,9 @@ use time::OffsetDateTime;
 
 use crate::env::EnvMeta;
 use crate::env::EnvSummary;
-pub(crate) use common::{copy_dir_recursive, ensure_dir, read_json, write_json};
+pub(crate) use common::{
+    ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, write_json,
+};
 pub(crate) use envs::save_environment_with_validated_launcher;
 pub(crate) use envs::{EnvironmentOperationLock, lock_environment_operation};
 pub use envs::{

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -24,6 +24,7 @@ pub use envs::{
     clone_environment, create_environment, export_environment, get_environment, import_environment,
     list_environments, remove_environment, save_environment,
 };
+pub(crate) use envs::{restore_environment_service_policy, set_environment_service_policy};
 pub(crate) use gateway_ports::{
     openclaw_port_family_available, openclaw_port_family_range, resolve_config_gateway_port,
     resolve_effective_gateway_ports, resolve_env_gateway_port,

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -7,8 +7,8 @@ use std::process::{Command, Stdio};
 
 use crate::host::verify_official_openclaw_runtime_host;
 use crate::infra::download::{
-    artifact_file_name_from_url, download_to_file, file_sha256, normalize_sha256,
-    verify_file_integrity, verify_file_sha256,
+    artifact_file_name_from_url, download_to_file, file_sha256, normalize_file_integrity,
+    normalize_sha256, verify_file_integrity, verify_file_sha256,
 };
 use crate::managed_node::managed_runtime_install_command;
 use crate::runtime::releases::{
@@ -24,11 +24,12 @@ use crate::runtime::{
 };
 
 use super::common::{
-    copy_dir_recursive, ensure_dir, load_json_files, path_exists, read_json, write_json,
+    ExclusiveFileLock, copy_dir_recursive, ensure_dir, load_json_files, lock_file, path_exists,
+    read_json, write_json,
 };
 use super::layout::{
-    clean_path, display_path, resolve_absolute_path, runtime_install_files_dir,
-    runtime_install_root, runtime_meta_path, validate_name,
+    clean_path, display_path, resolve_absolute_path, runtime_install_root, runtime_meta_path,
+    validate_name,
 };
 use super::now_utc;
 
@@ -72,7 +73,8 @@ fn symlink_or_copy_dir(source: &Path, target: &Path) -> Result<(), String> {
     }
     #[cfg(unix)]
     {
-        match std::os::unix::fs::symlink(source, target) {
+        let link_target = relative_symlink_target(source, target).unwrap_or_else(|| source.into());
+        match std::os::unix::fs::symlink(link_target, target) {
             Ok(()) => return Ok(()),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(()),
             Err(_) => {}
@@ -80,13 +82,37 @@ fn symlink_or_copy_dir(source: &Path, target: &Path) -> Result<(), String> {
     }
     #[cfg(windows)]
     {
-        match std::os::windows::fs::symlink_dir(source, target) {
+        let link_target = relative_symlink_target(source, target).unwrap_or_else(|| source.into());
+        match std::os::windows::fs::symlink_dir(link_target, target) {
             Ok(()) => return Ok(()),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(()),
             Err(_) => {}
         }
     }
     copy_dir_recursive(source, target)
+}
+
+fn relative_symlink_target(source: &Path, target: &Path) -> Option<PathBuf> {
+    let target_parent = target.parent()?;
+    let source_components = source.components().collect::<Vec<_>>();
+    let parent_components = target_parent.components().collect::<Vec<_>>();
+    let common = source_components
+        .iter()
+        .zip(&parent_components)
+        .take_while(|(left, right)| left == right)
+        .count();
+    if common == 0 {
+        return None;
+    }
+
+    let mut relative = PathBuf::new();
+    for _ in common..parent_components.len() {
+        relative.push("..");
+    }
+    for component in &source_components[common..] {
+        relative.push(component.as_os_str());
+    }
+    Some(relative)
 }
 
 fn expose_openclaw_package_runtime_dependencies(install_files: &Path) -> Result<(), String> {
@@ -252,12 +278,19 @@ impl RuntimeReleaseDetails {
     }
 }
 
-#[derive(Clone, Debug)]
 struct RuntimeInstallTarget {
     name: String,
-    meta_path: PathBuf,
+    final_meta_path: PathBuf,
+    final_install_root: PathBuf,
     install_root: PathBuf,
     install_files: PathBuf,
+    _lock: ExclusiveFileLock,
+}
+
+impl Drop for RuntimeInstallTarget {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.install_root);
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -498,11 +531,15 @@ fn build_installed_runtime_meta(
     release: &RuntimeReleaseDetails,
     description: Option<String>,
 ) -> RuntimeMeta {
+    let final_binary_path = binary_path
+        .strip_prefix(&target.install_root)
+        .map(|relative| target.final_install_root.join(relative))
+        .unwrap_or_else(|_| binary_path.to_path_buf());
     let created_at = now_utc();
     RuntimeMeta {
         kind: "ocm-runtime".to_string(),
         name: target.name.clone(),
-        binary_path: display_path(binary_path),
+        binary_path: display_path(&final_binary_path),
         source_kind: RuntimeSourceKind::Installed,
         source_path: source.path.as_deref().map(display_path),
         source_url: source.url.clone(),
@@ -512,7 +549,7 @@ fn build_installed_runtime_meta(
         release_channel: release.channel.clone(),
         release_selector_kind: release.selector_kind.clone(),
         release_selector_value: release.selector_value.clone(),
-        install_root: Some(display_path(&target.install_root)),
+        install_root: Some(display_path(&target.final_install_root)),
         description,
         created_at,
         updated_at: created_at,
@@ -569,14 +606,8 @@ fn install_runtime_at_path(
 
         let meta =
             build_installed_runtime_meta(&target, &binary_path, &source, &release, description);
-        write_json(&target.meta_path, &meta)?;
-        Ok(meta)
+        publish_runtime(target, meta)
     })();
-
-    if result.is_err() {
-        let _ = fs::remove_file(&target.meta_path);
-        let _ = fs::remove_dir_all(&target.install_root);
-    }
 
     result
 }
@@ -587,21 +618,52 @@ fn prepare_runtime_install_target(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<RuntimeInstallTarget, String> {
-    let meta_path = prepare_runtime_meta_path(&name, replace_existing, env, cwd)?;
-    let install_root = runtime_install_root(&name, env, cwd)?;
-    let install_files = runtime_install_files_dir(&name, env, cwd)?;
+    let final_meta_path = runtime_meta_path(&name, env, cwd)?;
+    let final_install_root = runtime_install_root(&name, env, cwd)?;
+    let lock = lock_runtime(&name, env, cwd)?;
+    let parent = final_install_root
+        .parent()
+        .ok_or_else(|| format!("runtime install root has no parent: {name}"))?;
+    if path_exists(&final_meta_path) && !replace_existing {
+        return Err(format!("runtime \"{name}\" already exists"));
+    }
+    let install_root = parent.join(format!(
+        ".{name}.stage-{}-{}",
+        std::process::id(),
+        now_utc().unix_timestamp_nanos()
+    ));
+    let _ = fs::remove_dir_all(&install_root);
+    let install_files = install_root.join("files");
     Ok(RuntimeInstallTarget {
         name,
-        meta_path,
+        final_meta_path,
+        final_install_root,
         install_root,
         install_files,
+        _lock: lock,
     })
+}
+
+fn lock_runtime(
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<ExclusiveFileLock, String> {
+    let install_root = runtime_install_root(name, env, cwd)?;
+    let parent = install_root
+        .parent()
+        .ok_or_else(|| format!("runtime install root has no parent: {name}"))?;
+    ensure_dir(parent)?;
+    lock_file(
+        &parent.join(format!(".{name}.lock")),
+        "runtime installation",
+    )
 }
 
 fn install_runtime_from_openclaw_package(
     target: RuntimeInstallTarget,
     source: RuntimeSourceDetails,
-    source_integrity: Option<String>,
+    source_integrity: String,
     release: RuntimeReleaseDetails,
     description: Option<String>,
     context: InstallContext<'_>,
@@ -620,11 +682,9 @@ fn install_runtime_from_openclaw_package(
         let archive_name = artifact_file_name_from_url(tarball_url)?;
         let archive_path = target.install_files.join(&archive_name);
         download_to_file(tarball_url, &archive_path)?;
-        if let Some(source_integrity) = source_integrity.as_deref() {
-            verify_file_integrity(&archive_path, source_integrity)?;
-        }
+        verify_file_integrity(&archive_path, &source_integrity)?;
 
-        let meta = install_runtime_from_openclaw_package_archive(
+        let meta = stage_runtime_from_openclaw_package_archive(
             &target,
             &archive_path,
             source,
@@ -633,18 +693,13 @@ fn install_runtime_from_openclaw_package(
             context,
         );
         let _ = fs::remove_file(&archive_path);
-        meta
+        publish_runtime(target, meta?)
     })();
-
-    if result.is_err() {
-        let _ = fs::remove_file(&target.meta_path);
-        let _ = fs::remove_dir_all(&target.install_root);
-    }
 
     result
 }
 
-fn install_runtime_from_openclaw_package_archive(
+fn stage_runtime_from_openclaw_package_archive(
     target: &RuntimeInstallTarget,
     archive_path: &Path,
     source: RuntimeSourceDetails,
@@ -679,25 +734,83 @@ fn install_runtime_from_openclaw_package_archive(
 
     let mut source = source;
     source.sha256 = Some(binary_sha256);
-    let meta = build_installed_runtime_meta(target, &binary_path, &source, &release, description);
-    write_json(&target.meta_path, &meta)?;
-    Ok(meta)
+    Ok(build_installed_runtime_meta(
+        target,
+        &binary_path,
+        &source,
+        &release,
+        description,
+    ))
 }
 
-fn prepare_runtime_meta_path(
-    name: &str,
-    replace_existing: bool,
-    env: &BTreeMap<String, String>,
-    cwd: &Path,
-) -> Result<PathBuf, String> {
-    let meta_path = runtime_meta_path(name, env, cwd)?;
-    if path_exists(&meta_path) {
-        if !replace_existing {
-            return Err(format!("runtime \"{name}\" already exists"));
-        }
-        remove_runtime(name, env, cwd)?;
+fn publish_runtime(target: RuntimeInstallTarget, meta: RuntimeMeta) -> Result<RuntimeMeta, String> {
+    let nonce = now_utc().unix_timestamp_nanos();
+    let backup_root = target
+        .final_install_root
+        .with_file_name(format!(".{}.backup-{nonce}", target.name));
+    let backup_meta = target
+        .final_meta_path
+        .with_file_name(format!(".{}.json.backup-{nonce}", target.name));
+    let had_root = path_exists(&target.final_install_root);
+    let had_meta = path_exists(&target.final_meta_path);
+
+    if had_root {
+        fs::rename(&target.final_install_root, &backup_root).map_err(|error| {
+            format!(
+                "failed to preserve runtime \"{}\" before replacement: {error}",
+                target.name
+            )
+        })?;
     }
-    Ok(meta_path)
+    if had_meta && let Err(error) = fs::rename(&target.final_meta_path, &backup_meta) {
+        if had_root {
+            let _ = fs::rename(&backup_root, &target.final_install_root);
+        }
+        return Err(format!(
+            "failed to preserve runtime \"{}\" metadata before replacement: {error}",
+            target.name
+        ));
+    }
+
+    let publish_result = (|| {
+        fs::rename(&target.install_root, &target.final_install_root).map_err(|error| {
+            format!(
+                "failed to publish runtime \"{}\" install root: {error}",
+                target.name
+            )
+        })?;
+        write_json(&target.final_meta_path, &meta).map_err(|error| {
+            format!(
+                "failed to publish runtime \"{}\" metadata: {error}",
+                target.name
+            )
+        })
+    })();
+
+    if let Err(error) = publish_result {
+        let _ = fs::remove_dir_all(&target.final_install_root);
+        let _ = fs::remove_file(&target.final_meta_path);
+        let mut rollback_errors = Vec::new();
+        if had_root
+            && let Err(rollback_error) = fs::rename(&backup_root, &target.final_install_root)
+        {
+            rollback_errors.push(format!("install root: {rollback_error}"));
+        }
+        if had_meta && let Err(rollback_error) = fs::rename(&backup_meta, &target.final_meta_path) {
+            rollback_errors.push(format!("metadata: {rollback_error}"));
+        }
+        if rollback_errors.is_empty() {
+            return Err(error);
+        }
+        return Err(format!(
+            "{error}; failed to restore previous runtime: {}",
+            rollback_errors.join("; ")
+        ));
+    }
+
+    let _ = fs::remove_dir_all(&backup_root);
+    let _ = fs::remove_file(&backup_meta);
+    Ok(meta)
 }
 
 pub fn list_runtimes(
@@ -741,6 +854,7 @@ pub fn add_runtime(
     cwd: &Path,
 ) -> Result<RuntimeMeta, String> {
     let name = validate_name(&options.name, "Runtime name")?;
+    let _lock = lock_runtime(&name, env, cwd)?;
     let meta_path = runtime_meta_path(&name, env, cwd)?;
     if path_exists(&meta_path) {
         return Err(format!("runtime \"{name}\" already exists"));
@@ -797,7 +911,9 @@ pub fn remove_runtime(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<RuntimeMeta, String> {
-    let meta = get_runtime(name, env, cwd)?;
+    let name = validate_name(name, "Runtime name")?;
+    let _lock = lock_runtime(&name, env, cwd)?;
+    let meta = get_runtime(&name, env, cwd)?;
     let path = runtime_meta_path(&meta.name, env, cwd)?;
     if let Some(install_root) = meta.install_root.as_deref() {
         let expected_root = runtime_install_root(&meta.name, env, cwd)?;
@@ -928,7 +1044,7 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
         ensure_dir(&target.install_files)?;
         let description = trim_description(options.description)
             .or_else(|| Some(default_local_build_description(&version, commit.as_deref())));
-        let meta = install_runtime_from_openclaw_package_archive(
+        let meta = stage_runtime_from_openclaw_package_archive(
             &target,
             &archive_path,
             RuntimeSourceDetails {
@@ -941,12 +1057,8 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
             },
             description,
             context,
-        );
-        if meta.is_err() {
-            let _ = fs::remove_file(&target.meta_path);
-            let _ = fs::remove_dir_all(&target.install_root);
-        }
-        meta
+        )?;
+        publish_runtime(target, meta)
     })();
 
     let _ = fs::remove_dir_all(&pack_dir);
@@ -959,7 +1071,6 @@ pub fn install_runtime_from_release(
     cwd: &Path,
 ) -> Result<RuntimeMeta, String> {
     let name = validate_name(&options.name, "Runtime name")?;
-    let target = prepare_runtime_install_target(name, options.force, env, cwd)?;
 
     let manifest = load_release_manifest(&options.manifest_url)?;
     let release = select_release(
@@ -967,6 +1078,17 @@ pub fn install_runtime_from_release(
         options.version.as_deref(),
         options.channel.as_deref(),
     )?;
+    let source_sha256 = release
+        .sha256
+        .as_deref()
+        .ok_or_else(|| {
+            format!(
+                "runtime release \"{}\" is missing required sha256 integrity",
+                release.version
+            )
+        })
+        .and_then(normalize_sha256)?;
+    let target = prepare_runtime_install_target(name, options.force, env, cwd)?;
     let (selector_kind, selector_value) =
         match (options.version.as_deref(), options.channel.as_deref()) {
             (Some(version), None) => (
@@ -995,7 +1117,7 @@ pub fn install_runtime_from_release(
         RuntimeSourceDetails {
             url: Some(release.url),
             manifest_url: Some(options.manifest_url),
-            sha256: release.sha256,
+            sha256: Some(source_sha256),
             ..RuntimeSourceDetails::default()
         },
         release_details,
@@ -1066,10 +1188,19 @@ pub(crate) fn install_runtime_from_selected_official_openclaw_release(
     description: Option<String>,
     context: InstallContext<'_>,
 ) -> Result<RuntimeMeta, String> {
+    let source_integrity = release
+        .integrity
+        .as_deref()
+        .ok_or_else(|| {
+            format!(
+                "official OpenClaw release \"{}\" is missing required sha512 integrity",
+                release.version
+            )
+        })
+        .and_then(normalize_file_integrity)?;
     let target = prepare_runtime_install_target(name, force, context.env, context.cwd)?;
     let description = trim_description(description)
         .or_else(|| Some(format!("Official OpenClaw release {}", release.version)));
-    let source_integrity = release.integrity.clone();
     let source = RuntimeSourceDetails {
         url: Some(release.tarball_url),
         manifest_url: Some(releases_url),

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -764,7 +764,13 @@ fn publish_runtime(target: RuntimeInstallTarget, meta: RuntimeMeta) -> Result<Ru
     }
     if had_meta && let Err(error) = fs::rename(&target.final_meta_path, &backup_meta) {
         if had_root {
-            let _ = fs::rename(&backup_root, &target.final_install_root);
+            if let Err(rollback_error) = fs::rename(&backup_root, &target.final_install_root) {
+                return Err(format!(
+                    "failed to preserve runtime \"{}\" metadata before replacement: {error}; failed to restore its install root from {}: {rollback_error}",
+                    target.name,
+                    display_path(&backup_root)
+                ));
+            }
         }
         return Err(format!(
             "failed to preserve runtime \"{}\" metadata before replacement: {error}",

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -23,7 +23,7 @@ use crate::service::platform::{
     managed_service_identity, service_manager_kind, write_managed_service_definition,
 };
 use crate::store::{
-    display_path, ensure_dir, ensure_store, list_environments, now_utc,
+    display_path, ensure_dir, ensure_store, list_environments, lock_file, now_utc,
     openclaw_port_family_available, openclaw_port_family_range, read_json, resolve_ocm_home,
     supervisor_logs_dir, supervisor_runtime_path, supervisor_state_path, write_json,
 };
@@ -258,6 +258,7 @@ impl<'a> SupervisorService<'a> {
     pub fn sync(&self) -> Result<SupervisorView, String> {
         let state_path = supervisor_state_path(self.env, self.cwd)?;
         let mut state = self.build_state()?;
+        let _lock = lock_supervisor_state(&state_path)?;
         preserve_persisted_restart_requests(&state_path, &mut state);
         if let Some(parent) = state_path.parent() {
             ensure_dir(parent)?;
@@ -335,17 +336,27 @@ impl<'a> SupervisorService<'a> {
     }
 
     pub fn recover_child_restart(&self, name: &str) -> Result<SupervisorDaemonSummary, String> {
+        self.recover_child_restart_with_request_id(name)
+            .map(|(summary, _)| summary)
+    }
+
+    pub(crate) fn recover_child_restart_with_request_id(
+        &self,
+        name: &str,
+    ) -> Result<(SupervisorDaemonSummary, String), String> {
         // Reissue only the target request; a full sync could reload unrelated children.
-        let _ = self.request_child_restart(name)?;
+        let request_id = self.request_child_restart(name)?;
         let status = self.daemon_status()?;
         if status.running {
-            return Ok(status);
+            return Ok((status, request_id));
         }
         self.activate_daemon("install")
+            .map(|summary| (summary, request_id))
     }
 
     pub fn request_child_restart(&self, name: &str) -> Result<String, String> {
         let state_path = supervisor_state_path(self.env, self.cwd)?;
+        let _lock = lock_supervisor_state(&state_path)?;
         let mut state = self.build_state()?;
         if let Ok(persisted_state) = read_json::<SupervisorState>(&state_path) {
             preserve_persisted_child_specs_except(&mut state, persisted_state.children, name);
@@ -374,6 +385,8 @@ impl<'a> SupervisorService<'a> {
     }
 
     pub fn clear_child_restart_request(&self, name: &str, request_id: &str) -> Result<(), String> {
+        let state_path = supervisor_state_path(self.env, self.cwd)?;
+        let _lock = lock_supervisor_state(&state_path)?;
         let (state_path, mut state) = self.read_persisted_state()?;
         let previous_len = state.restart_requests.len();
         state
@@ -688,6 +701,11 @@ impl<'a> SupervisorService<'a> {
             child_results,
         })
     }
+}
+
+fn lock_supervisor_state(state_path: &Path) -> Result<crate::store::ExclusiveFileLock, String> {
+    let lock_path = state_path.with_extension("lock");
+    lock_file(&lock_path, "supervisor state")
 }
 
 struct RunningSupervisorChild {
@@ -1124,6 +1142,17 @@ fn clear_processed_restart_requests(
         return;
     }
 
+    let _lock = match lock_supervisor_state(state_path) {
+        Ok(lock) => lock,
+        Err(error) => {
+            eprintln!(
+                "ocm service: failed locking state to clear processed restart request {}: {}",
+                display_path(state_path),
+                error
+            );
+            return;
+        }
+    };
     let mut state = match read_json::<SupervisorState>(state_path) {
         Ok(state) => state,
         Err(error) => {

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -257,8 +257,8 @@ impl<'a> SupervisorService<'a> {
 
     pub fn sync(&self) -> Result<SupervisorView, String> {
         let state_path = supervisor_state_path(self.env, self.cwd)?;
-        let mut state = self.build_state()?;
         let _lock = lock_supervisor_state(&state_path)?;
+        let mut state = self.build_state()?;
         preserve_persisted_restart_requests(&state_path, &mut state);
         if let Some(parent) = state_path.parent() {
             ensure_dir(parent)?;

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -1126,6 +1126,54 @@ fn official_runtime_install_uses_managed_node_when_npm_is_missing() {
 }
 
 #[test]
+fn official_runtime_install_rejects_untrusted_managed_node_archive() {
+    let root = TestDir::new("runtime-install-official-managed-node-integrity");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let tarball = openclaw_package_tarball("#!/usr/bin/env node\nconsole.log('stable');\n");
+    let integrity = sha512_integrity(&tarball);
+    let tarball_server = TestHttpServer::serve_bytes(
+        "/openclaw-2026.3.24.tgz",
+        "application/octet-stream",
+        &tarball,
+    );
+    let packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.24\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.3.24\":\"2026-03-25T16:35:52.000Z\"}}}}",
+        tarball_server.url(),
+        integrity
+    );
+    let packument_server =
+        TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "20.11.0");
+    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "22.14.0");
+    env.insert(
+        "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_SHA256".to_string(),
+        "0".repeat(64),
+    );
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+
+    let install = run_ocm(&cwd, &env, &["runtime", "install", "--channel", "stable"]);
+    assert!(!install.status.success());
+    assert!(
+        stderr(&install).contains("runtime artifact sha256 mismatch"),
+        "{}",
+        stderr(&install)
+    );
+    let toolchain_root = root.child("ocm-home/toolchains/node");
+    let installed_toolchains = fs::read_dir(toolchain_root)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("node-v"))
+        .count();
+    assert_eq!(installed_toolchains, 0);
+}
+
+#[test]
 fn official_runtime_install_uses_managed_node_when_host_node_is_too_old() {
     let root = TestDir::new("runtime-install-official-old-node");
     let cwd = root.child("workspace");
@@ -1685,6 +1733,74 @@ fn runtime_install_from_url_cleans_up_failed_install_roots_for_retry() {
 }
 
 #[test]
+fn release_backed_runtime_install_requires_sha256_before_download() {
+    let root = TestDir::new("runtime-install-manifest-integrity-required");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let artifact_server = TestHttpServer::serve_bytes(
+        "/artifacts/openclaw-stable",
+        "application/octet-stream",
+        b"runtime",
+    );
+    let manifest = format!(
+        "{{\"releases\":[{{\"version\":\"0.3.0\",\"channel\":\"stable\",\"url\":\"{}\"}}]}}",
+        artifact_server.url()
+    );
+    let manifest_server = TestHttpServer::serve_bytes(
+        "/manifests/releases.json",
+        "application/json",
+        manifest.as_bytes(),
+    );
+    let env = ocm_env(&root);
+
+    let install = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "install",
+            "stable",
+            "--manifest-url",
+            &manifest_server.url(),
+            "--version",
+            "0.3.0",
+        ],
+    );
+    assert!(!install.status.success());
+    assert!(stderr(&install).contains("missing required sha256 integrity"));
+    assert!(artifact_server.requests().is_empty());
+}
+
+#[test]
+fn official_runtime_install_requires_sha512_integrity_before_download() {
+    let root = TestDir::new("runtime-install-official-integrity-required");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let tarball_server = TestHttpServer::serve_bytes(
+        "/openclaw-2026.3.24.tgz",
+        "application/octet-stream",
+        b"runtime",
+    );
+    let packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.24\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\"}}}}}}}}",
+        tarball_server.url()
+    );
+    let packument_server =
+        TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+
+    let install = run_ocm(&cwd, &env, &["runtime", "install", "--channel", "stable"]);
+    assert!(!install.status.success());
+    assert!(stderr(&install).contains("missing required sha512 integrity"));
+    assert!(tarball_server.requests().is_empty());
+}
+
+#[test]
 fn runtime_install_force_replaces_an_existing_runtime_definition() {
     let root = TestDir::new("runtime-install-force");
     let cwd = root.child("workspace");
@@ -1744,6 +1860,82 @@ fn runtime_install_force_replaces_an_existing_runtime_definition() {
         "\"binaryPath\": \"{}\"",
         path_string(&expected_binary)
     )));
+}
+
+#[test]
+fn runtime_install_force_preserves_existing_runtime_when_replacement_fails() {
+    let root = TestDir::new("runtime-install-force-rollback");
+    let cwd = root.child("workspace");
+    let source_dir = cwd.join("downloads");
+    fs::create_dir_all(&source_dir).unwrap();
+    let source_path = source_dir.join("openclaw");
+    write_executable_script(&source_path, "#!/bin/sh\nprintf 'working\\n'\n");
+    let env = ocm_env(&root);
+
+    let install = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "install",
+            "stable",
+            "--path",
+            "./downloads/openclaw",
+        ],
+    );
+    assert!(install.status.success(), "{}", stderr(&install));
+
+    let replacement = TestHttpServer::serve_bytes(
+        "/artifacts/openclaw-stable",
+        "application/octet-stream",
+        b"broken replacement",
+    );
+    let manifest = format!(
+        "{{\"releases\":[{{\"version\":\"0.3.0\",\"channel\":\"stable\",\"url\":\"{}\",\"sha256\":\"{}\"}}]}}",
+        replacement.url(),
+        "0".repeat(64)
+    );
+    let manifest_server = TestHttpServer::serve_bytes(
+        "/manifests/releases.json",
+        "application/json",
+        manifest.as_bytes(),
+    );
+    let failed = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "install",
+            "stable",
+            "--manifest-url",
+            &manifest_server.url(),
+            "--version",
+            "0.3.0",
+            "--force",
+        ],
+    );
+    assert!(!failed.status.success());
+    assert!(stderr(&failed).contains("runtime artifact sha256 mismatch"));
+
+    let show = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    assert!(stdout(&show).contains("\"sourcePath\""));
+    let binary = runtime_install_root("stable", &env, &cwd)
+        .unwrap()
+        .join("files/openclaw");
+    assert_eq!(
+        fs::read_to_string(binary).unwrap(),
+        "#!/bin/sh\nprintf 'working\\n'\n"
+    );
+
+    let runtime_dir = root.child("ocm-home/runtimes");
+    let residues = fs::read_dir(runtime_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.contains(".stage-") || name.contains(".backup-"))
+        .collect::<Vec<_>>();
+    assert!(residues.is_empty(), "{residues:?}");
 }
 
 #[test]

--- a/tests/service_command_tests.rs
+++ b/tests/service_command_tests.rs
@@ -349,10 +349,19 @@ fn service_start_still_requires_a_managed_service_backend() {
     fs::create_dir_all(&cwd).unwrap();
     let env = unsupported_env(&root);
     setup_launcher_env(&cwd, &env);
+    let before = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(before.status.success(), "{}", stderr(&before));
+    let before = json_output(&before);
 
     let output = run_ocm(&cwd, &env, &["service", "start", "demo"]);
     assert!(!output.status.success());
     assert!(stderr(&output).contains("managed services are not supported on this platform yet"));
+
+    let after = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(after.status.success(), "{}", stderr(&after));
+    let after = json_output(&after);
+    assert_eq!(after["serviceEnabled"], before["serviceEnabled"]);
+    assert_eq!(after["serviceRunning"], before["serviceRunning"]);
 }
 
 #[test]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -619,6 +619,10 @@ pub fn install_fake_managed_node_archive(
     version: &str,
 ) -> TestHttpServer {
     let archive = fake_managed_node_archive(version);
+    let archive_sha256 = {
+        use sha2::{Digest, Sha256};
+        format!("{:x}", Sha256::digest(&archive))
+    };
     let server = TestHttpServer::serve_bytes(
         "/managed-node-toolchain",
         "application/octet-stream",
@@ -627,6 +631,10 @@ pub fn install_fake_managed_node_archive(
     env.insert(
         "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_URL".to_string(),
         server.url(),
+    );
+    env.insert(
+        "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_SHA256".to_string(),
+        archive_sha256,
     );
     server
 }


### PR DESCRIPTION
## What Problem This Solves

OCM trusted downloaded runtime and managed Node artifacts before authenticating them, replaced installed runtimes destructively, and allowed concurrent install/service operations to race across processes. Service definition ownership, permissions, rollback, and supervisor restart handling also had gaps that could produce corrupted state, cross-store conflicts, or misleading success.

## Why This Change Was Made

- authenticate official managed Node archives with pinned SHA-256 digests and require checksums for custom archives
- serialize managed Node bootstrap and runtime publication with cross-process file locks
- stage runtime roots and metadata, then publish transactionally with rollback that preserves the previous working runtime
- require manifest SHA-256 or npm SHA-512 integrity and reject non-portable artifact names
- keep service-policy changes field-scoped and revisioned so failed reconciliation cannot overwrite concurrent edits or a recreated environment
- serialize supervisor state snapshots and restart request mutation
- make service definitions private, atomic, ownership-checked, and resistant to directive/specifier injection
- preserve launcher-validated environment saves and existing per-environment operation locks from current `main`
- support systemd logging safely: append files on systemd 240+, journal on older or unknown versions

## User Impact

Runtime and managed Node installs now fail closed when artifact integrity is missing or invalid. Forced runtime replacement preserves the prior working install until the replacement is complete. Concurrent service and runtime operations no longer silently clobber each other, and service definitions reject unsafe directories or ownership conflicts.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test`
  - 201 unit tests
  - 34 runtime command tests
  - 27 service command tests
  - 16 daemon runtime tests
  - 18 upgrade tests
  - 12 guarded environment destroy tests
  - 39 dev lifecycle tests and 10 source-watch tests
  - launcher binding/removal serialization tests
- `cargo check`
- `git diff --check origin/main...HEAD`
- Sol/high autoreview against `origin/main`: clean, no accepted/actionable findings
