### PR TITLE
docs(validation): harden release candidate workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ All notable changes to OCM are documented here.
 - Write private service definitions, preserve existing service-directory modes, escape systemd specifiers, reject directive injection, and fail closed on unknown launchd users or cross-store service ownership.
 - Serialize supervisor restart requests, restore service policy after failed reconciliation, preserve raw warnings, and fail upgrades when a gateway restart cannot be observed.
 - Preserve every recognized npm release channel when multiple dist-tags point to the same OpenClaw version.
+- Make release-validation runs package-shaped, commit-pinned, concurrency-safe, credential-aware, and explicit about session-preserving fixtures and owned cleanup.

--- a/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
+++ b/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
@@ -13,10 +13,12 @@ failed.
 
 - Set `OCM_BIN=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm/target/debug/ocm`,
   verify it is executable, and use `"$OCM_BIN"` for every OCM command.
-- Fetch from the OpenClaw source repo at
+- Read the `origin` URL from the OpenClaw source repo at
   `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`,
-  resolve one immutable `origin/main` commit, and create a unique detached
-  worktree for the run.
+  but do not fetch into or mutate that shared checkout. Create per-run Git
+  metadata from the remote, optionally using the source repo as a read-only
+  object cache, resolve one immutable `origin/main` commit, and create a unique
+  detached worktree for the run.
 - Do not use `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
   or `../openclaw`; that is an active working repo.
 - Build a uniquely named package-shaped runtime with
@@ -147,7 +149,8 @@ Pass evidence:
 
 What to test:
 
-- Fetch and resolve one immutable `origin/main` commit.
+- Create per-run Git metadata from the source remote and resolve one immutable
+  `origin/main` commit without updating the shared source checkout.
 - Create a clean detached per-run worktree at that commit.
 - Run the source-built executable directly with `--version` as a narrow smoke
   check.

--- a/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
+++ b/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
@@ -11,15 +11,17 @@ failed.
 
 ## Operating Rules
 
-- Use OCM from `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm`.
+- Set `OCM_BIN=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm/target/debug/ocm`,
+  verify it is executable, and use `"$OCM_BIN"` for every OCM command.
 - Fetch from the OpenClaw source repo at
   `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`,
   resolve one immutable `origin/main` commit, and create a unique detached
   worktree for the run.
 - Do not use `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
   or `../openclaw`; that is an active working repo.
-- Build a uniquely named package-shaped runtime with `ocm runtime build-local`
-  from the detached worktree. Use that runtime for the matrix.
+- Build a uniquely named package-shaped runtime with
+  `"$OCM_BIN" runtime build-local` from the detached worktree. Use that runtime
+  for the matrix.
 - Use the detached worktree's `openclaw.mjs` only for the S02 direct boot smoke.
 - Do not use `pnpm openclaw` as the main release-validation path.
 - Use the local built OCM binary, usually `<ocm>/target/debug/ocm`.
@@ -31,8 +33,9 @@ failed.
 - Treat copied and cloned state as secret-bearing. Keep services stopped and
   make no external requests by default. Use mocks, credential-free fresh envs,
   or dedicated test accounts unless the run explicitly authorizes real access.
-- Use `ocm env clone` only when clearing sessions, logs, and backups is
-  intended. Use a copied `.openclaw` home plus `ocm adopt import` for S20.
+- Use `"$OCM_BIN" env clone` only when clearing sessions, logs, and backups is
+  intended. Use a copied `.openclaw` home plus `"$OCM_BIN" adopt import` for
+  S20.
 - Keep the report quiet: summarize pass/fail per scenario, then include details
   only for failures, blocked scenarios, or release-risk notes.
 - Redact credentials, private endpoints, user identifiers, and secret-bearing
@@ -51,24 +54,28 @@ every service side effect as an OCM bug.
 
 Use OCM this way during validation:
 
-- Create or bind envs with `ocm start`, `ocm dev`, `ocm env clone`,
-  `ocm adopt`, and `ocm migrate` as appropriate.
-- Run OpenClaw inside an env with `ocm @<env> -- <openclaw args>`.
+- Create or bind envs with `"$OCM_BIN" start`, `"$OCM_BIN" dev`,
+  `"$OCM_BIN" env clone`, `"$OCM_BIN" adopt`, and `"$OCM_BIN" migrate` as
+  appropriate.
+- Run OpenClaw inside an env with
+  `"$OCM_BIN" @<env> -- <openclaw args>`.
 - OCM env runs should inject `OPENCLAW_SERVICE_REPAIR_POLICY=external` so
   OpenClaw can report service health but does not mutate global/user-level
   service registrations from `doctor --fix`.
-- Inspect env services with `ocm service status <env>`, `ocm service list`,
-  and `ocm logs <env>`.
-- Simulate upgrades with `ocm upgrade simulate <env> --to <target>`.
-- Use `ocm help start`, `ocm help service`, `ocm help logs`, `ocm help
-  upgrade`, and `ocm help env` when the command shape is unclear.
+- Inspect env services with `"$OCM_BIN" service status <env>`,
+  `"$OCM_BIN" service list`, and `"$OCM_BIN" logs <env>`.
+- Simulate upgrades with
+  `"$OCM_BIN" upgrade simulate <env> --to <target>`.
+- Use `"$OCM_BIN" help start`, `"$OCM_BIN" help service`,
+  `"$OCM_BIN" help logs`, `"$OCM_BIN" help upgrade`, and
+  `"$OCM_BIN" help env` when the command shape is unclear.
 
 Service terminology:
 
 - OCM-managed service: background process policy/state owned by OCM for one
   environment.
 - OpenClaw service/gateway: OpenClaw's own gateway/service behavior, invoked
-  inside an OCM env through `ocm @<env> -- ...`.
+  inside an OCM env through `"$OCM_BIN" @<env> -- ...`.
 - LaunchAgent: macOS service registration. A test may intentionally create one,
   but it must match the scenario and be cleaned up.
 
@@ -182,7 +189,7 @@ What to test:
 - Run-specific `OCM_HOME` contains only the verified package runtime before the
   fresh env is created; it contains no prior env, snapshot, or supervisor
   state.
-- `ocm start <env> --runtime <run-runtime>` creates a usable env.
+- `"$OCM_BIN" start <env> --runtime <run-runtime>` creates a usable env.
 - First run writes only expected minimum config/state.
 - `openclaw --version`, `openclaw doctor`, `plugins list --json`, gateway
   status, and logs work.
@@ -201,13 +208,13 @@ What to test:
 
 - Copy the source env into the run root.
 - Import/adopt the copy into the run's OCM state.
-- Use `ocm env clone` only for scenarios that do not require sessions, logs, or
-  backups.
+- Use `"$OCM_BIN" env clone` only for scenarios that do not require sessions,
+  logs, or backups.
 - Keep the copied or cloned env service stopped while retained credentials are
   present.
 - Bind the fixture to the package-shaped runtime.
-- Run `ocm upgrade simulate <env> --to <run-worktree> --scenario current
-  --json`.
+- Run `"$OCM_BIN" upgrade simulate <env> --to <run-worktree> --scenario
+  current --json`.
 
 Run for:
 
@@ -223,8 +230,8 @@ Pass evidence:
 
 What to test:
 
-- `ocm upgrade --dry-run` previews without mutating env metadata, runtime
-  bindings, snapshots, service policy, or files.
+- `"$OCM_BIN" upgrade --dry-run` previews without mutating env metadata,
+  runtime bindings, snapshots, service policy, or files.
 - Failed upgrade paths roll back or clearly report retained changes when
   rollback is disabled.
 - Snapshot/backup references are usable.
@@ -244,7 +251,7 @@ Pass evidence:
 What to test:
 
 - Env resolves the intended runtime or launcher.
-- `ocm @<env> -- <command>` uses the selected OpenClaw artifact.
+- `"$OCM_BIN" @<env> -- <command>` uses the selected OpenClaw artifact.
 - Binding changes are visible in `env show`, status, and JSON output.
 - Clearing or replacing a binding does not leave stale execution paths.
 
@@ -417,7 +424,8 @@ Pass evidence:
 
 What to test:
 
-- `ocm logs <env>` and relevant OpenClaw log commands show current env logs.
+- `"$OCM_BIN" logs <env>` and relevant OpenClaw log commands show current env
+  logs.
 - JSON/raw log output is script-friendly.
 - Failed startup or plugin errors are visible without digging through random
   files.
@@ -494,8 +502,8 @@ Pass evidence:
 What to test:
 
 - Copy the source env's `.openclaw` directory into the run root and import that
-  copy with `ocm adopt import`. Do not use `ocm env clone`; clone intentionally
-  removes sessions, logs, and backups.
+  copy with `"$OCM_BIN" adopt import`. Do not use `"$OCM_BIN" env clone`;
+  clone intentionally removes sessions, logs, and backups.
 - Before upgrading, assert that at least one expected non-empty session fixture
   exists in the imported env and record its non-secret identifier.
 - Existing sessions, bindings, and conversation state can be read after upgrade.
@@ -613,7 +621,7 @@ What to test:
 - Temp OCM homes, copied envs, generated fixtures, worktrees, and services are
   removed when no longer needed.
 - Run-owned envs are destroyed before the run-owned package runtime is removed
-  with `ocm runtime remove`.
+  with `"$OCM_BIN" runtime remove`.
 - Every cleanup target carries the current run id or another explicit ownership
   marker.
 - Worktree status is inspected before removal; unclean or unowned worktrees are

