### PR TITLE
fix: support list and keyed OpenClaw agent configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 json5 = "0.4"
 serde_yaml = "0.9"
 sha2 = "0.10"

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -346,6 +346,31 @@ pub(crate) fn rewrite_identity_bound_workspace_paths_for_target(
         changed = true;
     }
 
+    if let Some(entries) = agents.get_mut("entries").and_then(Value::as_object_mut) {
+        for (agent_id, entry) in entries {
+            let Some(entry) = entry.as_object_mut() else {
+                continue;
+            };
+            let identity_bound = entry
+                .get("workspace")
+                .and_then(Value::as_str)
+                .is_some_and(workspace_uses_changing_runtime_identity);
+            if !identity_bound {
+                continue;
+            }
+            let Some(source_workspace) = source_workspaces.agent_workspace(agent_id) else {
+                continue;
+            };
+            let target_workspace =
+                rebase_workspace_path(source_workspace, source_root, target_root)?;
+            entry.insert(
+                "workspace".to_string(),
+                Value::String(display_path(&target_workspace)),
+            );
+            changed = true;
+        }
+    }
+
     if let Some(entries) = agents.get_mut("list").and_then(Value::as_array_mut) {
         for entry in entries {
             let Some(entry) = entry.as_object_mut() else {
@@ -449,19 +474,30 @@ pub(crate) fn ensure_minimum_local_openclaw_config(
         .entry("workspace".to_string())
         .or_insert_with(|| Value::String(workspace.clone()));
 
-    let list_needs_default = agents
-        .get("list")
-        .and_then(Value::as_array)
-        .map(|entries| entries.is_empty())
-        .unwrap_or(true);
-    if list_needs_default {
-        agents.insert(
-            "list".to_string(),
-            Value::Array(vec![json!({
+    if let Some(entries) = agents.get_mut("entries").and_then(Value::as_object_mut) {
+        if entries.is_empty() {
+            entries.insert(
+                "main".to_string(),
+                json!({"default": true, "workspace": workspace}),
+            );
+        }
+    } else if let Some(entries) = agents.get_mut("list").and_then(Value::as_array_mut) {
+        if entries.is_empty() {
+            entries.push(json!({
                 "id": "main",
                 "default": true,
                 "workspace": workspace,
-            })]),
+            }));
+        }
+    } else {
+        agents.insert(
+            "entries".to_string(),
+            json!({
+                "main": {
+                    "default": true,
+                    "workspace": workspace,
+                }
+            }),
         );
     }
 
@@ -1154,6 +1190,12 @@ fn agent_workspaces_include_scope(value: &Value) -> Option<&'static str> {
     {
         return Some("agents.defaults.workspace");
     }
+    if agents
+        .get("entries")
+        .is_some_and(agent_entries_contains_include)
+    {
+        return Some("agents.entries");
+    }
     agents
         .get("list")
         .is_some_and(agent_list_contains_include)
@@ -1170,6 +1212,22 @@ fn workspace_defaults_contains_include(value: &Value) -> bool {
             .is_some_and(value_contains_include)
 }
 
+fn agent_entries_contains_include(value: &Value) -> bool {
+    let Some(entries) = value.as_object() else {
+        return value_contains_include(value);
+    };
+    entries.contains_key("$include")
+        || entries.values().any(|entry| {
+            let Some(entry) = entry.as_object() else {
+                return value_contains_include(entry);
+            };
+            entry.contains_key("$include")
+                || entry
+                    .get("workspace")
+                    .is_some_and(value_contains_include)
+        })
+}
+
 fn agent_list_contains_include(value: &Value) -> bool {
     let Some(entries) = value.as_array() else {
         return value_contains_include(value);
@@ -1178,7 +1236,10 @@ fn agent_list_contains_include(value: &Value) -> bool {
         let Some(entry) = entry.as_object() else {
             return value_contains_include(entry);
         };
-        entry.contains_key("$include") || entry.get("workspace").is_some_and(value_contains_include)
+        entry.contains_key("$include")
+            || entry
+                .get("workspace")
+                .is_some_and(value_contains_include)
     })
 }
 
@@ -1506,6 +1567,18 @@ mod tests {
                 &json!({"agents": {"defaults": {"$include": "./defaults.json5"}}})
             ),
             Some("agents.defaults.workspace")
+        );
+        assert_eq!(
+            agent_workspaces_include_scope(
+                &json!({"agents": {"entries": {"$include": "./agents.json5"}}})
+            ),
+            Some("agents.entries")
+        );
+        assert_eq!(
+            agent_workspaces_include_scope(
+                &json!({"agents": {"entries": {"main": {"$include": "./main.json5"}}}})
+            ),
+            Some("agents.entries")
         );
         assert_eq!(
             agent_workspaces_include_scope(

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -472,34 +472,7 @@ pub(crate) fn ensure_minimum_local_openclaw_config(
     let defaults = ensure_object_field(agents, "defaults");
     defaults
         .entry("workspace".to_string())
-        .or_insert_with(|| Value::String(workspace.clone()));
-
-    if let Some(entries) = agents.get_mut("entries").and_then(Value::as_object_mut) {
-        if entries.is_empty() {
-            entries.insert(
-                "main".to_string(),
-                json!({"default": true, "workspace": workspace}),
-            );
-        }
-    } else if let Some(entries) = agents.get_mut("list").and_then(Value::as_array_mut) {
-        if entries.is_empty() {
-            entries.push(json!({
-                "id": "main",
-                "default": true,
-                "workspace": workspace,
-            }));
-        }
-    } else {
-        agents.insert(
-            "entries".to_string(),
-            json!({
-                "main": {
-                    "default": true,
-                    "workspace": workspace,
-                }
-            }),
-        );
-    }
+        .or_insert_with(|| Value::String(workspace));
 
     write_config_value(&target_paths.config_path, &value)
 }
@@ -1222,9 +1195,7 @@ fn agent_entries_contains_include(value: &Value) -> bool {
                 return value_contains_include(entry);
             };
             entry.contains_key("$include")
-                || entry
-                    .get("workspace")
-                    .is_some_and(value_contains_include)
+                || entry.get("workspace").is_some_and(value_contains_include)
         })
 }
 
@@ -1236,10 +1207,7 @@ fn agent_list_contains_include(value: &Value) -> bool {
         let Some(entry) = entry.as_object() else {
             return value_contains_include(entry);
         };
-        entry.contains_key("$include")
-            || entry
-                .get("workspace")
-                .is_some_and(value_contains_include)
+        entry.contains_key("$include") || entry.get("workspace").is_some_and(value_contains_include)
     })
 }
 
@@ -1292,6 +1260,40 @@ mod tests {
             created_at: OffsetDateTime::UNIX_EPOCH,
             updated_at: OffsetDateTime::UNIX_EPOCH,
             last_used_at: None,
+        }
+    }
+
+    fn test_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "ocm-openclaw-config-{label}-{}-{}",
+            std::process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ))
+    }
+
+    #[test]
+    fn minimum_config_preserves_existing_agent_collection_shape() {
+        for (label, agents, retained_key, absent_key) in [
+            ("list", json!({"list": []}), "list", "entries"),
+            ("entries", json!({"entries": {}}), "entries", "list"),
+        ] {
+            let root = test_root(label);
+            let paths = derive_env_paths(&root);
+            fs::create_dir_all(&paths.state_dir).unwrap();
+            write_config_value(&paths.config_path, &json!({"agents": agents})).unwrap();
+
+            ensure_minimum_local_openclaw_config(&paths, 19789).unwrap();
+
+            let value = read_config_value(&paths.config_path).unwrap().unwrap();
+            assert!(value["agents"].get(retained_key).is_some());
+            assert!(value["agents"].get(absent_key).is_none());
+            assert_eq!(value["gateway"]["port"], 19789);
+            assert_eq!(
+                value["agents"]["defaults"]["workspace"],
+                display_path(&paths.workspace_dir)
+            );
+
+            let _ = fs::remove_dir_all(root);
         }
     }
 

