### PR TITLE
fix: reconcile MCP App sandbox ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to OCM are documented here.
 
 ## Unreleased
 
+### Fixed
+
+- Keep MCP App sandbox listener ports aligned when environment lifecycle operations reassign gateway ports without rewriting user-managed public sandbox origins.
+
 ## 0.2.28 - 2026-07-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +224,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -269,6 +289,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +442,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -396,6 +525,7 @@ dependencies = [
  "time",
  "unicode-width",
  "ureq",
+ "url",
  "windows-sys 0.61.2",
  "zip",
 ]
@@ -423,6 +553,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -617,6 +756,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +782,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -683,6 +845,16 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -756,10 +928,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -893,6 +1083,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,10 +1099,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ terminal_size = "0.4"
 dialoguer = { version = "0.12", default-features = false }
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
 ctrlc = { version = "3.4", features = ["termination"] }
+url = "2.5"
 libc = "0.2"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -623,6 +623,7 @@ mod tests {
 
     use serde_json::Value;
 
+    use crate::env::{CreateEnvironmentOptions, EnvironmentService};
     use crate::launcher::{AddLauncherOptions, LauncherService};
     use crate::store::derive_env_paths;
 
@@ -817,6 +818,7 @@ mod tests {
                     "\"agents\":{{\"defaults\":{{\"workspace\":\"{}\"}}}},",
                     "\"gateway\":{{\"port\":18789}},",
                     "\"mcp\":{{\"apps\":{{",
+                    "\"sandboxPort\":18790,",
                     "\"sandboxOrigin\":\"https://node.example.test:18790\"",
                     "}}}}",
                     "}}\n"
@@ -860,6 +862,19 @@ mod tests {
             root.join("ocm-home").display().to_string(),
         );
         install_fake_openclaw_on_path(&root, &mut env);
+        EnvironmentService::new(&env, &cwd)
+            .create(CreateEnvironmentOptions {
+                name: "occupied".to_string(),
+                root: None,
+                gateway_port: Some(18_789),
+                service_enabled: false,
+                service_running: false,
+                default_runtime: None,
+                default_launcher: None,
+                dev: None,
+                protected: false,
+            })
+            .unwrap();
 
         let summary = migrate_plain_openclaw_home(
             MigrateHomeOptions {
@@ -888,8 +903,12 @@ mod tests {
         let migrated_gateway_port = config["gateway"]["port"].as_u64().unwrap();
         assert_ne!(migrated_gateway_port, 18_789);
         assert_eq!(
+            config["mcp"]["apps"]["sandboxPort"].as_u64(),
+            Some(migrated_gateway_port + 1)
+        );
+        assert_eq!(
             config["mcp"]["apps"]["sandboxOrigin"].as_str(),
-            Some(format!("https://node.example.test:{}", migrated_gateway_port + 1).as_str())
+            Some("https://node.example.test:18790")
         );
         assert!(target_paths.workspace_dir.join("notes.txt").exists());
         assert!(

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -621,6 +621,8 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
 
+    use serde_json::Value;
+
     use crate::launcher::{AddLauncherOptions, LauncherService};
     use crate::store::derive_env_paths;
 
@@ -810,7 +812,15 @@ mod tests {
         fs::write(
             source_home.join("openclaw.json"),
             format!(
-                "{{\"agents\":{{\"defaults\":{{\"workspace\":\"{}\"}}}}}}\n",
+                concat!(
+                    "{{",
+                    "\"agents\":{{\"defaults\":{{\"workspace\":\"{}\"}}}},",
+                    "\"gateway\":{{\"port\":18789}},",
+                    "\"mcp\":{{\"apps\":{{",
+                    "\"sandboxOrigin\":\"https://node.example.test:18790\"",
+                    "}}}}",
+                    "}}\n"
+                ),
                 source_home.join("workspace").display()
             ),
         )
@@ -873,6 +883,14 @@ mod tests {
             root.join("bin/openclaw").display().to_string()
         );
         assert!(target_paths.config_path.exists());
+        let config: Value =
+            serde_json::from_str(&fs::read_to_string(&target_paths.config_path).unwrap()).unwrap();
+        let migrated_gateway_port = config["gateway"]["port"].as_u64().unwrap();
+        assert_ne!(migrated_gateway_port, 18_789);
+        assert_eq!(
+            config["mcp"]["apps"]["sandboxOrigin"].as_str(),
+            Some(format!("https://node.example.test:{}", migrated_gateway_port + 1).as_str())
+        );
         assert!(target_paths.workspace_dir.join("notes.txt").exists());
         assert!(
             target_paths

--- a/src/store/gateway_ports.rs
+++ b/src/store/gateway_ports.rs
@@ -131,10 +131,15 @@ fn openclaw_port_family(base_port: u32) -> Vec<u32> {
 fn read_gateway_port_from_config(path: &Path) -> Option<u32> {
     let raw = fs::read_to_string(path).ok()?;
     let value: Value = serde_json::from_str(&raw).ok()?;
-    let port = value.get("gateway")?.get("port")?.as_u64()?;
-    if (1..=u16::MAX as u64).contains(&port) {
-        Some(port as u32)
-    } else {
-        None
+    read_port_number(value.get("gateway")?.get("port")?)
+}
+
+pub(super) fn read_port_number(value: &Value) -> Option<u32> {
+    let number = value.as_number()?;
+    if let Some(port) = number.as_u64() {
+        return (1..=u16::MAX as u64).contains(&port).then_some(port as u32);
     }
+
+    let port = number.as_f64()?;
+    (port.fract() == 0.0 && (1.0..=u16::MAX as f64).contains(&port)).then_some(port as u32)
 }

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -605,13 +605,14 @@ fn rewrite_gateway_port(value: &mut Value, gateway_port: u32) -> bool {
 
 fn rewrite_gateway_port_family(value: &mut Value, gateway_port: u32) -> bool {
     let source_gateway_port = read_gateway_port(value);
-    let mut changed = source_gateway_port
-        .is_some_and(|source| rewrite_port_coupled_mcp_app_sandbox(value, source, gateway_port));
+    let mut changed = source_gateway_port.is_some_and(|source| {
+        rewrite_port_coupled_mcp_app_sandbox_port(value, source, gateway_port)
+    });
     changed |= rewrite_gateway_port(value, gateway_port);
     changed
 }
 
-fn rewrite_port_coupled_mcp_app_sandbox(
+fn rewrite_port_coupled_mcp_app_sandbox_port(
     value: &mut Value,
     source_gateway_port: u32,
     target_gateway_port: u32,
@@ -637,48 +638,11 @@ fn rewrite_port_coupled_mcp_app_sandbox(
         return false;
     };
 
-    let mut changed = false;
     if apps.get("sandboxPort").and_then(Value::as_u64) == Some(source_sandbox_port as u64) {
         apps.insert("sandboxPort".to_string(), Value::from(target_sandbox_port));
-        changed = true;
+        return true;
     }
-    if let Some(Value::String(origin)) = apps.get_mut("sandboxOrigin") {
-        changed |= rewrite_http_origin_port(origin, source_sandbox_port, target_sandbox_port);
-    }
-    changed
-}
-
-fn rewrite_http_origin_port(origin: &mut String, source_port: u32, target_port: u32) -> bool {
-    let (without_trailing_slash, trailing_slash) = origin
-        .strip_suffix('/')
-        .map_or((origin.as_str(), ""), |value| (value, "/"));
-    let Some(authority) = without_trailing_slash
-        .strip_prefix("https://")
-        .or_else(|| without_trailing_slash.strip_prefix("http://"))
-    else {
-        return false;
-    };
-    if authority.is_empty()
-        || authority.contains('/')
-        || authority.contains('?')
-        || authority.contains('#')
-        || authority.contains('@')
-    {
-        return false;
-    }
-    let Some((host, port)) = authority.rsplit_once(':') else {
-        return false;
-    };
-    if host.is_empty() || port.parse::<u32>().ok() != Some(source_port) {
-        return false;
-    }
-
-    let source_suffix = format!(":{source_port}{trailing_slash}");
-    let Some(prefix) = origin.strip_suffix(&source_suffix) else {
-        return false;
-    };
-    *origin = format!("{prefix}:{target_port}{trailing_slash}");
-    true
+    false
 }
 
 fn looks_env_scoped_workspace(path: &Path) -> bool {
@@ -778,7 +742,7 @@ mod tests {
     }
 
     #[test]
-    fn gateway_port_rewrite_updates_default_coupled_mcp_app_sandbox_fields() {
+    fn gateway_port_rewrite_updates_coupled_sandbox_port_and_preserves_public_origin() {
         let mut value = json!({
             "gateway": {"port": 19789},
             "mcp": {
@@ -794,7 +758,7 @@ mod tests {
         assert_eq!(value["mcp"]["apps"]["sandboxPort"], 19901);
         assert_eq!(
             value["mcp"]["apps"]["sandboxOrigin"],
-            "https://node.example.test:19901/"
+            "https://node.example.test:19790/"
         );
     }
 
@@ -816,6 +780,26 @@ mod tests {
         assert_eq!(
             value["mcp"]["apps"]["sandboxOrigin"],
             "https://mcp-apps.example.test"
+        );
+    }
+
+    #[test]
+    fn gateway_port_rewrite_leaves_explicit_origin_without_sandbox_port_unchanged() {
+        let mut value = json!({
+            "gateway": {"port": 19789},
+            "mcp": {
+                "apps": {
+                    "sandboxOrigin": "https://node.example.test:19790"
+                }
+            }
+        });
+
+        assert!(rewrite_gateway_port_family(&mut value, 19900));
+        assert_eq!(value["gateway"]["port"], 19900);
+        assert!(value["mcp"]["apps"]["sandboxPort"].is_null());
+        assert_eq!(
+            value["mcp"]["apps"]["sandboxOrigin"],
+            "https://node.example.test:19790"
         );
     }
 }

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -671,7 +671,12 @@ fn rewrite_loopback_origin_port(origin: &mut String, source_port: u32, target_po
     let is_loopback = match parsed.host() {
         Some(Host::Domain(host)) => host.trim_end_matches('.').eq_ignore_ascii_case("localhost"),
         Some(Host::Ipv4(address)) => address.is_loopback(),
-        Some(Host::Ipv6(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => {
+            address.is_loopback()
+                || address
+                    .to_ipv4_mapped()
+                    .is_some_and(|mapped| mapped.is_loopback())
+        }
         None => false,
     };
     if !is_loopback || parsed.set_port(Some(target_port as u16)).is_err() {
@@ -888,6 +893,10 @@ mod tests {
             ("HTTP://LOCALHOST:19790/", "http://localhost:19901/"),
             ("http://127.1:19790", "http://127.0.0.1:19901"),
             ("http://[0:0:0:0:0:0:0:1]:19790", "http://[::1]:19901"),
+            (
+                "http://[::ffff:127.0.0.1]:19790",
+                "http://[::ffff:7f00:1]:19901",
+            ),
         ] {
             let mut value = json!({
                 "gateway": {"port": 19789},

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -605,14 +605,13 @@ fn rewrite_gateway_port(value: &mut Value, gateway_port: u32) -> bool {
 
 fn rewrite_gateway_port_family(value: &mut Value, gateway_port: u32) -> bool {
     let source_gateway_port = read_gateway_port(value);
-    let mut changed = source_gateway_port.is_some_and(|source| {
-        rewrite_port_coupled_mcp_app_sandbox_port(value, source, gateway_port)
-    });
+    let mut changed = source_gateway_port
+        .is_some_and(|source| rewrite_port_coupled_mcp_app_sandbox(value, source, gateway_port));
     changed |= rewrite_gateway_port(value, gateway_port);
     changed
 }
 
-fn rewrite_port_coupled_mcp_app_sandbox_port(
+fn rewrite_port_coupled_mcp_app_sandbox(
     value: &mut Value,
     source_gateway_port: u32,
     target_gateway_port: u32,
@@ -638,11 +637,43 @@ fn rewrite_port_coupled_mcp_app_sandbox_port(
         return false;
     };
 
-    if apps.get("sandboxPort").and_then(Value::as_u64) == Some(source_sandbox_port as u64) {
+    let configured_sandbox_port = apps.get("sandboxPort").and_then(Value::as_u64);
+    let follows_gateway_port = configured_sandbox_port.is_none()
+        || configured_sandbox_port == Some(source_sandbox_port as u64);
+
+    let mut changed = false;
+    if configured_sandbox_port == Some(source_sandbox_port as u64) {
         apps.insert("sandboxPort".to_string(), Value::from(target_sandbox_port));
-        return true;
+        changed = true;
     }
-    false
+    if follows_gateway_port && let Some(Value::String(origin)) = apps.get_mut("sandboxOrigin") {
+        changed |= rewrite_loopback_origin_port(origin, source_sandbox_port, target_sandbox_port);
+    }
+    changed
+}
+
+fn rewrite_loopback_origin_port(origin: &mut String, source_port: u32, target_port: u32) -> bool {
+    let (without_trailing_slash, trailing_slash) = origin
+        .strip_suffix('/')
+        .map_or((origin.as_str(), ""), |value| (value, "/"));
+    let source_suffix = format!(":{source_port}");
+    let Some(loopback_origin) = without_trailing_slash.strip_suffix(&source_suffix) else {
+        return false;
+    };
+    if !matches!(
+        loopback_origin,
+        "http://localhost"
+            | "https://localhost"
+            | "http://127.0.0.1"
+            | "https://127.0.0.1"
+            | "http://[::1]"
+            | "https://[::1]"
+    ) {
+        return false;
+    }
+
+    *origin = format!("{loopback_origin}:{target_port}{trailing_slash}");
+    true
 }
 
 fn looks_env_scoped_workspace(path: &Path) -> bool {
@@ -800,6 +831,65 @@ mod tests {
         assert_eq!(
             value["mcp"]["apps"]["sandboxOrigin"],
             "https://node.example.test:19790"
+        );
+    }
+
+    #[test]
+    fn gateway_port_rewrite_updates_coupled_loopback_origin() {
+        let mut value = json!({
+            "gateway": {"port": 19789},
+            "mcp": {
+                "apps": {
+                    "sandboxPort": 19790,
+                    "sandboxOrigin": "http://127.0.0.1:19790/"
+                }
+            }
+        });
+
+        assert!(rewrite_gateway_port_family(&mut value, 19900));
+        assert_eq!(value["gateway"]["port"], 19900);
+        assert_eq!(value["mcp"]["apps"]["sandboxPort"], 19901);
+        assert_eq!(
+            value["mcp"]["apps"]["sandboxOrigin"],
+            "http://127.0.0.1:19901/"
+        );
+    }
+
+    #[test]
+    fn gateway_port_rewrite_updates_default_loopback_origin_without_explicit_sandbox_port() {
+        let mut value = json!({
+            "gateway": {"port": 19789},
+            "mcp": {
+                "apps": {
+                    "sandboxOrigin": "http://[::1]:19790"
+                }
+            }
+        });
+
+        assert!(rewrite_gateway_port_family(&mut value, 19900));
+        assert_eq!(value["gateway"]["port"], 19900);
+        assert!(value["mcp"]["apps"]["sandboxPort"].is_null());
+        assert_eq!(value["mcp"]["apps"]["sandboxOrigin"], "http://[::1]:19901");
+    }
+
+    #[test]
+    fn gateway_port_rewrite_preserves_loopback_origin_for_custom_sandbox_port() {
+        let mut value = json!({
+            "gateway": {"port": 19789},
+            "mcp": {
+                "apps": {
+                    "sandboxPort": 25000,
+                    "sandboxOrigin": "http://localhost:19790"
+                }
+            }
+        });
+
+        assert!(rewrite_gateway_port_family(&mut value, 19900));
+        assert_eq!(value["gateway"]["port"], 19900);
+        assert_eq!(value["mcp"]["apps"]["sandboxPort"], 25000);
+        assert_eq!(
+            value["mcp"]["apps"]["sandboxOrigin"],
+            "http://localhost:19790"
         );
     }
 }

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -491,12 +491,17 @@ fn read_workspace_field(value: &Value) -> Option<&str> {
 }
 
 fn read_gateway_port(value: &Value) -> Option<u32> {
-    let port = value.get("gateway")?.get("port")?.as_u64()?;
-    if (1..=u16::MAX as u64).contains(&port) {
-        Some(port as u32)
-    } else {
-        None
+    read_port_number(value.get("gateway")?.get("port")?)
+}
+
+fn read_port_number(value: &Value) -> Option<u32> {
+    let number = value.as_number()?;
+    if let Some(port) = number.as_u64() {
+        return (1..=u16::MAX as u64).contains(&port).then_some(port as u32);
     }
+
+    let port = number.as_f64()?;
+    (port.fract() == 0.0 && (1.0..=u16::MAX as f64).contains(&port)).then_some(port as u32)
 }
 
 fn rewrite_env_root_paths(value: &mut Value, source_root: &Path, target_root: &Path) -> bool {
@@ -637,12 +642,15 @@ fn rewrite_port_coupled_mcp_app_sandbox(
         return false;
     };
 
-    let configured_sandbox_port = apps.get("sandboxPort").and_then(Value::as_u64);
-    let follows_gateway_port = configured_sandbox_port.is_none()
-        || configured_sandbox_port == Some(source_sandbox_port as u64);
+    let configured_sandbox_port = apps.get("sandboxPort").map(read_port_number);
+    let follows_gateway_port = match configured_sandbox_port {
+        None => true,
+        Some(Some(port)) => port == source_sandbox_port,
+        Some(None) => false,
+    };
 
     let mut changed = false;
-    if configured_sandbox_port == Some(source_sandbox_port as u64) {
+    if configured_sandbox_port == Some(Some(source_sandbox_port)) {
         apps.insert("sandboxPort".to_string(), Value::from(target_sandbox_port));
         changed = true;
     }
@@ -891,5 +899,62 @@ mod tests {
             value["mcp"]["apps"]["sandboxOrigin"],
             "http://localhost:19790"
         );
+    }
+
+    #[test]
+    fn gateway_port_rewrite_accepts_integral_json_number_encodings() {
+        for raw in [
+            r#"{
+                "gateway": {"port": 19789.0},
+                "mcp": {
+                    "apps": {
+                        "sandboxPort": 19790.0,
+                        "sandboxOrigin": "http://localhost:19790"
+                    }
+                }
+            }"#,
+            r#"{
+                "gateway": {"port": 1.9789e4},
+                "mcp": {
+                    "apps": {
+                        "sandboxPort": 1.979e4,
+                        "sandboxOrigin": "http://localhost:19790"
+                    }
+                }
+            }"#,
+        ] {
+            let mut value: Value = serde_json::from_str(raw).unwrap();
+
+            assert!(rewrite_gateway_port_family(&mut value, 19900));
+            assert_eq!(value["gateway"]["port"], 19900);
+            assert_eq!(value["mcp"]["apps"]["sandboxPort"], 19901);
+            assert_eq!(
+                value["mcp"]["apps"]["sandboxOrigin"],
+                "http://localhost:19901"
+            );
+        }
+    }
+
+    #[test]
+    fn gateway_port_rewrite_preserves_unknown_sandbox_port_values() {
+        for sandbox_port in [json!(19790.5), json!("19790")] {
+            let mut value = json!({
+                "gateway": {"port": 19789},
+                "mcp": {
+                    "apps": {
+                        "sandboxPort": sandbox_port,
+                        "sandboxOrigin": "http://localhost:19790"
+                    }
+                }
+            });
+
+            assert!(rewrite_gateway_port_family(&mut value, 19900));
+            assert_eq!(value["gateway"]["port"], 19900);
+            assert_eq!(value["mcp"]["apps"]["sandboxPort"], sandbox_port);
+            assert_eq!(
+                value["mcp"]["apps"]["sandboxOrigin"],
+                "http://localhost:19790"
+            );
+        }
     }
 }

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -88,7 +88,7 @@ pub(crate) fn repair_openclaw_config(
         changed |= rewrite_workspace_field(&mut value, &paths.workspace_dir);
     }
     if audit.repair_gateway_port {
-        changed |= rewrite_gateway_port(&mut value, meta.gateway_port.unwrap_or_default());
+        changed |= rewrite_gateway_port_family(&mut value, meta.gateway_port.unwrap_or_default());
     }
 
     if !changed {
@@ -145,7 +145,7 @@ fn rewrite_openclaw_config_with_root_mapping(
         &target_paths.workspace_dir,
     );
     if let Some(gateway_port) = gateway_port {
-        changed |= rewrite_gateway_port(&mut value, gateway_port);
+        changed |= rewrite_gateway_port_family(&mut value, gateway_port);
     }
 
     if !changed && !config_is_symlink {
@@ -603,6 +603,84 @@ fn rewrite_gateway_port(value: &mut Value, gateway_port: u32) -> bool {
     true
 }
 
+fn rewrite_gateway_port_family(value: &mut Value, gateway_port: u32) -> bool {
+    let source_gateway_port = read_gateway_port(value);
+    let mut changed = source_gateway_port
+        .is_some_and(|source| rewrite_port_coupled_mcp_app_sandbox(value, source, gateway_port));
+    changed |= rewrite_gateway_port(value, gateway_port);
+    changed
+}
+
+fn rewrite_port_coupled_mcp_app_sandbox(
+    value: &mut Value,
+    source_gateway_port: u32,
+    target_gateway_port: u32,
+) -> bool {
+    if source_gateway_port == target_gateway_port {
+        return false;
+    }
+    let Some(source_sandbox_port) = source_gateway_port.checked_add(1) else {
+        return false;
+    };
+    let Some(target_sandbox_port) = target_gateway_port.checked_add(1) else {
+        return false;
+    };
+    if source_sandbox_port > u16::MAX as u32 || target_sandbox_port > u16::MAX as u32 {
+        return false;
+    }
+    let Some(apps) = value
+        .get_mut("mcp")
+        .and_then(Value::as_object_mut)
+        .and_then(|mcp| mcp.get_mut("apps"))
+        .and_then(Value::as_object_mut)
+    else {
+        return false;
+    };
+
+    let mut changed = false;
+    if apps.get("sandboxPort").and_then(Value::as_u64) == Some(source_sandbox_port as u64) {
+        apps.insert("sandboxPort".to_string(), Value::from(target_sandbox_port));
+        changed = true;
+    }
+    if let Some(Value::String(origin)) = apps.get_mut("sandboxOrigin") {
+        changed |= rewrite_http_origin_port(origin, source_sandbox_port, target_sandbox_port);
+    }
+    changed
+}
+
+fn rewrite_http_origin_port(origin: &mut String, source_port: u32, target_port: u32) -> bool {
+    let (without_trailing_slash, trailing_slash) = origin
+        .strip_suffix('/')
+        .map_or((origin.as_str(), ""), |value| (value, "/"));
+    let Some(authority) = without_trailing_slash
+        .strip_prefix("https://")
+        .or_else(|| without_trailing_slash.strip_prefix("http://"))
+    else {
+        return false;
+    };
+    if authority.is_empty()
+        || authority.contains('/')
+        || authority.contains('?')
+        || authority.contains('#')
+        || authority.contains('@')
+    {
+        return false;
+    }
+    let Some((host, port)) = authority.rsplit_once(':') else {
+        return false;
+    };
+    if host.is_empty() || port.parse::<u32>().ok() != Some(source_port) {
+        return false;
+    }
+
+    let source_suffix = format!(":{source_port}{trailing_slash}");
+    let Some(prefix) = origin.strip_suffix(&source_suffix) else {
+        return false;
+    };
+    *origin = format!("{prefix}:{target_port}{trailing_slash}");
+    true
+}
+
 fn looks_env_scoped_workspace(path: &Path) -> bool {
     let components = path
         .components()
@@ -697,5 +775,47 @@ mod tests {
 
         assert_eq!(audit.status, "ok");
         assert!(!audit.repair_gateway_port);
+    }
+
+    #[test]
+    fn gateway_port_rewrite_updates_default_coupled_mcp_app_sandbox_fields() {
+        let mut value = json!({
+            "gateway": {"port": 19789},
+            "mcp": {
+                "apps": {
+                    "sandboxPort": 19790,
+                    "sandboxOrigin": "https://node.example.test:19790/"
+                }
+            }
+        });
+
+        assert!(rewrite_gateway_port_family(&mut value, 19900));
+        assert_eq!(value["gateway"]["port"], 19900);
+        assert_eq!(value["mcp"]["apps"]["sandboxPort"], 19901);
+        assert_eq!(
+            value["mcp"]["apps"]["sandboxOrigin"],
+            "https://node.example.test:19901/"
+        );
+    }
+
+    #[test]
+    fn gateway_port_rewrite_preserves_independent_mcp_app_sandbox_fields() {
+        let mut value = json!({
+            "gateway": {"port": 19789},
+            "mcp": {
+                "apps": {
+                    "sandboxPort": 25000,
+                    "sandboxOrigin": "https://mcp-apps.example.test"
+                }
+            }
+        });
+
+        assert!(rewrite_gateway_port_family(&mut value, 19900));
+        assert_eq!(value["gateway"]["port"], 19900);
+        assert_eq!(value["mcp"]["apps"]["sandboxPort"], 25000);
+        assert_eq!(
+            value["mcp"]["apps"]["sandboxOrigin"],
+            "https://mcp-apps.example.test"
+        );
     }
 }

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -9,6 +9,7 @@ use url::{Host, Url};
 use crate::env::EnvMeta;
 
 use super::common::{ensure_dir, path_exists, write_file_replacing_path};
+use super::gateway_ports::read_port_number;
 use super::layout::{EnvPaths, clean_path, derive_env_paths, display_path};
 
 #[derive(Clone, Debug)]
@@ -493,16 +494,6 @@ fn read_workspace_field(value: &Value) -> Option<&str> {
 
 fn read_gateway_port(value: &Value) -> Option<u32> {
     read_port_number(value.get("gateway")?.get("port")?)
-}
-
-fn read_port_number(value: &Value) -> Option<u32> {
-    let number = value.as_number()?;
-    if let Some(port) = number.as_u64() {
-        return (1..=u16::MAX as u64).contains(&port).then_some(port as u32);
-    }
-
-    let port = number.as_f64()?;
-    (port.fract() == 0.0 && (1.0..=u16::MAX as f64).contains(&port)).then_some(port as u32)
 }
 
 fn rewrite_env_root_paths(value: &mut Value, source_root: &Path, target_root: &Path) -> bool {

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 use serde_json::json;
+use url::{Host, Url};
 
 use crate::env::EnvMeta;
 
@@ -661,26 +662,36 @@ fn rewrite_port_coupled_mcp_app_sandbox(
 }
 
 fn rewrite_loopback_origin_port(origin: &mut String, source_port: u32, target_port: u32) -> bool {
-    let (without_trailing_slash, trailing_slash) = origin
-        .strip_suffix('/')
-        .map_or((origin.as_str(), ""), |value| (value, "/"));
-    let source_suffix = format!(":{source_port}");
-    let Some(loopback_origin) = without_trailing_slash.strip_suffix(&source_suffix) else {
+    let preserve_trailing_slash = origin.ends_with('/');
+    let Ok(mut parsed) = Url::parse(origin) else {
         return false;
     };
-    if !matches!(
-        loopback_origin,
-        "http://localhost"
-            | "https://localhost"
-            | "http://127.0.0.1"
-            | "https://127.0.0.1"
-            | "http://[::1]"
-            | "https://[::1]"
-    ) {
+    if !matches!(parsed.scheme(), "http" | "https")
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.path() != "/"
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || parsed.port_or_known_default() != Some(source_port as u16)
+    {
         return false;
     }
 
-    *origin = format!("{loopback_origin}:{target_port}{trailing_slash}");
+    let is_loopback = match parsed.host() {
+        Some(Host::Domain(host)) => host.trim_end_matches('.').eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    };
+    if !is_loopback || parsed.set_port(Some(target_port as u16)).is_err() {
+        return false;
+    }
+
+    let mut rewritten = parsed.to_string();
+    if !preserve_trailing_slash && rewritten.ends_with('/') {
+        rewritten.pop();
+    }
+    *origin = rewritten;
     true
 }
 
@@ -878,6 +889,24 @@ mod tests {
         assert_eq!(value["gateway"]["port"], 19900);
         assert!(value["mcp"]["apps"]["sandboxPort"].is_null());
         assert_eq!(value["mcp"]["apps"]["sandboxOrigin"], "http://[::1]:19901");
+    }
+
+    #[test]
+    fn gateway_port_rewrite_canonicalizes_equivalent_loopback_origins() {
+        for (origin, expected) in [
+            ("HTTP://LOCALHOST:19790/", "http://localhost:19901/"),
+            ("http://127.1:19790", "http://127.0.0.1:19901"),
+            ("http://[0:0:0:0:0:0:0:1]:19790", "http://[::1]:19901"),
+        ] {
+            let mut value = json!({
+                "gateway": {"port": 19789},
+                "mcp": {"apps": {"sandboxOrigin": origin}}
+            });
+
+            assert!(rewrite_gateway_port_family(&mut value, 19900));
+            assert_eq!(value["gateway"]["port"], 19900);
+            assert_eq!(value["mcp"]["apps"]["sandboxOrigin"], expected);
+        }
     }
 
     #[test]

--- a/tests/behavior_flow_tests.rs
+++ b/tests/behavior_flow_tests.rs
@@ -594,7 +594,7 @@ fn env_use_auto_assigns_distinct_gateway_ports_for_fresh_envs() {
 }
 
 #[test]
-fn env_use_skips_the_machine_global_openclaw_port_family() {
+fn env_use_skips_an_integral_decimal_machine_global_openclaw_port_family() {
     let root = TestDir::new("behavior-env-use-skips-global-openclaw");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -604,7 +604,7 @@ fn env_use_skips_the_machine_global_openclaw_port_family() {
     fs::create_dir_all(&global_root).unwrap();
     write_text(
         &global_root.join("openclaw.json"),
-        "{\n  \"gateway\": {\n    \"port\": 18789\n  }\n}\n",
+        "{\n  \"gateway\": {\n    \"port\": 18789.0\n  }\n}\n",
     );
 
     let create_demo = run_ocm(&cwd, &env, &["env", "create", "demo"]);
@@ -625,14 +625,14 @@ fn env_exec_skips_gateway_port_claimed_by_an_initialized_environment() {
     let create_demo = run_ocm(&cwd, &env, &["env", "create", "demo"]);
     assert!(create_demo.status.success(), "{}", stderr(&create_demo));
 
-    let create_test = run_ocm(&cwd, &env, &["env", "create", "test"]);
-    assert!(create_test.status.success(), "{}", stderr(&create_test));
-
     let demo_root = root.child("ocm-home/envs/demo");
     write_text(
         &demo_root.join(".openclaw/openclaw.json"),
         "{\n  \"gateway\": {\n    \"port\": 18789\n  }\n}\n",
     );
+
+    let create_test = run_ocm(&cwd, &env, &["env", "create", "test"]);
+    assert!(create_test.status.success(), "{}", stderr(&create_test));
 
     let exec_output = run_ocm(
         &cwd,

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -146,6 +146,45 @@ fn env_clone_rewrites_coupled_sandbox_port_and_preserves_public_origin() {
 }
 
 #[test]
+fn env_clone_rewrites_a_coupled_loopback_sandbox_origin() {
+    let root = TestDir::new("env-clone-mcp-app-loopback-origin");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source", "--port", "19789"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    write_text(
+        &root.child("ocm-home/envs/source/.openclaw/openclaw.json"),
+        concat!(
+            "{\n",
+            "  \"gateway\": { \"port\": 19789 },\n",
+            "  \"mcp\": {\n",
+            "    \"apps\": {\n",
+            "      \"enabled\": true,\n",
+            "      \"sandboxOrigin\": \"http://localhost:19790\"\n",
+            "    }\n",
+            "  }\n",
+            "}\n"
+        ),
+    );
+
+    let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
+    assert!(clone.status.success(), "{}", stderr(&clone));
+
+    let config_raw =
+        fs::read_to_string(root.child("ocm-home/envs/target/.openclaw/openclaw.json")).unwrap();
+    let config: Value = serde_json::from_str(&config_raw).unwrap();
+    let cloned_gateway_port = config["gateway"]["port"].as_u64().unwrap();
+    assert!(config["mcp"]["apps"]["sandboxPort"].is_null());
+    assert_eq!(
+        config["mcp"]["apps"]["sandboxOrigin"].as_str(),
+        Some(format!("http://localhost:{}", cloned_gateway_port + 1).as_str())
+    );
+}
+
+#[test]
 fn env_clone_keeps_agent_auth_but_drops_live_runtime_state() {
     let root = TestDir::new("env-clone-clears-runtime-state");
     let cwd = root.child("workspace");

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -102,7 +102,7 @@ fn env_clone_rewrites_openclaw_config_for_the_new_env_root() {
 }
 
 #[test]
-fn env_clone_rewrites_port_coupled_mcp_app_sandbox_config() {
+fn env_clone_rewrites_coupled_sandbox_port_and_preserves_public_origin() {
     let root = TestDir::new("env-clone-mcp-app-sandbox-rewrite");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -141,7 +141,7 @@ fn env_clone_rewrites_port_coupled_mcp_app_sandbox_config() {
     );
     assert_eq!(
         config["mcp"]["apps"]["sandboxOrigin"].as_str(),
-        Some(format!("https://node.example.test:{expected_sandbox_port}").as_str())
+        Some("https://node.example.test:19790")
     );
 }
 

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -102,6 +102,50 @@ fn env_clone_rewrites_openclaw_config_for_the_new_env_root() {
 }
 
 #[test]
+fn env_clone_rewrites_port_coupled_mcp_app_sandbox_config() {
+    let root = TestDir::new("env-clone-mcp-app-sandbox-rewrite");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source", "--port", "19789"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    write_text(
+        &root.child("ocm-home/envs/source/.openclaw/openclaw.json"),
+        concat!(
+            "{\n",
+            "  \"gateway\": { \"port\": 19789 },\n",
+            "  \"mcp\": {\n",
+            "    \"apps\": {\n",
+            "      \"enabled\": true,\n",
+            "      \"sandboxPort\": 19790,\n",
+            "      \"sandboxOrigin\": \"https://node.example.test:19790\"\n",
+            "    }\n",
+            "  }\n",
+            "}\n"
+        ),
+    );
+
+    let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
+    assert!(clone.status.success(), "{}", stderr(&clone));
+
+    let config_raw =
+        fs::read_to_string(root.child("ocm-home/envs/target/.openclaw/openclaw.json")).unwrap();
+    let config: Value = serde_json::from_str(&config_raw).unwrap();
+    let cloned_gateway_port = config["gateway"]["port"].as_u64().unwrap();
+    let expected_sandbox_port = cloned_gateway_port + 1;
+    assert_eq!(
+        config["mcp"]["apps"]["sandboxPort"].as_u64(),
+        Some(expected_sandbox_port)
+    );
+    assert_eq!(
+        config["mcp"]["apps"]["sandboxOrigin"].as_str(),
+        Some(format!("https://node.example.test:{expected_sandbox_port}").as_str())
+    );
+}
+
+#[test]
 fn env_clone_keeps_agent_auth_but_drops_live_runtime_state() {
     let root = TestDir::new("env-clone-clears-runtime-state");
     let cwd = root.child("workspace");

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -185,6 +185,50 @@ fn env_clone_rewrites_a_coupled_loopback_sandbox_origin() {
 }
 
 #[test]
+fn env_clone_rewrites_an_integral_number_sandbox_port_and_loopback_origin() {
+    let root = TestDir::new("env-clone-mcp-app-integral-number-port");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source", "--port", "19789"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    write_text(
+        &root.child("ocm-home/envs/source/.openclaw/openclaw.json"),
+        concat!(
+            "{\n",
+            "  \"gateway\": { \"port\": 19789.0 },\n",
+            "  \"mcp\": {\n",
+            "    \"apps\": {\n",
+            "      \"enabled\": true,\n",
+            "      \"sandboxPort\": 19790.0,\n",
+            "      \"sandboxOrigin\": \"http://localhost:19790\"\n",
+            "    }\n",
+            "  }\n",
+            "}\n"
+        ),
+    );
+
+    let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
+    assert!(clone.status.success(), "{}", stderr(&clone));
+
+    let config_raw =
+        fs::read_to_string(root.child("ocm-home/envs/target/.openclaw/openclaw.json")).unwrap();
+    let config: Value = serde_json::from_str(&config_raw).unwrap();
+    let cloned_gateway_port = config["gateway"]["port"].as_u64().unwrap();
+    let expected_sandbox_port = cloned_gateway_port + 1;
+    assert_eq!(
+        config["mcp"]["apps"]["sandboxPort"].as_u64(),
+        Some(expected_sandbox_port)
+    );
+    assert_eq!(
+        config["mcp"]["apps"]["sandboxOrigin"].as_str(),
+        Some(format!("http://localhost:{expected_sandbox_port}").as_str())
+    );
+}
+
+#[test]
 fn env_clone_keeps_agent_auth_but_drops_live_runtime_state() {
     let root = TestDir::new("env-clone-clears-runtime-state");
     let cwd = root.child("workspace");

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -163,7 +163,7 @@ fn env_clone_rewrites_a_coupled_loopback_sandbox_origin() {
             "  \"mcp\": {\n",
             "    \"apps\": {\n",
             "      \"enabled\": true,\n",
-            "      \"sandboxOrigin\": \"http://localhost:19790\"\n",
+            "      \"sandboxOrigin\": \"HTTP://LOCALHOST:19790/\"\n",
             "    }\n",
             "  }\n",
             "}\n"
@@ -180,7 +180,7 @@ fn env_clone_rewrites_a_coupled_loopback_sandbox_origin() {
     assert!(config["mcp"]["apps"]["sandboxPort"].is_null());
     assert_eq!(
         config["mcp"]["apps"]["sandboxOrigin"].as_str(),
-        Some(format!("http://localhost:{}", cloned_gateway_port + 1).as_str())
+        Some(format!("http://localhost:{}/", cloned_gateway_port + 1).as_str())
     );
 }
 

--- a/tests/env_output_tests.rs
+++ b/tests/env_output_tests.rs
@@ -70,7 +70,7 @@ fn env_create_and_show_json_report_the_same_effective_gateway_port() {
 }
 
 #[test]
-fn env_show_and_list_prefer_a_later_config_gateway_port() {
+fn env_show_and_list_accept_a_later_integral_decimal_config_gateway_port() {
     let root = TestDir::new("env-config-json-port");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -80,7 +80,7 @@ fn env_show_and_list_prefer_a_later_config_gateway_port() {
     assert!(created.status.success(), "{}", stderr(&created));
     fs::write(
         root.child("ocm-home/envs/demo/.openclaw/openclaw.json"),
-        "{\"gateway\":{\"port\":18888}}",
+        "{\"gateway\":{\"port\":18888.0}}",
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary

- keep MCP App sandbox listener ports aligned when OCM reassigns environment gateway ports
- update coupled `sandboxPort` values and direct loopback `sandboxOrigin` values while preserving user-managed public origins and custom listeners
- handle canonical-equivalent loopback URLs and integral JSON number encodings consistently across config rewrite and port allocation
- make migration port reassignment deterministic and add lifecycle regression coverage
- document the fix in the unreleased changelog

## Verification

- `cargo fmt --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings -A clippy::question_mark -A clippy::large_enum_variant`
- `cargo test --locked`
- independent review against current `origin/main`