--- a/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
+++ b/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
@@ -11,17 +11,17 @@ failed.
 
 ## Operating Rules
 
-- Set `OCM_BIN=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm/target/debug/ocm`,
+- Set `OCM_BIN=/path/to/ocm/target/debug/ocm`,
   verify it is executable, and use `"$OCM_BIN"` for every OCM command.
 - Read the `origin` URL from the OpenClaw source repo at
-  `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`,
+  `/path/to/openclaw-source-cache`,
   but do not fetch into or mutate that shared checkout. Create per-run Git
   metadata from the remote, optionally using the source repo as a clone-time
   read-only object cache and dissociating the clone from it. Resolve one
   immutable `origin/main` commit and create a unique detached worktree for the
   run.
-- Do not use `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
-  or `../openclaw`; that is an active working repo.
+- Do not use `/path/to/active-openclaw` or `../openclaw`; that is an active
+  working repo.
 - In the detached worktree, run `pnpm install --frozen-lockfile`,
   `pnpm check`, and `pnpm build`, then require `git status --porcelain` to
   remain empty.
@@ -34,8 +34,8 @@ failed.
 - Use one run-specific `OCM_HOME` for the package runtime, envs, snapshots, and
   supervisor state. Invoke the explicit local OCM binary for every command.
 - Use a run id in every worktree, runtime, env, report, and cleanup name.
-- Copy existing user state, preferably `~/.ocm/envs/Violet`, into the run root
-  before testing. Never mutate the real env.
+- Copy an existing user env from `~/.ocm/envs/<existing-env>` into the run
+  root before testing. Never mutate the real env.
 - Treat copied and cloned state as secret-bearing. Keep services stopped and
   make no external requests by default. Use mocks, credential-free fresh envs,
   or dedicated test accounts unless the run explicitly authorizes real access.
@@ -229,8 +229,8 @@ Run for:
 
 Pass evidence:
 
-- Simulation passes, original copied env is not mutated, real `Violet` is not
-  touched, expected simulation steps are recorded, and no unauthorized
+- Simulation passes, original copied env is not mutated, the real source env
+  is not touched, expected simulation steps are recorded, and no unauthorized
   external request is made.
 
 ### S06 - Upgrade Dry Run And Rollback Safety
@@ -635,8 +635,8 @@ What to test:
   retained and reported instead of force-removed.
 - The detached worktree still points at the recorded OpenClaw commit before it
   is removed.
-- Real `Violet` was not mutated.
-- `temp/test-build` has no unintended worktree changes.
+- The real source env was not mutated.
+- The source cache repo has no unintended worktree changes.
 
 Run for:
 

--- a/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
+++ b/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
@@ -23,6 +23,8 @@ failed.
 - Use the detached worktree's `openclaw.mjs` only for the S02 direct boot smoke.
 - Do not use `pnpm openclaw` as the main release-validation path.
 - Use the local built OCM binary, usually `<ocm>/target/debug/ocm`.
+- Use one run-specific `OCM_HOME` for the package runtime, envs, snapshots, and
+  supervisor state. Invoke the explicit local OCM binary for every command.
 - Use a run id in every worktree, runtime, env, report, and cleanup name.
 - Copy existing user state, preferably `~/.ocm/envs/Violet`, into the run root
   before testing. Never mutate the real env.
@@ -35,8 +37,9 @@ failed.
   only for failures, blocked scenarios, or release-risk notes.
 - Redact credentials, private endpoints, user identifiers, and secret-bearing
   command output from the report.
-- Clean up only temp envs, services, LaunchAgents, fixtures, and worktrees owned
-  by the current run id. Inspect worktree status before removal.
+- Clean up only temp envs, services, LaunchAgents, runtimes, fixtures, and
+  worktrees owned by the current run id. Destroy dependent envs before removing
+  the run runtime, and inspect worktree status before removal.
 
 ## OCM Usage Primer For Test Agents
 
@@ -175,7 +178,10 @@ Pass evidence:
 
 What to test:
 
-- Empty `HOME`, `OCM_HOME`, and OpenClaw state.
+- Empty isolated `HOME` and OpenClaw state.
+- Run-specific `OCM_HOME` contains only the verified package runtime before the
+  fresh env is created; it contains no prior env, snapshot, or supervisor
+  state.
 - `ocm start <env> --runtime <run-runtime>` creates a usable env.
 - First run writes only expected minimum config/state.
 - `openclaw --version`, `openclaw doctor`, `plugins list --json`, gateway
@@ -606,6 +612,8 @@ What to test:
 
 - Temp OCM homes, copied envs, generated fixtures, worktrees, and services are
   removed when no longer needed.
+- Run-owned envs are destroyed before the run-owned package runtime is removed
+  with `ocm runtime remove`.
 - Every cleanup target carries the current run id or another explicit ownership
   marker.
 - Worktree status is inspected before removal; unclean or unowned worktrees are

--- a/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
+++ b/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
@@ -16,9 +16,10 @@ failed.
 - Read the `origin` URL from the OpenClaw source repo at
   `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`,
   but do not fetch into or mutate that shared checkout. Create per-run Git
-  metadata from the remote, optionally using the source repo as a read-only
-  object cache, resolve one immutable `origin/main` commit, and create a unique
-  detached worktree for the run.
+  metadata from the remote, optionally using the source repo as a clone-time
+  read-only object cache and dissociating the clone from it. Resolve one
+  immutable `origin/main` commit and create a unique detached worktree for the
+  run.
 - Do not use `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
   or `../openclaw`; that is an active working repo.
 - Build a uniquely named package-shaped runtime with

--- a/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
+++ b/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
@@ -12,19 +12,31 @@ failed.
 ## Operating Rules
 
 - Use OCM from `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm`.
