### PR TITLE
fix(releases): preserve overlapping channel selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@ All notable changes to OCM are documented here.
 - Preserve working runtimes until replacement artifacts, dependencies, and metadata are ready; require release integrity and reject unsafe artifact names.
 - Write private service definitions, preserve existing service-directory modes, escape systemd specifiers, reject directive injection, and fail closed on unknown launchd users or cross-store service ownership.
 - Serialize supervisor restart requests, restore service policy after failed reconciliation, preserve raw warnings, and fail upgrades when a gateway restart cannot be observed.
+- Preserve every recognized npm release channel when multiple dist-tags point to the same OpenClaw version.

--- a/src/cli/render/release.rs
+++ b/src/cli/render/release.rs
@@ -366,6 +366,7 @@ mod tests {
         OpenClawRelease {
             version: "2026.3.24".to_string(),
             channel: Some("stable".to_string()),
+            channels: vec!["stable".to_string()],
             tarball_url: "https://registry.npmjs.org/openclaw/-/openclaw-2026.3.24.tgz".to_string(),
             shasum: Some("abc123".to_string()),
             integrity: Some("sha512-demo".to_string()),

--- a/src/runtime/releases.rs
+++ b/src/runtime/releases.rs
@@ -39,6 +39,8 @@ pub struct OpenClawRelease {
     pub version: String,
     #[serde(default)]
     pub channel: Option<String>,
+    #[serde(skip)]
+    pub channels: Vec<String>,
     pub tarball_url: String,
     #[serde(default)]
     pub shasum: Option<String>,
@@ -215,11 +217,16 @@ pub fn select_official_openclaw_release_by_channel(
         return Err("OpenClaw release channel is required".to_string());
     }
 
-    releases
+    let mut release = releases
         .iter()
-        .find(|release| release.channel.as_deref() == Some(channel.as_str()))
+        .find(|release| {
+            release.channel.as_deref() == Some(channel.as_str())
+                || release.channels.iter().any(|value| value == &channel)
+        })
         .cloned()
-        .ok_or_else(|| format!("OpenClaw release channel \"{channel}\" was not found"))
+        .ok_or_else(|| format!("OpenClaw release channel \"{channel}\" was not found"))?;
+    release.channel = Some(channel);
+    Ok(release)
 }
 
 pub fn query_official_openclaw_releases(
@@ -353,18 +360,19 @@ fn validate_official_openclaw_releases(
         return Err("OpenClaw package source does not contain any published versions".to_string());
     }
 
-    let mut channel_by_version = BTreeMap::<String, String>::new();
+    let mut channels_by_version = BTreeMap::<String, Vec<String>>::new();
     for (tag, version) in manifest.dist_tags {
         let Some(channel) = map_openclaw_dist_tag(&tag) else {
             continue;
         };
-        match channel_by_version.get(version.as_str()) {
-            Some(existing)
-                if openclaw_channel_priority(existing) <= openclaw_channel_priority(channel) => {}
-            _ => {
-                channel_by_version.insert(version, channel.to_string());
-            }
-        }
+        channels_by_version
+            .entry(version)
+            .or_default()
+            .push(channel.to_string());
+    }
+    for channels in channels_by_version.values_mut() {
+        channels.sort_by_key(|channel| openclaw_channel_priority(channel));
+        channels.dedup();
     }
 
     let mut releases = Vec::with_capacity(manifest.versions.len());
@@ -385,9 +393,14 @@ fn validate_official_openclaw_releases(
             OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).ok()
         });
 
+        let channels = channels_by_version
+            .get(version)
+            .cloned()
+            .unwrap_or_default();
         releases.push(OpenClawRelease {
             version: version.to_string(),
-            channel: channel_by_version.get(version).cloned(),
+            channel: channels.first().cloned(),
+            channels,
             tarball_url: tarball_url.to_string(),
             shasum: version_meta
                 .dist

--- a/tests/release_manifest_tests.rs
+++ b/tests/release_manifest_tests.rs
@@ -290,3 +290,39 @@ fn official_openclaw_release_queries_support_version_and_channel() {
     assert_eq!(by_version.len(), 1);
     assert_eq!(by_version[0].channel.as_deref(), Some("beta"));
 }
+
+#[test]
+fn official_openclaw_release_channels_preserve_overlapping_dist_tags() {
+    let server = TestHttpServer::serve_bytes(
+        "/openclaw",
+        "application/json",
+        json!({
+            "dist-tags": {
+                "latest": "2026.3.24",
+                "beta": "2026.3.24"
+            },
+            "versions": {
+                "2026.3.24": {
+                    "version": "2026.3.24",
+                    "dist": {
+                        "tarball": "https://registry.npmjs.org/openclaw/-/openclaw-2026.3.24.tgz"
+                    }
+                }
+            }
+        })
+        .to_string()
+        .as_bytes(),
+    );
+
+    let releases = load_official_openclaw_releases(&server.url()).unwrap();
+    assert_eq!(releases[0].channel.as_deref(), Some("stable"));
+    assert_eq!(releases[0].channels, ["stable", "beta"]);
+
+    let stable = select_official_openclaw_release_by_channel(&releases, "latest").unwrap();
+    assert_eq!(stable.version, "2026.3.24");
+    assert_eq!(stable.channel.as_deref(), Some("stable"));
+
+    let beta = select_official_openclaw_release_by_channel(&releases, "beta").unwrap();
+    assert_eq!(beta.version, "2026.3.24");
+    assert_eq!(beta.channel.as_deref(), Some("beta"));
+}


### PR DESCRIPTION
## What Problem This Solves

When npm points multiple recognized dist-tags at the same OpenClaw version, OCM currently keeps only the highest-priority channel. For example, if both `latest` and `beta` reference one version, selecting `beta` fails even though npm advertises it.

## Why This Change Was Made

OCM now retains every normalized channel associated with a published version while preserving the existing stable-first canonical channel for unfiltered and version-scoped views. Channel-scoped selection matches the retained aliases and returns the channel the operator requested, keeping runtime provenance and follow-up commands accurate.

This intentionally excludes the unrelated metadata validation, version ordering, dependency, and CLI changes from the original aggregate audit commit.

## User Impact

`release`, `runtime`, install, and upgrade paths can resolve `stable`, `beta`, or `dev` correctly even when two dist-tags temporarily point to the same package version during promotion. Existing JSON output remains unchanged because the internal alias list is not serialized.

## Evidence

- `cargo test --locked --test release_manifest_tests` (9 passed)
- `cargo test --locked --test release_command_tests` (8 passed)
- `cargo test --locked` (full suite passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- Sol/high autoreview: clean, no accepted/actionable findings