### PR TITLE
fix(runtime): package local workspace dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to OCM are documented here.
 
 ### Fixed
 
+- Let `runtime build-local` package unreleased OpenClaw `main` checkouts with local workspace dependencies through the repo-provided npm adapter, and report the failing command tail instead of early build chatter.
 - Prevent `runtime build-local` from reconciling or replacing an OpenClaw checkout's dependencies while running its package build.
 - Reject an already-running shared OCM daemon when its service definition belongs to another `OCM_HOME`, and remove the shared service binding after the last running environment stops or is uninstalled.
 - Reuse an identical healthy official runtime when concurrent installers publish it first instead of failing the waiting command.

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -10,7 +11,7 @@ use crate::infra::download::{
     artifact_file_name_from_url, download_to_file, file_sha256, normalize_file_integrity,
     normalize_sha256, verify_file_integrity, verify_file_sha256,
 };
-use crate::managed_node::managed_runtime_install_command;
+use crate::managed_node::{CommandSpec, managed_runtime_install_command};
 use crate::runtime::releases::{
     OpenClawRelease, load_official_openclaw_release_selection, load_release_manifest,
     normalize_openclaw_channel_selector, official_openclaw_releases_url,
@@ -328,11 +329,11 @@ fn summarize_command_output(stdout: &[u8], stderr: &[u8]) -> Option<String> {
             .filter(|line| !line.is_empty())
             .filter(|line| !line.starts_with("npm notice"))
             .filter(|line| !line.starts_with("npm warn"))
-            .take(12)
             .map(ToOwned::to_owned)
             .collect::<Vec<_>>();
         if !meaningful.is_empty() {
-            return Some(meaningful.join("\n"));
+            let start = meaningful.len().saturating_sub(12);
+            return Some(meaningful[start..].join("\n"));
         }
         fallback.extend(
             text.lines()
@@ -346,11 +347,191 @@ fn summarize_command_output(stdout: &[u8], stderr: &[u8]) -> Option<String> {
 }
 
 fn npm_program(env: &BTreeMap<String, String>) -> String {
+    configured_npm_program(env).unwrap_or_else(|| "npm".to_string())
+}
+
+fn configured_npm_program(env: &BTreeMap<String, String>) -> Option<String> {
     env.get("OCM_INTERNAL_NPM_BIN")
         .map(String::as_str)
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or("npm")
-        .to_string()
+        .map(str::to_string)
+}
+
+#[derive(Clone, Debug)]
+struct LocalBuildNpmAdapter {
+    command: CommandSpec,
+    real_npm: String,
+    workspace_dependency_dirs: Option<OsString>,
+}
+
+impl LocalBuildNpmAdapter {
+    fn apply_environment(&self, command: &mut Command) {
+        command.env("OPENCLAW_OCM_REAL_NPM_BIN", &self.real_npm);
+        if let Some(workspace_dependency_dirs) = &self.workspace_dependency_dirs {
+            command.env(
+                "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS",
+                workspace_dependency_dirs,
+            );
+        }
+    }
+}
+
+fn local_workspace_package_dirs(repo_path: &Path) -> Result<Vec<PathBuf>, String> {
+    let workspace_path = repo_path.join("pnpm-workspace.yaml");
+    let raw = fs::read_to_string(&workspace_path).map_err(|error| {
+        format!(
+            "failed to read OpenClaw workspace manifest at {}: {error}",
+            display_path(&workspace_path)
+        )
+    })?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&raw).map_err(|error| {
+        format!(
+            "failed to parse OpenClaw workspace manifest at {}: {error}",
+            display_path(&workspace_path)
+        )
+    })?;
+    let patterns = value
+        .get("packages")
+        .and_then(serde_yaml::Value::as_sequence)
+        .ok_or_else(|| "OpenClaw pnpm-workspace.yaml is missing a packages list".to_string())?;
+
+    let mut dirs = Vec::new();
+    for pattern in patterns {
+        let Some(pattern) = pattern.as_str() else {
+            continue;
+        };
+        if pattern == "." {
+            dirs.push(repo_path.to_path_buf());
+            continue;
+        }
+        if let Some(parent) = pattern.strip_suffix("/*")
+            && !parent.contains(['*', '?', '['])
+        {
+            let parent_path = repo_path.join(parent);
+            if !parent_path.is_dir() {
+                continue;
+            }
+            let entries = fs::read_dir(&parent_path).map_err(|error| {
+                format!(
+                    "failed to read OpenClaw workspace directory at {}: {error}",
+                    display_path(&parent_path)
+                )
+            })?;
+            dirs.extend(
+                entries
+                    .filter_map(Result::ok)
+                    .map(|entry| entry.path())
+                    .filter(|path| path.is_dir()),
+            );
+            continue;
+        }
+        if !pattern.contains(['*', '?', '[']) {
+            let path = repo_path.join(pattern);
+            if path.is_dir() {
+                dirs.push(path);
+            }
+        }
+    }
+    Ok(dirs)
+}
+
+fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>, String> {
+    let package_json_path = repo_path.join("package.json");
+    let raw = fs::read_to_string(&package_json_path).map_err(|error| {
+        format!(
+            "failed to read OpenClaw package.json at {}: {error}",
+            display_path(&package_json_path)
+        )
+    })?;
+    let value: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
+        format!(
+            "failed to parse OpenClaw package.json at {}: {error}",
+            display_path(&package_json_path)
+        )
+    })?;
+
+    let mut names = Vec::new();
+    for section in [
+        "dependencies",
+        "optionalDependencies",
+        "peerDependencies",
+        "devDependencies",
+    ] {
+        let Some(dependencies) = value.get(section).and_then(serde_json::Value::as_object) else {
+            continue;
+        };
+        for (name, spec) in dependencies {
+            if spec
+                .as_str()
+                .is_some_and(|value| value.starts_with("workspace:"))
+            {
+                names.push(name.clone());
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    if names.is_empty() {
+        return Ok(None);
+    }
+
+    let mut packages = BTreeMap::new();
+    for package_dir in local_workspace_package_dirs(repo_path)? {
+        let package_json_path = package_dir.join("package.json");
+        let Ok(package_raw) = fs::read_to_string(&package_json_path) else {
+            continue;
+        };
+        let package_value: serde_json::Value =
+            serde_json::from_str(&package_raw).map_err(|error| {
+                format!(
+                    "failed to parse workspace dependency package.json at {}: {error}",
+                    display_path(&package_json_path)
+                )
+            })?;
+        if let Some(name) = package_value
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+        {
+            packages.insert(name.to_string(), package_dir);
+        }
+    }
+
+    let dirs = names
+        .into_iter()
+        .map(|name| {
+            packages.remove(&name).ok_or_else(|| {
+                format!(
+                    "OpenClaw workspace dependency \"{name}\" is not declared by pnpm-workspace.yaml"
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    std::env::join_paths(dirs)
+        .map(Some)
+        .map_err(|error| format!("failed to encode OpenClaw workspace dependency paths: {error}"))
+}
+
+fn local_build_npm_adapter(
+    repo_path: &Path,
+    env: &BTreeMap<String, String>,
+) -> Result<Option<LocalBuildNpmAdapter>, String> {
+    if configured_npm_program(env).is_some() {
+        return Ok(None);
+    }
+
+    let adapter_path = repo_path.join("scripts/ocm-npm-workspace-deps.mjs");
+    if !adapter_path.is_file() {
+        return Ok(None);
+    }
+
+    Ok(Some(LocalBuildNpmAdapter {
+        command: CommandSpec {
+            program: "node".to_string(),
+            args: vec![display_path(&adapter_path)],
+        },
+        real_npm: "npm".to_string(),
+        workspace_dependency_dirs: local_workspace_dependency_dirs(repo_path)?,
+    }))
 }
 
 fn install_openclaw_package_with_npm(
@@ -358,10 +539,13 @@ fn install_openclaw_package_with_npm(
     install_files: &Path,
     cwd: &Path,
     env: &BTreeMap<String, String>,
+    local_adapter: Option<&LocalBuildNpmAdapter>,
 ) -> Result<(), String> {
     let host_ready = verify_official_openclaw_runtime_host(env).is_ok();
-    let install_command = if host_ready {
-        crate::managed_node::CommandSpec {
+    let install_command = if let Some(local_adapter) = local_adapter {
+        local_adapter.command.clone()
+    } else if host_ready {
+        CommandSpec {
             program: npm_program(env),
             args: Vec::new(),
         }
@@ -369,7 +553,8 @@ fn install_openclaw_package_with_npm(
         managed_runtime_install_command(env, cwd)?
     };
 
-    let output = Command::new(&install_command.program)
+    let mut command = Command::new(&install_command.program);
+    command
         .args(&install_command.args)
         .arg("install")
         .arg("--prefix")
@@ -383,14 +568,16 @@ fn install_openclaw_package_with_npm(
         .env("npm_config_update_notifier", "false")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .map_err(|error| {
-            format!(
-                "failed to run {} while installing the OpenClaw package: {error}",
-                install_command.program
-            )
-        })?;
+        .stderr(Stdio::piped());
+    if let Some(local_adapter) = local_adapter {
+        local_adapter.apply_environment(&mut command);
+    }
+    let output = command.output().map_err(|error| {
+        format!(
+            "failed to run {} while installing the OpenClaw package: {error}",
+            install_command.program
+        )
+    })?;
 
     if output.status.success() {
         return Ok(());
@@ -473,10 +660,18 @@ fn pack_local_openclaw_repo(
     repo_path: &Path,
     pack_dir: &Path,
     env: &BTreeMap<String, String>,
+    local_adapter: Option<&LocalBuildNpmAdapter>,
 ) -> Result<PathBuf, String> {
     ensure_dir(pack_dir)?;
-    let npm = npm_program(env);
-    let output = Command::new(&npm)
+    let npm = local_adapter
+        .map(|adapter| adapter.command.clone())
+        .unwrap_or_else(|| CommandSpec {
+            program: npm_program(env),
+            args: Vec::new(),
+        });
+    let mut command = Command::new(&npm.program);
+    command
+        .args(&npm.args)
         .arg("pack")
         .arg("--pack-destination")
         .arg(pack_dir)
@@ -485,17 +680,20 @@ fn pack_local_openclaw_repo(
         .env("npm_config_audit", "false")
         .env("npm_config_update_notifier", "false")
         .env("PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN", "false")
+        .env("OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG", "1")
         .current_dir(repo_path)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .map_err(|error| {
-            format!(
-                "failed to run npm pack for local OpenClaw build in {}: {error}",
-                display_path(repo_path)
-            )
-        })?;
+        .stderr(Stdio::piped());
+    if let Some(local_adapter) = local_adapter {
+        local_adapter.apply_environment(&mut command);
+    }
+    let output = command.output().map_err(|error| {
+        format!(
+            "failed to run npm pack for local OpenClaw build in {}: {error}",
+            display_path(repo_path)
+        )
+    })?;
 
     if !output.status.success() {
         let detail =
@@ -742,6 +940,7 @@ fn install_runtime_from_openclaw_package(
             release,
             description,
             context,
+            None,
         );
         let _ = fs::remove_file(&archive_path);
         publish_runtime(target, meta?)
@@ -755,12 +954,14 @@ fn stage_runtime_from_openclaw_package_archive(
     release: RuntimeReleaseDetails,
     description: Option<String>,
     context: InstallContext<'_>,
+    local_adapter: Option<&LocalBuildNpmAdapter>,
 ) -> Result<RuntimeMeta, String> {
     install_openclaw_package_with_npm(
         archive_path,
         &target.install_files,
         context.cwd,
         context.env,
+        local_adapter,
     )?;
     expose_openclaw_package_runtime_dependencies(&target.install_files)?;
 
@@ -1089,7 +1290,9 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
     let _ = fs::remove_dir_all(&pack_dir);
 
     let result = (|| {
-        let archive_path = pack_local_openclaw_repo(&repo_path, &pack_dir, context.env)?;
+        let local_adapter = local_build_npm_adapter(&repo_path, context.env)?;
+        let archive_path =
+            pack_local_openclaw_repo(&repo_path, &pack_dir, context.env, local_adapter.as_ref())?;
         let target = prepare_runtime_install_target(name, options.force, context.env, context.cwd)?;
         if path_exists(&target.install_root) {
             return Err(format!(
@@ -1113,6 +1316,7 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
             },
             description,
             context,
+            local_adapter.as_ref(),
         )?;
         publish_runtime(target, meta)
     })();
@@ -1370,5 +1574,31 @@ npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMExcep
         let summary = summarize_command_output(b"", stderr).unwrap();
 
         assert!(summary.contains("deprecated node-domexception"));
+    }
+
+    #[test]
+    fn command_summary_keeps_the_failure_tail() {
+        let stderr = br#"
+phase 01
+phase 02
+phase 03
+phase 04
+phase 05
+phase 06
+phase 07
+phase 08
+phase 09
+phase 10
+phase 11
+phase 12
+phase 13
+Error: CHANGELOG.md does not contain a release section
+"#;
+
+        let summary = summarize_command_output(b"", stderr).unwrap();
+
+        assert!(!summary.contains("phase 01"));
+        assert!(summary.contains("phase 03"));
+        assert!(summary.contains("Error: CHANGELOG.md does not contain a release section"));
     }
 }

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -100,7 +100,7 @@ fn install_fake_node_and_packing_npm(
     let log_path = root.child("fake-pack-npm.log");
     write_executable_script(
         &bin_dir.join("node"),
-        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'v22.14.0\\n'\n  exit 0\nfi\nprintf 'fake node\\n'\n",
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'v22.14.0\\n'\n  exit 0\nfi\nif [ \"$(basename \"$1\")\" = \"ocm-npm-workspace-deps.mjs\" ]; then\n  script=\"$1\"\n  shift\n  exec \"$script\" \"$@\"\nfi\nprintf 'fake node\\n'\n",
     );
     let npm_script = format!(
         r#"#!/bin/sh
@@ -112,6 +112,7 @@ fi
 
 if [ "$1" = "pack" ]; then
   printf 'verify-deps-before-run=%s\n' "$PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN" >> "{}"
+  printf 'allow-unreleased-changelog=%s\n' "$OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG" >> "{}"
   shift
   destination=""
   while [ "$#" -gt 0 ]; do
@@ -166,6 +167,7 @@ if grep -q '"chokidar"' "$prefix/node_modules/openclaw/package.json"; then
   printf '{{"name":"@scope/tool","version":"1.0.0"}}\n' > "$prefix/node_modules/@scope/tool/package.json"
 fi
 "#,
+        path_string(&log_path),
         path_string(&log_path),
         path_string(&log_path),
         path_string(archive_path),
@@ -408,6 +410,7 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
     let npm_log = fs::read_to_string(npm_log).unwrap();
     assert!(npm_log.contains("pack --pack-destination"));
     assert!(npm_log.contains("verify-deps-before-run=false"));
+    assert!(npm_log.contains("allow-unreleased-changelog=1"));
     assert!(npm_log.contains("install --prefix"));
 
     let install_root = runtime_install_root("main-local", &env, &cwd).unwrap();
@@ -433,6 +436,82 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
 
     let verify = run_ocm(&cwd, &env, &["runtime", "verify", "main-local", "--raw"]);
     assert!(verify.status.success(), "{}", stderr(&verify));
+}
+
+#[test]
+fn runtime_build_local_uses_repo_workspace_dependency_adapter() {
+    let root = TestDir::new("runtime-build-local-workspace-adapter");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    let workspace_dependency = repo.join("packages/ai");
+    fs::create_dir_all(repo.join("scripts")).unwrap();
+    fs::create_dir_all(&workspace_dependency).unwrap();
+    fs::write(
+        repo.join("pnpm-workspace.yaml"),
+        "packages:\n  - .\n  - packages/*\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.4.25","bin":{"openclaw":"openclaw.mjs"},"dependencies":{"@openclaw/ai":"workspace:*"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        workspace_dependency.join("package.json"),
+        br#"{"name":"@openclaw/ai","version":"2026.4.25"}"#,
+    )
+    .unwrap();
+
+    let adapter_log = root.child("workspace-adapter.log");
+    write_executable_script(
+        &repo.join("scripts/ocm-npm-workspace-deps.mjs"),
+        &format!(
+            r#"#!/bin/sh
+printf 'args=%s\n' "$*" >> "{}"
+printf 'real-npm=%s\n' "$OPENCLAW_OCM_REAL_NPM_BIN" >> "{}"
+printf 'workspace-dirs=%s\n' "$OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS" >> "{}"
+exec "$OPENCLAW_OCM_REAL_NPM_BIN" "$@"
+"#,
+            path_string(&adapter_log),
+            path_string(&adapter_log),
+            path_string(&adapter_log),
+        ),
+    );
+
+    let archive_path = root.child("packed-openclaw.tgz");
+    fs::write(
+        &archive_path,
+        openclaw_package_tarball_with_version(
+            "#!/usr/bin/env node\nconsole.log('local workspace package runtime');\n",
+            "2026.4.25",
+        ),
+    )
+    .unwrap();
+
+    let mut env = ocm_env(&root);
+    install_fake_node_and_packing_npm(&root, &mut env, &archive_path);
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "main-workspace",
+            "--repo",
+            "./openclaw",
+            "--raw",
+        ],
+    );
+
+    assert!(build.status.success(), "{}", stderr(&build));
+    let adapter_log = fs::read_to_string(adapter_log).unwrap();
+    assert!(adapter_log.contains("args=pack --pack-destination"));
+    assert!(adapter_log.contains("args=install --prefix"));
+    assert!(adapter_log.contains("real-npm=npm"));
+    assert!(adapter_log.contains(&format!(
+        "workspace-dirs={}",
+        path_string(&fs::canonicalize(workspace_dependency).unwrap())
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## What Problem This Solves

`ocm runtime build-local` could not build current OpenClaw `main`. The package preflight rejected the unreleased changelog, and after that was bypassed, npm rejected the packed root because it still referenced unpublished `workspace:*` dependencies.

## Why This Change Was Made

OpenClaw already owns a repository-local npm adapter for release-shaped OCM builds. OCM now detects that adapter for local builds, resolves the root package's workspace dependencies from `pnpm-workspace.yaml`, and passes the adapter contract to both pack and install. Older checkouts and explicit npm wrappers retain the existing plain-npm path.

Command failure summaries also retain the final meaningful lines so the actual build error is visible instead of early build chatter.

## User Impact

OCM can build and install an exact package-shaped runtime from current OpenClaw `main`, including local workspace packages, without modifying or reconciling the source checkout.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test --locked`: full suite passed
- focused build-local adapter and legacy npm-path tests passed
- release build completed
- exact OpenClaw `main` commit `cca22d93f65a3e2e62b6b35e75a556665ae0e814` built successfully as runtime `2026.7.2`
- `ocm runtime verify` reported the installed runtime healthy
- `gpt-5.6-sol` / high autoreview: clean, confidence 0.80