-- Use the OpenClaw test repo at
-  `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`.
+- Fetch from the OpenClaw source repo at
+  `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`,
+  resolve one immutable `origin/main` commit, and create a unique detached
+  worktree for the run.
 - Do not use `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
   or `../openclaw`; that is an active working repo.
-- Pull and test latest `origin/main` in `temp/test-build`.
-- Test the built OpenClaw artifact, usually `<test-build>/openclaw.mjs`.
+- Build a uniquely named package-shaped runtime with `ocm runtime build-local`
+  from the detached worktree. Use that runtime for the matrix.
+- Use the detached worktree's `openclaw.mjs` only for the S02 direct boot smoke.
 - Do not use `pnpm openclaw` as the main release-validation path.
 - Use the local built OCM binary, usually `<ocm>/target/debug/ocm`.
-- Copy existing user state, preferably `~/.ocm/envs/Violet`, into temp state
+- Use a run id in every worktree, runtime, env, report, and cleanup name.
+- Copy existing user state, preferably `~/.ocm/envs/Violet`, into the run root
   before testing. Never mutate the real env.
+- Treat copied and cloned state as secret-bearing. Keep services stopped and
+  make no external requests by default. Use mocks, credential-free fresh envs,
+  or dedicated test accounts unless the run explicitly authorizes real access.
+- Use `ocm env clone` only when clearing sessions, logs, and backups is
+  intended. Use a copied `.openclaw` home plus `ocm adopt import` for S20.
 - Keep the report quiet: summarize pass/fail per scenario, then include details
   only for failures, blocked scenarios, or release-risk notes.
-- Clean up temp envs, services, LaunchAgents, generated fixtures, and worktrees.
+- Redact credentials, private endpoints, user identifiers, and secret-bearing
+  command output from the report.
+- Clean up only temp envs, services, LaunchAgents, fixtures, and worktrees owned
+  by the current run id. Inspect worktree status before removal.
 
 ## OCM Usage Primer For Test Agents
 
@@ -72,9 +84,12 @@ Start each report with:
 
 - OCM commit/version
 - OpenClaw commit/version
+- package runtime identity
 - previous release or changelog baseline reviewed
+- run id
 - temp paths used
-- whether real user state was copied and left untouched
+- fixture modes used and whether real user state was left untouched
+- external-access policy used
 
 Then use this summary table:
 
@@ -122,10 +137,12 @@ Pass evidence:
 
 What to test:
 
-- Pull latest `origin/main` in `temp/test-build`.
-- Build the release artifact.
-- Run the built executable directly with `--version`.
-- Run the built executable through OCM-bound env execution.
+- Fetch and resolve one immutable `origin/main` commit.
+- Create a clean detached per-run worktree at that commit.
+- Run the source-built executable directly with `--version` as a narrow smoke
+  check.
+- Build and verify a named package-shaped OCM runtime from the worktree.
+- Run the package-shaped runtime through OCM-bound env execution.
 
 Run for:
 
@@ -134,7 +151,8 @@ Run for:
 
 Pass evidence:
 
-- Build passes, version prints expected commit/version, OCM runs that artifact.
+- Build and runtime verification pass, both version checks identify the
+  expected commit/version, and OCM runs the package-shaped runtime.
 
 ### S03 - Release Packaging And Postinstall Shape
 
@@ -158,8 +176,7 @@ Pass evidence:
 What to test:
 
 - Empty `HOME`, `OCM_HOME`, and OpenClaw state.
-- `ocm start <env> --command <built-openclaw> --cwd <test-build>` creates a
-  usable env.
+- `ocm start <env> --runtime <run-runtime>` creates a usable env.
 - First run writes only expected minimum config/state.
 - `openclaw --version`, `openclaw doctor`, `plugins list --json`, gateway
   status, and logs work.
@@ -176,11 +193,15 @@ Pass evidence:
 
 What to test:
 
-- Copy `Violet` into temp state.
-- Import/adopt the copy into temp OCM state.
-- Clone the copied env before destructive tests.
-- Bind the clone to the built artifact.
-- Run `ocm upgrade simulate <env> --to <test-build> --scenario current --json`.
+- Copy the source env into the run root.
+- Import/adopt the copy into the run's OCM state.
+- Use `ocm env clone` only for scenarios that do not require sessions, logs, or
+  backups.
+- Keep the copied or cloned env service stopped while retained credentials are
+  present.
+- Bind the fixture to the package-shaped runtime.
+- Run `ocm upgrade simulate <env> --to <run-worktree> --scenario current
+  --json`.
 
 Run for:
 
@@ -189,7 +210,8 @@ Run for:
 Pass evidence:
 
 - Simulation passes, original copied env is not mutated, real `Violet` is not
-  touched, and expected simulation steps are recorded.
+  touched, expected simulation steps are recorded, and no unauthorized
+  external request is made.
 
 ### S06 - Upgrade Dry Run And Rollback Safety
 
@@ -411,6 +433,9 @@ What to test:
 - Channel-specific env vars and secret/config validation behave correctly.
 - Telegram, Discord, Slack, MCP, browser, voice/video, TTS, or other changed
   channels do not break plugin discovery or doctor.
+- Use mocks or dedicated test accounts. Do not send through credentials copied
+  from a real user fixture without explicit authorization for that destination
+  and account.
 
 Run for:
 
@@ -429,6 +454,8 @@ What to test:
 - Default model/provider changes are reflected in config and startup.
 - Existing user provider settings are preserved.
 - Missing provider credentials fail with clear diagnostics, not startup crashes.
+- Use mocks or dedicated test credentials for live calls. Do not spend against
+  copied production credentials without explicit authorization.
 
 Run for:
 
@@ -460,6 +487,11 @@ Pass evidence:
 
 What to test:
 
+- Copy the source env's `.openclaw` directory into the run root and import that
+  copy with `ocm adopt import`. Do not use `ocm env clone`; clone intentionally
+  removes sessions, logs, and backups.
+- Before upgrading, assert that at least one expected non-empty session fixture
+  exists in the imported env and record its non-secret identifier.
 - Existing sessions, bindings, and conversation state can be read after upgrade.
 - New sessions can be created in clean state.
 - Session state paths stay under the intended OpenClaw home.
@@ -471,7 +503,8 @@ Run for:
 
 Pass evidence:
 
-- Existing state remains readable and new state is written to the env root.
+- The fixture exists before the upgrade, existing state remains readable after
+  it, and new state is written to the env root.
 
 ### S21 - Secrets And Environment Isolation
 
@@ -480,6 +513,10 @@ What to test:
 - Env-scoped secrets/config are resolved from the copied or clean env only.
 - Parent shell `OPENCLAW_*` or OCM variables do not leak into child envs.
 - Missing secrets produce actionable diagnostics.
+- Copied fixtures remain offline unless credentials were replaced with mocks or
+  dedicated test accounts, or real access was explicitly authorized.
+- Reports and attached evidence contain no credentials, private endpoints, raw
+  auth files, or secret-bearing config.
 
 Run for:
 
@@ -489,7 +526,8 @@ Run for:
 Pass evidence:
 
 - Commands use the intended env root and no cross-env secret/config leakage is
-  observed.
+  observed, no unauthorized external request is made, and report redaction is
+  verified.
 
 ### S22 - Filesystem And Path Safety
 
@@ -568,6 +606,12 @@ What to test:
 
 - Temp OCM homes, copied envs, generated fixtures, worktrees, and services are
   removed when no longer needed.
+- Every cleanup target carries the current run id or another explicit ownership
+  marker.
+- Worktree status is inspected before removal; unclean or unowned worktrees are
+  retained and reported instead of force-removed.
+- The detached worktree still points at the recorded OpenClaw commit before it
+  is removed.
 - Real `Violet` was not mutated.
 - `temp/test-build` has no unintended worktree changes.
 

--- a/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
+++ b/docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md
@@ -22,9 +22,12 @@ failed.
   run.
 - Do not use `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
   or `../openclaw`; that is an active working repo.
+- In the detached worktree, run `pnpm install --frozen-lockfile`,
+  `pnpm check`, and `pnpm build`, then require `git status --porcelain` to
+  remain empty.
 - Build a uniquely named package-shaped runtime with
   `"$OCM_BIN" runtime build-local` from the detached worktree. Use that runtime
-  for the matrix.
+  for the matrix, then verify the worktree is still clean.
 - Use the detached worktree's `openclaw.mjs` only for the S02 direct boot smoke.
 - Do not use `pnpm openclaw` as the main release-validation path.
 - Use the local built OCM binary, usually `<ocm>/target/debug/ocm`.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -291,7 +291,7 @@ Use `service install` when you want a background service for an environment that
 
 ```bash
 ocm logs mira --tail 50
-ocm logs mira --stderr
+ocm logs mira --stream error
 ocm logs mira --follow
 ```
 

--- a/skills/ocm-operator/SKILL.md
+++ b/skills/ocm-operator/SKILL.md
@@ -81,6 +81,11 @@ ocm help upgrade
 
 - Treat important user envs such as `Violet` and `Shaks` as durable state.
   Clone first for testing unless the user explicitly asks to mutate them.
+- Clones retain durable auth and settings. Treat them as secret-bearing, keep
+  services stopped by default, and require explicit authorization before
+  provider, channel, webhook, browser, or other external calls.
+- Use a credential-free fresh env for untrusted plugins or authentication
+  tests. Never export, publish, or attach an unsanitized clone.
 - Remove envs with `ocm env destroy`.
 - Manage OCM env gateway lifecycle with `ocm service`.
 - Remember OCM injects `OPENCLAW_SERVICE_REPAIR_POLICY=external` for env-run

--- a/skills/ocm-operator/SKILL.md
+++ b/skills/ocm-operator/SKILL.md
@@ -79,8 +79,8 @@ ocm help upgrade
 
 ## Safety Rules
 
-- Treat important user envs such as `Violet` and `Shaks` as durable state.
-  Clone first for testing unless the user explicitly asks to mutate them.
+- Treat important existing user envs as durable state. Clone first for testing
+  unless the user explicitly asks to mutate them.
 - Clones retain durable auth and settings. Treat them as secret-bearing, keep
   services stopped by default, and require explicit authorization before
   provider, channel, webhook, browser, or other external calls.

--- a/skills/ocm-operator/references/command-cookbook.md
+++ b/skills/ocm-operator/references/command-cookbook.md
@@ -146,14 +146,23 @@ ocm upgrade simulate <env> --to /path/to/openclaw --scenario all --keep-simulati
 
 ## Existing-User Test Flow
 
-Clone first:
+Clone first when the test does not need sessions, logs, or backups. A clone
+retains durable auth/settings and is therefore secret-bearing. Keep its service
+stopped until credentials are replaced with mocks or dedicated test accounts,
+or the user explicitly authorizes real external access.
 
 ```sh
 ocm env clone Violet <test-env>
-ocm start <test-env>
+ocm start <test-env> --no-service
 ocm service status <test-env>
 ocm logs <test-env> --tail 100
 ```
+
+For session/history validation, copy the source env's `.openclaw` directory to
+a task-owned temporary path and use `ocm adopt import --name <test-env>
+<copied-openclaw-home>`. Assert the expected session fixture exists before the
+upgrade. Do not use `ocm env clone` for that case because clone intentionally
+clears sessions, logs, and backups.
 
 Exercise:
 

--- a/skills/ocm-operator/references/command-cookbook.md
+++ b/skills/ocm-operator/references/command-cookbook.md
@@ -152,7 +152,7 @@ stopped until credentials are replaced with mocks or dedicated test accounts,
 or the user explicitly authorizes real external access.
 
 ```sh
-ocm env clone Violet <test-env>
+ocm env clone <existing-env> <test-env>
 ocm start <test-env> --no-service
 ocm service status <test-env>
 ocm logs <test-env> --tail 100

--- a/skills/ocm-operator/references/local-paths.md
+++ b/skills/ocm-operator/references/local-paths.md
@@ -71,15 +71,19 @@ ocm env destroy plugins-dev-test --yes
 set -euo pipefail
 
 source_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build
+ocm_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm
+ocm_bin="${ocm_repo}/target/debug/ocm"
 run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
 run_root="/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation/${run_id}"
 worktree="${run_root}/openclaw"
 runtime="openclaw-${run_id}"
+export OCM_HOME="${run_root}/ocm-home"
 
 test "$(git -C "$source_repo" rev-parse --show-toplevel)" = "$source_repo"
+test -x "$ocm_bin"
 git -C "$source_repo" fetch origin main --prune
 openclaw_sha="$(git -C "$source_repo" rev-parse origin/main)"
-mkdir -p "$run_root"
+mkdir -p "$run_root" "$OCM_HOME"
 git -C "$source_repo" worktree add --detach "$worktree" "$openclaw_sha"
 test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
 test -z "$(git -C "$worktree" status --porcelain)"
@@ -89,18 +93,20 @@ pnpm install
 pnpm check
 pnpm build
 
-cd /Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm
-ocm runtime build-local "$runtime" --repo "$worktree" --force
-ocm runtime verify "$runtime"
-ocm runtime show "$runtime"
-node "$HOME/.ocm/runtimes/$runtime/files/node_modules/openclaw/openclaw.mjs" --version
+cd "$ocm_repo"
+"$ocm_bin" runtime build-local "$runtime" --repo "$worktree" --force
+"$ocm_bin" runtime verify "$runtime"
+"$ocm_bin" runtime show "$runtime"
+runtime_bin="$("$ocm_bin" runtime which "$runtime" --raw)"
+"$runtime_bin" --version
 
 test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
 ```
 
 Keep `run_id`, `run_root`, `worktree`, `runtime`, env names, and the report
 together. Cleanup must target only those names and must inspect worktree status
