### PR TITLE
docs: prepare 0.2.28 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to OCM are documented here.
 
 ## Unreleased
 
+## 0.2.28 - 2026-07-16
+
 ### Fixed
 
 - Run directly supervised gateways through OpenClaw's external restart-handoff contract, keep wrapper-backed and legacy runtimes in no-respawn compatibility mode, and prevent child commands from inheriting the shared OCM service identity.


### PR DESCRIPTION
## Summary

- move the current unreleased fixes into the `0.2.28` changelog section
- date the release record July 16, 2026
- leave `Unreleased` ready for subsequent changes

## Verification

- `git diff --check`
- verified the changelog contains exactly one `0.2.28 - 2026-07-16` heading