--- a/src/store/openclaw_workspaces.rs
+++ b/src/store/openclaw_workspaces.rs
@@ -564,15 +564,25 @@ fn is_openclaw_env_var_name(name: &str) -> bool {
         && chars.all(|ch| ch == '_' || ch.is_ascii_uppercase() || ch.is_ascii_digit())
 }
 
-fn agent_entries(config: &Value) -> Vec<&Map<String, Value>> {
+fn agent_entries(config: &Value) -> Vec<Map<String, Value>> {
+    if let Some(entries) = config.pointer("/agents/entries").and_then(Value::as_object) {
+        return entries
+            .iter()
+            .filter_map(|(agent_id, entry)| {
+                let mut entry = entry.as_object()?.clone();
+                entry.insert("id".to_string(), Value::String(agent_id.clone()));
+                Some(entry)
+            })
+            .collect();
+    }
     config
         .pointer("/agents/list")
         .and_then(Value::as_array)
-        .map(|entries| entries.iter().filter_map(Value::as_object).collect())
+        .map(|entries| entries.iter().filter_map(Value::as_object).cloned().collect())
         .unwrap_or_default()
 }
 
-fn resolve_default_agent_id(entries: &[&Map<String, Value>]) -> String {
+fn resolve_default_agent_id(entries: &[Map<String, Value>]) -> String {
     let selected = entries
         .iter()
         .find(|entry| entry.get("default").and_then(Value::as_bool) == Some(true))
@@ -996,11 +1006,11 @@ mod tests {
             r#"{
               "agents": {
                 "defaults": { "workspace": "~/teams" },
-                "list": [
-                  { "id": "Primary", "default": true },
-                  { "id": "Ops Team" },
-                  { "id": "Custom", "workspace": "~/.openclaw/team/custom" }
-                ]
+                "entries": {
+                  "Primary": { "default": true },
+                  "ops-team": {},
+                  "Custom": { "workspace": "~/.openclaw/team/custom" }
+                }
               }
             }"#,
         )

--- a/src/store/openclaw_workspaces.rs
+++ b/src/store/openclaw_workspaces.rs
@@ -15,6 +15,7 @@ const DEFAULT_AGENT_ID: &str = "main";
 const MAX_INCLUDE_DEPTH: usize = 10;
 const MAX_INCLUDE_FILE_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_INCLUDE_PATH_LENGTH: usize = 4096;
+const BLOCKED_OBJECT_KEYS: [&str; 3] = ["__proto__", "prototype", "constructor"];
 
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct OpenClawWorkspaceRuntime<'a> {
@@ -568,6 +569,7 @@ fn agent_entries(config: &Value) -> Vec<Map<String, Value>> {
     if let Some(entries) = config.pointer("/agents/entries").and_then(Value::as_object) {
         return javascript_property_entries(entries)
             .into_iter()
+            .filter(|(agent_id, _)| agent_id.as_str() != "__proto__")
             .filter_map(|(agent_id, entry)| {
                 let mut entry = entry.as_object()?.clone();
                 entry.insert("id".to_string(), Value::String(agent_id.clone()));
@@ -586,6 +588,10 @@ fn agent_entries(config: &Value) -> Vec<Map<String, Value>> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn is_blocked_object_key(key: &str) -> bool {
+    BLOCKED_OBJECT_KEYS.contains(&key)
 }
 
 fn javascript_property_entries(entries: &Map<String, Value>) -> Vec<(&String, &Value)> {
@@ -910,7 +916,9 @@ fn deep_merge(base: Value, override_value: Value) -> Value {
             base.extend(override_values);
             Value::Array(base)
         }
-        (Value::Object(mut base), Value::Object(override_values)) => {
+        (Value::Object(base), Value::Object(override_values)) => {
+            let mut base = sanitize_plain_object(base);
+            let override_values = sanitize_plain_object(override_values);
             for (key, value) in override_values {
                 if let Some(current) = base.get_mut(&key) {
                     *current = deep_merge(std::mem::take(current), value);
@@ -920,8 +928,25 @@ fn deep_merge(base: Value, override_value: Value) -> Value {
             }
             Value::Object(base)
         }
+        (_, Value::Object(override_values)) => {
+            Value::Object(sanitize_plain_object(override_values))
+        }
         (_, override_value) => override_value,
     }
+}
+
+fn sanitize_plain_object(object: Map<String, Value>) -> Map<String, Value> {
+    object
+        .into_iter()
+        .filter(|(key, _)| !is_blocked_object_key(key))
+        .map(|(key, value)| {
+            let value = match value {
+                Value::Object(nested) => Value::Object(sanitize_plain_object(nested)),
+                value => value,
+            };
+            (key, value)
+        })
+        .collect()
 }
 
 fn canonicalize_path_allow_missing(path: &Path) -> Result<PathBuf, String> {
@@ -1123,6 +1148,98 @@ mod tests {
         )
         .unwrap();
         assert_eq!(inventory.default_agent_id, "2");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn keyed_workspace_inventory_preserves_direct_constructor_and_prototype_keys() {
+        let root = test_root("inventory-direct-object-keys");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{
+              "agents": {
+                "defaults": { "workspace": "~/teams" },
+                "entries": {
+                  "constructor": { "workspace": "~/constructor" },
+                  "prototype": { "workspace": "~/prototype" },
+                  "__proto__": { "workspace": "~/ignored-proto" },
+                  "ops": {}
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(
+            &paths,
+            &test_env(),
+            OpenClawWorkspaceRuntime::default(),
+        )
+        .unwrap();
+        assert_eq!(inventory.default_agent_id, "constructor");
+        assert_eq!(
+            inventory.default_agent_workspace(),
+            Some(root.join("constructor").as_path())
+        );
+        assert_eq!(
+            inventory.agent_workspace("prototype"),
+            Some(root.join("prototype").as_path())
+        );
+        assert_eq!(inventory.agent_workspace("__proto__"), None);
+        assert!(!inventory.contains(&root.join("ignored-proto")));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn keyed_workspace_inventory_matches_openclaw_include_sanitization() {
+        let root = test_root("inventory-included-object-keys");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(paths.state_dir.join("config")).unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{
+              "$include": "./config/agents.json5",
+              "env": {}
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            paths.state_dir.join("config/agents.json5"),
+            r#"{
+              "agents": {
+                "defaults": { "workspace": "~/teams" },
+                "entries": {
+                  "constructor": { "workspace": "~/ignored" },
+                  "prototype": { "workspace": "~/ignored-prototype" },
+                  "__proto__": { "workspace": "~/ignored-proto" },
+                  "ops": {}
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(
+            &paths,
+            &test_env(),
+            OpenClawWorkspaceRuntime::default(),
+        )
+        .unwrap();
+        assert_eq!(inventory.default_agent_id, "ops");
+        assert_eq!(
+            inventory.default_agent_workspace(),
+            Some(root.join("teams").as_path())
+        );
+        assert_eq!(inventory.agent_workspace("constructor"), None);
+        assert_eq!(inventory.agent_workspace("prototype"), None);
+        assert_eq!(inventory.agent_workspace("__proto__"), None);
+        assert!(!inventory.contains(&root.join("ignored")));
+        assert!(!inventory.contains(&root.join("ignored-prototype")));
+        assert!(!inventory.contains(&root.join("ignored-proto")));
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/store/openclaw_workspaces.rs
+++ b/src/store/openclaw_workspaces.rs
@@ -566,8 +566,8 @@ fn is_openclaw_env_var_name(name: &str) -> bool {
 
 fn agent_entries(config: &Value) -> Vec<Map<String, Value>> {
     if let Some(entries) = config.pointer("/agents/entries").and_then(Value::as_object) {
-        return entries
-            .iter()
+        return javascript_property_entries(entries)
+            .into_iter()
             .filter_map(|(agent_id, entry)| {
                 let mut entry = entry.as_object()?.clone();
                 entry.insert("id".to_string(), Value::String(agent_id.clone()));
@@ -586,6 +586,29 @@ fn agent_entries(config: &Value) -> Vec<Map<String, Value>> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn javascript_property_entries(entries: &Map<String, Value>) -> Vec<(&String, &Value)> {
+    let mut integer_entries = entries
+        .iter()
+        .filter_map(|entry @ (key, _)| javascript_array_index(key).map(|index| (index, entry)))
+        .collect::<Vec<_>>();
+    integer_entries.sort_unstable_by_key(|(index, _)| *index);
+
+    integer_entries
+        .into_iter()
+        .map(|(_, entry)| entry)
+        .chain(
+            entries
+                .iter()
+                .filter(|(key, _)| javascript_array_index(key).is_none()),
+        )
+        .collect()
+}
+
+fn javascript_array_index(key: &str) -> Option<u32> {
+    let index = key.parse::<u32>().ok()?;
+    (index != u32::MAX && index.to_string() == key).then_some(index)
 }
 
 fn resolve_default_agent_id(entries: &[Map<String, Value>]) -> String {
@@ -889,11 +912,11 @@ fn deep_merge(base: Value, override_value: Value) -> Value {
         }
         (Value::Object(mut base), Value::Object(override_values)) => {
             for (key, value) in override_values {
-                let merged = base
-                    .remove(&key)
-                    .map(|current| deep_merge(current, value.clone()))
-                    .unwrap_or(value);
-                base.insert(key, merged);
+                if let Some(current) = base.get_mut(&key) {
+                    *current = deep_merge(std::mem::take(current), value);
+                } else {
+                    base.insert(key, value);
+                }
             }
             Value::Object(base)
         }
@@ -1070,6 +1093,80 @@ mod tests {
         assert_eq!(
             inventory.default_agent_workspace(),
             Some(root.join("zeta").as_path())
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn keyed_workspace_inventory_matches_javascript_integer_key_order() {
+        let root = test_root("inventory-key-integer-order");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{
+              "agents": {
+                "entries": {
+                  "10": {},
+                  "2": {}
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(
+            &paths,
+            &test_env(),
+            OpenClawWorkspaceRuntime::default(),
+        )
+        .unwrap();
+        assert_eq!(inventory.default_agent_id, "2");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn keyed_workspace_inventory_preserves_included_key_position_on_override() {
+        let root = test_root("inventory-key-include-order");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(paths.state_dir.join("config")).unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{
+              "$include": "./config/agents.json5",
+              "agents": {
+                "entries": {
+                  "primary": { "name": "override" }
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            paths.state_dir.join("config/agents.json5"),
+            r#"{
+              agents: {
+                entries: {
+                  primary: {},
+                  ops: {}
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(
+            &paths,
+            &test_env(),
+            OpenClawWorkspaceRuntime::default(),
+        )
+        .unwrap();
+        assert_eq!(inventory.default_agent_id, "primary");
+        assert_eq!(
+            inventory.agent_workspace("ops"),
+            Some(paths.state_dir.join("workspace-ops").as_path())
         );
 
         let _ = fs::remove_dir_all(root);

--- a/src/store/openclaw_workspaces.rs
+++ b/src/store/openclaw_workspaces.rs
@@ -578,7 +578,13 @@ fn agent_entries(config: &Value) -> Vec<Map<String, Value>> {
     config
         .pointer("/agents/list")
         .and_then(Value::as_array)
-        .map(|entries| entries.iter().filter_map(Value::as_object).cloned().collect())
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(Value::as_object)
+                .cloned()
+                .collect()
+        })
         .unwrap_or_default()
 }
 
@@ -1030,6 +1036,40 @@ mod tests {
                 root.join("teams/ops-team"),
                 root.join(".openclaw/team/custom"),
             ])
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn keyed_workspace_inventory_preserves_the_first_entry_as_the_implicit_default() {
+        let root = test_root("inventory-key-order");
+        let paths = super::super::layout::derive_env_paths(&root);
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        fs::write(
+            &paths.config_path,
+            r#"{
+              "agents": {
+                "defaults": { "workspace": "~/teams" },
+                "entries": {
+                  "zeta": { "workspace": "~/zeta" },
+                  "alpha": { "workspace": "~/alpha" }
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let inventory = resolve_env_openclaw_workspaces(
+            &paths,
+            &test_env(),
+            OpenClawWorkspaceRuntime::default(),
+        )
+        .unwrap();
+        assert_eq!(inventory.default_agent_id, "zeta");
+        assert_eq!(
+            inventory.default_agent_workspace(),
+            Some(root.join("zeta").as_path())
         );
 
         let _ = fs::remove_dir_all(root);

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -537,7 +537,7 @@ fn dev_command_provisions_worktree_bootstraps_config_and_runs_gateway() {
         path_string(&workspace_dir)
     );
     assert!(config["agents"]["defaults"].get("skipBootstrap").is_none());
-    assert_eq!(config["agents"]["entries"]["main"]["default"], true);
+    assert!(config["agents"].get("entries").is_none());
     assert!(config["agents"].get("list").is_none());
     assert!(workspace_dir.exists());
 

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -537,7 +537,8 @@ fn dev_command_provisions_worktree_bootstraps_config_and_runs_gateway() {
         path_string(&workspace_dir)
     );
     assert!(config["agents"]["defaults"].get("skipBootstrap").is_none());
-    assert_eq!(config["agents"]["list"][0]["id"], "main");
+    assert_eq!(config["agents"]["entries"]["main"]["default"], true);
+    assert!(config["agents"].get("list").is_none());
     assert!(workspace_dir.exists());
 
     let pnpm_log = fs::read_to_string(root.child("pnpm.log")).unwrap();

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -159,6 +159,44 @@ fn env_clone_preserves_configured_custom_workspaces_without_prefix_lookalikes() 
 }
 
 #[test]
+fn env_clone_preserves_keyed_workspaces_using_javascript_property_order() {
+    let root = TestDir::new("env-clone-keyed-workspace-order");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let source_state = root.child("ocm-home/envs/source/.openclaw");
+    write_text(
+        &source_state.join("openclaw.json"),
+        r#"{"agents":{"entries":{"10":{},"2":{}}}}"#,
+    );
+    write_text(
+        &source_state.join("workspace/default.txt"),
+        "default workspace\n",
+    );
+    write_text(
+        &source_state.join("workspace-10/secondary.txt"),
+        "secondary workspace\n",
+    );
+
+    let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
+    assert!(clone.status.success(), "{}", stderr(&clone));
+
+    let target_state = root.child("ocm-home/envs/target/.openclaw");
+    assert_eq!(
+        fs::read_to_string(target_state.join("workspace/default.txt")).unwrap(),
+        "default workspace\n"
+    );
+    assert_eq!(
+        fs::read_to_string(target_state.join("workspace-10/secondary.txt")).unwrap(),
+        "secondary workspace\n"
+    );
+}
+
+#[test]
 fn env_clone_uses_openclaw_config_env_precedence_for_workspace_selection() {
     let root = TestDir::new("env-clone-config-env-precedence");
     let cwd = root.child("workspace");

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -319,7 +319,8 @@ fn env_snapshot_restore_preserves_configured_agent_workspaces_and_includes() {
     assert!(snapshot.status.success(), "{}", stderr(&snapshot));
     let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source", "--json"]);
     assert!(list.status.success(), "{}", stderr(&list));
-    let snapshot_id = stdout(&list)
+    let list_output = stdout(&list);
+    let snapshot_id = list_output
         .split("\"id\": \"")
         .nth(1)
         .and_then(|rest| rest.split('"').next())
@@ -350,6 +351,63 @@ fn env_snapshot_restore_preserves_configured_agent_workspaces_and_includes() {
     assert!(source_state.join("config/agents.json5").exists());
     assert!(!source_state.join("workspace-attestations").exists());
     assert!(!source_state.join("workspace-cache").exists());
+}
+
+#[test]
+fn env_snapshot_preserves_keyed_include_order_when_overriding_an_agent() {
+    let root = TestDir::new("env-snapshot-keyed-include-order");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let source_state = root.child("ocm-home/envs/source/.openclaw");
+    write_text(
+        &source_state.join("openclaw.json"),
+        concat!(
+            "{\n",
+            "  $include: './config/agents.json5',\n",
+            "  agents: { entries: { primary: { name: 'override' } } }\n",
+            "}\n"
+        ),
+    );
+    write_text(
+        &source_state.join("config/agents.json5"),
+        "{ agents: { entries: { primary: {}, ops: {} } } }\n",
+    );
+    write_text(
+        &source_state.join("workspace/default.txt"),
+        "default workspace\n",
+    );
+    write_text(
+        &source_state.join("workspace-ops/secondary.txt"),
+        "secondary workspace\n",
+    );
+
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source", "--json"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    let list_output = stdout(&list);
+    let snapshot_id = list_output
+        .split("\"id\": \"")
+        .nth(1)
+        .and_then(|rest| rest.split('"').next())
+        .unwrap();
+
+    fs::remove_dir_all(source_state.join("workspace-ops")).unwrap();
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    assert_eq!(
+        fs::read_to_string(source_state.join("workspace-ops/secondary.txt")).unwrap(),
+        "secondary workspace\n"
+    );
 }
 
 #[test]

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -411,6 +411,73 @@ fn env_snapshot_preserves_keyed_include_order_when_overriding_an_agent() {
 }
 
 #[test]
+fn env_snapshot_ignores_openclaw_blocked_keyed_agents() {
+    let root = TestDir::new("env-snapshot-blocked-keyed-agent");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let source_state = root.child("ocm-home/envs/source/.openclaw");
+    write_text(
+        &source_state.join("openclaw.json"),
+        r#"{
+          "$include": "./config/agents.json5",
+          "env": {}
+        }"#,
+    );
+    write_text(
+        &source_state.join("config/agents.json5"),
+        r#"{
+          "agents": {
+            "defaults": { "workspace": "${OPENCLAW_STATE_DIR}/team" },
+            "entries": {
+              "constructor": {
+                "workspace": "${OPENCLAW_STATE_DIR}/ignored"
+              },
+              "ops": {}
+            }
+          }
+        }"#,
+    );
+    write_text(
+        &source_state.join("team/real.txt"),
+        "actual OpenClaw default workspace\n",
+    );
+    write_text(
+        &source_state.join("ignored/ignored.txt"),
+        "ignored keyed agent workspace\n",
+    );
+
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source", "--json"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    let list_output = stdout(&list);
+    let snapshot_id = list_output
+        .split("\"id\": \"")
+        .nth(1)
+        .and_then(|rest| rest.split('"').next())
+        .unwrap();
+
+    fs::remove_dir_all(source_state.join("team")).unwrap();
+    fs::remove_dir_all(source_state.join("ignored")).unwrap();
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    assert_eq!(
+        fs::read_to_string(source_state.join("team/real.txt")).unwrap(),
+        "actual OpenClaw default workspace\n"
+    );
+    assert!(!source_state.join("ignored").exists());
+}
+
+#[test]
 fn env_snapshot_uses_openclaw_config_env_precedence_for_workspace_selection() {
     let root = TestDir::new("env-snapshot-config-env-precedence");
     let cwd = root.child("workspace");

--- a/tests/start_command_tests.rs
+++ b/tests/start_command_tests.rs
@@ -124,7 +124,8 @@ fn start_generates_an_env_name_and_uses_latest_stable_runtime() {
             .get("skipBootstrap")
             .is_none()
     );
-    assert_eq!(config_json["agents"]["list"][0]["id"], "main");
+    assert_eq!(config_json["agents"]["entries"]["main"]["default"], true);
+    assert!(config_json["agents"].get("list").is_none());
 }
 
 #[test]

--- a/tests/start_command_tests.rs
+++ b/tests/start_command_tests.rs
@@ -124,7 +124,7 @@ fn start_generates_an_env_name_and_uses_latest_stable_runtime() {
             .get("skipBootstrap")
             .is_none()
     );
-    assert_eq!(config_json["agents"]["entries"]["main"]["default"], true);
+    assert!(config_json["agents"].get("entries").is_none());
     assert!(config_json["agents"].get("list").is_none());
 }
 


### PR DESCRIPTION
## Summary

Keep fresh OCM environments compatible across older and current OpenClaw releases by writing a version-neutral agent config.

- Fresh configs write `agents.defaults.workspace` without `agents.list` or `agents.entries`, allowing each OpenClaw version to infer its default agent.
- Existing `agents.list` and keyed `agents.entries` configs remain supported for workspace inventory, identity-bound rewrites, and include safety checks.
- Keyed configs follow OpenClaw's JavaScript key ordering and include sanitization semantics so clone and snapshot operations preserve the correct workspaces.

## Scope

This PR intentionally does not migrate existing configs during upgrades. OpenClaw Doctor owns forward config and state migrations; OCM upgrade rollback and history are tracked for a follow-up.

## Verification

- `cargo fmt --check`
- `cargo test`
- `git diff --check`
- Fresh OCM environments against OpenClaw `2026.6.11`, `2026.6.33`, `2026.7.1`, `2026.7.1-2`, `2026.7.2-beta.3`, and current `main` at `a7e38f4`.
- Clone and snapshot regressions for keyed ordering, include overrides, and blocked include keys.