-before removal.
+before removal. Destroy dependent envs before running `"$ocm_bin" runtime
+remove "$runtime"`.
 
 ## Release Validation Cheatsheet
 

--- a/skills/ocm-operator/references/local-paths.md
+++ b/skills/ocm-operator/references/local-paths.md
@@ -1,33 +1,33 @@
 # Local Paths And Defaults
 
-These defaults match Shakker's current OpenClaw/OCM workspace. Verify with
-`pwd`, `git status --short --branch`, and `ocm env list` before relying on
-them.
+Configure these placeholders for the current OpenClaw/OCM workspace. Verify
+with `pwd`, `git status --short --branch`, and `ocm env list` before relying
+on them.
 
 ## Repos
 
 OCM repo:
 
 ```text
-/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm
+/path/to/ocm
 ```
 
 OpenClaw release/build test repo:
 
 ```text
-/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build
+/path/to/openclaw-source-cache
 ```
 
 OpenClaw dev/plugin test repo:
 
 ```text
-/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-install
+/path/to/openclaw-plugin-test
 ```
 
 Active OpenClaw repo to avoid unless the user explicitly permits it:
 
 ```text
-/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw
+/path/to/active-openclaw
 ```
 
 ## Long-Lived Envs
@@ -35,14 +35,14 @@ Active OpenClaw repo to avoid unless the user explicitly permits it:
 Treat these as real user state unless the user explicitly says otherwise:
 
 ```text
-Shaks
-Violet
+<existing-env>
+<second-existing-env>
 ```
 
-Use `Violet` as the source for existing-user clone tests:
+Use `<existing-env>` as the source for existing-user clone tests:
 
 ```sh
-ocm env clone Violet <test-env>
+ocm env clone <existing-env> <test-env>
 ```
 
 ## Common Test Names
@@ -50,7 +50,7 @@ ocm env clone Violet <test-env>
 Use descriptive, disposable names:
 
 ```text
-Violet-local-release-test
+existing-env-local-release-test
 fresh-local-release-test
 fresh-local-onboard-test
 plugins-dev-test
@@ -59,7 +59,7 @@ plugins-dev-test
 Destroy them when done:
 
 ```sh
-ocm env destroy Violet-local-release-test --yes
+ocm env destroy existing-env-local-release-test --yes
 ocm env destroy fresh-local-release-test --yes
 ocm env destroy fresh-local-onboard-test --yes
 ocm env destroy plugins-dev-test --yes
@@ -70,10 +70,10 @@ ocm env destroy plugins-dev-test --yes
 ```sh
 set -euo pipefail
 
-source_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build
-ocm_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm
+source_repo=/path/to/openclaw-source-cache
+ocm_repo=/path/to/ocm
 OCM_BIN="${ocm_repo}/target/debug/ocm"
-validation_root=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation
+validation_root=/path/to/release-validation
 mkdir -p "$validation_root"
 run_root="$(mktemp -d "${validation_root}/run-XXXXXXXXXX")"
 run_id="${run_root##*/}"
@@ -121,7 +121,7 @@ worktree status before removal. Destroy dependent envs before running
 If present, this local doc has a broader workflow checklist:
 
 ```text
-/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm/docs/TESTING_WORKFLOW_CHEATSHEET.md
+<ocm-repo>/docs/TESTING_WORKFLOW_CHEATSHEET.md
 ```
 
 It is a local ignored doc for this checkout.

--- a/skills/ocm-operator/references/local-paths.md
+++ b/skills/ocm-operator/references/local-paths.md
@@ -68,19 +68,39 @@ ocm env destroy plugins-dev-test --yes
 ## Local Release Runtime Pattern
 
 ```sh
-cd /Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build
-git switch main
-git pull origin main
+set -euo pipefail
+
+source_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build
+run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+run_root="/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation/${run_id}"
+worktree="${run_root}/openclaw"
+runtime="openclaw-${run_id}"
+
+test "$(git -C "$source_repo" rev-parse --show-toplevel)" = "$source_repo"
+git -C "$source_repo" fetch origin main --prune
+openclaw_sha="$(git -C "$source_repo" rev-parse origin/main)"
+mkdir -p "$run_root"
+git -C "$source_repo" worktree add --detach "$worktree" "$openclaw_sha"
+test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
+test -z "$(git -C "$worktree" status --porcelain)"
+
+cd "$worktree"
 pnpm install
 pnpm check
 pnpm build
 
 cd /Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm
-ocm runtime build-local test-build-1 --repo /Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build --force
-ocm runtime verify test-build-1
-ocm runtime show test-build-1
-node "$HOME/.ocm/runtimes/test-build-1/files/node_modules/openclaw/openclaw.mjs" --version
+ocm runtime build-local "$runtime" --repo "$worktree" --force
+ocm runtime verify "$runtime"
+ocm runtime show "$runtime"
+node "$HOME/.ocm/runtimes/$runtime/files/node_modules/openclaw/openclaw.mjs" --version
+
+test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
 ```
+
+Keep `run_id`, `run_root`, `worktree`, `runtime`, env names, and the report
+together. Cleanup must target only those names and must inspect worktree status
+before removal.
 
 ## Release Validation Cheatsheet
 

--- a/skills/ocm-operator/references/local-paths.md
+++ b/skills/ocm-operator/references/local-paths.md
@@ -94,9 +94,10 @@ test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
 test -z "$(git -C "$worktree" status --porcelain)"
 
 cd "$worktree"
-pnpm install
+pnpm install --frozen-lockfile
 pnpm check
 pnpm build
+test -z "$(git -C "$worktree" status --porcelain)"
 
 cd "$ocm_repo"
 "$ocm_bin" runtime build-local "$runtime" --repo "$worktree" --force
@@ -106,6 +107,7 @@ runtime_bin="$("$ocm_bin" runtime which "$runtime" --raw)"
 "$runtime_bin" --version
 
 test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
+test -z "$(git -C "$worktree" status --porcelain)"
 ```
 
 Keep `run_id`, `run_root`, `repo_store`, `worktree`, `runtime`, env names, and

--- a/skills/ocm-operator/references/local-paths.md
+++ b/skills/ocm-operator/references/local-paths.md
@@ -73,8 +73,10 @@ set -euo pipefail
 source_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build
 ocm_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm
 ocm_bin="${ocm_repo}/target/debug/ocm"
-run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
-run_root="/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation/${run_id}"
+validation_root=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation
+mkdir -p "$validation_root"
+run_root="$(mktemp -d "${validation_root}/run-XXXXXXXXXX")"
+run_id="${run_root##*/}"
 repo_store="${run_root}/repo"
 worktree="${run_root}/openclaw"
 runtime="openclaw-${run_id}"
@@ -83,7 +85,7 @@ export OCM_HOME="${run_root}/ocm-home"
 test "$(git -C "$source_repo" rev-parse --show-toplevel)" = "$source_repo"
 test -x "$ocm_bin"
 source_remote="$(git -C "$source_repo" remote get-url origin)"
-mkdir -p "$run_root" "$OCM_HOME"
+mkdir -p "$OCM_HOME"
 git clone --no-checkout --single-branch --branch main \
   --reference-if-able "$source_repo" "$source_remote" "$repo_store"
 openclaw_sha="$(git -C "$repo_store" rev-parse origin/main)"

--- a/skills/ocm-operator/references/local-paths.md
+++ b/skills/ocm-operator/references/local-paths.md
@@ -87,7 +87,8 @@ test -x "$ocm_bin"
 source_remote="$(git -C "$source_repo" remote get-url origin)"
 mkdir -p "$OCM_HOME"
 git clone --no-checkout --single-branch --branch main \
-  --reference-if-able "$source_repo" "$source_remote" "$repo_store"
+  --reference-if-able "$source_repo" --dissociate \
+  "$source_remote" "$repo_store"
 openclaw_sha="$(git -C "$repo_store" rev-parse origin/main)"
 git -C "$repo_store" worktree add --detach "$worktree" "$openclaw_sha"
 test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"

--- a/skills/ocm-operator/references/local-paths.md
+++ b/skills/ocm-operator/references/local-paths.md
@@ -75,16 +75,19 @@ ocm_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm
 ocm_bin="${ocm_repo}/target/debug/ocm"
 run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
 run_root="/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation/${run_id}"
+repo_store="${run_root}/repo"
 worktree="${run_root}/openclaw"
 runtime="openclaw-${run_id}"
 export OCM_HOME="${run_root}/ocm-home"
 
 test "$(git -C "$source_repo" rev-parse --show-toplevel)" = "$source_repo"
 test -x "$ocm_bin"
-git -C "$source_repo" fetch origin main --prune
-openclaw_sha="$(git -C "$source_repo" rev-parse origin/main)"
+source_remote="$(git -C "$source_repo" remote get-url origin)"
 mkdir -p "$run_root" "$OCM_HOME"
