### PR TITLE
fix(runtime): avoid local dependency reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to OCM are documented here.
 
 ### Fixed
 
+- Prevent `runtime build-local` from reconciling or replacing an OpenClaw checkout's dependencies while running its package build.
 - Reject an already-running shared OCM daemon when its service definition belongs to another `OCM_HOME`, and remove the shared service binding after the last running environment stops or is uninstalled.
 - Reuse an identical healthy official runtime when concurrent installers publish it first instead of failing the waiting command.
 - Match environment-owned processes by path components so destroy never targets sibling-prefix directories.

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -484,6 +484,7 @@ fn pack_local_openclaw_repo(
         .env("npm_config_fund", "false")
         .env("npm_config_audit", "false")
         .env("npm_config_update_notifier", "false")
+        .env("PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN", "false")
         .current_dir(repo_path)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -111,6 +111,7 @@ if [ "$1" = "--version" ]; then
 fi
 
 if [ "$1" = "pack" ]; then
+  printf 'verify-deps-before-run=%s\n' "$PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN" >> "{}"
   shift
   destination=""
   while [ "$#" -gt 0 ]; do
@@ -165,6 +166,7 @@ if grep -q '"chokidar"' "$prefix/node_modules/openclaw/package.json"; then
   printf '{{"name":"@scope/tool","version":"1.0.0"}}\n' > "$prefix/node_modules/@scope/tool/package.json"
 fi
 "#,
+        path_string(&log_path),
         path_string(&log_path),
         path_string(archive_path),
     );
@@ -405,6 +407,7 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
 
     let npm_log = fs::read_to_string(npm_log).unwrap();
     assert!(npm_log.contains("pack --pack-destination"));
+    assert!(npm_log.contains("verify-deps-before-run=false"));
     assert!(npm_log.contains("install --prefix"));
 
     let install_root = runtime_install_root("main-local", &env, &cwd).unwrap();


### PR DESCRIPTION
## What Problem This Solves

`ocm runtime build-local` runs OpenClaw's release-style `npm pack` flow in the selected checkout. In linked worktrees with shared `node_modules`, pnpm's pre-run dependency verification can interpret worktree-relative patch paths as a dependency-layout change and try to purge or reinstall the shared dependency tree. That makes the build fail without a TTY and risks mutating a checkout OCM does not own.

## Why This Change Was Made

Set `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false` only for the `npm pack` subprocess. OpenClaw's actual build still runs and still fails on missing or unusable dependencies, but pnpm no longer performs an implicit dependency reconciliation before the package scripts execute.

## User Impact

Local release-shaped runtime builds now work from linked OpenClaw worktrees without replacing shared dependencies.

## Evidence

- reproduced through Kova + OCM `channel-model-turn-baseline` against an OpenClaw gwt
- `cargo fmt --check`
- `cargo test --test runtime_command_tests`: 36 passed
- `cargo build --release`
- fresh `gpt-5.6-sol` high autoreview: clean, 0.93