### PR TITLE
chore(release): bump version to 0.2.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.28"
+version = "0.2.29"
 edition = "2024"
 rust-version = "1.88"
 description = "OpenClaw Manager: the local control plane for isolated OpenClaw environments, launchers, runtimes, and services."


### PR DESCRIPTION
Prepare v0.2.29. Squash-merge this pull request, update local main, then rerun `scripts/release.sh 0.2.29` to sign and push the release tag.