-git -C "$source_repo" worktree add --detach "$worktree" "$openclaw_sha"
+git clone --no-checkout --single-branch --branch main \
+  --reference-if-able "$source_repo" "$source_remote" "$repo_store"
+openclaw_sha="$(git -C "$repo_store" rev-parse origin/main)"
+git -C "$repo_store" worktree add --detach "$worktree" "$openclaw_sha"
 test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
 test -z "$(git -C "$worktree" status --porcelain)"
 
@@ -103,10 +106,10 @@ runtime_bin="$("$ocm_bin" runtime which "$runtime" --raw)"
 test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
 ```
 
-Keep `run_id`, `run_root`, `worktree`, `runtime`, env names, and the report
-together. Cleanup must target only those names and must inspect worktree status
-before removal. Destroy dependent envs before running `"$ocm_bin" runtime
-remove "$runtime"`.
+Keep `run_id`, `run_root`, `repo_store`, `worktree`, `runtime`, env names, and
+the report together. Cleanup must target only those names and must inspect
+worktree status before removal. Destroy dependent envs before running
+`"$ocm_bin" runtime remove "$runtime"`.
 
 ## Release Validation Cheatsheet
 

--- a/skills/ocm-operator/references/local-paths.md
+++ b/skills/ocm-operator/references/local-paths.md
@@ -72,7 +72,7 @@ set -euo pipefail
 
 source_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build
 ocm_repo=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm
-ocm_bin="${ocm_repo}/target/debug/ocm"
+OCM_BIN="${ocm_repo}/target/debug/ocm"
 validation_root=/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation
 mkdir -p "$validation_root"
 run_root="$(mktemp -d "${validation_root}/run-XXXXXXXXXX")"
@@ -83,7 +83,7 @@ runtime="openclaw-${run_id}"
 export OCM_HOME="${run_root}/ocm-home"
 
 test "$(git -C "$source_repo" rev-parse --show-toplevel)" = "$source_repo"
-test -x "$ocm_bin"
+test -x "$OCM_BIN"
 source_remote="$(git -C "$source_repo" remote get-url origin)"
 mkdir -p "$OCM_HOME"
 git clone --no-checkout --single-branch --branch main \
@@ -101,10 +101,10 @@ pnpm build
 test -z "$(git -C "$worktree" status --porcelain)"
 
 cd "$ocm_repo"
-"$ocm_bin" runtime build-local "$runtime" --repo "$worktree" --force
-"$ocm_bin" runtime verify "$runtime"
-"$ocm_bin" runtime show "$runtime"
-runtime_bin="$("$ocm_bin" runtime which "$runtime" --raw)"
+"$OCM_BIN" runtime build-local "$runtime" --repo "$worktree" --force
+"$OCM_BIN" runtime verify "$runtime"
+"$OCM_BIN" runtime show "$runtime"
+runtime_bin="$("$OCM_BIN" runtime which "$runtime" --raw)"
 "$runtime_bin" --version
 
 test "$(git -C "$worktree" rev-parse HEAD)" = "$openclaw_sha"
@@ -114,7 +114,7 @@ test -z "$(git -C "$worktree" status --porcelain)"
 Keep `run_id`, `run_root`, `repo_store`, `worktree`, `runtime`, env names, and
 the report together. Cleanup must target only those names and must inspect
 worktree status before removal. Destroy dependent envs before running
-`"$ocm_bin" runtime remove "$runtime"`.
+`"$OCM_BIN" runtime remove "$runtime"`.
 
 ## Release Validation Cheatsheet
 

--- a/skills/ocm-operator/references/safety-and-state.md
+++ b/skills/ocm-operator/references/safety-and-state.md
@@ -38,7 +38,7 @@ import` on that copy. Verify the expected fixture exists before mutation.
 Pattern:
 
 ```sh
-ocm env clone Violet <test-env>
+ocm env clone <existing-env> <test-env>
 ocm upgrade <test-env> --runtime <runtime>
 ocm @<test-env> -- doctor --fix
 ocm env destroy <test-env> --yes

--- a/skills/ocm-operator/references/safety-and-state.md
+++ b/skills/ocm-operator/references/safety-and-state.md
@@ -21,6 +21,20 @@ For tests involving existing users:
 3. Keep the source env untouched.
 4. Destroy the clone when done.
 
+Clones keep durable auth/settings but clear sessions, logs, and backups. Treat
+every clone as secret-bearing:
+
+- keep its service stopped by default
+- do not contact providers, channels, webhooks, browsers, or other external
+  services without explicit authorization
+- use mocks, dedicated test accounts, or a credential-free fresh env for
+  networked and untrusted-plugin checks
+- do not export, publish, attach, or paste raw clone config or auth data
+
+When the test must preserve sessions or history, copy the source env's
+`.openclaw` directory into a task-owned temporary root and use `ocm adopt
+import` on that copy. Verify the expected fixture exists before mutation.
+
 Pattern:
 
 ```sh
@@ -133,8 +147,14 @@ Remove temp worktrees created by manual git commands:
 
 ```sh
 git -C /path/to/openclaw worktree list
-git -C /path/to/openclaw worktree remove --force /path/to/worktree
+git -C /path/to/worktree status --short
+git -C /path/to/openclaw worktree remove /path/to/worktree
 ```
+
+Remove only a worktree whose path and run id prove it belongs to the current
+task. If status is not clean, stop and inspect it. Use `--force` only after
+separately confirming that the worktree is disposable and every change in it
+belongs to the current task.
 
 Remove temp archives/directories:
 

--- a/skills/openclaw-release-validation/SKILL.md
+++ b/skills/openclaw-release-validation/SKILL.md
@@ -21,7 +21,7 @@ Before running tests, read:
 - `references/release-validation-paths.md`
 - `../../docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md`
 - the current validation report if one exists under
-  `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/`
+  `/path/to/release-validation/`
 
 If repo-level AGENTS instructions are present, read and follow them first.
 

--- a/skills/openclaw-release-validation/SKILL.md
+++ b/skills/openclaw-release-validation/SKILL.md
@@ -27,37 +27,69 @@ If repo-level AGENTS instructions are present, read and follow them first.
 
 ## Workflow
 
-1. Confirm paths, permissions, OCM binary, OpenClaw test repo, and report path.
-2. Pull latest `origin/main` in the OpenClaw test repo and record the commit.
-3. Build OpenClaw and use the built executable path, usually `openclaw.mjs`.
-4. Review OCM command usage for the touched scenario using `README.md`,
+1. Confirm paths, permissions, OCM binary, OpenClaw source repo, and report
+   root.
+2. Create a unique run id. Derive the worktree, runtime, env, report, and
+   cleanup names from that id so concurrent validations cannot share mutable
+   resources.
+3. Fetch the OpenClaw source repo once, resolve `origin/main` to an immutable
+   commit, and create a clean detached worktree for that commit. Record the
+   commit before building.
+4. Build the primary validation target with
+   `ocm runtime build-local <run-runtime> --repo <run-worktree> --force`, then
+   run `ocm runtime verify <run-runtime>`. This package-shaped runtime is the
+   target for the matrix. Direct `<run-worktree>/openclaw.mjs` execution is
+   limited to the S02 source-artifact boot smoke check.
+5. Review OCM command usage for the touched scenario using `README.md`,
    `docs/USAGE.md`, and targeted help:
    `ocm help start`, `ocm help service`, `ocm help logs`, `ocm help upgrade`,
    and `ocm help env`.
-5. Review changelogs and commits since the last release to identify changed
+6. Review changelogs and commits since the last release to identify changed
    surfaces and extra tests.
-6. Run the broad scenario matrix from
+7. Prepare existing-user fixtures before mutation:
+   - use `ocm env clone` only when clearing sessions, logs, and backups is
+     intended;
+   - for S20, copy the source env's `.openclaw` directory into the run root,
+     import that copy with `ocm adopt import`, and assert the expected session
+     fixture exists before the upgrade.
+8. Treat every copied or cloned user fixture as secret-bearing. Keep its
+   service stopped and make no provider, channel, webhook, browser, or other
+   external connection by default. Use a credential-free fresh env, mocks, or
+   dedicated test accounts for networked checks. Real external access requires
+   explicit authorization for the run.
+9. Run the broad scenario matrix from
    `docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md`.
-7. Copy existing user state before mutation; never mutate `Violet` directly.
-8. For each scenario, test both clean new-user state and copied existing-user
+10. For each scenario, test both clean new-user state and copied existing-user
    state when applicable.
-9. Run OpenClaw commands through `ocm @<env> -- ...` unless the scenario
+11. Run OpenClaw commands through `ocm @<env> -- ...` unless the scenario
    explicitly requires direct execution. Verify OCM env runs expose
    `OPENCLAW_SERVICE_REPAIR_POLICY=external` as part of normal env execution;
    do not run broad LaunchAgent/service mutation tests unless the release
    changed service behavior.
-10. Add extra checks for changed release surfaces, but keep them attached to the
+12. Add extra checks for changed release surfaces, but keep them attached to the
    closest scenario.
-11. Record a concise scenario table while testing; add detailed notes only for
+13. Record a concise scenario table while testing; add detailed notes only for
    failures, blocked scenarios, or explicit gaps.
-12. Clean up temp envs, services, LaunchAgents, plugin fixtures, and worktrees.
+14. Before reporting, verify the detached worktree still points at the recorded
+    commit and the runtime identity matches the run. Redact credentials,
+    private endpoints, user identifiers, and secret-bearing command output.
+15. Clean up only resources carrying the current run id. Inspect worktree
+    status before removal and do not force-remove an unclean or unowned
+    worktree.
 
 ## Non-Negotiables
 
 - Do not use the active `../openclaw` repo.
