### PR TITLE
fix(service): serialize daemon ownership lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to OCM are documented here.
 
 ### Fixed
 
+- Reject an already-running shared OCM daemon when its service definition belongs to another `OCM_HOME`, and remove the shared service binding after the last running environment stops or is uninstalled.
 - Reuse an identical healthy official runtime when concurrent installers publish it first instead of failing the waiting command.
 - Match environment-owned processes by path components so destroy never targets sibling-prefix directories.
 - Replace copied OpenClaw config symlinks with environment-owned files without rewriting external targets.

--- a/src/service/inspect.rs
+++ b/src/service/inspect.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use serde::Serialize;
 
-use super::platform::{ServiceManagerKind, service_manager_kind};
+use super::platform::{ManagedServiceEnablement, ServiceManagerKind, service_manager_kind};
 use crate::cli::render::format_rfc3339;
 use crate::env::GatewayProcessSpec;
 use crate::env::{EnvMeta, EnvironmentService};
@@ -33,6 +33,7 @@ pub(crate) struct LaunchdJobStatus {
     pub(crate) installed: bool,
     pub(crate) loaded: bool,
     pub(crate) running: bool,
+    pub(crate) enablement: Option<ManagedServiceEnablement>,
     pub(crate) pid: Option<u32>,
     pub(crate) state: Option<String>,
     pub(crate) definition_path: Option<String>,
@@ -598,6 +599,12 @@ fn parse_systemctl_show(raw: &str, status: &mut LaunchdJobStatus) {
         || unit_file_state
             .as_deref()
             .is_some_and(|value| !matches!(value, "not-found" | "masked"));
+    status.enablement = unit_file_state.as_deref().and_then(|value| match value {
+        "enabled" => Some(ManagedServiceEnablement::Enabled),
+        "enabled-runtime" => Some(ManagedServiceEnablement::EnabledRuntime),
+        "disabled" => Some(ManagedServiceEnablement::Disabled),
+        _ => None,
+    });
     status.running = active_state.as_deref() == Some("active");
     status.state = sub_state.or(active_state);
 }
@@ -605,6 +612,7 @@ fn parse_systemctl_show(raw: &str, status: &mut LaunchdJobStatus) {
 #[cfg(test)]
 mod service_issue_tests {
     use super::{ServiceIssueContext, service_issue, tcp_port_reachable};
+    use crate::service::platform::ManagedServiceEnablement;
     use crate::supervisor::SupervisorDaemonSummary;
     use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
 
@@ -615,6 +623,7 @@ mod service_issue_tests {
             installed: true,
             loaded: true,
             running: true,
+            enablement: Some(ManagedServiceEnablement::Enabled),
             pid: Some(42),
             state: Some("active".to_string()),
             managed_label: "ai.openclaw.ocm".to_string(),

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -207,12 +207,14 @@ fn ensure_gateway_binding(
         .map(|_| ())
 }
 
-fn ensure_supervisor_running(env: &BTreeMap<String, String>, cwd: &Path) -> Result<(), String> {
+fn ensure_supervisor_running_locked(
+    supervisor: &SupervisorService<'_>,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
     if let Some(error) = service_backend_support_error(env) {
         return Err(error);
     }
-    let supervisor = SupervisorService::new(env, cwd);
-    supervisor.ensure_daemon_running()?;
+    supervisor.ensure_daemon_running_locked()?;
     Ok(())
 }
 
@@ -227,23 +229,62 @@ fn update_service(
     if require_binding {
         ensure_gateway_binding(name, env, cwd)?;
     }
+    let supervisor = SupervisorService::new(env, cwd);
+    // Service policy and the shared daemon are one lifecycle decision. Holding
+    // this lock prevents another store or command from racing ownership/teardown.
+    let _lifecycle_lock = supervisor.lock_daemon_lifecycle()?;
+    supervisor.validate_daemon_owner_locked()?;
+    let daemon_before = supervisor.daemon_status()?;
     if let ServiceSupervisorPolicy::EnsureRunning = supervisor_policy {
-        ensure_supervisor_running(env, cwd)?;
+        if let Err(error) = ensure_supervisor_running_locked(&supervisor, env) {
+            return match supervisor.restore_daemon_state_locked(&daemon_before) {
+                Ok(()) => Err(error),
+                Err(rollback_error) => Err(format!(
+                    "{error}; failed to restore the previous daemon state: {rollback_error}"
+                )),
+            };
+        }
     }
-    let change = set_environment_service_policy(name, service_enabled, service_running, env, cwd)?;
-    if let Err(error) = sync_supervisor_if_present(env, cwd) {
-        let rollback = restore_environment_service_policy(&change, env, cwd).and_then(|restored| {
-            if restored {
-                sync_supervisor_if_present(env, cwd).map(|_| ())
-            } else {
-                Ok(())
+    let change =
+        match set_environment_service_policy(name, service_enabled, service_running, env, cwd) {
+            Ok(change) => change,
+            Err(error) => {
+                return match supervisor.restore_daemon_state_locked(&daemon_before) {
+                    Ok(()) => Err(error),
+                    Err(rollback_error) => Err(format!(
+                        "{error}; failed to restore the previous daemon state: {rollback_error}"
+                    )),
+                };
             }
-        });
-        return match rollback {
-            Ok(()) => Err(error),
-            Err(rollback_error) => Err(format!(
-                "{error}; failed to restore the previous service policy: {rollback_error}"
-            )),
+        };
+    let update_result = sync_supervisor_if_present(env, cwd).and_then(|_| {
+        if matches!(update, ServiceUpdate::Stop | ServiceUpdate::Uninstall)
+            && !supervisor.has_desired_running_services()?
+        {
+            supervisor.uninstall_daemon_locked()?;
+        }
+        Ok(())
+    });
+    if let Err(error) = update_result {
+        let mut rollback_errors = Vec::new();
+        match restore_environment_service_policy(&change, env, cwd) {
+            Ok(restored) => {
+                if restored && let Err(rollback_error) = sync_supervisor_if_present(env, cwd) {
+                    rollback_errors.push(rollback_error);
+                }
+            }
+            Err(rollback_error) => rollback_errors.push(rollback_error),
+        }
+        if let Err(rollback_error) = supervisor.restore_daemon_state_locked(&daemon_before) {
+            rollback_errors.push(rollback_error);
+        }
+        return if rollback_errors.is_empty() {
+            Err(error)
+        } else {
+            Err(format!(
+                "{error}; failed to restore the previous service state: {}",
+                rollback_errors.join("; ")
+            ))
         };
     }
     let (summary, warnings) = wait_for_action_summary(name, action, env, cwd)?;

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -235,60 +235,90 @@ fn update_service(
     let _lifecycle_lock = supervisor.lock_daemon_lifecycle()?;
     supervisor.validate_daemon_owner_locked()?;
     let daemon_before = supervisor.daemon_status()?;
-    if let ServiceSupervisorPolicy::EnsureRunning = supervisor_policy {
-        if let Err(error) = ensure_supervisor_running_locked(&supervisor, env) {
-            return match supervisor.restore_daemon_state_locked(&daemon_before) {
-                Ok(()) => Err(error),
-                Err(rollback_error) => Err(format!(
-                    "{error}; failed to restore the previous daemon state: {rollback_error}"
-                )),
-            };
-        }
-    }
     let change =
         match set_environment_service_policy(name, service_enabled, service_running, env, cwd) {
             Ok(change) => change,
-            Err(error) => {
-                return match supervisor.restore_daemon_state_locked(&daemon_before) {
-                    Ok(()) => Err(error),
-                    Err(rollback_error) => Err(format!(
-                        "{error}; failed to restore the previous daemon state: {rollback_error}"
-                    )),
-                };
-            }
+            Err(error) => return Err(error),
         };
-    let update_result = sync_supervisor_if_present(env, cwd).and_then(|_| {
-        if matches!(update, ServiceUpdate::Stop | ServiceUpdate::Uninstall)
-            && !supervisor.has_desired_running_services()?
-        {
-            supervisor.uninstall_daemon_locked()?;
+    let update_result = match supervisor_policy {
+        ServiceSupervisorPolicy::EnsureRunning => {
+            ensure_supervisor_running_locked(&supervisor, env)
         }
-        Ok(())
-    });
+        ServiceSupervisorPolicy::LeaveAsIs => sync_supervisor_if_present(env, cwd).map(|_| ()),
+    };
     if let Err(error) = update_result {
-        let mut rollback_errors = Vec::new();
-        match restore_environment_service_policy(&change, env, cwd) {
-            Ok(restored) => {
-                if restored && let Err(rollback_error) = sync_supervisor_if_present(env, cwd) {
-                    rollback_errors.push(rollback_error);
+        return Err(rollback_service_update(
+            error,
+            &change,
+            &supervisor,
+            &daemon_before,
+            env,
+            cwd,
+        ));
+    }
+    let (mut summary, warnings) = wait_for_action_summary(name, action, env, cwd)?;
+    let should_remove_daemon =
+        if matches!(update, ServiceUpdate::Stop | ServiceUpdate::Uninstall) && !summary.running {
+            match supervisor.has_desired_running_services() {
+                Ok(has_desired_running_services) => !has_desired_running_services,
+                Err(error) => {
+                    return Err(rollback_service_update(
+                        error,
+                        &change,
+                        &supervisor,
+                        &daemon_before,
+                        env,
+                        cwd,
+                    ));
                 }
             }
-            Err(rollback_error) => rollback_errors.push(rollback_error),
-        }
-        if let Err(rollback_error) = supervisor.restore_daemon_state_locked(&daemon_before) {
-            rollback_errors.push(rollback_error);
-        }
-        return if rollback_errors.is_empty() {
-            Err(error)
         } else {
-            Err(format!(
-                "{error}; failed to restore the previous service state: {}",
-                rollback_errors.join("; ")
-            ))
+            false
         };
+    if should_remove_daemon {
+        if let Err(error) = supervisor.uninstall_daemon_locked() {
+            return Err(rollback_service_update(
+                error,
+                &change,
+                &supervisor,
+                &daemon_before,
+                env,
+                cwd,
+            ));
+        }
+        summary = super::inspect::service_status_fast(name, env, cwd)?;
     }
-    let (summary, warnings) = wait_for_action_summary(name, action, env, cwd)?;
     Ok(service_action_summary(action, summary, warnings))
+}
+
+fn rollback_service_update(
+    error: String,
+    change: &crate::store::EnvironmentServicePolicyChange,
+    supervisor: &SupervisorService<'_>,
+    daemon_before: &crate::supervisor::SupervisorDaemonSummary,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> String {
+    let mut rollback_errors = Vec::new();
+    match restore_environment_service_policy(change, env, cwd) {
+        Ok(restored) => {
+            if restored && let Err(rollback_error) = sync_supervisor_if_present(env, cwd) {
+                rollback_errors.push(rollback_error);
+            }
+        }
+        Err(rollback_error) => rollback_errors.push(rollback_error),
+    }
+    if let Err(rollback_error) = supervisor.restore_daemon_state_locked(daemon_before) {
+        rollback_errors.push(rollback_error);
+    }
+    if rollback_errors.is_empty() {
+        error
+    } else {
+        format!(
+            "{error}; failed to restore the previous service state: {}",
+            rollback_errors.join("; ")
+        )
+    }
 }
 
 fn wait_for_action_summary(

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -7,6 +7,8 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 
 use crate::store::{display_path, lock_file, resolve_user_home};
 
@@ -43,6 +45,13 @@ pub(crate) enum ServiceManagerKind {
     Launchd,
     SystemdUser,
     Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ManagedServiceEnablement {
+    Enabled,
+    EnabledRuntime,
+    Disabled,
 }
 
 pub(crate) fn unsupported_service_manager_message() -> &'static str {
@@ -428,16 +437,151 @@ pub(crate) fn activate_managed_service(
     }
 }
 
-pub(crate) fn register_managed_service(
+pub(crate) fn restore_managed_service_registration(
     label: &str,
     definition_path: &Path,
+    running: bool,
+    enablement: Option<ManagedServiceEnablement>,
     env: &BTreeMap<String, String>,
 ) -> Result<(), String> {
     match service_manager_kind(env) {
-        ServiceManagerKind::Launchd => activate_launchd_service(label, definition_path, env),
-        ServiceManagerKind::SystemdUser => register_systemd_user_service(label, env),
+        ServiceManagerKind::Launchd => {
+            restore_launchd_service_registration(label, definition_path, running, enablement, env)
+        }
+        ServiceManagerKind::SystemdUser => {
+            restore_systemd_user_service_registration(label, running, enablement, env)
+        }
         ServiceManagerKind::Unsupported => Err(unsupported_service_manager_message().to_string()),
     }
+}
+
+pub(crate) fn managed_service_enablement(
+    label: &str,
+    env: &BTreeMap<String, String>,
+) -> Result<Option<ManagedServiceEnablement>, String> {
+    if service_manager_kind(env) != ServiceManagerKind::Launchd {
+        return Ok(None);
+    }
+    let domain = gui_domain(env)?;
+    let output = run_launchctl(env, ["print-disabled", domain.as_str()])?;
+    if !output.status.success() {
+        return Err(format!(
+            "launchctl print-disabled failed for {domain}: {}",
+            launchctl_detail(&output)
+        ));
+    }
+    let disabled = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once("=>"))
+        .any(|(key, value)| {
+            key.trim().trim_matches('"') == label && value.trim().starts_with("true")
+        });
+    Ok(Some(if disabled {
+        ManagedServiceEnablement::Disabled
+    } else {
+        ManagedServiceEnablement::Enabled
+    }))
+}
+
+fn restore_launchd_service_registration(
+    label: &str,
+    definition_path: &Path,
+    running: bool,
+    enablement: Option<ManagedServiceEnablement>,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let previous_enablement =
+        enablement.ok_or_else(|| format!("failed to capture the enabled state for {label}"))?;
+    let domain = gui_domain(env)?;
+    let target = format!("{domain}/{label}");
+    set_launchd_service_enablement(&target, ManagedServiceEnablement::Enabled, env)?;
+    if let Err(error) = activate_launchd_service(label, definition_path, env) {
+        return match set_launchd_service_enablement(&target, previous_enablement, env) {
+            Ok(()) => Err(error),
+            Err(enablement_error) => Err(format!(
+                "{error}; failed to restore the previous launchd enabled state: {enablement_error}"
+            )),
+        };
+    }
+    if running {
+        return set_launchd_service_enablement(&target, previous_enablement, env);
+    }
+
+    set_launchd_service_enablement(&target, ManagedServiceEnablement::Disabled, env)?;
+    let stop_result = stop_launchd_job_for_restore(&target, env);
+    let enablement_result = set_launchd_service_enablement(&target, previous_enablement, env);
+    match (stop_result, enablement_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(enablement_error)) => Err(format!(
+            "{error}; failed to restore the previous launchd enabled state: {enablement_error}"
+        )),
+    }
+}
+
+fn stop_launchd_job_for_restore(
+    target: &str,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    if !launchd_job_is_running(target, env)? {
+        return Ok(());
+    }
+    let terminate = run_launchctl(env, ["kill", "SIGTERM", target])?;
+    if !terminate.status.success() {
+        return Err(format!(
+            "launchctl kill failed while restoring {target}: {}",
+            launchctl_detail(&terminate)
+        ));
+    }
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        if !launchd_job_is_running(target, env)? {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "launchctl kept {target} running while restoring its stopped state"
+            ));
+        }
+        sleep(Duration::from_millis(25));
+    }
+}
+
+fn set_launchd_service_enablement(
+    target: &str,
+    enablement: ManagedServiceEnablement,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let action = match enablement {
+        ManagedServiceEnablement::Enabled => "enable",
+        ManagedServiceEnablement::Disabled => "disable",
+        ManagedServiceEnablement::EnabledRuntime => {
+            return Err("launchd does not support runtime-only enablement".to_string());
+        }
+    };
+    let output = run_launchctl(env, [action, target])?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "launchctl {action} failed while restoring {target}: {}",
+            launchctl_detail(&output)
+        ))
+    }
+}
+
+fn launchd_job_is_running(target: &str, env: &BTreeMap<String, String>) -> Result<bool, String> {
+    let output = run_launchctl(env, ["print", target])?;
+    if !output.status.success() {
+        return Err(format!(
+            "launchctl lost {target} while restoring its stopped state: {}",
+            launchctl_detail(&output)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .any(|line| matches!(line, "state = running" | "state = active")))
 }
 
 fn build_launch_agent_plist(
@@ -742,6 +886,76 @@ fn register_systemd_user_service(
     Ok(())
 }
 
+fn restore_systemd_user_service_registration(
+    label: &str,
+    running: bool,
+    enablement: Option<ManagedServiceEnablement>,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let previous_enablement =
+        enablement.ok_or_else(|| format!("failed to capture the enabled state for {label}"))?;
+    let reload = run_systemctl(env, ["--user", "daemon-reload"])?;
+    if !reload.status.success() {
+        return Err(format!(
+            "systemctl --user daemon-reload failed: {}",
+            systemctl_detail(&reload)
+        ));
+    }
+    let running_result = if running {
+        let restart = run_systemctl(env, ["--user", "restart", label])?;
+        if restart.status.success() {
+            Ok(())
+        } else {
+            let start = run_systemctl(env, ["--user", "start", label])?;
+            if start.status.success() {
+                Ok(())
+            } else {
+                Err(format!(
+                    "systemctl --user restart/start failed while restoring {label}: {}; {}",
+                    systemctl_detail(&restart),
+                    systemctl_detail(&start)
+                ))
+            }
+        }
+    } else {
+        Ok(())
+    };
+    let enablement_result = set_systemd_service_enablement(label, previous_enablement, env);
+    match (running_result, enablement_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(enablement_error)) => Err(format!(
+            "{error}; failed to restore the previous systemd enablement: {enablement_error}"
+        )),
+    }
+}
+
+fn set_systemd_service_enablement(
+    label: &str,
+    enablement: ManagedServiceEnablement,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let (action, output) = match enablement {
+        ManagedServiceEnablement::Enabled => {
+            ("enable", run_systemctl(env, ["--user", "enable", label])?)
+        }
+        ManagedServiceEnablement::EnabledRuntime => (
+            "enable --runtime",
+            run_systemctl(env, ["--user", "enable", "--runtime", label])?,
+        ),
+        ManagedServiceEnablement::Disabled => {
+            ("disable", run_systemctl(env, ["--user", "disable", label])?)
+        }
+    };
+    if !output.status.success() {
+        return Err(format!(
+            "systemctl --user {action} failed while restoring {label}: {}",
+            systemctl_detail(&output)
+        ));
+    }
+    Ok(())
+}
+
 fn gui_domain(env: &BTreeMap<String, String>) -> Result<String, String> {
     let id_bin = env
         .get(ID_BIN_OVERRIDE)
@@ -854,10 +1068,11 @@ mod tests {
     use crate::store::display_path;
 
     use super::{
-        ManagedServiceDefinition, ManagedServiceIdentity, OCM_SERVICE_LABEL, ServiceManagerKind,
-        gui_domain, managed_service_identity, managed_service_label, register_managed_service,
-        service_backend_support_error, service_definition_dir, service_manager_kind,
-        systemd_output_mode_for_version, write_managed_service_definition,
+        ManagedServiceDefinition, ManagedServiceEnablement, ManagedServiceIdentity,
+        OCM_SERVICE_LABEL, ServiceManagerKind, gui_domain, managed_service_identity,
+        managed_service_label, restore_managed_service_registration, service_backend_support_error,
+        service_definition_dir, service_manager_kind, systemd_output_mode_for_version,
+        write_managed_service_definition,
     };
 
     #[test]
@@ -925,11 +1140,92 @@ mod tests {
             ),
         ]);
 
-        register_managed_service("ai.openclaw.ocm", Path::new("/unused"), &env).unwrap();
+        restore_managed_service_registration(
+            "ai.openclaw.ocm",
+            Path::new("/unused"),
+            false,
+            Some(ManagedServiceEnablement::Enabled),
+            &env,
+        )
+        .unwrap();
 
         assert_eq!(
             fs::read_to_string(&log).unwrap(),
             "--user daemon-reload\n--user enable ai.openclaw.ocm\n"
+        );
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restoring_stopped_launchd_service_keeps_it_loaded_without_running() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("ocm-platform-restore-launchd-{unique}"));
+        fs::create_dir_all(&root).unwrap();
+        let launchctl = root.join("launchctl");
+        let log = root.join("launchctl.log");
+        let state = root.join("launchctl-state.txt");
+        let definition = root.join("ai.openclaw.ocm.plist");
+        fs::write(
+            &launchctl,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\ncase \"$1\" in\n  bootout|unload) rm -f '{}';;\n  bootstrap) printf 'path = {}\\nstate = running\\npid = 42\\n' > '{}';;\n  kill) printf 'path = {}\\nstate = waiting\\n' > '{}';;\n  print) if [ -f '{}' ]; then cat '{}'; else printf 'Could not find service\\n' >&2; exit 1; fi;;\nesac\n",
+                display_path(&log),
+                display_path(&state),
+                display_path(&definition),
+                display_path(&state),
+                display_path(&definition),
+                display_path(&state),
+                display_path(&state),
+                display_path(&state),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&launchctl, fs::Permissions::from_mode(0o755)).unwrap();
+        let env = BTreeMap::from([
+            (
+                "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+                "launchd".to_string(),
+            ),
+            (
+                "OCM_INTERNAL_LAUNCHCTL_BIN".to_string(),
+                display_path(&launchctl),
+            ),
+        ]);
+
+        restore_managed_service_registration(
+            "ai.openclaw.ocm",
+            &definition,
+            false,
+            Some(ManagedServiceEnablement::Enabled),
+            &env,
+        )
+        .unwrap();
+
+        assert!(
+            fs::read_to_string(&state)
+                .unwrap()
+                .contains("state = waiting")
+        );
+        let commands = fs::read_to_string(&log).unwrap();
+        assert!(
+            commands
+                .lines()
+                .any(|line| line.starts_with("disable gui/"))
+        );
+        assert!(
+            commands
+                .lines()
+                .any(|line| line.starts_with("kill SIGTERM gui/"))
+        );
+        assert!(
+            commands
+                .lines()
+                .last()
+                .is_some_and(|line| line.starts_with("enable gui/"))
         );
         fs::remove_dir_all(&root).unwrap();
     }

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -229,7 +229,7 @@ pub(crate) fn write_managed_service_definition(
     ensure_service_definition_dir(parent)?;
     let lock_path = definition.definition_path.with_extension("lock");
     let _lock = lock_file(&lock_path, "managed service definition")?;
-    validate_existing_service_owner(definition, env)?;
+    validate_managed_service_owner(definition, env)?;
 
     let raw = match service_manager_kind(env) {
         ServiceManagerKind::Launchd => build_launch_agent_plist(
@@ -257,7 +257,7 @@ pub(crate) fn write_managed_service_definition(
     write_private_service_file(&definition.definition_path, raw.as_bytes())
 }
 
-fn validate_existing_service_owner(
+pub(crate) fn validate_managed_service_owner(
     definition: &ManagedServiceDefinition,
     env: &BTreeMap<String, String>,
 ) -> Result<(), String> {
@@ -296,6 +296,126 @@ fn validate_existing_service_owner(
     ))
 }
 
+pub(crate) fn deactivate_managed_service(
+    definition: &ManagedServiceDefinition,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let definition_path = &definition.definition_path;
+    let lock_path = definition_path.with_extension("lock");
+    let _lock = lock_file(&lock_path, "managed service definition")?;
+    validate_managed_service_owner(definition, env)?;
+    if !definition_path.exists() {
+        // A completed teardown removes the ownership marker. Repeated stop or
+        // uninstall calls must not probe or mutate an unowned manager unit.
+        return Ok(());
+    }
+    match service_manager_kind(env) {
+        ServiceManagerKind::Launchd => {
+            let domain = gui_domain(env)?;
+            deactivate_launchd_service(&definition.label, definition_path, &domain, env)?;
+        }
+        ServiceManagerKind::SystemdUser => {
+            let stop = run_systemctl(env, ["--user", "stop", definition.label.as_str()])?;
+            if !stop.status.success() {
+                return Err(format!(
+                    "systemctl --user stop failed: {}",
+                    systemctl_detail(&stop)
+                ));
+            }
+            let disable = run_systemctl(env, ["--user", "disable", definition.label.as_str()])?;
+            if !disable.status.success() {
+                return Err(format!(
+                    "systemctl --user disable failed: {}",
+                    systemctl_detail(&disable)
+                ));
+            }
+        }
+        ServiceManagerKind::Unsupported => {}
+    }
+
+    match fs::remove_file(definition_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "failed to remove managed service definition {}: {error}",
+                display_path(definition_path)
+            ));
+        }
+    }
+
+    if service_manager_kind(env) == ServiceManagerKind::SystemdUser {
+        let reload = run_systemctl(env, ["--user", "daemon-reload"])?;
+        if !reload.status.success() {
+            return Err(format!(
+                "systemctl --user daemon-reload failed: {}",
+                systemctl_detail(&reload)
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn deactivate_launchd_service(
+    label: &str,
+    definition_path: &Path,
+    domain: &str,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let target = format!("{domain}/{label}");
+    if !launchd_job_is_loaded(&target, env)? {
+        return Ok(());
+    }
+
+    let definition_path = display_path(definition_path);
+    let mut failures = Vec::new();
+    let output = run_launchctl(env, ["bootout", target.as_str()])?;
+    if !launchd_job_is_loaded(&target, env)? {
+        return Ok(());
+    }
+    failures.push(launchctl_detail(&output));
+    let output = run_launchctl(env, ["bootout", domain, definition_path.as_str()])?;
+    if !launchd_job_is_loaded(&target, env)? {
+        return Ok(());
+    }
+    failures.push(launchctl_detail(&output));
+    let output = run_launchctl(env, ["unload", definition_path.as_str()])?;
+    if !launchd_job_is_loaded(&target, env)? {
+        return Ok(());
+    }
+    failures.push(launchctl_detail(&output));
+
+    let details = failures
+        .into_iter()
+        .filter(|detail| !detail.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ");
+    Err(if details.is_empty() {
+        format!("launchctl failed to unload {target}")
+    } else {
+        format!("launchctl failed to unload {target}: {details}")
+    })
+}
+
+fn launchd_job_is_loaded(target: &str, env: &BTreeMap<String, String>) -> Result<bool, String> {
+    let output = run_launchctl(env, ["print", target])?;
+    if output.status.success() {
+        return Ok(true);
+    }
+    let detail = launchctl_detail(&output);
+    if detail
+        .to_ascii_lowercase()
+        .contains("could not find service")
+    {
+        return Ok(false);
+    }
+    Err(if detail.is_empty() {
+        format!("launchctl print failed for {target}")
+    } else {
+        format!("launchctl print failed for {target}: {detail}")
+    })
+}
+
 pub(crate) fn activate_managed_service(
     label: &str,
     definition_path: &Path,
@@ -304,6 +424,18 @@ pub(crate) fn activate_managed_service(
     match service_manager_kind(env) {
         ServiceManagerKind::Launchd => activate_launchd_service(label, definition_path, env),
         ServiceManagerKind::SystemdUser => activate_systemd_user_service(label, env),
+        ServiceManagerKind::Unsupported => Err(unsupported_service_manager_message().to_string()),
+    }
+}
+
+pub(crate) fn register_managed_service(
+    label: &str,
+    definition_path: &Path,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    match service_manager_kind(env) {
+        ServiceManagerKind::Launchd => activate_launchd_service(label, definition_path, env),
+        ServiceManagerKind::SystemdUser => register_systemd_user_service(label, env),
         ServiceManagerKind::Unsupported => Err(unsupported_service_manager_message().to_string()),
     }
 }
@@ -463,7 +595,7 @@ fn ensure_private_dir(path: &Path) -> Result<(), String> {
     set_mode(path, SERVICE_DIR_MODE)
 }
 
-fn ensure_service_definition_dir(path: &Path) -> Result<(), String> {
+pub(crate) fn ensure_service_definition_dir(path: &Path) -> Result<(), String> {
     let existed = path.exists();
     fs::create_dir_all(path).map_err(|error| error.to_string())?;
     if existed {
@@ -569,21 +701,7 @@ fn activate_systemd_user_service(
     label: &str,
     env: &BTreeMap<String, String>,
 ) -> Result<(), String> {
-    let reload = run_systemctl(env, ["--user", "daemon-reload"])?;
-    if !reload.status.success() {
-        return Err(format!(
-            "systemctl --user daemon-reload failed: {}",
-            systemctl_detail(&reload)
-        ));
-    }
-
-    let enable = run_systemctl(env, ["--user", "enable", label])?;
-    if !enable.status.success() {
-        return Err(format!(
-            "systemctl --user enable failed: {}",
-            systemctl_detail(&enable)
-        ));
-    }
+    register_systemd_user_service(label, env)?;
 
     let restart = run_systemctl(env, ["--user", "restart", label])?;
     if restart.status.success() {
@@ -599,6 +717,28 @@ fn activate_systemd_user_service(
         ));
     }
 
+    Ok(())
+}
+
+fn register_systemd_user_service(
+    label: &str,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let reload = run_systemctl(env, ["--user", "daemon-reload"])?;
+    if !reload.status.success() {
+        return Err(format!(
+            "systemctl --user daemon-reload failed: {}",
+            systemctl_detail(&reload)
+        ));
+    }
+
+    let enable = run_systemctl(env, ["--user", "enable", label])?;
+    if !enable.status.success() {
+        return Err(format!(
+            "systemctl --user enable failed: {}",
+            systemctl_detail(&enable)
+        ));
+    }
     Ok(())
 }
 
@@ -715,9 +855,9 @@ mod tests {
 
     use super::{
         ManagedServiceDefinition, ManagedServiceIdentity, OCM_SERVICE_LABEL, ServiceManagerKind,
-        gui_domain, managed_service_identity, managed_service_label, service_backend_support_error,
-        service_definition_dir, service_manager_kind, systemd_output_mode_for_version,
-        write_managed_service_definition,
+        gui_domain, managed_service_identity, managed_service_label, register_managed_service,
+        service_backend_support_error, service_definition_dir, service_manager_kind,
+        systemd_output_mode_for_version, write_managed_service_definition,
     };
 
     #[test]
@@ -752,6 +892,46 @@ mod tests {
             systemd_output_mode_for_version(None),
             super::SystemdOutputMode::Journal
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registering_systemd_service_does_not_start_it() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("ocm-platform-register-systemd-{unique}"));
+        fs::create_dir_all(&root).unwrap();
+        let systemctl = root.join("systemctl");
+        let log = root.join("systemctl.log");
+        fs::write(
+            &systemctl,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n",
+                display_path(&log)
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&systemctl, fs::Permissions::from_mode(0o755)).unwrap();
+        let env = BTreeMap::from([
+            (
+                "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+                "systemd-user".to_string(),
+            ),
+            (
+                "OCM_INTERNAL_SYSTEMCTL_BIN".to_string(),
+                display_path(&systemctl),
+            ),
+        ]);
+
+        register_managed_service("ai.openclaw.ocm", Path::new("/unused"), &env).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&log).unwrap(),
+            "--user daemon-reload\n--user enable ai.openclaw.ocm\n"
+        );
+        fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -20,11 +20,14 @@ pub(crate) use common::{
 };
 pub(crate) use envs::save_environment_with_validated_launcher;
 pub(crate) use envs::{EnvironmentOperationLock, lock_environment_operation};
+pub(crate) use envs::{
+    EnvironmentServicePolicyChange, restore_environment_service_policy,
+    set_environment_service_policy,
+};
 pub use envs::{
     clone_environment, create_environment, export_environment, get_environment, import_environment,
     list_environments, remove_environment, save_environment,
 };
-pub(crate) use envs::{restore_environment_service_policy, set_environment_service_policy};
 pub(crate) use gateway_ports::{
     openclaw_port_family_available, openclaw_port_family_range, resolve_config_gateway_port,
     resolve_effective_gateway_ports, resolve_env_gateway_port,

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -20,7 +20,9 @@ use crate::env::EnvironmentService;
 use crate::service::inspect::inspect_job;
 use crate::service::platform::{
     ManagedServiceDefinition, ServiceManagerKind, activate_managed_service,
-    managed_service_identity, service_manager_kind, write_managed_service_definition,
+    deactivate_managed_service, ensure_service_definition_dir, managed_service_identity,
+    register_managed_service, service_manager_kind, validate_managed_service_owner,
+    write_managed_service_definition,
 };
 use crate::store::{
     display_path, ensure_dir, ensure_store, list_environments, lock_file, now_utc,
@@ -323,16 +325,76 @@ impl<'a> SupervisorService<'a> {
     }
 
     pub fn install_daemon(&self) -> Result<SupervisorDaemonSummary, String> {
+        let _lifecycle_lock = self.lock_daemon_lifecycle()?;
         self.refresh_daemon("install")
     }
 
     pub fn ensure_daemon_running(&self) -> Result<SupervisorDaemonSummary, String> {
+        let _lifecycle_lock = self.lock_daemon_lifecycle()?;
+        self.ensure_daemon_running_locked()
+    }
+
+    pub(crate) fn ensure_daemon_running_locked(&self) -> Result<SupervisorDaemonSummary, String> {
+        let definition = self.supervisor_daemon_definition()?;
+        validate_managed_service_owner(&definition, self.env)?;
         let _ = self.sync()?;
         let status = self.daemon_status()?;
         if status.running {
             return Ok(status);
         }
         self.activate_daemon("install")
+    }
+
+    pub(crate) fn validate_daemon_owner_locked(&self) -> Result<(), String> {
+        let definition = self.supervisor_daemon_definition()?;
+        validate_managed_service_owner(&definition, self.env)
+    }
+
+    pub(crate) fn restore_daemon_state_locked(
+        &self,
+        before: &SupervisorDaemonSummary,
+    ) -> Result<(), String> {
+        if before.running {
+            self.ensure_daemon_running_locked()?;
+            return Ok(());
+        }
+        let definition = self.supervisor_daemon_definition()?;
+        deactivate_managed_service(&definition, self.env)?;
+        if before.installed {
+            write_managed_service_definition(&definition, self.env)?;
+            if before.loaded {
+                register_managed_service(&definition.label, &definition.definition_path, self.env)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn uninstall_daemon_locked(&self) -> Result<SupervisorDaemonSummary, String> {
+        let definition = self.supervisor_daemon_definition()?;
+        deactivate_managed_service(&definition, self.env)?;
+        self.daemon_summary("uninstall")
+    }
+
+    pub(crate) fn lock_daemon_lifecycle(&self) -> Result<crate::store::ExclusiveFileLock, String> {
+        let identity = managed_service_identity(self.env, self.cwd)?;
+        let definition_dir = identity.definition_path.parent().ok_or_else(|| {
+            format!(
+                "failed to resolve managed service directory for {}",
+                display_path(&identity.definition_path)
+            )
+        })?;
+        // Prepare and validate the manager-owned directory before placing the
+        // lifecycle lock in it; lock_file's generic parent creation has no
+        // service-directory permission contract.
+        ensure_service_definition_dir(definition_dir)?;
+        let lock_path = identity.definition_path.with_extension("lifecycle.lock");
+        lock_file(&lock_path, "managed service lifecycle")
+    }
+
+    pub(crate) fn has_desired_running_services(&self) -> Result<bool, String> {
+        Ok(list_environments(self.env, self.cwd)?
+            .iter()
+            .any(|meta| meta.service_enabled && meta.service_running))
     }
 
     pub fn recover_child_restart(&self, name: &str) -> Result<SupervisorDaemonSummary, String> {

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -19,10 +19,10 @@ use time::OffsetDateTime;
 use crate::env::EnvironmentService;
 use crate::service::inspect::inspect_job;
 use crate::service::platform::{
-    ManagedServiceDefinition, ServiceManagerKind, activate_managed_service,
-    deactivate_managed_service, ensure_service_definition_dir, managed_service_identity,
-    register_managed_service, service_manager_kind, validate_managed_service_owner,
-    write_managed_service_definition,
+    ManagedServiceDefinition, ManagedServiceEnablement, ServiceManagerKind,
+    activate_managed_service, deactivate_managed_service, ensure_service_definition_dir,
+    managed_service_enablement, managed_service_identity, restore_managed_service_registration,
+    service_manager_kind, validate_managed_service_owner, write_managed_service_definition,
 };
 use crate::store::{
     display_path, ensure_dir, ensure_store, list_environments, lock_file, now_utc,
@@ -138,6 +138,8 @@ pub struct SupervisorDaemonSummary {
     pub installed: bool,
     pub loaded: bool,
     pub running: bool,
+    #[serde(skip)]
+    pub(crate) enablement: Option<ManagedServiceEnablement>,
     pub pid: Option<u32>,
     pub state: Option<String>,
 }
@@ -354,16 +356,18 @@ impl<'a> SupervisorService<'a> {
         &self,
         before: &SupervisorDaemonSummary,
     ) -> Result<(), String> {
-        if before.running {
-            self.ensure_daemon_running_locked()?;
-            return Ok(());
-        }
         let definition = self.supervisor_daemon_definition()?;
         deactivate_managed_service(&definition, self.env)?;
         if before.installed {
             write_managed_service_definition(&definition, self.env)?;
             if before.loaded {
-                register_managed_service(&definition.label, &definition.definition_path, self.env)?;
+                restore_managed_service_registration(
+                    &definition.label,
+                    &definition.definition_path,
+                    before.running,
+                    before.enablement,
+                    self.env,
+                )?;
             }
         }
         Ok(())
@@ -579,6 +583,12 @@ impl<'a> SupervisorService<'a> {
         let stdout_path = logs_dir.join("daemon.stdout.log");
         let stderr_path = logs_dir.join("daemon.stderr.log");
         let status = inspect_job(&identity.label, &identity.definition_path, self.env);
+        let enablement =
+            if status.loaded && service_manager_kind(self.env) == ServiceManagerKind::Launchd {
+                managed_service_enablement(&identity.label, self.env)?
+            } else {
+                status.enablement
+            };
         let executable_path = self.supervisor_executable_path()?;
 
         Ok(SupervisorDaemonSummary {
@@ -593,6 +603,7 @@ impl<'a> SupervisorService<'a> {
             installed: status.installed,
             loaded: status.loaded,
             running: status.running,
+            enablement,
             pid: status.pid,
             state: status.state,
         })

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1482,7 +1482,11 @@ fn dev_watch_force_restores_runtime_service_when_source_watch_cannot_spawn() {
         ],
     );
     assert!(!watch.status.success());
-    assert!(stderr(&watch).contains("failed to run \"node\""));
+    assert!(
+        stderr(&watch).contains("failed to run \"node\""),
+        "{}",
+        stderr(&watch)
+    );
 
     let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
     assert!(show.status.success(), "{}", stderr(&show));

--- a/tests/env_destroy_tests.rs
+++ b/tests/env_destroy_tests.rs
@@ -26,7 +26,7 @@ fn install_fake_launchctl(root: &TestDir, env: &mut BTreeMap<String, String>) {
     fs::create_dir_all(&bin_dir).unwrap();
     let log_path = root.child("launchctl.log");
     let script = format!(
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$1\" in\n  print)\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$1\" in\n  print)\n    printf 'Could not find service\\n' >&2\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
         path_string(&log_path)
     );
     write_executable_script(&bin_dir.join("launchctl"), &script);
@@ -472,7 +472,7 @@ fn env_destroy_yes_uninstalls_service_removes_snapshots_and_deletes_env() {
     assert!(!show.status.success());
     assert!(stderr(&show).contains("environment \"demo\" does not exist"));
 
-    assert!(service_path.exists());
+    assert!(!service_path.exists());
     assert!(!root.child("ocm-home/snapshots/demo").exists());
 }
 

--- a/tests/service_command_tests.rs
+++ b/tests/service_command_tests.rs
@@ -6,7 +6,8 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
-use std::thread::sleep;
+use std::sync::{Arc, Barrier};
+use std::thread::{self, sleep};
 use std::time::Duration;
 
 use ocm::env::EnvironmentService;
@@ -254,6 +255,15 @@ fn service_install_enables_the_env_and_installs_the_ocm_service() {
         "missing {}",
         path_string(&service_path)
     );
+    #[cfg(unix)]
+    assert_eq!(
+        fs::metadata(service_path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
 }
 
 #[test]
@@ -444,6 +454,7 @@ fn service_stop_keeps_the_env_installed_but_stopped() {
     let env_body = json_output(&env_show);
     assert_eq!(env_body["serviceEnabled"], true);
     assert_eq!(env_body["serviceRunning"], false);
+    assert!(!managed_service_definition_path(&env, &cwd, "ocm").exists());
 }
 
 #[test]
@@ -485,6 +496,265 @@ fn service_uninstall_disables_the_env_service() {
     let env_body = json_output(&env_show);
     assert_eq!(env_body["serviceEnabled"], false);
     assert_eq!(env_body["serviceRunning"], false);
+    assert!(!managed_service_definition_path(&env, &cwd, "ocm").exists());
+}
+
+#[test]
+fn systemd_service_uninstall_is_idempotent_after_stop_removed_the_unit() {
+    let root = TestDir::new("service-systemd-stop-uninstall");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = systemd_env(&root);
+    setup_launcher_env(&cwd, &env);
+
+    let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    let stopped = run_ocm(&cwd, &env, &["service", "stop", "demo"]);
+    assert!(stopped.status.success(), "{}", stderr(&stopped));
+    assert!(!managed_service_definition_path(&env, &cwd, "ocm").exists());
+
+    write_executable_script(
+        &root.child("fake-bin/systemctl"),
+        "#!/bin/sh\nprintf 'unexpected systemctl call: %s\\n' \"$*\" >&2\nexit 1\n",
+    );
+    let uninstalled = run_ocm(&cwd, &env, &["service", "uninstall", "demo"]);
+    assert!(uninstalled.status.success(), "{}", stderr(&uninstalled));
+}
+
+#[test]
+fn service_stop_keeps_the_daemon_while_a_sibling_env_is_running() {
+    let root = TestDir::new("service-stop-running-sibling");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = launchd_env(&root);
+    setup_launcher_env(&cwd, &env);
+    let created = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "prod", "--launcher", "stable"],
+    );
+    assert!(created.status.success(), "{}", stderr(&created));
+
+    for name in ["demo", "prod"] {
+        let started = run_ocm(&cwd, &env, &["service", "start", name]);
+        assert!(started.status.success(), "{}", stderr(&started));
+    }
+
+    let stopped = run_ocm(&cwd, &env, &["service", "stop", "demo", "--json"]);
+    assert!(stopped.status.success(), "{}", stderr(&stopped));
+    assert!(managed_service_definition_path(&env, &cwd, "ocm").exists());
+}
+
+#[test]
+fn service_start_rejects_a_daemon_owned_by_another_store() {
+    let root = TestDir::new("service-start-other-store-owner");
+    let first_cwd = root.child("first-workspace");
+    fs::create_dir_all(&first_cwd).unwrap();
+    let first_env = launchd_env(&root);
+    setup_launcher_env(&first_cwd, &first_env);
+    let first_started = run_ocm(&first_cwd, &first_env, &["service", "start", "demo"]);
+    assert!(first_started.status.success(), "{}", stderr(&first_started));
+
+    let second_cwd = root.child("second-workspace");
+    fs::create_dir_all(&second_cwd).unwrap();
+    let mut second_env = first_env.clone();
+    second_env.insert(
+        "OCM_HOME".to_string(),
+        path_string(&root.child("second-ocm-home")),
+    );
+    setup_launcher_env(&second_cwd, &second_env);
+
+    let second_started = run_ocm(&second_cwd, &second_env, &["service", "start", "demo"]);
+    assert!(!second_started.status.success());
+    assert!(
+        stderr(&second_started).contains("already bound to a different OCM_HOME"),
+        "{}",
+        stderr(&second_started)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn failed_initial_service_start_releases_the_daemon_owner() {
+    let root = TestDir::new("service-start-initial-policy-failure");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = launchd_env(&root);
+    setup_launcher_env(&cwd, &env);
+
+    let ocm_home = Path::new(env.get("OCM_HOME").unwrap());
+    let registry_lock = ocm_home.join("envs.lock");
+    let mut permissions = fs::metadata(&registry_lock).unwrap().permissions();
+    permissions.set_mode(0o400);
+    fs::set_permissions(&registry_lock, permissions).unwrap();
+
+    let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+
+    let mut permissions = fs::metadata(&registry_lock).unwrap().permissions();
+    permissions.set_mode(0o600);
+    fs::set_permissions(&registry_lock, permissions).unwrap();
+    assert!(!started.status.success());
+    assert!(
+        stderr(&started).contains("failed to open environment registry lock"),
+        "{}",
+        stderr(&started)
+    );
+    assert!(!managed_service_definition_path(&env, &cwd, "ocm").exists());
+    assert!(!root.child("launchctl-print.txt").exists());
+
+    let second_cwd = root.child("second-workspace");
+    fs::create_dir_all(&second_cwd).unwrap();
+    let mut second_env = env.clone();
+    second_env.insert(
+        "OCM_HOME".to_string(),
+        path_string(&root.child("second-ocm-home")),
+    );
+    setup_launcher_env(&second_cwd, &second_env);
+    let second_started = run_ocm(&second_cwd, &second_env, &["service", "start", "demo"]);
+    assert!(
+        second_started.status.success(),
+        "{}",
+        stderr(&second_started)
+    );
+}
+
+#[test]
+fn concurrent_service_starts_allow_only_one_store_owner() {
+    let root = TestDir::new("service-start-concurrent-store-owners");
+    let first_cwd = root.child("first-workspace");
+    let second_cwd = root.child("second-workspace");
+    fs::create_dir_all(&first_cwd).unwrap();
+    fs::create_dir_all(&second_cwd).unwrap();
+
+    let first_env = launchd_env(&root);
+    setup_launcher_env(&first_cwd, &first_env);
+    let mut second_env = first_env.clone();
+    second_env.insert(
+        "OCM_HOME".to_string(),
+        path_string(&root.child("second-ocm-home")),
+    );
+    setup_launcher_env(&second_cwd, &second_env);
+
+    let barrier = Arc::new(Barrier::new(3));
+    let first_barrier = Arc::clone(&barrier);
+    let first = thread::spawn(move || {
+        first_barrier.wait();
+        run_ocm(&first_cwd, &first_env, &["service", "start", "demo"])
+    });
+    let second_barrier = Arc::clone(&barrier);
+    let second = thread::spawn(move || {
+        second_barrier.wait();
+        run_ocm(&second_cwd, &second_env, &["service", "start", "demo"])
+    });
+    barrier.wait();
+
+    let outputs = [first.join().unwrap(), second.join().unwrap()];
+    assert_eq!(
+        outputs
+            .iter()
+            .filter(|output| output.status.success())
+            .count(),
+        1
+    );
+    let rejected = outputs
+        .iter()
+        .find(|output| !output.status.success())
+        .unwrap();
+    assert!(
+        stderr(rejected).contains("already bound to a different OCM_HOME"),
+        "{}",
+        stderr(rejected)
+    );
+}
+
+#[test]
+fn service_stop_does_not_remove_a_daemon_owned_by_another_store() {
+    let root = TestDir::new("service-stop-other-store-owner");
+    let first_cwd = root.child("first-workspace");
+    fs::create_dir_all(&first_cwd).unwrap();
+    let first_env = launchd_env(&root);
+    setup_launcher_env(&first_cwd, &first_env);
+    let first_started = run_ocm(&first_cwd, &first_env, &["service", "start", "demo"]);
+    assert!(first_started.status.success(), "{}", stderr(&first_started));
+
+    let second_cwd = root.child("second-workspace");
+    fs::create_dir_all(&second_cwd).unwrap();
+    let mut second_env = first_env.clone();
+    second_env.insert(
+        "OCM_HOME".to_string(),
+        path_string(&root.child("second-ocm-home")),
+    );
+    setup_launcher_env(&second_cwd, &second_env);
+
+    let stopped = run_ocm(&second_cwd, &second_env, &["service", "stop", "demo"]);
+    assert!(!stopped.status.success());
+    assert!(
+        stderr(&stopped).contains("already bound to a different OCM_HOME"),
+        "{}",
+        stderr(&stopped)
+    );
+    assert!(managed_service_definition_path(&first_env, &first_cwd, "ocm").exists());
+}
+
+#[test]
+fn service_stop_preserves_the_daemon_when_launchctl_cannot_unload_it() {
+    let root = TestDir::new("service-stop-launchctl-unload-failure");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = launchd_env(&root);
+    setup_launcher_env(&cwd, &env);
+    let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+
+    let log_path = root.child("launchctl.log");
+    let print_path = root.child("launchctl-print.txt");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$1\" in\n  print)\n    /bin/cat \"{}\"\n    ;;\n  bootout|unload)\n    printf 'forced unload failure\\n' >&2\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
+        path_string(&log_path),
+        path_string(&print_path),
+    );
+    write_executable_script(&root.child("fake-bin/launchctl"), &script);
+
+    let stopped = run_ocm(&cwd, &env, &["service", "stop", "demo"]);
+    assert!(!stopped.status.success());
+    assert!(
+        stderr(&stopped).contains("launchctl failed to unload"),
+        "{}",
+        stderr(&stopped)
+    );
+    assert!(managed_service_definition_path(&env, &cwd, "ocm").exists());
+    let shown = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert_eq!(json_output(&shown)["serviceRunning"], true);
+}
+
+#[test]
+fn service_stop_preserves_the_daemon_when_launchctl_cannot_confirm_state() {
+    let root = TestDir::new("service-stop-launchctl-print-failure");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = launchd_env(&root);
+    setup_launcher_env(&cwd, &env);
+    let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+
+    let log_path = root.child("launchctl.log");
+    fs::write(&log_path, "").unwrap();
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [ \"$1\" = \"print\" ]; then\n  printf 'Operation not permitted\\n' >&2\n  exit 1\nfi\nprintf 'unexpected mutation\\n' >&2\nexit 1\n",
+        path_string(&log_path),
+    );
+    write_executable_script(&root.child("fake-bin/launchctl"), &script);
+
+    let stopped = run_ocm(&cwd, &env, &["service", "stop", "demo"]);
+    assert!(!stopped.status.success());
+    assert!(
+        stderr(&stopped).contains("launchctl print failed"),
+        "{}",
+        stderr(&stopped)
+    );
+    assert!(managed_service_definition_path(&env, &cwd, "ocm").exists());
+    let calls = fs::read_to_string(log_path).unwrap();
+    assert_eq!(calls.lines().next(), Some("print gui/501/ai.openclaw.ocm"));
 }
 
 #[test]

--- a/tests/service_command_tests.rs
+++ b/tests/service_command_tests.rs
@@ -754,7 +754,11 @@ fn service_stop_preserves_the_daemon_when_launchctl_cannot_confirm_state() {
     );
     assert!(managed_service_definition_path(&env, &cwd, "ocm").exists());
     let calls = fs::read_to_string(log_path).unwrap();
-    assert_eq!(calls.lines().next(), Some("print gui/501/ai.openclaw.ocm"));
+    assert!(
+        calls.lines().next().is_some_and(
+            |line| line.starts_with("print gui/") && line.ends_with("/ai.openclaw.ocm")
+        )
+    );
 }
 
 #[test]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -285,7 +285,7 @@ pub fn install_fake_launchctl(root: &TestDir, env: &mut BTreeMap<String, String>
     let log_path = root.child("launchctl.log");
     let print_path = root.child("launchctl-print.txt");
     let script = format!(
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$1\" in\n  bootstrap)\n    printf 'state = running\\npid = 23613\\n' > \"{}\"\n    exit 0\n    ;;\n  bootout|unload)\n    rm -f \"{}\"\n    exit 0\n    ;;\n  print)\n    if [ -f \"{}\" ]; then\n      /bin/cat \"{}\"\n      exit 0\n    fi\n    printf 'Could not find service \"%s\" in domain for user gui\\n' \"$2\" >&2\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$1\" in\n  bootstrap)\n    printf 'state = running\\npid = 23613\\n' > \"{}\"\n    exit 0\n    ;;\n  bootout|unload)\n    /bin/rm -f \"{}\"\n    exit 0\n    ;;\n  print)\n    if [ -f \"{}\" ]; then\n      /bin/cat \"{}\"\n      exit 0\n    fi\n    printf 'Could not find service \"%s\" in domain for user gui\\n' \"$2\" >&2\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
         path_string(&log_path),
         path_string(&print_path),
         path_string(&print_path),

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -285,7 +285,7 @@ pub fn install_fake_launchctl(root: &TestDir, env: &mut BTreeMap<String, String>
     let log_path = root.child("launchctl.log");
     let print_path = root.child("launchctl-print.txt");
     let script = format!(
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$1\" in\n  bootstrap)\n    printf 'state = running\\npid = 23613\\n' > \"{}\"\n    exit 0\n    ;;\n  bootout|unload)\n    rm -f \"{}\"\n    exit 0\n    ;;\n  print)\n    if [ -f \"{}\" ]; then\n      /bin/cat \"{}\"\n      exit 0\n    fi\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\ncase \"$1\" in\n  bootstrap)\n    printf 'state = running\\npid = 23613\\n' > \"{}\"\n    exit 0\n    ;;\n  bootout|unload)\n    rm -f \"{}\"\n    exit 0\n    ;;\n  print)\n    if [ -f \"{}\" ]; then\n      /bin/cat \"{}\"\n      exit 0\n    fi\n    printf 'Could not find service \"%s\" in domain for user gui\\n' \"$2\" >&2\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
         path_string(&log_path),
         path_string(&print_path),
         path_string(&print_path),


### PR DESCRIPTION
## What Problem This Solves

OCM stores share one OS daemon identity. Concurrent lifecycle commands could race ownership checks, and stopping the last environment could leave the shared definition installed. Failure rollback could also strand ownership after a partially completed first start.

## Why This Change Was Made

- serialize daemon ownership, policy mutation, synchronization, and teardown under one lifecycle lock
- validate the complete expected service definition before teardown
- remove the shared daemon after the last desired-running environment stops or is uninstalled
- restore the prior installed, registered, and running daemon state on failures
- make launchd teardown confirm each unload attempt and keep systemd stop/uninstall idempotent

## User Impact

Multiple OCM stores can no longer steal or strand the shared daemon binding. Repeated stop/uninstall remains safe, foreign-owned definitions are preserved, and failed first starts release ownership for another store.

## Evidence

- `cargo fmt --all`
- `cargo test --test service_command_tests` (35 passed)
- `cargo test service::platform --lib` (18 passed)
- high-thinking `gpt-5.6-sol` autoreview: clean
