### PR TITLE
fix: preserve configured OpenClaw workspaces

### DIFF
--- a/src/env/health.rs
+++ b/src/env/health.rs
@@ -71,7 +71,7 @@ impl<'a> EnvironmentService<'a> {
     pub fn cleanup_preview(&self, name: &str) -> Result<EnvCleanupSummary, String> {
         let env = self.get(name)?;
         let config_audit = audit_openclaw_config(&env, &self.list()?);
-        let state_audit = audit_openclaw_state(&env, &self.list()?);
+        let state_audit = audit_openclaw_state(&env, &self.list()?, self.env);
         let doctor = self.doctor(name)?;
         let actions = cleanup_actions(&env, &doctor, &config_audit, &state_audit);
         Ok(build_cleanup_summary(&env, doctor, false, actions, None))
@@ -81,7 +81,7 @@ impl<'a> EnvironmentService<'a> {
         let _operation_lock = self.lock_operation(name)?;
         let mut env = self.get(name)?;
         let config_audit = audit_openclaw_config(&env, &self.list()?);
-        let state_audit = audit_openclaw_state(&env, &self.list()?);
+        let state_audit = audit_openclaw_state(&env, &self.list()?, self.env);
         let doctor_before = self.doctor(name)?;
         let actions = cleanup_actions(&env, &doctor_before, &config_audit, &state_audit);
 
@@ -98,7 +98,7 @@ impl<'a> EnvironmentService<'a> {
                     repair_openclaw_config(&env, &known_envs)?;
                 }
                 "reset-openclaw-runtime-state" => {
-                    repair_openclaw_runtime_state(&env)?;
+                    repair_openclaw_runtime_state(&env, self.env)?;
                 }
                 _ => {}
             }
@@ -157,7 +157,7 @@ impl<'a> EnvironmentService<'a> {
             push_issue(&mut issues, issue.clone());
         }
         let config_status = config_audit.status.clone();
-        let state_audit = audit_openclaw_state(&env, &known_envs);
+        let state_audit = audit_openclaw_state(&env, &known_envs, self.env);
         for issue in &state_audit.issues {
             push_issue(&mut issues, issue.clone());
         }

--- a/src/infra/archive.rs
+++ b/src/infra/archive.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs::{self, File};
 use std::io::{self, Cursor};
 use std::path::{Path, PathBuf};
@@ -83,16 +84,29 @@ pub enum EnvArchiveEntryKind {
     Other,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct EnvArchiveOptions {
     pub should_skip_path: fn(&Path, EnvArchiveEntryKind) -> bool,
+    pub included_path_roots: BTreeSet<PathBuf>,
 }
 
 impl Default for EnvArchiveOptions {
     fn default() -> Self {
         Self {
             should_skip_path: include_env_archive_path,
+            included_path_roots: BTreeSet::new(),
         }
+    }
+}
+
+impl EnvArchiveOptions {
+    fn should_skip(&self, relative_path: &Path, kind: EnvArchiveEntryKind) -> bool {
+        let explicitly_included = self.included_path_roots.iter().any(|root| {
+            relative_path == root
+                || relative_path.starts_with(root)
+                || root.starts_with(relative_path)
+        });
+        !explicitly_included && (self.should_skip_path)(relative_path, kind)
     }
 }
 
@@ -120,7 +134,7 @@ pub fn write_env_archive_with_options<T: Serialize>(
     options: EnvArchiveOptions,
 ) -> Result<(), String> {
     for attempt in 0..MAX_ENV_ARCHIVE_WRITE_ATTEMPTS {
-        match write_env_archive_attempt(metadata, source_root, output_path, options) {
+        match write_env_archive_attempt(metadata, source_root, output_path, options.clone()) {
             Ok(()) => return Ok(()),
             Err(EnvArchiveWriteError::EntryDisappeared(_))
                 if attempt + 1 < MAX_ENV_ARCHIVE_WRITE_ATTEMPTS => {}
@@ -160,7 +174,7 @@ fn write_env_archive_attempt<T: Serialize>(
             Cursor::new(metadata_bytes),
         )
         .map_err(|error| EnvArchiveWriteError::Fatal(error.to_string()))?;
-    append_env_root(&mut builder, source_root, options)?;
+    append_env_root(&mut builder, source_root, &options)?;
     builder
         .finish()
         .map_err(|error| EnvArchiveWriteError::Fatal(error.to_string()))
@@ -169,7 +183,7 @@ fn write_env_archive_attempt<T: Serialize>(
 fn append_env_root(
     builder: &mut Builder<File>,
     source_root: &Path,
-    options: EnvArchiveOptions,
+    options: &EnvArchiveOptions,
 ) -> Result<(), EnvArchiveWriteError> {
     builder
         .append_dir(ENV_ARCHIVE_ROOT_DIR, source_root)
@@ -196,7 +210,7 @@ fn append_env_root(
             ))
         })?;
         let entry_kind = env_archive_entry_kind(&metadata);
-        if (options.should_skip_path)(relative_path, entry_kind) {
+        if options.should_skip(relative_path, entry_kind) {
             continue;
         }
 
@@ -346,6 +360,7 @@ pub fn extract_zip(archive_path: &Path, destination_dir: &Path) -> Result<(), St
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::path::{Path, PathBuf};
     use std::sync::{
         Mutex,
@@ -385,6 +400,34 @@ mod tests {
         false
     }
 
+    fn skip_openclaw_paths(relative_path: &Path, _kind: EnvArchiveEntryKind) -> bool {
+        relative_path.starts_with(".openclaw")
+    }
+
+    #[test]
+    fn archive_options_include_only_the_selected_path_branch() {
+        let options = EnvArchiveOptions {
+            should_skip_path: skip_openclaw_paths,
+            included_path_roots: BTreeSet::from([PathBuf::from(".openclaw/team/ops")]),
+        };
+
+        for path in [
+            ".openclaw",
+            ".openclaw/team",
+            ".openclaw/team/ops",
+            ".openclaw/team/ops/notes.md",
+        ] {
+            assert!(
+                !options.should_skip(Path::new(path), EnvArchiveEntryKind::File),
+                "{path} should be traversed"
+            );
+        }
+        assert!(options.should_skip(
+            Path::new(".openclaw/team/cache"),
+            EnvArchiveEntryKind::Directory
+        ));
+    }
+
     #[test]
     fn env_archive_retries_when_entry_disappears_before_archive_insertion() {
         let _test_guard = DISAPPEARING_TEST_LOCK.lock().unwrap();
@@ -403,6 +446,7 @@ mod tests {
             &archive_path,
             EnvArchiveOptions {
                 should_skip_path: remove_configured_path_before_archive,
+                ..EnvArchiveOptions::default()
             },
         )
         .unwrap();
@@ -440,6 +484,7 @@ mod tests {
             &archive_path,
             EnvArchiveOptions {
                 should_skip_path: remove_configured_path_before_archive,
+                ..EnvArchiveOptions::default()
             },
         )
         .unwrap_err();

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -10,7 +10,8 @@ use crate::launcher::{AddLauncherOptions, LauncherService};
 use crate::store::{
     copy_dir_recursive, default_env_root, derive_env_paths, display_path, list_environments,
     normalize_new_environment_sandbox_origin, prepare_migrated_runtime_state,
-    reject_include_owned_sandbox_origin, resolve_user_home, rewrite_openclaw_config_for_migration,
+    reject_include_owned_agent_workspaces, reject_include_owned_sandbox_origin,
+    resolve_plain_openclaw_workspaces, resolve_user_home, rewrite_openclaw_config_for_migration,
     validate_name,
 };
 
@@ -149,6 +150,7 @@ fn migrate_plain_openclaw_home_inner(
         ));
     }
     reject_include_owned_sandbox_origin(&source_home.join("openclaw.json"))?;
+    reject_include_owned_agent_workspaces(&source_home.join("openclaw.json"))?;
     let target_root = resolve_migration_target_root(options.root.as_deref(), &env_name, env, cwd)?;
     let target_root_string = target_root
         .to_str()
@@ -160,6 +162,14 @@ fn migrate_plain_openclaw_home_inner(
         })?
         .to_string();
     reject_overlapping_migration_paths(&source_home, &target_root)?;
+    let workspace_source_home = fs::canonicalize(&source_home).map_err(|error| {
+        format!(
+            "failed to resolve plain OpenClaw home {}: {error}",
+            display_path(&source_home)
+        )
+    })?;
+    resolve_plain_openclaw_workspaces(&workspace_source_home)?
+        .archive_relative_roots(&workspace_source_home)?;
     let migrated_launcher = preflight_migrated_launcher(&env_name, env, cwd)?;
 
     let created = service.create(CreateEnvironmentOptions {

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -168,7 +168,7 @@ fn migrate_plain_openclaw_home_inner(
             display_path(&source_home)
         )
     })?;
-    resolve_plain_openclaw_workspaces(&workspace_source_home)?
+    resolve_plain_openclaw_workspaces(&workspace_source_home, env)?
         .archive_relative_roots(&workspace_source_home)?;
     let migrated_launcher = preflight_migrated_launcher(&env_name, env, cwd)?;
 
@@ -272,7 +272,7 @@ fn complete_migration_import(
         created.gateway_port,
         sandbox_origin,
     )?;
-    prepare_migrated_runtime_state(target_paths, source_home)?;
+    prepare_migrated_runtime_state(target_paths, source_home, env)?;
 
     let Some(launcher) = migrated_launcher else {
         return Ok((

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -34,8 +34,9 @@ use super::now_utc;
 use super::{
     clear_nonportable_runtime_state, normalize_new_environment_sandbox_origin,
     openclaw_config_include_paths, openclaw_config_uses_includes, openclaw_env_archive_options,
-    reject_include_owned_sandbox_origin, rewrite_openclaw_config_for_new_environment,
-    rewrite_openclaw_config_for_simulation,
+    reject_include_owned_agent_workspaces, reject_include_owned_sandbox_origin,
+    resolve_env_openclaw_workspaces, rewrite_openclaw_config_for_new_environment,
+    rewrite_openclaw_config_for_simulation, rewrite_openclaw_config_includes_for_target,
 };
 
 static NEXT_IMPORT_ID: AtomicU64 = AtomicU64::new(0);
@@ -497,7 +498,9 @@ fn clone_environment_with_policy(
     }
     if matches!(policy, CloneEnvironmentPolicy::Standard) {
         reject_include_owned_sandbox_origin(&source_paths.config_path)?;
+        reject_include_owned_agent_workspaces(&source_paths.config_path)?;
     }
+    resolve_env_openclaw_workspaces(&source_paths)?.archive_relative_roots(&source_paths.root)?;
     let result = (|| {
         copy_dir_recursive(&source_paths.root, &target_paths.root)?;
         let created_at = now_utc();
@@ -521,6 +524,12 @@ fn clone_environment_with_policy(
                     &target_paths,
                     Some(&source_paths.root),
                     gateway_port,
+                )?;
+                rewrite_openclaw_config_includes_for_target(
+                    &target_paths.config_path,
+                    &target_paths.state_dir,
+                    &source_paths.root,
+                    &target_paths.root,
                 )?;
                 clear_simulation_runtime_state_preserving_includes(&target_paths)?;
                 Default::default()
@@ -702,7 +711,7 @@ pub fn export_environment(
         &metadata,
         &env_paths.root,
         &output_path,
-        openclaw_env_archive_options(),
+        openclaw_env_archive_options(&env_paths)?,
     );
     if result.is_err() {
         let _ = fs::remove_file(&output_path);
@@ -787,7 +796,9 @@ pub(crate) fn import_environment_with_sandbox_origin(
         if !path_exists(&extracted.root_dir) {
             return Err("archive is missing root/".to_string());
         }
-        reject_include_owned_sandbox_origin(&derive_env_paths(&extracted.root_dir).config_path)?;
+        let extracted_paths = derive_env_paths(&extracted.root_dir);
+        reject_include_owned_sandbox_origin(&extracted_paths.config_path)?;
+        reject_include_owned_agent_workspaces(&extracted_paths.config_path)?;
         let imported = (|| {
             let preferred_gateway_port = extracted
                 .metadata
@@ -1048,7 +1059,10 @@ mod tests {
                 r#"{{
                   // OpenClaw include files support JSON5.
                   gateway: {{ port: 19789 }},
-                  agents: {{ defaults: {{ workspace: "{}" }} }},
+                  agents: {{
+                    defaults: {{ workspace: "{}" }},
+                    list: [{{ id: "main", default: true, workspace: "{}" }}],
+                  }},
                   mcp: {{ apps: {{
                     sandboxPort: 19790,
                     sandboxOrigin: "https://source.example.test",
@@ -1056,6 +1070,7 @@ mod tests {
                   nested: {{ $include: "./nested.json5" }},
                 }}
 "#,
+                source_paths.workspace_dir.display(),
                 source_paths.workspace_dir.display()
             ),
         )
@@ -1107,11 +1122,24 @@ mod tests {
         );
         assert!(target_paths.state_dir.join("config/base.json").exists());
         assert!(target_paths.state_dir.join("config/nested.json5").exists());
+        let included: Value = serde_json::from_str(
+            &fs::read_to_string(target_paths.state_dir.join("config/base.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            included["agents"]["list"][0]["workspace"],
+            target_paths.workspace_dir.display().to_string()
+        );
         assert!(!target_paths.state_dir.join("run").exists());
         assert!(!target_paths.state_dir.join("agents/main/sessions").exists());
         assert!(!target_paths.state_dir.join("logs").exists());
         assert!(!target_paths.state_dir.join("openclaw.json.bak").exists());
         assert!(source_paths.state_dir.join("config/base.json").exists());
+        assert!(
+            fs::read_to_string(source_paths.state_dir.join("config/base.json"))
+                .unwrap()
+                .contains(&source_paths.workspace_dir.display().to_string())
+        );
 
         remove_environment("simulation", false, &env, &cwd).unwrap();
         remove_environment("source", false, &env, &cwd).unwrap();

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -1148,7 +1148,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn simulation_cleanup_does_not_mutate_workspace_include_symlinks() {
+    fn simulation_cleanup_rejects_escaping_include_symlinks_without_mutation() {
         let id = NEXT_IMPORT_ID.fetch_add(1, Ordering::Relaxed);
         let root = std::env::temp_dir()
             .join("ocm-env-simulation-symlink-tests")
@@ -1167,7 +1167,11 @@ mod tests {
         )
         .unwrap();
 
-        clear_simulation_runtime_state_preserving_includes(&paths).unwrap();
+        let error = clear_simulation_runtime_state_preserving_includes(&paths).unwrap_err();
+        assert!(
+            error.contains("OpenClaw $include path resolves outside the config directory"),
+            "{error}"
+        );
 
         assert_eq!(
             fs::read_to_string(&external).unwrap(),
@@ -1179,7 +1183,7 @@ mod tests {
                 .file_type()
                 .is_symlink()
         );
-        assert!(!paths.state_dir.join("logs").exists());
+        assert!(paths.state_dir.join("logs/gateway.log").exists());
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -500,7 +500,8 @@ fn clone_environment_with_policy(
         reject_include_owned_sandbox_origin(&source_paths.config_path)?;
         reject_include_owned_agent_workspaces(&source_paths.config_path)?;
     }
-    resolve_env_openclaw_workspaces(&source_paths)?.archive_relative_roots(&source_paths.root)?;
+    resolve_env_openclaw_workspaces(&source_paths, env)?
+        .archive_relative_roots(&source_paths.root)?;
     let result = (|| {
         copy_dir_recursive(&source_paths.root, &target_paths.root)?;
         let created_at = now_utc();
@@ -514,7 +515,7 @@ fn clone_environment_with_policy(
                     Some(gateway_port),
                     sandbox_origin.as_deref(),
                 )?;
-                clear_nonportable_runtime_state(&target_paths)?;
+                clear_nonportable_runtime_state(&target_paths, env)?;
                 outcome
             }
             CloneEnvironmentPolicy::Simulation
@@ -531,7 +532,7 @@ fn clone_environment_with_policy(
                     &source_paths.root,
                     &target_paths.root,
                 )?;
-                clear_simulation_runtime_state_preserving_includes(&target_paths)?;
+                clear_simulation_runtime_state_preserving_includes(&target_paths, env)?;
                 Default::default()
             }
             CloneEnvironmentPolicy::Simulation => {
@@ -541,7 +542,7 @@ fn clone_environment_with_policy(
                     Some(gateway_port),
                     None,
                 )?;
-                clear_nonportable_runtime_state(&target_paths)?;
+                clear_nonportable_runtime_state(&target_paths, env)?;
                 outcome
             }
         };
@@ -580,11 +581,12 @@ fn clone_environment_with_policy(
 
 fn clear_simulation_runtime_state_preserving_includes(
     target_paths: &super::layout::EnvPaths,
+    env: &BTreeMap<String, String>,
 ) -> Result<(), String> {
     let include_paths =
         openclaw_config_include_paths(&target_paths.config_path, &target_paths.state_dir)?;
     if include_paths.is_empty() {
-        clear_nonportable_runtime_state(target_paths)?;
+        clear_nonportable_runtime_state(target_paths, env)?;
         return Ok(());
     }
 
@@ -596,7 +598,7 @@ fn clear_simulation_runtime_state_preserving_includes(
                 .map_err(|error| error.to_string())?;
             copy_path(include_path, &staging_root.join(relative))?;
         }
-        clear_nonportable_runtime_state(target_paths)?;
+        clear_nonportable_runtime_state(target_paths, env)?;
         for include_path in &include_paths {
             let relative = include_path
                 .strip_prefix(&target_paths.state_dir)
@@ -711,7 +713,7 @@ pub fn export_environment(
         &metadata,
         &env_paths.root,
         &output_path,
-        openclaw_env_archive_options(&env_paths)?,
+        openclaw_env_archive_options(&env_paths, env)?,
     );
     if result.is_err() {
         let _ = fs::remove_file(&output_path);
@@ -815,7 +817,7 @@ pub(crate) fn import_environment_with_sandbox_origin(
                 Some(gateway_port),
                 sandbox_origin.as_deref(),
             )?;
-            clear_nonportable_runtime_state(&target_paths)?;
+            clear_nonportable_runtime_state(&target_paths, env)?;
 
             let created_at = now_utc();
             let meta = EnvMeta {
@@ -1167,7 +1169,8 @@ mod tests {
         )
         .unwrap();
 
-        let error = clear_simulation_runtime_state_preserving_includes(&paths).unwrap_err();
+        let error = clear_simulation_runtime_state_preserving_includes(&paths, &BTreeMap::new())
+            .unwrap_err();
         assert!(
             error.contains("OpenClaw $include path resolves outside the config directory"),
             "{error}"

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -5,6 +5,7 @@ mod launchers;
 mod layout;
 mod openclaw_config;
 mod openclaw_state;
+mod openclaw_workspaces;
 mod runtimes;
 mod snapshots;
 
@@ -49,13 +50,17 @@ pub(crate) use openclaw_config::{
     OpenClawConfigAudit, audit_openclaw_config, clear_skip_bootstrap_for_openclaw_onboarding,
     ensure_minimum_local_openclaw_config, normalize_new_environment_sandbox_origin,
     openclaw_config_include_paths, openclaw_config_uses_includes,
-    reject_include_owned_sandbox_origin, repair_openclaw_config,
-    rewrite_openclaw_config_for_migration, rewrite_openclaw_config_for_new_environment,
-    rewrite_openclaw_config_for_simulation, rewrite_openclaw_config_for_target,
+    reject_include_owned_agent_workspaces, reject_include_owned_sandbox_origin,
+    repair_openclaw_config, rewrite_openclaw_config_for_migration,
+    rewrite_openclaw_config_for_new_environment, rewrite_openclaw_config_for_simulation,
+    rewrite_openclaw_config_for_target, rewrite_openclaw_config_includes_for_target,
 };
 pub(crate) use openclaw_state::{
     OpenClawStateAudit, audit_openclaw_state, clear_nonportable_runtime_state,
     openclaw_env_archive_options, prepare_migrated_runtime_state, repair_openclaw_runtime_state,
+};
+pub(crate) use openclaw_workspaces::{
+    resolve_env_openclaw_workspaces, resolve_plain_openclaw_workspaces,
 };
 pub(crate) use runtimes::install_runtime_from_local_openclaw_build;
 pub(crate) use runtimes::install_runtime_from_selected_official_openclaw_release;

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -1039,9 +1039,45 @@ fn agent_workspaces_include_scope(value: &Value) -> Option<&'static str> {
     if root.contains_key("$include") {
         return Some("the config root");
     }
-    root.get("agents")
-        .is_some_and(value_contains_include)
-        .then_some("agents")
+    let agents = root.get("agents")?;
+    let Some(agents) = agents.as_object() else {
+        return value_contains_include(agents).then_some("agents");
+    };
+    if agents.contains_key("$include") {
+        return Some("agents");
+    }
+    if agents
+        .get("defaults")
+        .is_some_and(workspace_defaults_contains_include)
+    {
+        return Some("agents.defaults.workspace");
+    }
+    agents
+        .get("list")
+        .is_some_and(agent_list_contains_include)
+        .then_some("agents.list")
+}
+
+fn workspace_defaults_contains_include(value: &Value) -> bool {
+    let Some(defaults) = value.as_object() else {
+        return value_contains_include(value);
+    };
+    defaults.contains_key("$include")
+        || defaults
+            .get("workspace")
+            .is_some_and(value_contains_include)
+}
+
+fn agent_list_contains_include(value: &Value) -> bool {
+    let Some(entries) = value.as_array() else {
+        return value_contains_include(value);
+    };
+    entries.iter().any(|entry| {
+        let Some(entry) = entry.as_object() else {
+            return value_contains_include(entry);
+        };
+        entry.contains_key("$include") || entry.get("workspace").is_some_and(value_contains_include)
+    })
 }
 
 fn value_contains_include(value: &Value) -> bool {
@@ -1365,6 +1401,18 @@ mod tests {
         );
         assert_eq!(
             agent_workspaces_include_scope(
+                &json!({"agents": {"defaults": {"$include": "./defaults.json5"}}})
+            ),
+            Some("agents.defaults.workspace")
+        );
+        assert_eq!(
+            agent_workspaces_include_scope(
+                &json!({"agents": {"list": [{"$include": "./main.json5"}]}})
+            ),
+            Some("agents.list")
+        );
+        assert_eq!(
+            agent_workspaces_include_scope(
                 &json!({"agents": {"defaults": {"workspace": "/tmp/workspace"}}})
             ),
             None
@@ -1372,6 +1420,12 @@ mod tests {
         assert_eq!(
             agent_workspaces_include_scope(
                 &json!({"mcp": {"$include": "./mcp.json5"}, "agents": {}})
+            ),
+            None
+        );
+        assert_eq!(
+            agent_workspaces_include_scope(
+                &json!({"agents": {"defaults": {"memorySearch": {"$include": "./memory.json5"}}}})
             ),
             None
         );

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -11,6 +12,7 @@ use crate::env::EnvMeta;
 use super::common::{ensure_dir, path_exists, write_file_replacing_path};
 use super::gateway_ports::read_port_number;
 use super::layout::{EnvPaths, clean_path, derive_env_paths, display_path};
+use super::openclaw_workspaces::load_effective_openclaw_config;
 
 #[derive(Clone, Debug)]
 pub(crate) struct OpenClawConfigAudit {
@@ -55,13 +57,13 @@ pub(crate) fn audit_openclaw_config(meta: &EnvMeta, known_envs: &[EnvMeta]) -> O
         }
     };
 
-    let value: Value = match serde_json::from_str(&raw) {
+    let value: Value = match json5::from_str(&raw) {
         Ok(value) => value,
         Err(error) => {
             return OpenClawConfigAudit {
                 status: "invalid".to_string(),
                 issues: vec![format!(
-                    "OpenClaw config is invalid JSON: {} ({error})",
+                    "OpenClaw config is invalid JSON/JSON5: {} ({error})",
                     display_path(&paths.config_path)
                 )],
                 repair_source_root: None,
@@ -167,6 +169,18 @@ pub(crate) fn reject_include_owned_sandbox_origin(config_path: &Path) -> Result<
     ))
 }
 
+pub(crate) fn reject_include_owned_agent_workspaces(config_path: &Path) -> Result<(), String> {
+    let Some(value) = read_config_value(config_path)? else {
+        return Ok(());
+    };
+    let Some(scope) = agent_workspaces_include_scope(&value) else {
+        return Ok(());
+    };
+    Err(format!(
+        "cannot safely rewrite OpenClaw agent workspaces because config uses $include at {scope}; flatten the agents section before creating a new OCM environment"
+    ))
+}
+
 pub(crate) fn openclaw_config_uses_includes(config_path: &Path) -> Result<bool, String> {
     Ok(read_config_value(config_path)?
         .as_ref()
@@ -177,88 +191,20 @@ pub(crate) fn openclaw_config_include_paths(
     config_path: &Path,
     state_dir: &Path,
 ) -> Result<Vec<PathBuf>, String> {
-    let Some(value) = read_config_value(config_path)? else {
+    let Some(resolved) = load_effective_openclaw_config(config_path)? else {
         return Ok(Vec::new());
     };
-    let mut paths = BTreeSet::new();
-    let mut visited = BTreeSet::new();
-    collect_config_include_paths(&value, config_path, state_dir, &mut paths, &mut visited)?;
-    Ok(paths.into_iter().collect())
-}
-
-fn collect_config_include_paths(
-    value: &Value,
-    containing_file: &Path,
-    state_dir: &Path,
-    paths: &mut BTreeSet<PathBuf>,
-    visited: &mut BTreeSet<PathBuf>,
-) -> Result<(), String> {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                collect_config_include_paths(value, containing_file, state_dir, paths, visited)?;
-            }
-        }
-        Value::Object(object) => {
-            if let Some(include) = object.get("$include") {
-                let include_paths = match include {
-                    Value::String(path) => vec![path.as_str()],
-                    Value::Array(values) => values
-                        .iter()
-                        .map(|value| {
-                            value.as_str().ok_or_else(|| {
-                                "OpenClaw $include arrays must contain only paths".to_string()
-                            })
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                    _ => {
-                        return Err(
-                            "OpenClaw $include must be a path or an array of paths".to_string()
-                        );
-                    }
-                };
-                for include_path in include_paths {
-                    let include_path = Path::new(include_path);
-                    let resolved = if include_path.is_absolute() {
-                        clean_path(include_path)
-                    } else {
-                        clean_path(
-                            &containing_file
-                                .parent()
-                                .unwrap_or(state_dir)
-                                .join(include_path),
-                        )
-                    };
-                    if !resolved.starts_with(state_dir) || !visited.insert(resolved.clone()) {
-                        continue;
-                    }
-                    paths.insert(resolved.clone());
-                    let raw = fs::read_to_string(&resolved).map_err(|error| {
-                        format!(
-                            "failed to read OpenClaw include {}: {error}",
-                            display_path(&resolved)
-                        )
-                    })?;
-                    if raw.contains("$include") {
-                        let included: Value = json5::from_str(&raw).map_err(|error| {
-                            format!(
-                                "cannot preserve nested OpenClaw includes from {}: {error}",
-                                display_path(&resolved)
-                            )
-                        })?;
-                        collect_config_include_paths(
-                            &included, &resolved, state_dir, paths, visited,
-                        )?;
-                    }
-                }
-            }
-            for value in object.values() {
-                collect_config_include_paths(value, containing_file, state_dir, paths, visited)?;
-            }
-        }
-        _ => {}
+    if let Some(path) = resolved
+        .include_paths
+        .iter()
+        .find(|path| !path.starts_with(state_dir))
+    {
+        return Err(format!(
+            "OpenClaw include resolves outside the state directory: {}",
+            display_path(path)
+        ));
     }
-    Ok(())
+    Ok(resolved.include_paths.into_iter().collect())
 }
 
 #[derive(Clone, Copy)]
@@ -334,6 +280,35 @@ pub(crate) fn rewrite_openclaw_config_for_simulation(
         SandboxOriginPolicy::Simulation,
     )
     .map(|_| ())
+}
+
+pub(crate) fn rewrite_openclaw_config_includes_for_target(
+    config_path: &Path,
+    state_dir: &Path,
+    source_root: &Path,
+    target_root: &Path,
+) -> Result<bool, String> {
+    let include_paths = openclaw_config_include_paths(config_path, state_dir)?;
+    let mut changed = false;
+    for include_path in include_paths {
+        let raw = fs::read_to_string(&include_path).map_err(|error| {
+            format!(
+                "failed to read OpenClaw include {}: {error}",
+                display_path(&include_path)
+            )
+        })?;
+        let mut value: Value = json5::from_str(&raw).map_err(|error| {
+            format!(
+                "failed to parse OpenClaw include {}: {error}",
+                display_path(&include_path)
+            )
+        })?;
+        if rewrite_env_root_paths(&mut value, source_root, target_root) {
+            write_config_value(&include_path, &value)?;
+            changed = true;
+        }
+    }
+    Ok(changed)
 }
 
 pub(crate) fn ensure_minimum_local_openclaw_config(
@@ -516,7 +491,7 @@ fn read_config_value(config_path: &Path) -> Result<Option<Value>, String> {
     }
 
     let raw = fs::read_to_string(config_path).map_err(|error| error.to_string())?;
-    let value = serde_json::from_str(&raw).map_err(|error| error.to_string())?;
+    let value = json5::from_str(&raw).map_err(|error| error.to_string())?;
     Ok(Some(value))
 }
 
@@ -702,12 +677,43 @@ fn rewrite_env_root_string(raw: &mut String, source_root: &Path, target_root: &P
         return false;
     }
 
-    let Ok(suffix) = path.strip_prefix(source_root) else {
-        return false;
+    let suffix = if let Ok(suffix) = path.strip_prefix(source_root) {
+        suffix.to_path_buf()
+    } else {
+        let Some(normalized_path) = normalize_path_allow_missing(path) else {
+            return false;
+        };
+        let Some(normalized_source_root) = normalize_path_allow_missing(source_root) else {
+            return false;
+        };
+        let Ok(suffix) = normalized_path.strip_prefix(normalized_source_root) else {
+            return false;
+        };
+        suffix.to_path_buf()
     };
 
     *raw = display_path(&clean_path(&target_root.join(suffix)));
     true
+}
+
+fn normalize_path_allow_missing(path: &Path) -> Option<PathBuf> {
+    let mut existing = path;
+    let mut missing = Vec::<OsString>::new();
+    loop {
+        match fs::canonicalize(existing) {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Some(clean_path(&resolved));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                missing.push(existing.file_name()?.to_os_string());
+                existing = existing.parent()?;
+            }
+            Err(_) => return None,
+        }
+    }
 }
 
 fn rewrite_workspace_field_if_env_scoped(
@@ -1028,6 +1034,16 @@ fn sandbox_origin_include_scope(value: &Value) -> Option<&'static str> {
         .then_some("mcp.apps.sandboxOrigin")
 }
 
+fn agent_workspaces_include_scope(value: &Value) -> Option<&'static str> {
+    let root = value.as_object()?;
+    if root.contains_key("$include") {
+        return Some("the config root");
+    }
+    root.get("agents")
+        .is_some_and(value_contains_include)
+        .then_some("agents")
+}
+
 fn value_contains_include(value: &Value) -> bool {
     match value {
         Value::Array(values) => values.iter().any(value_contains_include),
@@ -1332,6 +1348,30 @@ mod tests {
         assert_eq!(
             sandbox_origin_include_scope(
                 &json!({"agents": {"$include": "./agents.json5"}, "mcp": {"apps": {}}})
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn agent_workspace_include_scope_only_flags_agent_governing_includes() {
+        assert_eq!(
+            agent_workspaces_include_scope(&json!({"$include": "./base.json5"})),
+            Some("the config root")
+        );
+        assert_eq!(
+            agent_workspaces_include_scope(&json!({"agents": {"$include": "./agents.json5"}})),
+            Some("agents")
+        );
+        assert_eq!(
+            agent_workspaces_include_scope(
+                &json!({"agents": {"defaults": {"workspace": "/tmp/workspace"}}})
+            ),
+            None
+        );
+        assert_eq!(
+            agent_workspaces_include_scope(
+                &json!({"mcp": {"$include": "./mcp.json5"}, "agents": {}})
             ),
             None
         );

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -102,12 +102,12 @@ pub(crate) fn prepare_migrated_runtime_state(
     changed |= rewrite_runtime_state_root_refs(
         &paths.state_dir,
         &paths.config_path,
-        &paths.workspace_dir,
+        &paths.state_dir,
         source_state_root,
         &paths.state_dir,
     )?;
     changed |=
-        clear_volatile_runtime_state(&paths.state_dir, &paths.config_path, &paths.workspace_dir)?;
+        clear_volatile_runtime_state(&paths.state_dir, &paths.config_path, &paths.state_dir)?;
     Ok(changed)
 }
 
@@ -122,7 +122,9 @@ pub(crate) fn clear_nonportable_runtime_state(paths: &EnvPaths) -> Result<bool, 
         let entry = entry.map_err(|error| error.to_string())?;
         let path = entry.path();
         let name = entry.file_name();
-        if name == OsStr::new("openclaw.json") || name == OsStr::new("workspace") {
+        if name == OsStr::new("openclaw.json")
+            || name.to_str().is_some_and(is_openclaw_workspace_name)
+        {
             continue;
         }
         if name == OsStr::new("agents") {
@@ -142,7 +144,7 @@ pub(crate) fn clear_nonportable_runtime_state(paths: &EnvPaths) -> Result<bool, 
 fn rewrite_runtime_state_root_refs(
     root: &Path,
     config_path: &Path,
-    workspace_dir: &Path,
+    state_dir: &Path,
     source_state_root: &Path,
     target_state_root: &Path,
 ) -> Result<bool, String> {
@@ -152,7 +154,7 @@ fn rewrite_runtime_state_root_refs(
     rewrite_runtime_state_root_refs_inner(
         root,
         config_path,
-        workspace_dir,
+        state_dir,
         &source_root,
         &target_root,
         &mut changed,
@@ -163,7 +165,7 @@ fn rewrite_runtime_state_root_refs(
 fn rewrite_runtime_state_root_refs_inner(
     root: &Path,
     config_path: &Path,
-    workspace_dir: &Path,
+    state_dir: &Path,
     source_root: &str,
     target_root: &str,
     changed: &mut bool,
@@ -176,7 +178,7 @@ fn rewrite_runtime_state_root_refs_inner(
     for entry in entries {
         let entry = entry.map_err(|error| error.to_string())?;
         let path = entry.path();
-        if path == config_path || path.starts_with(workspace_dir) {
+        if path == config_path || is_openclaw_workspace_path(&path, state_dir) {
             continue;
         }
 
@@ -185,7 +187,7 @@ fn rewrite_runtime_state_root_refs_inner(
             rewrite_runtime_state_root_refs_inner(
                 &path,
                 config_path,
-                workspace_dir,
+                state_dir,
                 source_root,
                 target_root,
                 changed,
@@ -213,7 +215,7 @@ fn rewrite_runtime_state_root_refs_inner(
 fn clear_volatile_runtime_state(
     root: &Path,
     config_path: &Path,
-    workspace_dir: &Path,
+    state_dir: &Path,
 ) -> Result<bool, String> {
     if !path_exists(root) {
         return Ok(false);
@@ -224,7 +226,7 @@ fn clear_volatile_runtime_state(
     for entry in entries {
         let entry = entry.map_err(|error| error.to_string())?;
         let path = entry.path();
-        if path == config_path || path.starts_with(workspace_dir) {
+        if path == config_path || is_openclaw_workspace_path(&path, state_dir) {
             continue;
         }
 
@@ -237,7 +239,7 @@ fn clear_volatile_runtime_state(
         }
 
         if metadata.is_dir() {
-            changed |= clear_volatile_runtime_state(&path, config_path, workspace_dir)?;
+            changed |= clear_volatile_runtime_state(&path, config_path, state_dir)?;
         }
     }
 
@@ -315,19 +317,31 @@ fn path_components(path: &Path) -> Vec<&str> {
 }
 
 fn is_durable_openclaw_archive_path(components: &[&str]) -> bool {
-    matches!(
-        components,
-        [".openclaw"]
-            | [".openclaw", "workspace", ..]
-            | [".openclaw", "openclaw.json"]
-            | [".openclaw", "agents", ..]
-            | [".openclaw", "credentials", ..]
-            | [".openclaw", "cron", ..]
-            | [".openclaw", "devices", ..]
-            | [".openclaw", "identity", ..]
-            | [".openclaw", "memory", ..]
-            | [".openclaw", "plugins", ..]
-    )
+    match components {
+        [".openclaw"] => true,
+        [".openclaw", name, ..] if is_openclaw_workspace_name(name) => true,
+        [".openclaw", "openclaw.json"]
+        | [".openclaw", "agents", ..]
+        | [".openclaw", "credentials", ..]
+        | [".openclaw", "cron", ..]
+        | [".openclaw", "devices", ..]
+        | [".openclaw", "identity", ..]
+        | [".openclaw", "memory", ..]
+        | [".openclaw", "plugins", ..] => true,
+        _ => false,
+    }
+}
+
+fn is_openclaw_workspace_name(name: &str) -> bool {
+    name == "workspace" || name.starts_with("workspace-")
+}
+
+fn is_openclaw_workspace_path(path: &Path, state_dir: &Path) -> bool {
+    path.strip_prefix(state_dir)
+        .ok()
+        .and_then(|relative| relative.components().next())
+        .and_then(|component| component.as_os_str().to_str())
+        .is_some_and(is_openclaw_workspace_name)
 }
 
 fn collect_runtime_state_path_refs(
@@ -340,7 +354,7 @@ fn collect_runtime_state_path_refs(
     visit_runtime_state_files(
         &paths.state_dir,
         &paths.config_path,
-        &paths.workspace_dir,
+        &paths.state_dir,
         &mut |path| {
             let Ok(raw) = fs::read_to_string(path) else {
                 return;
@@ -368,7 +382,7 @@ fn collect_runtime_state_path_refs(
 fn visit_runtime_state_files(
     root: &Path,
     config_path: &Path,
-    workspace_dir: &Path,
+    state_dir: &Path,
     on_file: &mut dyn FnMut(&Path),
 ) {
     let Ok(entries) = fs::read_dir(root) else {
@@ -376,7 +390,7 @@ fn visit_runtime_state_files(
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path == config_path || path.starts_with(workspace_dir) {
+        if path == config_path || is_openclaw_workspace_path(&path, state_dir) {
             continue;
         }
 
@@ -384,7 +398,7 @@ fn visit_runtime_state_files(
             continue;
         };
         if metadata.is_dir() {
-            visit_runtime_state_files(&path, config_path, workspace_dir, on_file);
+            visit_runtime_state_files(&path, config_path, state_dir, on_file);
         } else if metadata.is_file() {
             on_file(&path);
         }
@@ -524,6 +538,7 @@ mod tests {
         let _ = fs::remove_dir_all(&temp);
         let paths = derive_env_paths(&temp);
         fs::create_dir_all(paths.workspace_dir.join("notes")).unwrap();
+        fs::create_dir_all(paths.state_dir.join("workspace-clawforce/skills")).unwrap();
         fs::write(&paths.config_path, "{}\n").unwrap();
         fs::create_dir_all(paths.state_dir.join("agents/main/agent")).unwrap();
         fs::create_dir_all(paths.state_dir.join("agents/main/sessions")).unwrap();
@@ -534,11 +549,22 @@ mod tests {
         .unwrap();
         fs::write(paths.state_dir.join("logs.txt"), "log\n").unwrap();
         fs::write(paths.workspace_dir.join("notes/todo.txt"), "keep\n").unwrap();
+        fs::write(
+            paths.state_dir.join("workspace-clawforce/skills/social.md"),
+            "keep secondary workspace\n",
+        )
+        .unwrap();
 
         let changed = clear_nonportable_runtime_state(&paths).unwrap();
         assert!(changed);
         assert!(paths.config_path.exists());
         assert!(paths.workspace_dir.join("notes/todo.txt").exists());
+        assert!(
+            paths
+                .state_dir
+                .join("workspace-clawforce/skills/social.md")
+                .exists()
+        );
         assert!(
             paths
                 .state_dir
@@ -559,12 +585,18 @@ mod tests {
         let source_state_root = temp.join("legacy-home/.openclaw");
         let paths = derive_env_paths(temp.join("target"));
         fs::create_dir_all(paths.workspace_dir.join("notes")).unwrap();
+        fs::create_dir_all(paths.state_dir.join("workspace-clawforce/tmp")).unwrap();
         fs::create_dir_all(paths.state_dir.join("agents/main/agent")).unwrap();
         fs::create_dir_all(paths.state_dir.join("agents/main/sessions")).unwrap();
         fs::create_dir_all(paths.state_dir.join("logs")).unwrap();
         fs::create_dir_all(paths.state_dir.join("run")).unwrap();
         fs::write(&paths.config_path, "{}\n").unwrap();
         fs::write(paths.workspace_dir.join("notes/todo.txt"), "keep\n").unwrap();
+        fs::write(
+            paths.state_dir.join("workspace-clawforce/tmp/durable.txt"),
+            "keep workspace tmp\n",
+        )
+        .unwrap();
         fs::write(
             paths.state_dir.join("agents/main/agent/auth-profiles.json"),
             "{}\n",
@@ -598,6 +630,12 @@ mod tests {
         assert!(
             paths
                 .state_dir
+                .join("workspace-clawforce/tmp/durable.txt")
+                .exists()
+        );
+        assert!(
+            paths
+                .state_dir
                 .join("agents/main/sessions/main.jsonl")
                 .exists()
         );
@@ -619,5 +657,25 @@ mod tests {
         assert!(!backup_raw.contains(&display_path(&source_state_root)));
 
         let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn archive_policy_preserves_all_top_level_openclaw_workspaces() {
+        for path in [
+            ".openclaw/workspace/notes.txt",
+            ".openclaw/workspace-clawforce/skills/social.md",
+            ".openclaw/workspace-clawdred/IDENTITY.md",
+            ".openclaw/workspace-attestations/manifest.json",
+        ] {
+            assert!(
+                !should_skip_openclaw_env_archive_path(Path::new(path), EnvArchiveEntryKind::File),
+                "{path} should be durable"
+            );
+        }
+
+        assert!(should_skip_openclaw_env_archive_path(
+            Path::new(".openclaw/logs/gateway.log"),
+            EnvArchiveEntryKind::File
+        ));
     }
 }

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -8,6 +8,7 @@ use crate::infra::archive::{EnvArchiveEntryKind, EnvArchiveOptions};
 
 use super::common::path_exists;
 use super::layout::{EnvPaths, clean_path, derive_env_paths, display_path};
+use super::openclaw_workspaces::{OpenClawWorkspaceInventory, resolve_env_openclaw_workspaces};
 
 #[derive(Clone, Debug)]
 pub(crate) struct OpenClawStateAudit {
@@ -23,11 +24,23 @@ pub(crate) fn audit_openclaw_state(meta: &EnvMeta, known_envs: &[EnvMeta]) -> Op
             repair_runtime_state: false,
         };
     }
+    let workspaces = match resolve_archivable_workspaces(&paths) {
+        Ok(workspaces) => workspaces,
+        Err(error) => {
+            return OpenClawStateAudit {
+                issues: vec![format!(
+                    "OpenClaw workspace inventory could not be resolved safely: {error}"
+                )],
+                repair_runtime_state: false,
+            };
+        }
+    };
 
     let mut known_refs = BTreeMap::<String, (PathBuf, usize)>::new();
     let mut inferred_refs = BTreeMap::<PathBuf, usize>::new();
     collect_runtime_state_path_refs(
         &paths,
+        &workspaces,
         meta,
         known_envs,
         &mut known_refs,
@@ -72,11 +85,12 @@ pub(crate) fn repair_openclaw_runtime_state(meta: &EnvMeta) -> Result<bool, Stri
     clear_nonportable_runtime_state(&paths)
 }
 
-pub(crate) fn openclaw_env_archive_options() -> EnvArchiveOptions {
-    EnvArchiveOptions {
+pub(crate) fn openclaw_env_archive_options(paths: &EnvPaths) -> Result<EnvArchiveOptions, String> {
+    let workspaces = resolve_env_openclaw_workspaces(paths)?;
+    Ok(EnvArchiveOptions {
         should_skip_path: should_skip_openclaw_env_archive_path,
-        ..EnvArchiveOptions::default()
-    }
+        included_path_roots: workspaces.archive_relative_roots(&paths.root)?,
+    })
 }
 
 pub(crate) fn should_skip_openclaw_env_archive_path(
@@ -98,17 +112,17 @@ pub(crate) fn prepare_migrated_runtime_state(
     if !path_exists(&paths.state_dir) {
         return Ok(false);
     }
+    let workspaces = resolve_archivable_workspaces(paths)?;
 
     let mut changed = false;
     changed |= rewrite_runtime_state_root_refs(
         &paths.state_dir,
         &paths.config_path,
-        &paths.state_dir,
+        &workspaces,
         source_state_root,
         &paths.state_dir,
     )?;
-    changed |=
-        clear_volatile_runtime_state(&paths.state_dir, &paths.config_path, &paths.state_dir)?;
+    changed |= clear_volatile_runtime_state(&paths.state_dir, &paths.config_path, &workspaces)?;
     Ok(changed)
 }
 
@@ -116,6 +130,7 @@ pub(crate) fn clear_nonportable_runtime_state(paths: &EnvPaths) -> Result<bool, 
     if !path_exists(&paths.state_dir) {
         return Ok(false);
     }
+    let workspaces = resolve_archivable_workspaces(paths)?;
 
     let mut changed = false;
     let entries = fs::read_dir(&paths.state_dir).map_err(|error| error.to_string())?;
@@ -123,15 +138,17 @@ pub(crate) fn clear_nonportable_runtime_state(paths: &EnvPaths) -> Result<bool, 
         let entry = entry.map_err(|error| error.to_string())?;
         let path = entry.path();
         let name = entry.file_name();
-        if name == OsStr::new("openclaw.json")
-            || name.to_str().is_some_and(is_openclaw_workspace_name)
-        {
+        if name == OsStr::new("openclaw.json") || workspaces.contains(&path) {
             continue;
         }
         if name == OsStr::new("agents") {
-            if prune_agent_runtime_state(&path)? {
+            if prune_agent_runtime_state(&path, &workspaces)? {
                 changed = true;
             }
+            continue;
+        }
+        if workspaces.has_descendant(&path) {
+            changed |= clear_parent_preserving_workspaces(&path, &workspaces)?;
             continue;
         }
 
@@ -145,7 +162,7 @@ pub(crate) fn clear_nonportable_runtime_state(paths: &EnvPaths) -> Result<bool, 
 fn rewrite_runtime_state_root_refs(
     root: &Path,
     config_path: &Path,
-    state_dir: &Path,
+    workspaces: &OpenClawWorkspaceInventory,
     source_state_root: &Path,
     target_state_root: &Path,
 ) -> Result<bool, String> {
@@ -155,7 +172,7 @@ fn rewrite_runtime_state_root_refs(
     rewrite_runtime_state_root_refs_inner(
         root,
         config_path,
-        state_dir,
+        workspaces,
         &source_root,
         &target_root,
         &mut changed,
@@ -166,7 +183,7 @@ fn rewrite_runtime_state_root_refs(
 fn rewrite_runtime_state_root_refs_inner(
     root: &Path,
     config_path: &Path,
-    state_dir: &Path,
+    workspaces: &OpenClawWorkspaceInventory,
     source_root: &str,
     target_root: &str,
     changed: &mut bool,
@@ -179,7 +196,7 @@ fn rewrite_runtime_state_root_refs_inner(
     for entry in entries {
         let entry = entry.map_err(|error| error.to_string())?;
         let path = entry.path();
-        if path == config_path || is_openclaw_workspace_path(&path, state_dir) {
+        if path == config_path || workspaces.contains(&path) {
             continue;
         }
 
@@ -188,7 +205,7 @@ fn rewrite_runtime_state_root_refs_inner(
             rewrite_runtime_state_root_refs_inner(
                 &path,
                 config_path,
-                state_dir,
+                workspaces,
                 source_root,
                 target_root,
                 changed,
@@ -216,7 +233,7 @@ fn rewrite_runtime_state_root_refs_inner(
 fn clear_volatile_runtime_state(
     root: &Path,
     config_path: &Path,
-    state_dir: &Path,
+    workspaces: &OpenClawWorkspaceInventory,
 ) -> Result<bool, String> {
     if !path_exists(root) {
         return Ok(false);
@@ -227,11 +244,15 @@ fn clear_volatile_runtime_state(
     for entry in entries {
         let entry = entry.map_err(|error| error.to_string())?;
         let path = entry.path();
-        if path == config_path || is_openclaw_workspace_path(&path, state_dir) {
+        if path == config_path || workspaces.contains(&path) {
             continue;
         }
 
         let metadata = fs::symlink_metadata(&path).map_err(|error| error.to_string())?;
+        if metadata.is_dir() && workspaces.has_descendant(&path) {
+            changed |= clear_volatile_runtime_state(&path, config_path, workspaces)?;
+            continue;
+        }
         let file_name = entry.file_name();
         if should_remove_volatile_runtime_path(&file_name, metadata.is_dir()) {
             remove_path(&path)?;
@@ -240,14 +261,44 @@ fn clear_volatile_runtime_state(
         }
 
         if metadata.is_dir() {
-            changed |= clear_volatile_runtime_state(&path, config_path, state_dir)?;
+            changed |= clear_volatile_runtime_state(&path, config_path, workspaces)?;
         }
     }
 
     Ok(changed)
 }
 
-fn prune_agent_runtime_state(agents_root: &Path) -> Result<bool, String> {
+fn clear_parent_preserving_workspaces(
+    root: &Path,
+    workspaces: &OpenClawWorkspaceInventory,
+) -> Result<bool, String> {
+    if workspaces.contains(root) {
+        return Ok(false);
+    }
+
+    let mut changed = false;
+    let entries = fs::read_dir(root).map_err(|error| error.to_string())?;
+    for entry in entries {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let path = entry.path();
+        if workspaces.contains(&path) {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(&path).map_err(|error| error.to_string())?;
+        if metadata.is_dir() && workspaces.has_descendant(&path) {
+            changed |= clear_parent_preserving_workspaces(&path, workspaces)?;
+            continue;
+        }
+        remove_path(&path)?;
+        changed = true;
+    }
+    Ok(changed)
+}
+
+fn prune_agent_runtime_state(
+    agents_root: &Path,
+    workspaces: &OpenClawWorkspaceInventory,
+) -> Result<bool, String> {
     if !path_exists(agents_root) {
         return Ok(false);
     }
@@ -257,6 +308,9 @@ fn prune_agent_runtime_state(agents_root: &Path) -> Result<bool, String> {
     for entry in agent_entries {
         let entry = entry.map_err(|error| error.to_string())?;
         let agent_root = entry.path();
+        if workspaces.contains(&agent_root) {
+            continue;
+        }
         let metadata = fs::symlink_metadata(&agent_root).map_err(|error| error.to_string())?;
         if !metadata.is_dir() {
             remove_path(&agent_root)?;
@@ -268,7 +322,11 @@ fn prune_agent_runtime_state(agents_root: &Path) -> Result<bool, String> {
         for child in child_entries {
             let child = child.map_err(|error| error.to_string())?;
             let child_path = child.path();
-            if child.file_name() == OsStr::new("agent") {
+            if child.file_name() == OsStr::new("agent") || workspaces.contains(&child_path) {
+                continue;
+            }
+            if workspaces.has_descendant(&child_path) {
+                changed |= clear_parent_preserving_workspaces(&child_path, workspaces)?;
                 continue;
             }
             remove_path(&child_path)?;
@@ -289,6 +347,12 @@ fn prune_agent_runtime_state(agents_root: &Path) -> Result<bool, String> {
     }
 
     Ok(changed)
+}
+
+fn resolve_archivable_workspaces(paths: &EnvPaths) -> Result<OpenClawWorkspaceInventory, String> {
+    let workspaces = resolve_env_openclaw_workspaces(paths)?;
+    workspaces.archive_relative_roots(&paths.root)?;
+    Ok(workspaces)
 }
 
 fn should_remove_volatile_runtime_path(name: &OsStr, is_dir: bool) -> bool {
@@ -318,35 +382,24 @@ fn path_components(path: &Path) -> Vec<&str> {
 }
 
 fn is_durable_openclaw_archive_path(components: &[&str]) -> bool {
-    match components {
-        [".openclaw"] => true,
-        [".openclaw", name, ..] if is_openclaw_workspace_name(name) => true,
-        [".openclaw", "openclaw.json"]
-        | [".openclaw", "agents", ..]
-        | [".openclaw", "credentials", ..]
-        | [".openclaw", "cron", ..]
-        | [".openclaw", "devices", ..]
-        | [".openclaw", "identity", ..]
-        | [".openclaw", "memory", ..]
-        | [".openclaw", "plugins", ..] => true,
-        _ => false,
-    }
-}
-
-fn is_openclaw_workspace_name(name: &str) -> bool {
-    name == "workspace" || name.starts_with("workspace-")
-}
-
-fn is_openclaw_workspace_path(path: &Path, state_dir: &Path) -> bool {
-    path.strip_prefix(state_dir)
-        .ok()
-        .and_then(|relative| relative.components().next())
-        .and_then(|component| component.as_os_str().to_str())
-        .is_some_and(is_openclaw_workspace_name)
+    matches!(
+        components,
+        [".openclaw"]
+            | [".openclaw", "workspace", ..]
+            | [".openclaw", "openclaw.json"]
+            | [".openclaw", "agents", ..]
+            | [".openclaw", "credentials", ..]
+            | [".openclaw", "cron", ..]
+            | [".openclaw", "devices", ..]
+            | [".openclaw", "identity", ..]
+            | [".openclaw", "memory", ..]
+            | [".openclaw", "plugins", ..]
+    )
 }
 
 fn collect_runtime_state_path_refs(
     paths: &EnvPaths,
+    workspaces: &OpenClawWorkspaceInventory,
     current: &EnvMeta,
     known_envs: &[EnvMeta],
     known_refs: &mut BTreeMap<String, (PathBuf, usize)>,
@@ -355,7 +408,7 @@ fn collect_runtime_state_path_refs(
     visit_runtime_state_files(
         &paths.state_dir,
         &paths.config_path,
-        &paths.state_dir,
+        workspaces,
         &mut |path| {
             let Ok(raw) = fs::read_to_string(path) else {
                 return;
@@ -383,7 +436,7 @@ fn collect_runtime_state_path_refs(
 fn visit_runtime_state_files(
     root: &Path,
     config_path: &Path,
-    state_dir: &Path,
+    workspaces: &OpenClawWorkspaceInventory,
     on_file: &mut dyn FnMut(&Path),
 ) {
     let Ok(entries) = fs::read_dir(root) else {
@@ -391,7 +444,7 @@ fn visit_runtime_state_files(
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path == config_path || is_openclaw_workspace_path(&path, state_dir) {
+        if path == config_path || workspaces.contains(&path) {
             continue;
         }
 
@@ -399,7 +452,7 @@ fn visit_runtime_state_files(
             continue;
         };
         if metadata.is_dir() {
-            visit_runtime_state_files(&path, config_path, state_dir, on_file);
+            visit_runtime_state_files(&path, config_path, workspaces, on_file);
         } else if metadata.is_file() {
             on_file(&path);
         }
@@ -540,7 +593,11 @@ mod tests {
         let paths = derive_env_paths(&temp);
         fs::create_dir_all(paths.workspace_dir.join("notes")).unwrap();
         fs::create_dir_all(paths.state_dir.join("workspace-clawforce/skills")).unwrap();
-        fs::write(&paths.config_path, "{}\n").unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{"agents":{"list":[{"id":"main","default":true},{"id":"clawforce"}]}}"#,
+        )
+        .unwrap();
         fs::create_dir_all(paths.state_dir.join("agents/main/agent")).unwrap();
         fs::create_dir_all(paths.state_dir.join("agents/main/sessions")).unwrap();
         fs::write(
@@ -591,7 +648,11 @@ mod tests {
         fs::create_dir_all(paths.state_dir.join("agents/main/sessions")).unwrap();
         fs::create_dir_all(paths.state_dir.join("logs")).unwrap();
         fs::create_dir_all(paths.state_dir.join("run")).unwrap();
-        fs::write(&paths.config_path, "{}\n").unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{"agents":{"list":[{"id":"main","default":true},{"id":"clawforce"}]}}"#,
+        )
+        .unwrap();
         fs::write(paths.workspace_dir.join("notes/todo.txt"), "keep\n").unwrap();
         fs::write(
             paths.state_dir.join("workspace-clawforce/tmp/durable.txt"),
@@ -661,22 +722,45 @@ mod tests {
     }
 
     #[test]
-    fn archive_policy_preserves_all_top_level_openclaw_workspaces() {
-        for path in [
-            ".openclaw/workspace/notes.txt",
-            ".openclaw/workspace-clawforce/skills/social.md",
-            ".openclaw/workspace-clawdred/IDENTITY.md",
-            ".openclaw/workspace-attestations/manifest.json",
-        ] {
-            assert!(
-                !should_skip_openclaw_env_archive_path(Path::new(path), EnvArchiveEntryKind::File),
-                "{path} should be durable"
-            );
-        }
+    fn archive_policy_uses_configured_workspace_roots_without_prefix_guessing() {
+        let temp =
+            std::env::temp_dir().join(format!("ocm-openclaw-archive-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&temp);
+        let paths = derive_env_paths(&temp);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        fs::write(
+            &paths.config_path,
+            format!(
+                r#"{{"agents":{{"defaults":{{"workspace":"{}"}},"list":[{{"id":"primary","default":true}},{{"id":"ops"}}]}}}}"#,
+                paths.state_dir.join("team").display()
+            ),
+        )
+        .unwrap();
 
-        assert!(should_skip_openclaw_env_archive_path(
-            Path::new(".openclaw/logs/gateway.log"),
+        let options = openclaw_env_archive_options(&paths).unwrap();
+        assert!(
+            options
+                .included_path_roots
+                .contains(Path::new(".openclaw/team"))
+        );
+        assert!(
+            options
+                .included_path_roots
+                .contains(Path::new(".openclaw/workspace"))
+        );
+        assert!(!should_skip_openclaw_env_archive_path(
+            Path::new(".openclaw/workspace/notes.txt"),
             EnvArchiveEntryKind::File
         ));
+        assert!(should_skip_openclaw_env_archive_path(
+            Path::new(".openclaw/workspace-attestations/manifest.json"),
+            EnvArchiveEntryKind::File
+        ));
+        assert!(should_skip_openclaw_env_archive_path(
+            Path::new(".openclaw/workspace-cache/data.json"),
+            EnvArchiveEntryKind::File
+        ));
+
+        let _ = fs::remove_dir_all(&temp);
     }
 }

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -16,7 +16,11 @@ pub(crate) struct OpenClawStateAudit {
     pub repair_runtime_state: bool,
 }
 
-pub(crate) fn audit_openclaw_state(meta: &EnvMeta, known_envs: &[EnvMeta]) -> OpenClawStateAudit {
+pub(crate) fn audit_openclaw_state(
+    meta: &EnvMeta,
+    known_envs: &[EnvMeta],
+    env: &BTreeMap<String, String>,
+) -> OpenClawStateAudit {
     let paths = derive_env_paths(Path::new(&meta.root));
     if !path_exists(&paths.state_dir) {
         return OpenClawStateAudit {
@@ -24,7 +28,7 @@ pub(crate) fn audit_openclaw_state(meta: &EnvMeta, known_envs: &[EnvMeta]) -> Op
             repair_runtime_state: false,
         };
     }
-    let workspaces = match resolve_archivable_workspaces(&paths) {
+    let workspaces = match resolve_archivable_workspaces(&paths, env) {
         Ok(workspaces) => workspaces,
         Err(error) => {
             return OpenClawStateAudit {
@@ -80,13 +84,19 @@ pub(crate) fn audit_openclaw_state(meta: &EnvMeta, known_envs: &[EnvMeta]) -> Op
     }
 }
 
-pub(crate) fn repair_openclaw_runtime_state(meta: &EnvMeta) -> Result<bool, String> {
+pub(crate) fn repair_openclaw_runtime_state(
+    meta: &EnvMeta,
+    env: &BTreeMap<String, String>,
+) -> Result<bool, String> {
     let paths = derive_env_paths(Path::new(&meta.root));
-    clear_nonportable_runtime_state(&paths)
+    clear_nonportable_runtime_state(&paths, env)
 }
 
-pub(crate) fn openclaw_env_archive_options(paths: &EnvPaths) -> Result<EnvArchiveOptions, String> {
-    let workspaces = resolve_env_openclaw_workspaces(paths)?;
+pub(crate) fn openclaw_env_archive_options(
+    paths: &EnvPaths,
+    env: &BTreeMap<String, String>,
+) -> Result<EnvArchiveOptions, String> {
+    let workspaces = resolve_env_openclaw_workspaces(paths, env)?;
     Ok(EnvArchiveOptions {
         should_skip_path: should_skip_openclaw_env_archive_path,
         included_path_roots: workspaces.archive_relative_roots(&paths.root)?,
@@ -108,11 +118,12 @@ pub(crate) fn should_skip_openclaw_env_archive_path(
 pub(crate) fn prepare_migrated_runtime_state(
     paths: &EnvPaths,
     source_state_root: &Path,
+    env: &BTreeMap<String, String>,
 ) -> Result<bool, String> {
     if !path_exists(&paths.state_dir) {
         return Ok(false);
     }
-    let workspaces = resolve_archivable_workspaces(paths)?;
+    let workspaces = resolve_archivable_workspaces(paths, env)?;
 
     let mut changed = false;
     changed |= rewrite_runtime_state_root_refs(
@@ -126,11 +137,14 @@ pub(crate) fn prepare_migrated_runtime_state(
     Ok(changed)
 }
 
-pub(crate) fn clear_nonportable_runtime_state(paths: &EnvPaths) -> Result<bool, String> {
+pub(crate) fn clear_nonportable_runtime_state(
+    paths: &EnvPaths,
+    env: &BTreeMap<String, String>,
+) -> Result<bool, String> {
     if !path_exists(&paths.state_dir) {
         return Ok(false);
     }
-    let workspaces = resolve_archivable_workspaces(paths)?;
+    let workspaces = resolve_archivable_workspaces(paths, env)?;
 
     let mut changed = false;
     let entries = fs::read_dir(&paths.state_dir).map_err(|error| error.to_string())?;
@@ -349,8 +363,11 @@ fn prune_agent_runtime_state(
     Ok(changed)
 }
 
-fn resolve_archivable_workspaces(paths: &EnvPaths) -> Result<OpenClawWorkspaceInventory, String> {
-    let workspaces = resolve_env_openclaw_workspaces(paths)?;
+fn resolve_archivable_workspaces(
+    paths: &EnvPaths,
+    env: &BTreeMap<String, String>,
+) -> Result<OpenClawWorkspaceInventory, String> {
+    let workspaces = resolve_env_openclaw_workspaces(paths, env)?;
     workspaces.archive_relative_roots(&paths.root)?;
     Ok(workspaces)
 }
@@ -576,7 +593,7 @@ mod tests {
 
         let current = meta("target", &display_path(&target_root));
         let known_envs = vec![meta("source", &display_path(&source_root)), current.clone()];
-        let audit = audit_openclaw_state(&current, &known_envs);
+        let audit = audit_openclaw_state(&current, &known_envs, &BTreeMap::new());
         assert!(audit.repair_runtime_state);
         assert!(audit.issues.iter().any(|issue| issue.contains(
             "OpenClaw runtime state contains 1 copied path reference(s) under env \"source\" root"
@@ -613,7 +630,7 @@ mod tests {
         )
         .unwrap();
 
-        let changed = clear_nonportable_runtime_state(&paths).unwrap();
+        let changed = clear_nonportable_runtime_state(&paths, &BTreeMap::new()).unwrap();
         assert!(changed);
         assert!(paths.config_path.exists());
         assert!(paths.workspace_dir.join("notes/todo.txt").exists());
@@ -686,7 +703,8 @@ mod tests {
         fs::write(paths.state_dir.join("gateway.pid"), "4242\n").unwrap();
         fs::write(paths.state_dir.join("run/live.sock"), "sock\n").unwrap();
 
-        let changed = prepare_migrated_runtime_state(&paths, &source_state_root).unwrap();
+        let changed =
+            prepare_migrated_runtime_state(&paths, &source_state_root, &BTreeMap::new()).unwrap();
         assert!(changed);
         assert!(paths.workspace_dir.join("notes/todo.txt").exists());
         assert!(
@@ -737,7 +755,7 @@ mod tests {
         )
         .unwrap();
 
-        let options = openclaw_env_archive_options(&paths).unwrap();
+        let options = openclaw_env_archive_options(&paths, &BTreeMap::new()).unwrap();
         assert!(
             options
                 .included_path_roots

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -75,6 +75,7 @@ pub(crate) fn repair_openclaw_runtime_state(meta: &EnvMeta) -> Result<bool, Stri
 pub(crate) fn openclaw_env_archive_options() -> EnvArchiveOptions {
     EnvArchiveOptions {
         should_skip_path: should_skip_openclaw_env_archive_path,
+        ..EnvArchiveOptions::default()
     }
 }
 

--- a/src/store/openclaw_workspaces.rs
+++ b/src/store/openclaw_workspaces.rs
@@ -1,0 +1,751 @@
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use super::common::path_exists;
+use super::layout::{EnvPaths, clean_path, display_path};
+
+const DEFAULT_AGENT_ID: &str = "main";
+const MAX_INCLUDE_DEPTH: usize = 10;
+const MAX_INCLUDE_FILE_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_INCLUDE_PATH_LENGTH: usize = 4096;
+
+#[derive(Clone, Debug)]
+pub(crate) struct EffectiveOpenClawConfig {
+    pub(crate) value: Value,
+    pub(crate) include_paths: BTreeSet<PathBuf>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OpenClawWorkspaceInventory {
+    workspace_roots: BTreeSet<PathBuf>,
+    config_include_paths: BTreeSet<PathBuf>,
+}
+
+impl OpenClawWorkspaceInventory {
+    pub(crate) fn contains(&self, path: &Path) -> bool {
+        let path = clean_path(path);
+        self.workspace_roots
+            .iter()
+            .any(|root| path == *root || path.starts_with(root))
+            || self.config_include_paths.contains(&path)
+    }
+
+    pub(crate) fn has_descendant(&self, path: &Path) -> bool {
+        let path = clean_path(path);
+        self.workspace_roots
+            .iter()
+            .chain(self.config_include_paths.iter())
+            .any(|root| root.starts_with(&path))
+    }
+
+    pub(crate) fn archive_relative_roots(
+        &self,
+        archive_root: &Path,
+    ) -> Result<BTreeSet<PathBuf>, String> {
+        let archive_root = clean_path(archive_root);
+        let canonical_archive_root = canonicalize_path_allow_missing(&archive_root)?;
+        let mut relative_roots = BTreeSet::new();
+
+        for preserved_path in self
+            .workspace_roots
+            .iter()
+            .chain(self.config_include_paths.iter())
+        {
+            let canonical_preserved_path = canonicalize_path_allow_missing(preserved_path)?;
+            if canonical_preserved_path == canonical_archive_root
+                || !canonical_preserved_path.starts_with(&canonical_archive_root)
+            {
+                return Err(format!(
+                    "cannot safely preserve configured OpenClaw workspace or config include that resolves outside the environment root: {} (resolved: {}; environment root resolves to: {})",
+                    display_path(preserved_path),
+                    display_path(&canonical_preserved_path),
+                    display_path(&canonical_archive_root)
+                ));
+            }
+
+            let canonical_relative = canonical_preserved_path
+                .strip_prefix(&canonical_archive_root)
+                .map_err(|error| error.to_string())?;
+            if let Ok(relative) = preserved_path.strip_prefix(&archive_root) {
+                if relative != canonical_relative {
+                    return Err(format!(
+                        "cannot safely preserve configured OpenClaw workspace or config include through a symlink: {}",
+                        display_path(preserved_path)
+                    ));
+                }
+                relative_roots.insert(relative.to_path_buf());
+            }
+            relative_roots.insert(canonical_relative.to_path_buf());
+        }
+
+        Ok(relative_roots)
+    }
+}
+
+pub(crate) fn resolve_env_openclaw_workspaces(
+    paths: &EnvPaths,
+) -> Result<OpenClawWorkspaceInventory, String> {
+    let mut inventory =
+        resolve_openclaw_workspaces(&paths.config_path, &paths.state_dir, &paths.openclaw_home)?;
+    inventory
+        .workspace_roots
+        .insert(paths.workspace_dir.clone());
+    Ok(inventory)
+}
+
+pub(crate) fn resolve_plain_openclaw_workspaces(
+    state_dir: &Path,
+) -> Result<OpenClawWorkspaceInventory, String> {
+    let state_dir = canonicalize_path_allow_missing(state_dir)?;
+    let openclaw_home = state_dir.parent().unwrap_or(&state_dir);
+    let mut inventory =
+        resolve_openclaw_workspaces(&state_dir.join("openclaw.json"), &state_dir, openclaw_home)?;
+    inventory
+        .workspace_roots
+        .insert(state_dir.join("workspace"));
+    Ok(inventory)
+}
+
+pub(crate) fn load_effective_openclaw_config(
+    config_path: &Path,
+) -> Result<Option<EffectiveOpenClawConfig>, String> {
+    if !path_exists(config_path) {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(config_path).map_err(|error| {
+        format!(
+            "failed to read OpenClaw config {}: {error}",
+            display_path(config_path)
+        )
+    })?;
+    let value = parse_json5(&raw, config_path, "OpenClaw config")?;
+    let config_root = config_path.parent().ok_or_else(|| {
+        format!(
+            "OpenClaw config path has no parent: {}",
+            config_path.display()
+        )
+    })?;
+    let mut processor = IncludeProcessor::new(config_root)?;
+    let value = processor.process(value, config_path, 0, &mut vec![clean_path(config_path)])?;
+
+    Ok(Some(EffectiveOpenClawConfig {
+        value,
+        include_paths: processor.include_paths,
+    }))
+}
+
+fn resolve_openclaw_workspaces(
+    config_path: &Path,
+    state_dir: &Path,
+    openclaw_home: &Path,
+) -> Result<OpenClawWorkspaceInventory, String> {
+    let resolved = load_effective_openclaw_config(config_path)?;
+    let config = resolved
+        .as_ref()
+        .map(|resolved| resolved.value.clone())
+        .unwrap_or_else(|| Value::Object(Map::new()));
+    let config_include_paths = resolved
+        .map(|resolved| resolved.include_paths)
+        .unwrap_or_default();
+    let entries = agent_entries(&config);
+    let default_agent_id = resolve_default_agent_id(&entries);
+    let default_workspace = config
+        .pointer("/agents/defaults/workspace")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let mut agent_ids = entries
+        .iter()
+        .filter_map(|entry| entry.get("id").and_then(Value::as_str))
+        .map(normalize_agent_id)
+        .collect::<BTreeSet<_>>();
+    agent_ids.insert(default_agent_id.clone());
+
+    let mut workspace_roots = BTreeSet::new();
+    for agent_id in agent_ids {
+        let explicit = entries
+            .iter()
+            .find(|entry| {
+                entry
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .is_some_and(|id| normalize_agent_id(id) == agent_id)
+            })
+            .and_then(|entry| entry.get("workspace"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let raw = if let Some(explicit) = explicit {
+            explicit.to_string()
+        } else if agent_id == default_agent_id {
+            default_workspace
+                .map(str::to_string)
+                .unwrap_or_else(|| display_path(&state_dir.join("workspace")))
+        } else if let Some(default_workspace) = default_workspace {
+            display_path(&resolve_workspace_path(default_workspace, openclaw_home)?.join(&agent_id))
+        } else {
+            display_path(&state_dir.join(format!("workspace-{agent_id}")))
+        };
+        let workspace = resolve_workspace_path(&raw, openclaw_home)?;
+        if workspace == clean_path(state_dir) {
+            return Err(format!(
+                "configured OpenClaw workspace cannot be the state directory itself: {}",
+                display_path(&workspace)
+            ));
+        }
+        workspace_roots.insert(workspace);
+    }
+    Ok(OpenClawWorkspaceInventory {
+        workspace_roots,
+        config_include_paths,
+    })
+}
+
+fn agent_entries(config: &Value) -> Vec<&Map<String, Value>> {
+    config
+        .pointer("/agents/list")
+        .and_then(Value::as_array)
+        .map(|entries| entries.iter().filter_map(Value::as_object).collect())
+        .unwrap_or_default()
+}
+
+fn resolve_default_agent_id(entries: &[&Map<String, Value>]) -> String {
+    let selected = entries
+        .iter()
+        .find(|entry| entry.get("default").and_then(Value::as_bool) == Some(true))
+        .or_else(|| entries.first());
+    selected
+        .and_then(|entry| entry.get("id"))
+        .and_then(Value::as_str)
+        .map(normalize_agent_id)
+        .unwrap_or_else(|| DEFAULT_AGENT_ID.to_string())
+}
+
+fn normalize_agent_id(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return DEFAULT_AGENT_ID.to_string();
+    }
+    let lowercase = trimmed.to_lowercase();
+    let valid = trimmed.len() <= 64
+        && trimmed
+            .chars()
+            .next()
+            .is_some_and(|ch| ch.is_ascii_alphanumeric())
+        && trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-');
+    if valid {
+        return lowercase;
+    }
+
+    let mut normalized = String::new();
+    let mut replacing = false;
+    for ch in lowercase.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            normalized.push(ch);
+            replacing = false;
+        } else if !replacing {
+            normalized.push('-');
+            replacing = true;
+        }
+    }
+    let normalized = normalized
+        .trim_matches('-')
+        .chars()
+        .take(64)
+        .collect::<String>();
+    if normalized.is_empty() {
+        DEFAULT_AGENT_ID.to_string()
+    } else {
+        normalized
+    }
+}
+
+fn resolve_workspace_path(raw: &str, openclaw_home: &Path) -> Result<PathBuf, String> {
+    let trimmed = raw.trim();
+    if trimmed.contains('\0') {
+        return Err("OpenClaw workspace path must not contain null bytes".to_string());
+    }
+    let expanded = match trimmed {
+        "~" => openclaw_home.to_path_buf(),
+        _ if trimmed.starts_with("~/") || trimmed.starts_with("~\\") => {
+            openclaw_home.join(&trimmed[2..])
+        }
+        _ => PathBuf::from(trimmed),
+    };
+    if !expanded.is_absolute() {
+        return Err(format!(
+            "cannot safely preserve relative OpenClaw workspace path \"{trimmed}\"; configure an absolute path or a path under ~"
+        ));
+    }
+    Ok(clean_path(&expanded))
+}
+
+struct IncludeProcessor {
+    root_dir: PathBuf,
+    canonical_root_dir: PathBuf,
+    include_paths: BTreeSet<PathBuf>,
+}
+
+impl IncludeProcessor {
+    fn new(root_dir: &Path) -> Result<Self, String> {
+        let root_dir = clean_path(root_dir);
+        let canonical_root_dir = canonicalize_path_allow_missing(&root_dir)?;
+        Ok(Self {
+            root_dir,
+            canonical_root_dir,
+            include_paths: BTreeSet::new(),
+        })
+    }
+
+    fn process(
+        &mut self,
+        value: Value,
+        containing_file: &Path,
+        depth: usize,
+        stack: &mut Vec<PathBuf>,
+    ) -> Result<Value, String> {
+        match value {
+            Value::Array(values) => values
+                .into_iter()
+                .map(|value| self.process(value, containing_file, depth, stack))
+                .collect::<Result<Vec<_>, _>>()
+                .map(Value::Array),
+            Value::Object(mut object) => {
+                let Some(include) = object.remove("$include") else {
+                    let mut resolved = Map::new();
+                    for (key, value) in object {
+                        resolved.insert(key, self.process(value, containing_file, depth, stack)?);
+                    }
+                    return Ok(Value::Object(resolved));
+                };
+
+                let included = self.resolve_include(include, containing_file, depth, stack)?;
+                if object.is_empty() {
+                    return Ok(included);
+                }
+                if !included.is_object() {
+                    return Err(
+                        "OpenClaw $include sibling keys require included content to be an object"
+                            .to_string(),
+                    );
+                }
+
+                let mut siblings = Map::new();
+                for (key, value) in object {
+                    siblings.insert(key, self.process(value, containing_file, depth, stack)?);
+                }
+                Ok(deep_merge(included, Value::Object(siblings)))
+            }
+            value => Ok(value),
+        }
+    }
+
+    fn resolve_include(
+        &mut self,
+        include: Value,
+        containing_file: &Path,
+        depth: usize,
+        stack: &mut Vec<PathBuf>,
+    ) -> Result<Value, String> {
+        match include {
+            Value::String(path) => self.load_include(&path, containing_file, depth, stack),
+            Value::Array(paths) => {
+                let mut merged = Value::Object(Map::new());
+                for path in paths {
+                    let path = path.as_str().ok_or_else(|| {
+                        "OpenClaw $include arrays must contain only paths".to_string()
+                    })?;
+                    merged = deep_merge(
+                        merged,
+                        self.load_include(path, containing_file, depth, stack)?,
+                    );
+                }
+                Ok(merged)
+            }
+            _ => Err("OpenClaw $include must be a path or an array of paths".to_string()),
+        }
+    }
+
+    fn load_include(
+        &mut self,
+        include_path: &str,
+        containing_file: &Path,
+        depth: usize,
+        stack: &mut Vec<PathBuf>,
+    ) -> Result<Value, String> {
+        if depth >= MAX_INCLUDE_DEPTH {
+            return Err(format!(
+                "maximum OpenClaw $include depth ({MAX_INCLUDE_DEPTH}) exceeded at {include_path}"
+            ));
+        }
+        let resolved = self.resolve_include_path(include_path, containing_file)?;
+        if stack.contains(&resolved) {
+            let chain = stack
+                .iter()
+                .chain(std::iter::once(&resolved))
+                .map(|path| display_path(path))
+                .collect::<Vec<_>>()
+                .join(" -> ");
+            return Err(format!("circular OpenClaw $include detected: {chain}"));
+        }
+
+        let metadata = fs::metadata(&resolved).map_err(|error| {
+            format!(
+                "failed to inspect OpenClaw include {}: {error}",
+                display_path(&resolved)
+            )
+        })?;
+        if metadata.len() > MAX_INCLUDE_FILE_BYTES {
+            return Err(format!(
+                "OpenClaw include exceeds {} bytes: {}",
+                MAX_INCLUDE_FILE_BYTES,
+                display_path(&resolved)
+            ));
+        }
+        let raw = fs::read_to_string(&resolved).map_err(|error| {
+            format!(
+                "failed to read OpenClaw include {}: {error}",
+                display_path(&resolved)
+            )
+        })?;
+        let parsed = parse_json5(&raw, &resolved, "OpenClaw include")?;
+        self.include_paths.insert(resolved.clone());
+        stack.push(resolved.clone());
+        let result = self.process(parsed, &resolved, depth + 1, stack);
+        stack.pop();
+        result
+    }
+
+    fn resolve_include_path(
+        &self,
+        include_path: &str,
+        containing_file: &Path,
+    ) -> Result<PathBuf, String> {
+        if include_path.contains('\0') {
+            return Err("OpenClaw $include path must not contain null bytes".to_string());
+        }
+        if include_path.len() >= MAX_INCLUDE_PATH_LENGTH {
+            return Err(format!(
+                "OpenClaw $include path exceeds {MAX_INCLUDE_PATH_LENGTH} characters"
+            ));
+        }
+        let include_path = Path::new(include_path);
+        let resolved = if include_path.is_absolute() {
+            clean_path(include_path)
+        } else {
+            clean_path(
+                &containing_file
+                    .parent()
+                    .unwrap_or(&self.root_dir)
+                    .join(include_path),
+            )
+        };
+        if display_path(&resolved).len() >= MAX_INCLUDE_PATH_LENGTH {
+            return Err(format!(
+                "resolved OpenClaw $include path exceeds {MAX_INCLUDE_PATH_LENGTH} characters"
+            ));
+        }
+        if !resolved.starts_with(&self.root_dir) {
+            return Err(format!(
+                "OpenClaw $include path escapes the config directory: {}",
+                display_path(&resolved)
+            ));
+        }
+        let canonical = canonicalize_path_allow_missing(&resolved)?;
+        if !canonical.starts_with(&self.canonical_root_dir) {
+            return Err(format!(
+                "OpenClaw $include path resolves outside the config directory: {}",
+                display_path(&resolved)
+            ));
+        }
+        Ok(resolved)
+    }
+}
+
+fn parse_json5(raw: &str, path: &Path, label: &str) -> Result<Value, String> {
+    json5::from_str(raw)
+        .map_err(|error| format!("failed to parse {label} {}: {error}", display_path(path)))
+}
+
+fn deep_merge(base: Value, override_value: Value) -> Value {
+    match (base, override_value) {
+        (Value::Array(mut base), Value::Array(override_values)) => {
+            base.extend(override_values);
+            Value::Array(base)
+        }
+        (Value::Object(mut base), Value::Object(override_values)) => {
+            for (key, value) in override_values {
+                let merged = base
+                    .remove(&key)
+                    .map(|current| deep_merge(current, value.clone()))
+                    .unwrap_or(value);
+                base.insert(key, merged);
+            }
+            Value::Object(base)
+        }
+        (_, override_value) => override_value,
+    }
+}
+
+fn canonicalize_path_allow_missing(path: &Path) -> Result<PathBuf, String> {
+    let mut existing = path;
+    let mut missing = Vec::<OsString>::new();
+    loop {
+        match fs::canonicalize(existing) {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(clean_path(&resolved));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let name = existing
+                    .file_name()
+                    .ok_or_else(|| format!("failed to resolve path: {}", display_path(path)))?;
+                missing.push(name.to_os_string());
+                existing = existing
+                    .parent()
+                    .ok_or_else(|| format!("failed to resolve path: {}", display_path(path)))?;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to resolve path {}: {error}",
+                    display_path(path)
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn test_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "ocm-openclaw-workspaces-{label}-{}-{}",
+            std::process::id(),
+            NEXT_ID.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn effective_config_resolves_json5_nested_includes_and_merges_arrays() {
+        let root = test_root("includes");
+        let state_dir = root.join(".openclaw");
+        fs::create_dir_all(state_dir.join("config")).unwrap();
+        fs::write(
+            state_dir.join("openclaw.json"),
+            "{ $include: ['./config/base.json5', './config/agents.json5'], agents: { list: [{ id: 'local' }] } }",
+        )
+        .unwrap();
+        fs::write(
+            state_dir.join("config/base.json5"),
+            "{ agents: { defaults: { workspace: '~/teams' } } }",
+        )
+        .unwrap();
+        fs::write(
+            state_dir.join("config/agents.json5"),
+            "{ $include: './nested.json5', agents: { list: [{ id: 'ops' }] } }",
+        )
+        .unwrap();
+        fs::write(
+            state_dir.join("config/nested.json5"),
+            "{ agents: { list: [{ id: 'main', default: true }] } }",
+        )
+        .unwrap();
+
+        let resolved = load_effective_openclaw_config(&state_dir.join("openclaw.json"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            resolved.value.pointer("/agents/defaults/workspace"),
+            Some(&Value::String("~/teams".to_string()))
+        );
+        let ids = resolved
+            .value
+            .pointer("/agents/list")
+            .and_then(Value::as_array)
+            .unwrap()
+            .iter()
+            .filter_map(|entry| entry.get("id").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["main", "ops", "local"]);
+        assert_eq!(resolved.include_paths.len(), 3);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn workspace_inventory_matches_openclaw_agent_resolution() {
+        let root = test_root("inventory");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{
+              "agents": {
+                "defaults": { "workspace": "~/teams" },
+                "list": [
+                  { "id": "Primary", "default": true },
+                  { "id": "Ops Team" },
+                  { "id": "Custom", "workspace": "~/.openclaw/team/custom" }
+                ]
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+        assert_eq!(
+            inventory.workspace_roots,
+            BTreeSet::from([
+                root.join(".openclaw/workspace"),
+                root.join("teams"),
+                root.join("teams/ops-team"),
+                root.join(".openclaw/team/custom"),
+            ])
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn workspace_inventory_rejects_external_and_symlink_escaped_paths() {
+        let root = test_root("external");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        let external = test_root("external-target");
+        fs::create_dir_all(&external).unwrap();
+        fs::write(
+            &paths.config_path,
+            format!(
+                "{{\"agents\":{{\"defaults\":{{\"workspace\":\"{}\"}}}}}}",
+                external.display()
+            ),
+        )
+        .unwrap();
+        let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+        assert!(
+            inventory.archive_relative_roots(&paths.root).is_err(),
+            "external workspace must be rejected"
+        );
+
+        #[cfg(unix)]
+        {
+            let linked = paths.state_dir.join("linked");
+            std::os::unix::fs::symlink(&external, &linked).unwrap();
+            fs::write(
+                &paths.config_path,
+                format!(
+                    "{{\"agents\":{{\"defaults\":{{\"workspace\":\"{}\"}}}}}}",
+                    linked.display()
+                ),
+            )
+            .unwrap();
+            let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+            assert!(
+                inventory.archive_relative_roots(&paths.root).is_err(),
+                "workspace symlink escaping the env root must be rejected"
+            );
+        }
+
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(external);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_inventory_rejects_internal_workspace_symlinks() {
+        let root = test_root("internal-symlink");
+        let paths = super::super::layout::derive_env_paths(&root);
+        let target = paths.state_dir.join("team/ops");
+        let linked = paths.state_dir.join("linked");
+        fs::create_dir_all(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &linked).unwrap();
+        fs::write(
+            &paths.config_path,
+            format!(
+                "{{\"agents\":{{\"defaults\":{{\"workspace\":\"{}\"}}}}}}",
+                linked.display()
+            ),
+        )
+        .unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+        assert!(inventory.contains(&linked));
+        let error = inventory.archive_relative_roots(&paths.root).unwrap_err();
+        assert!(error.contains("through a symlink"), "{error}");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn workspace_inventory_rejects_relative_paths() {
+        let root = test_root("relative");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{"agents":{"defaults":{"workspace":"relative/workspace"}}}"#,
+        )
+        .unwrap();
+
+        let error = resolve_env_openclaw_workspaces(&paths).unwrap_err();
+        assert!(
+            error.contains("relative OpenClaw workspace path"),
+            "{error}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn workspace_inventory_does_not_infer_prefix_lookalikes() {
+        let root = test_root("lookalikes");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        fs::write(&paths.config_path, "{}").unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+        assert!(inventory.contains(&paths.workspace_dir));
+        assert!(!inventory.contains(&paths.state_dir.join("workspace-attestations")));
+        assert!(!inventory.contains(&paths.state_dir.join("workspace-cache")));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn effective_config_rejects_circular_includes() {
+        let root = test_root("circular");
+        let state_dir = root.join(".openclaw");
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("openclaw.json"),
+            r#"{"$include":"./a.json5"}"#,
+        )
+        .unwrap();
+        fs::write(
+            state_dir.join("a.json5"),
+            r#"{"$include":"./openclaw.json"}"#,
+        )
+        .unwrap();
+
+        let error = load_effective_openclaw_config(&state_dir.join("openclaw.json")).unwrap_err();
+        assert!(error.contains("circular OpenClaw $include"), "{error}");
+
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/store/openclaw_workspaces.rs
+++ b/src/store/openclaw_workspaces.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -88,9 +88,14 @@ impl OpenClawWorkspaceInventory {
 
 pub(crate) fn resolve_env_openclaw_workspaces(
     paths: &EnvPaths,
+    env: &BTreeMap<String, String>,
 ) -> Result<OpenClawWorkspaceInventory, String> {
-    let mut inventory =
-        resolve_openclaw_workspaces(&paths.config_path, &paths.state_dir, &paths.openclaw_home)?;
+    let mut inventory = resolve_openclaw_workspaces(
+        &paths.config_path,
+        &paths.state_dir,
+        &paths.openclaw_home,
+        env,
+    )?;
     inventory
         .workspace_roots
         .insert(paths.workspace_dir.clone());
@@ -99,11 +104,16 @@ pub(crate) fn resolve_env_openclaw_workspaces(
 
 pub(crate) fn resolve_plain_openclaw_workspaces(
     state_dir: &Path,
+    env: &BTreeMap<String, String>,
 ) -> Result<OpenClawWorkspaceInventory, String> {
     let state_dir = canonicalize_path_allow_missing(state_dir)?;
     let openclaw_home = state_dir.parent().unwrap_or(&state_dir);
-    let mut inventory =
-        resolve_openclaw_workspaces(&state_dir.join("openclaw.json"), &state_dir, openclaw_home)?;
+    let mut inventory = resolve_openclaw_workspaces(
+        &state_dir.join("openclaw.json"),
+        &state_dir,
+        openclaw_home,
+        env,
+    )?;
     inventory
         .workspace_roots
         .insert(state_dir.join("workspace"));
@@ -143,12 +153,16 @@ fn resolve_openclaw_workspaces(
     config_path: &Path,
     state_dir: &Path,
     openclaw_home: &Path,
+    env: &BTreeMap<String, String>,
 ) -> Result<OpenClawWorkspaceInventory, String> {
     let resolved = load_effective_openclaw_config(config_path)?;
     let config = resolved
         .as_ref()
         .map(|resolved| resolved.value.clone())
         .unwrap_or_else(|| Value::Object(Map::new()));
+    let mut config_env = openclaw_config_env(env, openclaw_home, state_dir, config_path);
+    apply_openclaw_config_env(&config, &mut config_env);
+    let config = resolve_config_env_vars(config, &config_env);
     let config_include_paths = resolved
         .map(|resolved| resolved.include_paths)
         .unwrap_or_default();
@@ -205,6 +219,169 @@ fn resolve_openclaw_workspaces(
         workspace_roots,
         config_include_paths,
     })
+}
+
+fn openclaw_config_env(
+    env: &BTreeMap<String, String>,
+    openclaw_home: &Path,
+    state_dir: &Path,
+    config_path: &Path,
+) -> BTreeMap<String, String> {
+    let mut resolved = env
+        .iter()
+        .filter(|(key, _)| !key.starts_with("OPENCLAW_"))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<BTreeMap<_, _>>();
+    resolved.insert("OPENCLAW_HOME".to_string(), display_path(openclaw_home));
+    resolved.insert("OPENCLAW_STATE_DIR".to_string(), display_path(state_dir));
+    resolved.insert(
+        "OPENCLAW_CONFIG_PATH".to_string(),
+        display_path(config_path),
+    );
+    resolved
+}
+
+fn apply_openclaw_config_env(config: &Value, env: &mut BTreeMap<String, String>) {
+    let Some(config_env) = config.get("env").and_then(Value::as_object) else {
+        return;
+    };
+    if let Some(vars) = config_env.get("vars").and_then(Value::as_object) {
+        for (key, value) in vars {
+            apply_openclaw_config_env_entry(key, value, env);
+        }
+    }
+    for (key, value) in config_env {
+        if key != "shellEnv" && key != "vars" {
+            apply_openclaw_config_env_entry(key, value, env);
+        }
+    }
+}
+
+fn apply_openclaw_config_env_entry(key: &str, value: &Value, env: &mut BTreeMap<String, String>) {
+    let Some(value) = value.as_str().filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    if !is_portable_env_var_name(key)
+        || contains_config_env_reference(value)
+        || env.get(key).is_some_and(|value| !value.trim().is_empty())
+    {
+        return;
+    }
+    env.insert(key.to_string(), value.to_string());
+}
+
+fn contains_config_env_reference(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            index += 1;
+            continue;
+        }
+        if bytes.get(index + 1) == Some(&b'$') && bytes.get(index + 2) == Some(&b'{') {
+            index += 2;
+            continue;
+        }
+        if bytes.get(index + 1) == Some(&b'{') {
+            let name_start = index + 2;
+            if let Some(relative_end) = value[name_start..].find('}') {
+                let name_end = name_start + relative_end;
+                if is_openclaw_env_var_name(&value[name_start..name_end]) {
+                    return true;
+                }
+            }
+        }
+        index += 1;
+    }
+    false
+}
+
+fn is_portable_env_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn resolve_config_env_vars(value: Value, env: &BTreeMap<String, String>) -> Value {
+    match value {
+        Value::String(value) => Value::String(resolve_config_env_string(&value, env)),
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(|value| resolve_config_env_vars(value, env))
+                .collect(),
+        ),
+        Value::Object(values) => Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, resolve_config_env_vars(value, env)))
+                .collect(),
+        ),
+        value => value,
+    }
+}
+
+fn resolve_config_env_string(value: &str, env: &BTreeMap<String, String>) -> String {
+    let mut resolved = String::with_capacity(value.len());
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            let ch = value[index..]
+                .chars()
+                .next()
+                .expect("valid string boundary");
+            resolved.push(ch);
+            index += ch.len_utf8();
+            continue;
+        }
+
+        let (escaped, name_start) =
+            if bytes.get(index + 1) == Some(&b'$') && bytes.get(index + 2) == Some(&b'{') {
+                (true, index + 3)
+            } else if bytes.get(index + 1) == Some(&b'{') {
+                (false, index + 2)
+            } else {
+                resolved.push('$');
+                index += 1;
+                continue;
+            };
+        let Some(relative_end) = value[name_start..].find('}') else {
+            resolved.push('$');
+            index += 1;
+            continue;
+        };
+        let name_end = name_start + relative_end;
+        let name = &value[name_start..name_end];
+        if !is_openclaw_env_var_name(name) {
+            resolved.push('$');
+            index += 1;
+            continue;
+        }
+        if escaped {
+            resolved.push_str("${");
+            resolved.push_str(name);
+            resolved.push('}');
+        } else if let Some(env_value) = env.get(name).filter(|value| !value.is_empty()) {
+            resolved.push_str(env_value);
+        } else {
+            resolved.push_str("${");
+            resolved.push_str(name);
+            resolved.push('}');
+        }
+        index = name_end + 1;
+    }
+    resolved
+}
+
+fn is_openclaw_env_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_uppercase())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_uppercase() || ch.is_ascii_digit())
 }
 
 fn agent_entries(config: &Value) -> Vec<&Map<String, Value>> {
@@ -541,6 +718,10 @@ mod tests {
         ))
     }
 
+    fn test_env() -> BTreeMap<String, String> {
+        BTreeMap::new()
+    }
+
     #[test]
     fn effective_config_resolves_json5_nested_includes_and_merges_arrays() {
         let root = test_root("includes");
@@ -608,7 +789,7 @@ mod tests {
         )
         .unwrap();
 
-        let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+        let inventory = resolve_env_openclaw_workspaces(&paths, &test_env()).unwrap();
         assert_eq!(
             inventory.workspace_roots,
             BTreeSet::from([
@@ -617,6 +798,71 @@ mod tests {
                 root.join("teams/ops-team"),
                 root.join(".openclaw/team/custom"),
             ])
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn workspace_inventory_resolves_openclaw_config_env_substitution() {
+        let root = test_root("env-substitution");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{
+              "agents": {
+                "defaults": {
+                  "workspace": "${OPENCLAW_HOME}/.openclaw/team"
+                },
+                "list": [
+                  { "id": "main", "default": true },
+                  { "id": "ops", "workspace": "${CUSTOM_WORKSPACE_ROOT}/ops" }
+                ]
+              }
+            }"#,
+        )
+        .unwrap();
+        let env = BTreeMap::from([(
+            "CUSTOM_WORKSPACE_ROOT".to_string(),
+            display_path(&paths.state_dir.join("custom")),
+        )]);
+        let mut config: Value =
+            serde_json::from_str(&fs::read_to_string(&paths.config_path).unwrap()).unwrap();
+        config["env"] = serde_json::json!({
+            "vars": {
+                "CONFIG_WORKSPACE_ROOT": display_path(&paths.state_dir.join("configured")),
+                "IGNORED_REFERENCE": "${CUSTOM_WORKSPACE_ROOT}"
+            }
+        });
+        config["agents"]["list"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "id": "config",
+                "workspace": "${CONFIG_WORKSPACE_ROOT}/agent"
+            }));
+        fs::write(
+            &paths.config_path,
+            serde_json::to_vec_pretty(&config).unwrap(),
+        )
+        .unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(&paths, &env).unwrap();
+        assert!(inventory.contains(&paths.state_dir.join("team")));
+        assert!(inventory.contains(&paths.state_dir.join("custom/ops")));
+        assert!(inventory.contains(&paths.state_dir.join("configured/agent")));
+        assert_eq!(
+            resolve_config_env_string(
+                "$${OPENCLAW_HOME}/${OPENCLAW_HOME}",
+                &openclaw_config_env(
+                    &env,
+                    &paths.openclaw_home,
+                    &paths.state_dir,
+                    &paths.config_path
+                )
+            ),
+            format!("${{OPENCLAW_HOME}}/{}", display_path(&paths.openclaw_home))
         );
 
         let _ = fs::remove_dir_all(root);
@@ -637,7 +883,7 @@ mod tests {
             ),
         )
         .unwrap();
-        let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+        let inventory = resolve_env_openclaw_workspaces(&paths, &test_env()).unwrap();
         assert!(
             inventory.archive_relative_roots(&paths.root).is_err(),
             "external workspace must be rejected"
@@ -655,7 +901,7 @@ mod tests {
                 ),
             )
             .unwrap();
-            let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+            let inventory = resolve_env_openclaw_workspaces(&paths, &test_env()).unwrap();
             assert!(
                 inventory.archive_relative_roots(&paths.root).is_err(),
                 "workspace symlink escaping the env root must be rejected"
@@ -684,7 +930,7 @@ mod tests {
         )
         .unwrap();
 
-        let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+        let inventory = resolve_env_openclaw_workspaces(&paths, &test_env()).unwrap();
         assert!(inventory.contains(&linked));
         let error = inventory.archive_relative_roots(&paths.root).unwrap_err();
         assert!(error.contains("through a symlink"), "{error}");
@@ -703,7 +949,7 @@ mod tests {
         )
         .unwrap();
 
-        let error = resolve_env_openclaw_workspaces(&paths).unwrap_err();
+        let error = resolve_env_openclaw_workspaces(&paths, &test_env()).unwrap_err();
         assert!(
             error.contains("relative OpenClaw workspace path"),
             "{error}"
@@ -719,7 +965,7 @@ mod tests {
         fs::create_dir_all(&paths.state_dir).unwrap();
         fs::write(&paths.config_path, "{}").unwrap();
 
-        let inventory = resolve_env_openclaw_workspaces(&paths).unwrap();
+        let inventory = resolve_env_openclaw_workspaces(&paths, &test_env()).unwrap();
         assert!(inventory.contains(&paths.workspace_dir));
         assert!(!inventory.contains(&paths.state_dir.join("workspace-attestations")));
         assert!(!inventory.contains(&paths.state_dir.join("workspace-cache")));

--- a/src/store/openclaw_workspaces.rs
+++ b/src/store/openclaw_workspaces.rs
@@ -1,6 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
@@ -127,12 +130,7 @@ pub(crate) fn load_effective_openclaw_config(
         return Ok(None);
     }
 
-    let raw = fs::read_to_string(config_path).map_err(|error| {
-        format!(
-            "failed to read OpenClaw config {}: {error}",
-            display_path(config_path)
-        )
-    })?;
+    let raw = read_regular_text_file(config_path, "OpenClaw config", None)?;
     let value = parse_json5(&raw, config_path, "OpenClaw config")?;
     let config_root = config_path.parent().ok_or_else(|| {
         format!(
@@ -453,7 +451,9 @@ fn resolve_workspace_path(raw: &str, openclaw_home: &Path) -> Result<PathBuf, St
     let expanded = match trimmed {
         "~" => openclaw_home.to_path_buf(),
         _ if trimmed.starts_with("~/") || trimmed.starts_with("~\\") => {
-            openclaw_home.join(&trimmed[2..])
+            let mut expanded = openclaw_home.as_os_str().to_os_string();
+            expanded.push(&trimmed[1..]);
+            PathBuf::from(expanded)
         }
         _ => PathBuf::from(trimmed),
     };
@@ -574,25 +574,8 @@ impl IncludeProcessor {
             return Err(format!("circular OpenClaw $include detected: {chain}"));
         }
 
-        let metadata = fs::metadata(&resolved).map_err(|error| {
-            format!(
-                "failed to inspect OpenClaw include {}: {error}",
-                display_path(&resolved)
-            )
-        })?;
-        if metadata.len() > MAX_INCLUDE_FILE_BYTES {
-            return Err(format!(
-                "OpenClaw include exceeds {} bytes: {}",
-                MAX_INCLUDE_FILE_BYTES,
-                display_path(&resolved)
-            ));
-        }
-        let raw = fs::read_to_string(&resolved).map_err(|error| {
-            format!(
-                "failed to read OpenClaw include {}: {error}",
-                display_path(&resolved)
-            )
-        })?;
+        let raw =
+            read_regular_text_file(&resolved, "OpenClaw include", Some(MAX_INCLUDE_FILE_BYTES))?;
         let parsed = parse_json5(&raw, &resolved, "OpenClaw include")?;
         self.include_paths.insert(resolved.clone());
         stack.push(resolved.clone());
@@ -645,6 +628,54 @@ impl IncludeProcessor {
         }
         Ok(resolved)
     }
+}
+
+fn read_regular_text_file(
+    path: &Path,
+    label: &str,
+    max_bytes: Option<u64>,
+) -> Result<String, String> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NONBLOCK);
+
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("failed to open {label} {}: {error}", display_path(path)))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect {label} {}: {error}", display_path(path)))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "{label} must be a regular file: {}",
+            display_path(path)
+        ));
+    }
+    if max_bytes.is_some_and(|max_bytes| metadata.len() > max_bytes) {
+        return Err(format!(
+            "{label} exceeds {} bytes: {}",
+            max_bytes.unwrap_or_default(),
+            display_path(path)
+        ));
+    }
+
+    let mut raw = String::new();
+    if let Some(max_bytes) = max_bytes {
+        file.take(max_bytes + 1)
+            .read_to_string(&mut raw)
+            .map_err(|error| format!("failed to read {label} {}: {error}", display_path(path)))?;
+        if raw.len() as u64 > max_bytes {
+            return Err(format!(
+                "{label} exceeds {max_bytes} bytes: {}",
+                display_path(path)
+            ));
+        }
+    } else {
+        file.read_to_string(&mut raw)
+            .map_err(|error| format!("failed to read {label} {}: {error}", display_path(path)))?;
+    }
+    Ok(raw)
 }
 
 fn parse_json5(raw: &str, path: &Path, label: &str) -> Result<Value, String> {
@@ -704,6 +735,10 @@ fn canonicalize_path_allow_missing(path: &Path) -> Result<PathBuf, String> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::ffi::CString;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStrExt;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
@@ -993,5 +1028,35 @@ mod tests {
         assert!(error.contains("circular OpenClaw $include"), "{error}");
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn effective_config_rejects_non_regular_includes_without_blocking() {
+        let root = test_root("fifo-include");
+        let state_dir = root.join(".openclaw");
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("openclaw.json"),
+            r#"{"$include":"./agents.json5"}"#,
+        )
+        .unwrap();
+        let fifo = state_dir.join("agents.json5");
+        let fifo_path = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+
+        let error = load_effective_openclaw_config(&state_dir.join("openclaw.json")).unwrap_err();
+        assert!(error.contains("must be a regular file"), "{error}");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_home_expansion_preserves_backslashes_on_unix() {
+        assert_eq!(
+            resolve_workspace_path(r"~\team", Path::new("/tmp/openclaw-home")).unwrap(),
+            PathBuf::from(r"/tmp/openclaw-home\team")
+        );
     }
 }

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -113,7 +113,7 @@ pub fn create_env_snapshot(
             &metadata,
             &env_paths.root,
             &archive_path,
-            openclaw_env_archive_options(&env_paths)?,
+            openclaw_env_archive_options(&env_paths, env)?,
         )?;
         write_json(&meta_path, &snapshot)?;
         Ok(snapshot)
@@ -231,9 +231,9 @@ pub fn restore_env_snapshot(
                 last_used_at: current.last_used_at,
             };
             let known_envs = list_environments(env, cwd)?;
-            let audit = audit_openclaw_state(&restored, &known_envs);
+            let audit = audit_openclaw_state(&restored, &known_envs, env);
             if audit.repair_runtime_state {
-                clear_nonportable_runtime_state(&current_paths)?;
+                clear_nonportable_runtime_state(&current_paths, env)?;
             }
             save_environment(restored, env, cwd)
         })();

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -113,7 +113,7 @@ pub fn create_env_snapshot(
             &metadata,
             &env_paths.root,
             &archive_path,
-            openclaw_env_archive_options(),
+            openclaw_env_archive_options(&env_paths)?,
         )?;
         write_json(&meta_path, &snapshot)?;
         Ok(snapshot)

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -116,9 +116,18 @@ fn env_clone_preserves_configured_custom_workspaces_without_prefix_lookalikes() 
     write_text(
         &source_state.join("openclaw.json"),
         &format!(
-            r#"{{"agents":{{"list":[{{"id":"main","default":true}},{{"id":"ops","workspace":"{}"}}]}}}}"#,
+            concat!(
+                r#"{{"agents":{{"#,
+                r#""defaults":{{"memorySearch":{{"$include":"./config/memory.json5"}}}},"#,
+                r#""list":[{{"id":"main","default":true}},{{"id":"ops","workspace":"{}"}}]"#,
+                "}}}}"
+            ),
             source_state.join("team/ops").display()
         ),
+    );
+    write_text(
+        &source_state.join("config/memory.json5"),
+        "{ enabled: false }\n",
     );
     write_text(
         &source_state.join("team/ops/notes.txt"),
@@ -146,6 +155,7 @@ fn env_clone_preserves_configured_custom_workspaces_without_prefix_lookalikes() 
         config["agents"]["list"][1]["workspace"].as_str(),
         Some(expected_workspace.as_str())
     );
+    assert!(target_state.join("config/memory.json5").exists());
 }
 
 #[test]

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -102,6 +102,89 @@ fn env_clone_rewrites_openclaw_config_for_the_new_env_root() {
 }
 
 #[test]
+fn env_clone_preserves_configured_custom_workspaces_without_prefix_lookalikes() {
+    let root = TestDir::new("env-clone-custom-workspace");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let source_root = root.child("ocm-home/envs/source");
+    let source_state = source_root.join(".openclaw");
+    write_text(
+        &source_state.join("openclaw.json"),
+        &format!(
+            r#"{{"agents":{{"list":[{{"id":"main","default":true}},{{"id":"ops","workspace":"{}"}}]}}}}"#,
+            source_state.join("team/ops").display()
+        ),
+    );
+    write_text(
+        &source_state.join("team/ops/notes.txt"),
+        "custom workspace should survive\n",
+    );
+    write_text(
+        &source_state.join("workspace-cache/cache.json"),
+        "unconfigured lookalike\n",
+    );
+
+    let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
+    assert!(clone.status.success(), "{}", stderr(&clone));
+
+    let target_state = root.child("ocm-home/envs/target/.openclaw");
+    assert_eq!(
+        fs::read_to_string(target_state.join("team/ops/notes.txt")).unwrap(),
+        "custom workspace should survive\n"
+    );
+    assert!(!target_state.join("workspace-cache").exists());
+    let config: Value =
+        serde_json::from_str(&fs::read_to_string(target_state.join("openclaw.json")).unwrap())
+            .unwrap();
+    let expected_workspace = target_state.join("team/ops").display().to_string();
+    assert_eq!(
+        config["agents"]["list"][1]["workspace"].as_str(),
+        Some(expected_workspace.as_str())
+    );
+}
+
+#[test]
+fn env_clone_rejects_external_workspaces_before_creating_the_target() {
+    let root = TestDir::new("env-clone-external-workspace");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+    let external = root.child("external-workspace");
+    write_text(
+        &external.join("notes.txt"),
+        "must not be silently omitted\n",
+    );
+    write_text(
+        &root.child("ocm-home/envs/source/.openclaw/openclaw.json"),
+        &format!(
+            r#"{{"agents":{{"defaults":{{"workspace":"{}"}}}}}}"#,
+            external.display()
+        ),
+    );
+
+    let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
+    assert_eq!(clone.status.code(), Some(1));
+    assert!(
+        stderr(&clone).contains("outside the environment root"),
+        "{}",
+        stderr(&clone)
+    );
+    assert!(!root.child("ocm-home/envs/target").exists());
+    assert_eq!(
+        fs::read_to_string(external.join("notes.txt")).unwrap(),
+        "must not be silently omitted\n"
+    );
+}
+
+#[test]
 fn env_clone_rewrites_coupled_sandbox_port_and_clears_public_origin() {
     let root = TestDir::new("env-clone-mcp-app-sandbox-rewrite");
     let cwd = root.child("workspace");
@@ -276,6 +359,36 @@ fn env_clone_rejects_include_owned_sandbox_configuration_before_copying() {
     assert!(
         stderr(&clone).contains(
             "cannot safely reset mcp.apps.sandboxOrigin because OpenClaw config uses $include at mcp"
+        ),
+        "{}",
+        stderr(&clone)
+    );
+    assert!(!root.child("ocm-home/envs/target").exists());
+}
+
+#[test]
+fn env_clone_rejects_include_owned_agent_workspaces_before_copying() {
+    let root = TestDir::new("env-clone-include-owned-agent-workspace");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+    write_text(
+        &root.child("ocm-home/envs/source/.openclaw/openclaw.json"),
+        "{\n  \"agents\": { \"$include\": \"./agents.json5\" }\n}\n",
+    );
+    write_text(
+        &root.child("ocm-home/envs/source/.openclaw/agents.json5"),
+        "{ defaults: { workspace: '~/.openclaw/team/ops' } }\n",
+    );
+
+    let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
+    assert_eq!(clone.status.code(), Some(1));
+    assert!(
+        stderr(&clone).contains(
+            "cannot safely rewrite OpenClaw agent workspaces because config uses $include at agents"
         ),
         "{}",
         stderr(&clone)

--- a/tests/env_import_tests.rs
+++ b/tests/env_import_tests.rs
@@ -24,6 +24,18 @@ fn env_import_restores_an_archive_with_a_new_name_and_root() {
         &root.child("ocm-home/envs/source/.openclaw/workspace/notes.txt"),
         "hello import",
     );
+    let source_state = root.child("ocm-home/envs/source/.openclaw");
+    write_text(
+        &source_state.join("openclaw.json"),
+        &format!(
+            r#"{{"agents":{{"list":[{{"id":"main","default":true}},{{"id":"ops","workspace":"{}"}}]}}}}"#,
+            source_state.join("team/ops").display()
+        ),
+    );
+    write_text(
+        &source_state.join("team/ops/custom.txt"),
+        "hello custom import",
+    );
 
     let export = run_ocm(
         &cwd,
@@ -72,6 +84,20 @@ fn env_import_restores_an_archive_with_a_new_name_and_root() {
         .unwrap(),
         "hello import"
     );
+    let target_state = root.child("workspace/imports/target-root/.openclaw");
+    assert_eq!(
+        fs::read_to_string(target_state.join("team/ops/custom.txt")).unwrap(),
+        "hello custom import"
+    );
+    let config: Value =
+        serde_json::from_str(&fs::read_to_string(target_state.join("openclaw.json")).unwrap())
+            .unwrap();
+    let actual_workspace = fs::canonicalize(Path::new(
+        config["agents"]["list"][1]["workspace"].as_str().unwrap(),
+    ))
+    .unwrap();
+    let expected_workspace = fs::canonicalize(target_state.join("team/ops")).unwrap();
+    assert_eq!(actual_workspace, expected_workspace);
 }
 
 #[test]
@@ -295,6 +321,10 @@ fn env_import_rejects_include_owned_sandbox_configuration_before_creating_the_ta
     write_text(
         &root.child("ocm-home/envs/source/.openclaw/openclaw.json"),
         "{\n  \"$include\": \"./base.json5\"\n}\n",
+    );
+    write_text(
+        &root.child("ocm-home/envs/source/.openclaw/base.json5"),
+        "{ mcp: { apps: { sandboxOrigin: 'https://source.example.test' } } }\n",
     );
     let export = run_ocm(
         &cwd,

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -269,6 +269,57 @@ fn env_snapshot_restore_reverts_state_from_the_selected_snapshot() {
 }
 
 #[test]
+fn env_snapshot_restore_preserves_secondary_agent_workspaces() {
+    let root = TestDir::new("env-snapshot-secondary-workspaces");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let source_state = root.child("ocm-home/envs/source/.openclaw");
+    write_text(
+        &source_state.join("workspace-clawforce/skills/social/SKILL.md"),
+        "clawforce skill before upgrade\n",
+    );
+    write_text(
+        &source_state.join("workspace-clawdred/IDENTITY.md"),
+        "Clawd Red before upgrade\n",
+    );
+
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source", "--json"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    let snapshot_id = stdout(&list)
+        .split("\"id\": \"")
+        .nth(1)
+        .and_then(|rest| rest.split('"').next())
+        .unwrap()
+        .to_string();
+
+    fs::remove_dir_all(source_state.join("workspace-clawforce")).unwrap();
+    fs::remove_dir_all(source_state.join("workspace-clawdred")).unwrap();
+
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", &snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    assert_eq!(
+        fs::read_to_string(source_state.join("workspace-clawforce/skills/social/SKILL.md"))
+            .unwrap(),
+        "clawforce skill before upgrade\n"
+    );
+    assert_eq!(
+        fs::read_to_string(source_state.join("workspace-clawdred/IDENTITY.md")).unwrap(),
+        "Clawd Red before upgrade\n"
+    );
+}
+
+#[test]
 fn env_snapshot_restore_json_reports_the_restored_binding_shape() {
     let root = TestDir::new("env-snapshot-restore-json");
     let cwd = root.child("workspace");

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -281,19 +281,21 @@ fn env_snapshot_restore_preserves_configured_agent_workspaces_and_includes() {
     let source_state = root.child("ocm-home/envs/source/.openclaw");
     write_text(
         &source_state.join("openclaw.json"),
-        "{ $include: './config/agents.json5' }\n",
+        concat!(
+            "{\n",
+            "  $include: './config/agents.json5',\n",
+            "  env: { vars: { SECONDARY_WORKSPACE: 'team/ops' } }\n",
+            "}\n"
+        ),
     );
     write_text(
         &source_state.join("config/agents.json5"),
-        &format!(
-            concat!(
-                "{{ agents: {{ list: [\n",
-                "  {{ id: 'main', default: true }},\n",
-                "  {{ id: 'clawforce' }},\n",
-                "  {{ id: 'custom', workspace: '{}' }}\n",
-                "] }} }}\n"
-            ),
-            source_state.join("team/ops").display()
+        concat!(
+            "{ agents: { list: [\n",
+            "  { id: 'main', default: true },\n",
+            "  { id: 'clawforce' },\n",
+            "  { id: 'custom', workspace: '${OPENCLAW_HOME}/.openclaw/${SECONDARY_WORKSPACE}' }\n",
+            "] } }\n"
         ),
     );
     write_text(

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -269,7 +269,7 @@ fn env_snapshot_restore_reverts_state_from_the_selected_snapshot() {
 }
 
 #[test]
-fn env_snapshot_restore_preserves_secondary_agent_workspaces() {
+fn env_snapshot_restore_preserves_configured_agent_workspaces_and_includes() {
     let root = TestDir::new("env-snapshot-secondary-workspaces");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -280,12 +280,37 @@ fn env_snapshot_restore_preserves_secondary_agent_workspaces() {
 
     let source_state = root.child("ocm-home/envs/source/.openclaw");
     write_text(
+        &source_state.join("openclaw.json"),
+        "{ $include: './config/agents.json5' }\n",
+    );
+    write_text(
+        &source_state.join("config/agents.json5"),
+        &format!(
+            concat!(
+                "{{ agents: {{ list: [\n",
+                "  {{ id: 'main', default: true }},\n",
+                "  {{ id: 'clawforce' }},\n",
+                "  {{ id: 'custom', workspace: '{}' }}\n",
+                "] }} }}\n"
+            ),
+            source_state.join("team/ops").display()
+        ),
+    );
+    write_text(
         &source_state.join("workspace-clawforce/skills/social/SKILL.md"),
         "clawforce skill before upgrade\n",
     );
     write_text(
-        &source_state.join("workspace-clawdred/IDENTITY.md"),
-        "Clawd Red before upgrade\n",
+        &source_state.join("team/ops/IDENTITY.md"),
+        "custom workspace before upgrade\n",
+    );
+    write_text(
+        &source_state.join("workspace-attestations/manifest.json"),
+        "legacy generated state\n",
+    );
+    write_text(
+        &source_state.join("workspace-cache/cache.json"),
+        "unconfigured prefix lookalike\n",
     );
 
     let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
@@ -300,7 +325,10 @@ fn env_snapshot_restore_preserves_secondary_agent_workspaces() {
         .to_string();
 
     fs::remove_dir_all(source_state.join("workspace-clawforce")).unwrap();
-    fs::remove_dir_all(source_state.join("workspace-clawdred")).unwrap();
+    fs::remove_dir_all(source_state.join("team")).unwrap();
+    fs::remove_dir_all(source_state.join("config")).unwrap();
+    fs::remove_dir_all(source_state.join("workspace-attestations")).unwrap();
+    fs::remove_dir_all(source_state.join("workspace-cache")).unwrap();
 
     let restore = run_ocm(
         &cwd,
@@ -314,8 +342,44 @@ fn env_snapshot_restore_preserves_secondary_agent_workspaces() {
         "clawforce skill before upgrade\n"
     );
     assert_eq!(
-        fs::read_to_string(source_state.join("workspace-clawdred/IDENTITY.md")).unwrap(),
-        "Clawd Red before upgrade\n"
+        fs::read_to_string(source_state.join("team/ops/IDENTITY.md")).unwrap(),
+        "custom workspace before upgrade\n"
+    );
+    assert!(source_state.join("config/agents.json5").exists());
+    assert!(!source_state.join("workspace-attestations").exists());
+    assert!(!source_state.join("workspace-cache").exists());
+}
+
+#[test]
+fn env_snapshot_rejects_external_workspaces_before_writing_an_archive() {
+    let root = TestDir::new("env-snapshot-external-workspace");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+    let external = root.child("external-workspace");
+    write_text(&external.join("notes.txt"), "external data\n");
+    write_text(
+        &root.child("ocm-home/envs/source/.openclaw/openclaw.json"),
+        &format!(
+            r#"{{"agents":{{"defaults":{{"workspace":"{}"}}}}}}"#,
+            external.display()
+        ),
+    );
+
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
+    assert_eq!(snapshot.status.code(), Some(1));
+    assert!(
+        stderr(&snapshot).contains("outside the environment root"),
+        "{}",
+        stderr(&snapshot)
+    );
+    assert!(!root.child("ocm-home/snapshots/source").exists());
+    assert_eq!(
+        fs::read_to_string(external.join("notes.txt")).unwrap(),
+        "external data\n"
     );
 }
 

--- a/tests/migrate_command_tests.rs
+++ b/tests/migrate_command_tests.rs
@@ -360,6 +360,7 @@ fn migrate_rejects_alias_after_name_flag_with_clear_error() {
 
 fn seed_plain_openclaw_home(source_home: &std::path::Path) {
     fs::create_dir_all(source_home.join("workspace")).unwrap();
+    fs::create_dir_all(source_home.join("team/ops")).unwrap();
     fs::create_dir_all(source_home.join("logs")).unwrap();
     fs::create_dir_all(source_home.join("run")).unwrap();
     fs::create_dir_all(source_home.join("agents/main/agent")).unwrap();
@@ -367,8 +368,9 @@ fn seed_plain_openclaw_home(source_home: &std::path::Path) {
     fs::write(
         source_home.join("openclaw.json"),
         format!(
-            "{{\"agents\":{{\"defaults\":{{\"workspace\":\"{}\"}}}},\"externalProject\":\"{}\"}}\n",
+            "{{\"agents\":{{\"defaults\":{{\"workspace\":\"{}\"}},\"list\":[{{\"id\":\"main\",\"default\":true}},{{\"id\":\"ops\",\"workspace\":\"{}\"}}]}},\"externalProject\":\"{}\"}}\n",
             source_home.join("workspace").display(),
+            source_home.join("team/ops").display(),
             source_home
                 .parent()
                 .unwrap()
@@ -378,6 +380,11 @@ fn seed_plain_openclaw_home(source_home: &std::path::Path) {
     )
     .unwrap();
     fs::write(source_home.join("workspace/notes.txt"), "hello\n").unwrap();
+    fs::write(
+        source_home.join("team/ops/custom.txt"),
+        "secondary workspace\n",
+    )
+    .unwrap();
     fs::write(
         source_home.join("logs/app.log"),
         format!("cwd={}\n", source_home.join("workspace").display()),
@@ -411,6 +418,10 @@ fn assert_imported_plain_openclaw_home(
     source_home: &std::path::Path,
 ) {
     assert!(imported_state.join("workspace/notes.txt").exists());
+    assert_eq!(
+        fs::read_to_string(imported_state.join("team/ops/custom.txt")).unwrap(),
+        "secondary workspace\n"
+    );
     assert!(
         imported_state
             .join("agents/main/agent/auth-profiles.json")
@@ -871,6 +882,44 @@ fn migrate_validates_the_target_origin_before_reading_the_source_home() {
         "--sandbox-origin must be an HTTP(S) origin without a path, query, or credentials"
     ));
     assert!(!stderr(&output).contains("plain OpenClaw home does not exist"));
+}
+
+#[test]
+fn migrate_rejects_external_workspaces_before_creating_the_environment() {
+    let root = TestDir::new("migrate-external-workspace");
+    let cwd = root.child("workspace");
+    let source_home = root.child("legacy-home/.openclaw");
+    let external = root.child("external-workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(&source_home).unwrap();
+    fs::create_dir_all(&external).unwrap();
+    fs::write(external.join("notes.txt"), "external data\n").unwrap();
+    fs::write(
+        source_home.join("openclaw.json"),
+        format!(
+            r#"{{"agents":{{"defaults":{{"workspace":"{}"}}}}}}"#,
+            external.display()
+        ),
+    )
+    .unwrap();
+    let env = ocm_env(&root);
+
+    let output = run_ocm(
+        &cwd,
+        &env,
+        &["migrate", "mira", source_home.to_string_lossy().as_ref()],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        stderr(&output).contains("outside the environment root"),
+        "{}",
+        stderr(&output)
+    );
+    assert!(!root.child("ocm-home/envs/mira").exists());
+    assert_eq!(
+        fs::read_to_string(external.join("notes.txt")).unwrap(),
+        "external data\n"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -1560,6 +1560,11 @@ fn upgrade_rolls_back_runtime_binding_when_update_finalization_fails() {
     );
     assert!(create.status.success(), "{}", stderr(&create));
 
+    let secondary_skill =
+        root.child("ocm-home/envs/demo/.openclaw/workspace-clawforce/skills/social/SKILL.md");
+    fs::create_dir_all(secondary_skill.parent().unwrap()).unwrap();
+    fs::write(&secondary_skill, "skill before upgrade\n").unwrap();
+
     env.insert("OCM_TEST_FAIL_UPDATE_FINALIZE".to_string(), "1".to_string());
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
     assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
@@ -1575,6 +1580,10 @@ fn upgrade_rolls_back_runtime_binding_when_update_finalization_fails() {
     assert!(show.status.success(), "{}", stderr(&show));
     let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     assert_eq!(env_json["defaultRuntime"], "old-local");
+    assert_eq!(
+        fs::read_to_string(secondary_skill).unwrap(),
+        "skill before upgrade\n"
+    );
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -1560,6 +1560,11 @@ fn upgrade_rolls_back_runtime_binding_when_update_finalization_fails() {
     );
     assert!(create.status.success(), "{}", stderr(&create));
 
+    fs::write(
+        root.child("ocm-home/envs/demo/.openclaw/openclaw.json"),
+        r#"{"agents":{"list":[{"id":"main","default":true},{"id":"clawforce"}]}}"#,
+    )
+    .unwrap();
     let secondary_skill =
         root.child("ocm-home/envs/demo/.openclaw/workspace-clawforce/skills/social/SKILL.md");
     fs::create_dir_all(secondary_skill.parent().unwrap()).unwrap();


### PR DESCRIPTION
## Summary

- preserve OpenClaw workspaces derived from effective agent configuration across snapshots, exports, clones, imports, migrations, cleanup, and upgrade rollback
- resolve JSON5 includes, generated and explicit agent workspaces, and OpenClaw environment substitution without preserving unconfigured workspace-like runtime directories
- reject relative, external, symlink-escaping, non-regular, or include-owned workspace configurations before unsafe mutation

## Incident

An OCM-managed OpenClaw upgrade rollback restored only `.openclaw/workspace`. Secondary agent workspaces were absent from the snapshot and could be deleted during rollback.

The original prefix-based fix covered common `.openclaw/workspace-*` directories, but it did not cover arbitrary configured workspace paths and could preserve unrelated lookalike directories. This revision derives the durable workspace set from OpenClaw's effective configuration instead.

## Validation

- `cargo test --locked`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings -A clippy::question_mark -A clippy::large_enum_variant`
- `cargo fmt --check`
- targeted clone, import, migration, snapshot, cleanup, upgrade, include, environment substitution, path containment, and non-regular file regressions