-- Do not substitute `pnpm openclaw` for release validation of the built artifact.
-- Do not mutate the real existing-user env; clone or copy it first.
+- Do not substitute `pnpm openclaw` or the source-tree executable for
+  validation of the package-shaped runtime.
+- Do not mutate the real existing-user env; copy it into the run root first.
+- Do not assume `ocm env clone` preserves sessions, logs, or backups.
+- Do not start a copied user's gateway or make external requests with retained
+  credentials unless the run explicitly authorizes the destination and
+  account.
+- Do not include credentials or raw secret-bearing config in the report.
 - Do not leave temporary services or LaunchAgents running.
+- Do not clean up resources that are not owned by the current run id.
 - Do not mark a scenario passed unless postconditions were checked.
 - Do not rely on reasoning alone for release readiness; run real command flows.
 
@@ -73,7 +105,8 @@ Use these statuses:
 
 Report shape:
 
-- Start with OCM/OpenClaw commits, baseline reviewed, temp paths, and state used.
+- Start with OCM/OpenClaw commits, package runtime identity, baseline reviewed,
+  run id, temp paths, and fixture modes used.
 - Include one summary row per scenario with New User, Existing User, Result, and
   Notes.
 - For each failure, include impact, repro commands, expected, actual, and a

--- a/skills/openclaw-release-validation/SKILL.md
+++ b/skills/openclaw-release-validation/SKILL.md
@@ -33,9 +33,11 @@ If repo-level AGENTS instructions are present, read and follow them first.
 2. Create a unique run id. Derive the worktree, runtime, env, report, and
    cleanup names from that id so concurrent validations cannot share mutable
    resources.
-3. Fetch the OpenClaw source repo once, resolve `origin/main` to an immutable
-   commit, and create a clean detached worktree for that commit. Record the
-   commit before building.
+3. Read the OpenClaw source repo's `origin` URL without fetching or changing
+   that shared checkout. Create per-run Git metadata from that remote, using
+   the source repo only as a read-only object cache, then resolve `origin/main`
+   to an immutable commit and create a clean detached worktree for it. Record
+   the commit before building.
 4. Build the primary validation target with
    `"$OCM_BIN" runtime build-local <run-runtime> --repo <run-worktree>
    --force`, then run `"$OCM_BIN" runtime verify <run-runtime>`. This

--- a/skills/openclaw-release-validation/SKILL.md
+++ b/skills/openclaw-release-validation/SKILL.md
@@ -39,10 +39,13 @@ If repo-level AGENTS instructions are present, read and follow them first.
    dissociating the clone from it. Then resolve `origin/main` to an immutable
    commit and create a clean detached worktree for it. Record the commit
    before building.
-4. Build the primary validation target with
+4. In the detached worktree, run `pnpm install --frozen-lockfile`,
+   `pnpm check`, and `pnpm build`, then require `git status --porcelain` to
+   remain empty. Build the primary validation target with
    `"$OCM_BIN" runtime build-local <run-runtime> --repo <run-worktree>
-   --force`, then run `"$OCM_BIN" runtime verify <run-runtime>`. This
-   package-shaped runtime is the target for the matrix. Direct
+   --force`, then run
+   `"$OCM_BIN" runtime verify <run-runtime>` and recheck worktree cleanliness.
+   This package-shaped runtime is the target for the matrix. Direct
    `<run-worktree>/openclaw.mjs` execution is limited to the S02
    source-artifact boot smoke check.
 5. Review OCM command usage for the touched scenario using `README.md`,

--- a/skills/openclaw-release-validation/SKILL.md
+++ b/skills/openclaw-release-validation/SKILL.md
@@ -73,9 +73,10 @@ If repo-level AGENTS instructions are present, read and follow them first.
 14. Before reporting, verify the detached worktree still points at the recorded
     commit and the runtime identity matches the run. Redact credentials,
     private endpoints, user identifiers, and secret-bearing command output.
-15. Clean up only resources carrying the current run id. Inspect worktree
-    status before removal and do not force-remove an unclean or unowned
-    worktree.
+15. Destroy run-owned envs, then run
+    `ocm runtime remove <run-runtime>`. Clean up only resources carrying the
+    current run id. Inspect worktree status before removal and do not
+    force-remove an unclean or unowned worktree.
 
 ## Non-Negotiables
 
@@ -89,6 +90,8 @@ If repo-level AGENTS instructions are present, read and follow them first.
   account.
 - Do not include credentials or raw secret-bearing config in the report.
 - Do not leave temporary services or LaunchAgents running.
+- Do not leave the per-run package runtime installed after its envs are
+  destroyed.
 - Do not clean up resources that are not owned by the current run id.
 - Do not mark a scenario passed unless postconditions were checked.
 - Do not rely on reasoning alone for release readiness; run real command flows.

--- a/skills/openclaw-release-validation/SKILL.md
+++ b/skills/openclaw-release-validation/SKILL.md
@@ -35,9 +35,10 @@ If repo-level AGENTS instructions are present, read and follow them first.
    resources.
 3. Read the OpenClaw source repo's `origin` URL without fetching or changing
    that shared checkout. Create per-run Git metadata from that remote, using
-   the source repo only as a read-only object cache, then resolve `origin/main`
-   to an immutable commit and create a clean detached worktree for it. Record
-   the commit before building.
+   the source repo only as a clone-time read-only object cache and
+   dissociating the clone from it. Then resolve `origin/main` to an immutable
+   commit and create a clean detached worktree for it. Record the commit
+   before building.
 4. Build the primary validation target with
    `"$OCM_BIN" runtime build-local <run-runtime> --repo <run-worktree>
    --force`, then run `"$OCM_BIN" runtime verify <run-runtime>`. This

--- a/skills/openclaw-release-validation/SKILL.md
+++ b/skills/openclaw-release-validation/SKILL.md
@@ -27,8 +27,9 @@ If repo-level AGENTS instructions are present, read and follow them first.
 
 ## Workflow
 
-1. Confirm paths, permissions, OCM binary, OpenClaw source repo, and report
-   root.
+1. Confirm paths, permissions, OpenClaw source repo, and report root. Set
+   `OCM_BIN=<ocm-repo>/target/debug/ocm`, verify it is executable, and invoke
+   that absolute binary for every OCM command in the run.
 2. Create a unique run id. Derive the worktree, runtime, env, report, and
    cleanup names from that id so concurrent validations cannot share mutable
    resources.
@@ -36,22 +37,22 @@ If repo-level AGENTS instructions are present, read and follow them first.
    commit, and create a clean detached worktree for that commit. Record the
    commit before building.
 4. Build the primary validation target with
-   `ocm runtime build-local <run-runtime> --repo <run-worktree> --force`, then
-   run `ocm runtime verify <run-runtime>`. This package-shaped runtime is the
-   target for the matrix. Direct `<run-worktree>/openclaw.mjs` execution is
-   limited to the S02 source-artifact boot smoke check.
+   `"$OCM_BIN" runtime build-local <run-runtime> --repo <run-worktree>
+   --force`, then run `"$OCM_BIN" runtime verify <run-runtime>`. This
+   package-shaped runtime is the target for the matrix. Direct
+   `<run-worktree>/openclaw.mjs` execution is limited to the S02
+   source-artifact boot smoke check.
 5. Review OCM command usage for the touched scenario using `README.md`,
-   `docs/USAGE.md`, and targeted help:
-   `ocm help start`, `ocm help service`, `ocm help logs`, `ocm help upgrade`,
-   and `ocm help env`.
+   `docs/USAGE.md`, and targeted help from the same `"$OCM_BIN"`:
+   `help start`, `help service`, `help logs`, `help upgrade`, and `help env`.
 6. Review changelogs and commits since the last release to identify changed
    surfaces and extra tests.
 7. Prepare existing-user fixtures before mutation:
-   - use `ocm env clone` only when clearing sessions, logs, and backups is
-     intended;
+   - use `"$OCM_BIN" env clone` only when clearing sessions, logs, and backups
+     is intended;
    - for S20, copy the source env's `.openclaw` directory into the run root,
-     import that copy with `ocm adopt import`, and assert the expected session
-     fixture exists before the upgrade.
+     import that copy with `"$OCM_BIN" adopt import`, and assert the expected
+     session fixture exists before the upgrade.
 8. Treat every copied or cloned user fixture as secret-bearing. Keep its
    service stopped and make no provider, channel, webhook, browser, or other
    external connection by default. Use a credential-free fresh env, mocks, or
@@ -61,8 +62,8 @@ If repo-level AGENTS instructions are present, read and follow them first.
    `docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md`.
 10. For each scenario, test both clean new-user state and copied existing-user
    state when applicable.
-11. Run OpenClaw commands through `ocm @<env> -- ...` unless the scenario
-   explicitly requires direct execution. Verify OCM env runs expose
+11. Run OpenClaw commands through `"$OCM_BIN" @<env> -- ...` unless the
+    scenario explicitly requires direct execution. Verify OCM env runs expose
    `OPENCLAW_SERVICE_REPAIR_POLICY=external` as part of normal env execution;
    do not run broad LaunchAgent/service mutation tests unless the release
    changed service behavior.
@@ -74,8 +75,8 @@ If repo-level AGENTS instructions are present, read and follow them first.
     commit and the runtime identity matches the run. Redact credentials,
     private endpoints, user identifiers, and secret-bearing command output.
 15. Destroy run-owned envs, then run
-    `ocm runtime remove <run-runtime>`. Clean up only resources carrying the
-    current run id. Inspect worktree status before removal and do not
+    `"$OCM_BIN" runtime remove <run-runtime>`. Clean up only resources carrying
+    the current run id. Inspect worktree status before removal and do not
     force-remove an unclean or unowned worktree.
 
 ## Non-Negotiables
@@ -84,7 +85,7 @@ If repo-level AGENTS instructions are present, read and follow them first.
 - Do not substitute `pnpm openclaw` or the source-tree executable for
   validation of the package-shaped runtime.
 - Do not mutate the real existing-user env; copy it into the run root first.
-- Do not assume `ocm env clone` preserves sessions, logs, or backups.
+- Do not assume `"$OCM_BIN" env clone` preserves sessions, logs, or backups.
 - Do not start a copied user's gateway or make external requests with retained
   credentials unless the run explicitly authorizes the destination and
   account.

--- a/skills/openclaw-release-validation/references/release-validation-paths.md
+++ b/skills/openclaw-release-validation/references/release-validation-paths.md
@@ -3,10 +3,12 @@
 Default paths for this machine:
 
 - OCM repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm`
-- OpenClaw source repo and read-only object cache:
+- OpenClaw source repo and clone-time read-only object cache:
   `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`
 - Per-run root: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation/<run-id>`
 - Per-run Git metadata: `<run-root>/repo`
+- Dissociate that per-run clone so it owns every object needed by the recorded
+  commit.
 - Detached OpenClaw worktree: `<run-root>/openclaw`
 - Do not use active OpenClaw repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
 - Existing user source env: `/Users/shakker/.ocm/envs/Violet`

--- a/skills/openclaw-release-validation/references/release-validation-paths.md
+++ b/skills/openclaw-release-validation/references/release-validation-paths.md
@@ -3,8 +3,10 @@
 Default paths for this machine:
 
 - OCM repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm`
-- OpenClaw source repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`
+- OpenClaw source repo and read-only object cache:
+  `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`
 - Per-run root: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation/<run-id>`
+- Per-run Git metadata: `<run-root>/repo`
 - Detached OpenClaw worktree: `<run-root>/openclaw`
 - Do not use active OpenClaw repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
 - Existing user source env: `/Users/shakker/.ocm/envs/Violet`

--- a/skills/openclaw-release-validation/references/release-validation-paths.md
+++ b/skills/openclaw-release-validation/references/release-validation-paths.md
@@ -1,17 +1,17 @@
 # Release Validation Paths
 
-Default paths for this machine:
+Configure these path roles for the validation host:
 
-- OCM repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm`
+- OCM repo: `/path/to/ocm`
 - OpenClaw source repo and clone-time read-only object cache:
-  `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`
-- Per-run root: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation/<run-id>`
+  `/path/to/openclaw-source-cache`
+- Per-run root: `/path/to/release-validation/<run-id>`
 - Per-run Git metadata: `<run-root>/repo`
 - Dissociate that per-run clone so it owns every object needed by the recorded
   commit.
 - Detached OpenClaw worktree: `<run-root>/openclaw`
-- Do not use active OpenClaw repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
-- Existing user source env: `/Users/shakker/.ocm/envs/Violet`
+- Do not use active OpenClaw repo: `/path/to/active-openclaw`
+- Existing user source env: `~/.ocm/envs/<existing-env>`
 - Report pattern: `<run-root>/ocm-openclaw-release-validation-<run-id>.md`
 
 Preferred binaries:

--- a/skills/openclaw-release-validation/references/release-validation-paths.md
+++ b/skills/openclaw-release-validation/references/release-validation-paths.md
@@ -3,15 +3,31 @@
 Default paths for this machine:
 
 - OCM repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/ocm`
-- OpenClaw test repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`
+- OpenClaw source repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/test-build`
+- Per-run root: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/release-validation/<run-id>`
+- Detached OpenClaw worktree: `<run-root>/openclaw`
 - Do not use active OpenClaw repo: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/openclaw`
 - Existing user source env: `/Users/shakker/.ocm/envs/Violet`
-- Report pattern: `/Users/shakker/WorkSpace/ShakkerNerd/OpenSource/OpenClaw/temp/ocm-openclaw-release-validation-YYYY-MM-DD.md`
+- Report pattern: `<run-root>/ocm-openclaw-release-validation-<run-id>.md`
 
 Preferred binaries:
 
 - OCM: `<ocm repo>/target/debug/ocm`
-- OpenClaw: `<test-build>/openclaw.mjs`
+- Package-shaped OpenClaw runtime: an OCM runtime named with `<run-id>`, built
+  from `<run-root>/openclaw` with `ocm runtime build-local`
+- Direct OpenClaw executable: `<run-root>/openclaw/openclaw.mjs`, only for the
+  S02 source-artifact boot smoke check
+
+Existing-user fixture modes:
+
+- Durable-state clone: `ocm env clone`; keeps auth/settings but intentionally
+  clears sessions, logs, and backups.
+- Session-preserving fixture: copy the source `.openclaw` directory under
+  `<run-root>`, then import that copy with `ocm adopt import`.
+
+Both modes are secret-bearing until credentials are removed or replaced. Keep
+their services stopped and use mocks or dedicated test accounts for external
+checks unless the run explicitly authorizes real access.
 
 Canonical scenario matrix:
 

--- a/skills/openclaw-release-validation/references/release-validation-paths.md
+++ b/skills/openclaw-release-validation/references/release-validation-paths.md
@@ -16,16 +16,16 @@ Preferred binaries:
 
 - OCM: `<ocm repo>/target/debug/ocm`
 - Package-shaped OpenClaw runtime: an OCM runtime named with `<run-id>`, built
-  from `<run-root>/openclaw` with `ocm runtime build-local`
+  from `<run-root>/openclaw` with `"$OCM_BIN" runtime build-local`
 - Direct OpenClaw executable: `<run-root>/openclaw/openclaw.mjs`, only for the
   S02 source-artifact boot smoke check
 
 Existing-user fixture modes:
 
-- Durable-state clone: `ocm env clone`; keeps auth/settings but intentionally
-  clears sessions, logs, and backups.
+- Durable-state clone: `"$OCM_BIN" env clone`; keeps auth/settings but
+  intentionally clears sessions, logs, and backups.
 - Session-preserving fixture: copy the source `.openclaw` directory under
-  `<run-root>`, then import that copy with `ocm adopt import`.
+  `<run-root>`, then import that copy with `"$OCM_BIN" adopt import`.
 
 Both modes are secret-bearing until credentials are removed or replaced. Keep
 their services stopped and use mocks or dedicated test accounts for external

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -13,14 +13,14 @@ fn release_validation_requires_isolated_package_shaped_runs() {
     let normalized = combined.to_lowercase();
 
     for required in [
-        "ocm runtime build-local",
+        "\"$ocm_bin\" runtime build-local",
         "immutable",
         "detached worktree",
         "run id",
         "package-shaped runtime",
     ] {
         assert!(
-            combined.contains(required),
+            normalized.contains(required),
             "release-validation contract must mention {required:?}"
         );
     }
@@ -62,6 +62,8 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     let safety = read("skills/ocm-operator/references/safety-and-state.md");
     let paths = read("skills/ocm-operator/references/local-paths.md");
     let release_skill = read("skills/openclaw-release-validation/SKILL.md");
+    let release_paths =
+        read("skills/openclaw-release-validation/references/release-validation-paths.md");
     let matrix = read("docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md");
 
     assert!(usage.contains("ocm logs mira --stream error"));
@@ -84,6 +86,8 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(release_skill.contains("\"$OCM_BIN\" runtime verify"));
     assert!(release_skill.contains("\"$OCM_BIN\" runtime remove"));
     assert!(release_skill.contains("\"$OCM_BIN\" @<env> --"));
+    assert!(!release_skill.contains("`ocm "));
+    assert!(!release_paths.contains("`ocm "));
     assert!(matrix.contains("OCM_BIN="));
     assert!(matrix.contains("/target/debug/ocm"));
     assert!(matrix.contains("\"$OCM_BIN\" runtime build-local"));

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -76,6 +76,10 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(paths.contains("export OCM_HOME="));
     assert!(paths.contains("runtime which"));
     assert!(!paths.contains("$HOME/.ocm/runtimes"));
-    assert!(release_skill.contains("ocm runtime remove"));
+    assert!(release_skill.contains("OCM_BIN=<ocm-repo>/target/debug/ocm"));
+    assert!(release_skill.contains("\"$OCM_BIN\" runtime build-local"));
+    assert!(release_skill.contains("\"$OCM_BIN\" runtime verify"));
+    assert!(release_skill.contains("\"$OCM_BIN\" runtime remove"));
+    assert!(release_skill.contains("\"$OCM_BIN\" @<env> --"));
     assert!(matrix.contains("run-owned package runtime is removed"));
 }

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -74,7 +74,8 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(paths.contains("set -euo pipefail"));
     assert!(paths.contains("status --porcelain"));
     assert!(paths.contains("rev-parse HEAD"));
-    assert!(paths.contains("ocm_bin="));
+    assert!(paths.contains("OCM_BIN="));
+    assert!(!paths.contains("ocm_bin="));
     assert!(paths.contains("export OCM_HOME="));
     assert!(paths.contains("run_root=\"$(mktemp -d"));
     assert!(paths.contains("run_id=\"${run_root##*/}\""));
@@ -95,6 +96,8 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(release_skill.contains("\"$OCM_BIN\" runtime verify"));
     assert!(release_skill.contains("\"$OCM_BIN\" runtime remove"));
     assert!(release_skill.contains("\"$OCM_BIN\" @<env> --"));
+    assert!(release_skill.contains("pnpm install --frozen-lockfile"));
+    assert!(release_skill.contains("git status --porcelain"));
     assert!(!release_skill.contains("`ocm "));
     assert!(!release_paths.contains("`ocm "));
     assert!(matrix.contains("OCM_BIN="));

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -86,6 +86,7 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     );
     assert!(paths.contains("git clone --no-checkout"));
     assert!(paths.contains("--reference-if-able"));
+    assert!(paths.contains("--dissociate"));
     assert!(!paths.contains("git -C \"$source_repo\" fetch"));
     assert!(paths.contains("runtime which"));
     assert!(!paths.contains("$HOME/.ocm/runtimes"));

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -1,0 +1,73 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+}
+
+#[test]
+fn release_validation_requires_isolated_package_shaped_runs() {
+    let skill = read("skills/openclaw-release-validation/SKILL.md");
+    let paths = read("skills/openclaw-release-validation/references/release-validation-paths.md");
+    let matrix = read("docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md");
+    let combined = format!("{skill}\n{paths}\n{matrix}");
+    let normalized = combined.to_lowercase();
+
+    for required in [
+        "ocm runtime build-local",
+        "immutable",
+        "detached worktree",
+        "run id",
+        "package-shaped runtime",
+    ] {
+        assert!(
+            combined.contains(required),
+            "release-validation contract must mention {required:?}"
+        );
+    }
+    assert!(
+        normalized.contains("only for the s02") || normalized.contains("limited to the s02"),
+        "direct source execution must be limited to the S02 smoke check"
+    );
+}
+
+#[test]
+fn release_validation_distinguishes_session_and_secret_boundaries() {
+    let release_skill = read("skills/openclaw-release-validation/SKILL.md");
+    let operator_skill = read("skills/ocm-operator/SKILL.md");
+    let cookbook = read("skills/ocm-operator/references/command-cookbook.md");
+    let safety = read("skills/ocm-operator/references/safety-and-state.md");
+    let matrix = read("docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md");
+    let combined = format!("{release_skill}\n{operator_skill}\n{cookbook}\n{safety}\n{matrix}");
+    let normalized = combined.to_lowercase();
+
+    for required in [
+        "secret-bearing",
+        "explicit authorization",
+        "dedicated test account",
+        "ocm adopt import",
+        "sessions, logs, and backups",
+        "redact",
+    ] {
+        assert!(
+            normalized.contains(required),
+            "existing-user safety contract must mention {required:?}"
+        );
+    }
+}
+
+#[test]
+fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
+    let usage = read("docs/USAGE.md");
+    let cookbook = read("skills/ocm-operator/references/command-cookbook.md");
+    let safety = read("skills/ocm-operator/references/safety-and-state.md");
+    let paths = read("skills/ocm-operator/references/local-paths.md");
+
+    assert!(usage.contains("ocm logs mira --stream error"));
+    assert!(!usage.contains("ocm logs mira --stderr"));
+    assert!(cookbook.contains("ocm logs <env> --stream error"));
+    assert!(safety.contains("git -C /path/to/worktree status --short"));
+    assert!(!safety.contains("worktree remove --force"));
+    assert!(paths.contains("set -euo pipefail"));
+    assert!(paths.contains("status --porcelain"));
+    assert!(paths.contains("rev-parse HEAD"));
+}

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -76,6 +76,9 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(paths.contains("rev-parse HEAD"));
     assert!(paths.contains("ocm_bin="));
     assert!(paths.contains("export OCM_HOME="));
+    assert!(paths.contains("run_root=\"$(mktemp -d"));
+    assert!(paths.contains("run_id=\"${run_root##*/}\""));
+    assert!(!paths.contains("date -u +%Y%m%dT%H%M%SZ"));
     assert!(paths.contains("git clone --no-checkout"));
     assert!(paths.contains("--reference-if-able"));
     assert!(!paths.contains("git -C \"$source_repo\" fetch"));

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -79,6 +79,11 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(paths.contains("run_root=\"$(mktemp -d"));
     assert!(paths.contains("run_id=\"${run_root##*/}\""));
     assert!(!paths.contains("date -u +%Y%m%dT%H%M%SZ"));
+    assert!(paths.contains("pnpm install --frozen-lockfile"));
+    assert!(
+        paths.matches("status --porcelain").count() >= 3,
+        "release recipe must prove cleanliness before and after packaging"
+    );
     assert!(paths.contains("git clone --no-checkout"));
     assert!(paths.contains("--reference-if-able"));
     assert!(!paths.contains("git -C \"$source_repo\" fetch"));

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -106,4 +106,10 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(matrix.contains("\"$OCM_BIN\" upgrade simulate"));
     assert!(!matrix.contains("`ocm "));
     assert!(matrix.contains("run-owned package runtime is removed"));
+    assert!(
+        [&paths, &release_skill, &release_paths, &matrix]
+            .iter()
+            .all(|document| !document.contains("/Users/")),
+        "release-validation docs must not publish machine-local home paths"
+    );
 }

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -61,6 +61,8 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     let cookbook = read("skills/ocm-operator/references/command-cookbook.md");
     let safety = read("skills/ocm-operator/references/safety-and-state.md");
     let paths = read("skills/ocm-operator/references/local-paths.md");
+    let release_skill = read("skills/openclaw-release-validation/SKILL.md");
+    let matrix = read("docs/OPENCLAW_RELEASE_SCENARIO_MATRIX.md");
 
     assert!(usage.contains("ocm logs mira --stream error"));
     assert!(!usage.contains("ocm logs mira --stderr"));
@@ -70,4 +72,10 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(paths.contains("set -euo pipefail"));
     assert!(paths.contains("status --porcelain"));
     assert!(paths.contains("rev-parse HEAD"));
+    assert!(paths.contains("ocm_bin="));
+    assert!(paths.contains("export OCM_HOME="));
+    assert!(paths.contains("runtime which"));
+    assert!(!paths.contains("$HOME/.ocm/runtimes"));
+    assert!(release_skill.contains("ocm runtime remove"));
+    assert!(matrix.contains("run-owned package runtime is removed"));
 }

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -81,5 +81,10 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(release_skill.contains("\"$OCM_BIN\" runtime verify"));
     assert!(release_skill.contains("\"$OCM_BIN\" runtime remove"));
     assert!(release_skill.contains("\"$OCM_BIN\" @<env> --"));
+    assert!(matrix.contains("OCM_BIN="));
+    assert!(matrix.contains("/target/debug/ocm"));
+    assert!(matrix.contains("\"$OCM_BIN\" runtime build-local"));
+    assert!(matrix.contains("\"$OCM_BIN\" upgrade simulate"));
+    assert!(!matrix.contains("`ocm "));
     assert!(matrix.contains("run-owned package runtime is removed"));
 }

--- a/tests/skill_contract_tests.rs
+++ b/tests/skill_contract_tests.rs
@@ -74,6 +74,9 @@ fn operator_recipes_use_current_cli_and_safe_cleanup_contracts() {
     assert!(paths.contains("rev-parse HEAD"));
     assert!(paths.contains("ocm_bin="));
     assert!(paths.contains("export OCM_HOME="));
+    assert!(paths.contains("git clone --no-checkout"));
+    assert!(paths.contains("--reference-if-able"));
+    assert!(!paths.contains("git -C \"$source_repo\" fetch"));
     assert!(paths.contains("runtime which"));
     assert!(!paths.contains("$HOME/.ocm/runtimes"));
     assert!(release_skill.contains("OCM_BIN=<ocm-repo>/target/debug/ocm"));


### PR DESCRIPTION
## What Problem This Solves

OCM's OpenClaw release-validation guidance allowed shared mutable checkouts, source-shaped execution, ambiguous fixture semantics, copied production credentials, and cleanup that could remove resources owned by another run. The documented paths also drifted from current CLI behavior.

## Why This Change Was Made

Release validation should be repeatable, concurrency-safe, and tied to one immutable OpenClaw commit. This stack makes the executable recipe, canonical skill, scenario matrix, and operator references agree on one workflow:

- allocate an atomic run root and run-owned `OCM_HOME`
- create a detached, dissociated, commit-pinned Git worktree
- use a frozen install, build checks, and cleanliness assertions
- package and verify OpenClaw through an explicit local `OCM_BIN`
- distinguish durable-state clones from session-preserving imports
- keep copied credentials offline unless real access is explicitly authorized
- clean up only run-owned environments, runtimes, and clean worktrees
- use current log stream flags and redact machine-local path examples

Focused contract tests prevent these guarantees from drifting across the documentation surfaces.

## User Impact

Maintainers get a release-validation workflow that can run concurrently without sharing mutable Git, OCM, runtime, environment, or cleanup state. Existing-user validation preserves the intended session fixtures without risking the real source environment or silently contacting production services.

## Evidence

- `cargo fmt --check`
- `cargo test --locked`
- `cargo install --locked --path . --root <temporary-root>` and installed `ocm --version`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- Bash syntax and ShellCheck on the extracted local release runtime recipe
- `git diff --check origin/main...HEAD`
- focused `cargo test --locked --test skill_contract_tests`
- Codex Sol/high autoreview: clean, no accepted findings, overall confidence 0.90

Base verified at `271af63dd226d23aa53f65c4e5be45e7281a23c7`.
