### PR TITLE
fix: finalize runtime migrations before cutover

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -1356,13 +1356,45 @@ impl Cli {
             &args[1..]
         };
         Self::assert_no_extra_args(extra_args)?;
-        if matches!(runtime_name.as_deref(), Some(name) if name.eq_ignore_ascii_case("none"))
-            && (version.is_some() || channel.is_some())
-        {
+        if runtime_name.is_some() && (version.is_some() || channel.is_some()) {
             return Err(
                 "env set-runtime accepts only one runtime source: --runtime, --version, or --channel"
                     .to_string(),
             );
+        }
+        if version.is_some() && channel.is_some() {
+            return Err("env set-runtime accepts only one of --version or --channel".to_string());
+        }
+
+        let current = self.environment_service().get(name)?;
+        let has_existing_binding =
+            current.default_runtime.is_some() || current.default_launcher.is_some();
+        let clears_runtime = matches!(runtime_name.as_deref(), Some(runtime) if runtime.eq_ignore_ascii_case("none"));
+        if has_existing_binding && !clears_runtime {
+            let runtime = runtime_name
+                .map(|runtime| validate_name(&runtime, "Runtime name"))
+                .transpose()?;
+            let summary = self.upgrade_env_to_runtime_target(name, version, channel, runtime)?;
+            if matches!(
+                summary.outcome.as_str(),
+                "failed" | "rolled-back" | "rollback-failed"
+            ) {
+                return Err(summary.note.unwrap_or_else(|| {
+                    format!("runtime transition failed with outcome {}", summary.outcome)
+                }));
+            }
+            let meta = self.environment_service().get(name)?;
+            if json_flag {
+                self.print_json(&meta)?;
+                return Ok(0);
+            }
+            let default_runtime = meta.default_runtime.unwrap_or_else(|| "none".to_string());
+            self.stdout_lines(render::env::env_runtime_updated(
+                &meta.name,
+                &default_runtime,
+                profile,
+            ));
+            return Ok(0);
         }
 
         let validated = match runtime_name {

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1328,7 +1328,10 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
                 format!("{cmd} env set-runtime mira --version 2026.3.24"),
                 format!("{cmd} env set-runtime mira none"),
             ],
-            &["Use only one of a runtime name, `--version`, or `--channel`."],
+            &[
+                "Use only one of a runtime name, `--version`, or `--channel`.",
+                "Replacing an existing binding runs OpenClaw update finalization with snapshot-backed rollback before publishing the new runtime.",
+            ],
         ),
         "set-launcher" => render_leaf(
             "Bind or clear a launcher",

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -192,6 +192,35 @@ impl UpgradeTarget {
 }
 
 impl Cli {
+    pub(super) fn upgrade_env_to_runtime_target(
+        &self,
+        name: &str,
+        version: Option<String>,
+        channel: Option<String>,
+        runtime: Option<String>,
+    ) -> Result<UpgradeEnvSummary, String> {
+        let explicit_count = usize::from(version.is_some())
+            + usize::from(channel.is_some())
+            + usize::from(runtime.is_some());
+        if explicit_count != 1 {
+            return Err(
+                "runtime transition requires exactly one version, channel, or runtime".to_string(),
+            );
+        }
+        self.upgrade_env(
+            name,
+            &UpgradeTarget {
+                version,
+                channel,
+                runtime,
+            },
+            UpgradeOptions {
+                dry_run: false,
+                rollback_enabled: true,
+            },
+        )
+    }
+
     pub(super) fn handle_upgrade_command(&self, args: Vec<String>) -> Result<i32, String> {
         let (args, json_flag, profile) = self.consume_human_output_flags(args, "upgrade")?;
         if matches!(args.first().map(String::as_str), Some("simulate")) {
@@ -1078,11 +1107,7 @@ impl Cli {
                 }
             };
             let binding_changed = prepared.name != current.name;
-            if binding_changed {
-                self.environment_service()
-                    .set_runtime(env_name, prepared.name.as_str())?;
-            }
-            let post_update_note = match self.run_post_core_update(env_name) {
+            let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
                 Ok(note) => note,
                 Err(error) => {
                     return self.rollback_failed_upgrade(
@@ -1098,6 +1123,26 @@ impl Cli {
                     );
                 }
             };
+            let publish_result = if binding_changed {
+                self.environment_service()
+                    .set_runtime(env_name, prepared.name.as_str())
+                    .map(|_| ())
+            } else {
+                self.runtime_service().refresh_supervisor_if_present()
+            };
+            if let Err(error) = publish_result {
+                return self.rollback_failed_upgrade(
+                    env_name,
+                    "runtime",
+                    previous_binding_name,
+                    "runtime",
+                    prepared.name,
+                    prepared.meta.release_version,
+                    prepared.meta.release_channel,
+                    transaction,
+                    format!("failed to publish upgraded runtime: {error}"),
+                );
+            }
             let service_result =
                 self.reconcile_upgraded_service(env_name, service.as_ref(), binding_changed, true);
             let (service_action, service_note) = match service_result {
@@ -1262,7 +1307,7 @@ impl Cli {
                 OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
             );
             let post_update_note = if changed {
-                match self.run_post_core_update(env_name) {
+                match self.run_post_core_update(env_name, &prepared.name) {
                     Ok(note) => note,
                     Err(error) => {
                         return self.rollback_failed_upgrade(
@@ -1281,6 +1326,19 @@ impl Cli {
             } else {
                 None
             };
+            if changed && let Err(error) = self.runtime_service().refresh_supervisor_if_present() {
+                return self.rollback_failed_upgrade(
+                    env_name,
+                    "runtime",
+                    previous_binding_name,
+                    "runtime",
+                    prepared.name,
+                    prepared.meta.release_version,
+                    prepared.meta.release_channel,
+                    transaction,
+                    format!("failed to publish upgraded runtime: {error}"),
+                );
+            }
             let service_result =
                 self.reconcile_upgraded_service(env_name, service.as_ref(), false, changed);
             let (service_action, service_note) = match service_result {
@@ -1350,7 +1408,7 @@ impl Cli {
             options.rollback_enabled,
         )?;
         let updated = match self.with_progress(format!("Updating runtime {}", current.name), || {
-            self.runtime_service().update_from_release(
+            self.runtime_service().update_from_release_deferred(
                 crate::runtime::UpdateRuntimeFromReleaseOptions {
                     name: current.name.clone(),
                     version: None,
@@ -1373,7 +1431,7 @@ impl Cli {
                 );
             }
         };
-        let post_update_note = match self.run_post_core_update(env_name) {
+        let post_update_note = match self.run_post_core_update(env_name, &updated.name) {
             Ok(note) => note,
             Err(error) => {
                 return self.rollback_failed_upgrade(
@@ -1389,6 +1447,19 @@ impl Cli {
                 );
             }
         };
+        if let Err(error) = self.runtime_service().refresh_supervisor_if_present() {
+            return self.rollback_failed_upgrade(
+                env_name,
+                "runtime",
+                previous_binding_name,
+                "runtime",
+                updated.name,
+                updated.release_version,
+                updated.release_channel,
+                transaction,
+                format!("failed to publish upgraded runtime: {error}"),
+            );
+        }
         let service_result =
             self.reconcile_upgraded_service(env_name, service.as_ref(), false, true);
         let (service_action, service_note) = match service_result {
@@ -1515,9 +1586,7 @@ impl Cli {
                 );
             }
         };
-        self.environment_service()
-            .set_runtime(env_name, prepared.name.as_str())?;
-        let post_update_note = match self.run_post_core_update(env_name) {
+        let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
             Ok(note) => note,
             Err(error) => {
                 return self.rollback_failed_upgrade(
@@ -1533,6 +1602,22 @@ impl Cli {
                 );
             }
         };
+        if let Err(error) = self
+            .environment_service()
+            .set_runtime(env_name, prepared.name.as_str())
+        {
+            return self.rollback_failed_upgrade(
+                env_name,
+                "launcher",
+                launcher_name.to_string(),
+                "runtime",
+                prepared.name,
+                prepared.meta.release_version,
+                prepared.meta.release_channel,
+                transaction,
+                format!("failed to publish upgraded runtime: {error}"),
+            );
+        }
         let service_result =
             self.reconcile_upgraded_service(env_name, service.as_ref(), true, true);
         let (service_action, service_note) = match service_result {
@@ -1625,15 +1710,16 @@ impl Cli {
         }
         let (meta, action) =
             self.with_progress(format!("Preparing OpenClaw runtime for {env_name}"), || {
-                self.runtime_service().prepare_official_openclaw_runtime(
-                    InstallRuntimeFromOfficialReleaseOptions {
-                        name: runtime_name.clone(),
-                        version: target.version.clone(),
-                        channel: target.channel.clone(),
-                        description: None,
-                        force: false,
-                    },
-                )
+                self.runtime_service()
+                    .prepare_official_openclaw_runtime_deferred(
+                        InstallRuntimeFromOfficialReleaseOptions {
+                            name: runtime_name.clone(),
+                            version: target.version.clone(),
+                            channel: target.channel.clone(),
+                            description: None,
+                            force: false,
+                        },
+                    )
             })?;
         Ok(PreparedUpgradeTarget {
             name: runtime_name,
@@ -1768,9 +1854,16 @@ impl Cli {
         }
     }
 
-    fn run_post_core_update(&self, env_name: &str) -> Result<Option<String>, String> {
+    fn run_post_core_update(
+        &self,
+        env_name: &str,
+        runtime_name: &str,
+    ) -> Result<Option<String>, String> {
+        // Resolve the replacement explicitly while the previous binding remains published.
+        // A failed finalizer can then roll back without ever activating the replacement.
         self.run_update_mode_openclaw_command(
             env_name,
+            runtime_name,
             "openclaw update finalize",
             &["update", "finalize", "--json", "--yes", "--no-restart"],
         )?;
@@ -1780,13 +1873,14 @@ impl Cli {
     fn run_update_mode_openclaw_command(
         &self,
         env_name: &str,
+        runtime_name: &str,
         name: &str,
         args: &[&str],
     ) -> Result<(), String> {
         let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
         let resolved = self
             .environment_service()
-            .resolve(env_name, None, None, &args)
+            .resolve(env_name, Some(runtime_name.to_string()), None, &args)
             .map_err(|error| format!("{name} failed: {error}"))?;
         match self.run_resolved_for_simulation(
             resolved,
@@ -1950,6 +2044,11 @@ impl Cli {
         env_name: &str,
         transaction: &UpgradeTransaction,
     ) -> Result<(), String> {
+        // Restore runtime bytes and metadata before the snapshot republishes supervisor
+        // state; otherwise rollback can briefly advertise the failed runtime revision.
+        for runtime_backup in &transaction.runtime_backups {
+            self.restore_runtime_backup(runtime_backup)?;
+        }
         self.environment_service()
             .restore_snapshot(RestoreEnvSnapshotOptions {
                 env_name: env_name.to_string(),
@@ -1957,9 +2056,6 @@ impl Cli {
             })?;
         for runtime_name in &transaction.created_runtime_names {
             self.remove_runtime_created_during_upgrade(runtime_name)?;
-        }
-        for runtime_backup in &transaction.runtime_backups {
-            self.restore_runtime_backup(runtime_backup)?;
         }
         Ok(())
     }

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -143,6 +143,23 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: InstallRuntimeFromOfficialReleaseOptions,
     ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
+        self.prepare_official_openclaw_runtime_with_refresh(options, true)
+    }
+
+    pub(crate) fn prepare_official_openclaw_runtime_deferred(
+        &self,
+        options: InstallRuntimeFromOfficialReleaseOptions,
+    ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
+        // Upgrade finalization must run before changed runtime metadata reaches the live
+        // supervisor; the upgrade transaction publishes one coherent state afterward.
+        self.prepare_official_openclaw_runtime_with_refresh(options, false)
+    }
+
+    fn prepare_official_openclaw_runtime_with_refresh(
+        &self,
+        options: InstallRuntimeFromOfficialReleaseOptions,
+        refresh_supervisor: bool,
+    ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
         let version = options
             .version
             .map(|value| value.trim().to_string())
@@ -253,7 +270,9 @@ impl<'a> RuntimeService<'a> {
         } else {
             OfficialRuntimePrepareAction::Installed
         };
-        self.refresh_supervisor_if_present()?;
+        if refresh_supervisor {
+            self.refresh_supervisor_if_present()?;
+        }
         Ok((install.meta, action))
     }
 
@@ -311,6 +330,23 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: UpdateRuntimeFromReleaseOptions,
     ) -> Result<RuntimeMeta, String> {
+        self.update_from_release_with_refresh(options, true)
+    }
+
+    pub(crate) fn update_from_release_deferred(
+        &self,
+        options: UpdateRuntimeFromReleaseOptions,
+    ) -> Result<RuntimeMeta, String> {
+        // Keep the existing supervisor spec active until the replacement runtime has
+        // migrated and validated the environment it will own.
+        self.update_from_release_with_refresh(options, false)
+    }
+
+    fn update_from_release_with_refresh(
+        &self,
+        options: UpdateRuntimeFromReleaseOptions,
+        refresh_supervisor: bool,
+    ) -> Result<RuntimeMeta, String> {
         if options.version.is_some() && options.channel.is_some() {
             return Err("runtime update accepts only one of --version or --channel".to_string());
         }
@@ -354,7 +390,9 @@ impl<'a> RuntimeService<'a> {
                 self.cwd,
             );
             let meta = meta?;
-            self.refresh_supervisor_if_present()?;
+            if refresh_supervisor {
+                self.refresh_supervisor_if_present()?;
+            }
             return Ok(meta);
         }
 
@@ -370,7 +408,9 @@ impl<'a> RuntimeService<'a> {
             self.env,
             self.cwd,
         )?;
-        self.refresh_supervisor_if_present()?;
+        if refresh_supervisor {
+            self.refresh_supervisor_if_present()?;
+        }
         Ok(meta)
     }
 

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -132,6 +132,34 @@ exit 1
     )
 }
 
+fn prebinding_guard_openclaw_script(version: &str, expected_runtime: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+home="${{OPENCLAW_HOME:-$PWD}}"
+mkdir -p "$home"
+printf '%s\n' "$*" >> "$home/sim-commands.log"
+case "$1" in
+  --version)
+    printf '{version}\n'
+    exit 0
+    ;;
+  update)
+    if [ "$2" = "finalize" ]; then
+      if ! grep -q '"defaultRuntime": "{expected_runtime}"' "$OCM_HOME/envs.json"; then
+        echo "replacement runtime was published before update finalization" >&2
+        exit 24
+      fi
+      printf '{{"status":"ok"}}\n'
+      exit 0
+    fi
+    ;;
+esac
+echo "unexpected args: $*" >&2
+exit 1
+"#
+    )
+}
+
 fn scenario_sensitive_openclaw_script(version: &str) -> String {
     format!(
         r#"#!/bin/sh
@@ -1452,7 +1480,10 @@ fn upgrade_can_switch_env_to_an_installed_runtime() {
     let old_runtime = root.child("old-openclaw");
     let new_runtime = root.child("new-openclaw");
     write_executable_script(&old_runtime, &recording_openclaw_script("old-openclaw"));
-    write_executable_script(&new_runtime, &recording_openclaw_script("new-openclaw"));
+    write_executable_script(
+        &new_runtime,
+        &prebinding_guard_openclaw_script("new-openclaw", "old-local"),
+    );
 
     let env = ocm_env(&root);
     let add_old = run_ocm(
@@ -1513,6 +1544,55 @@ fn upgrade_can_switch_env_to_an_installed_runtime() {
         !command_log.contains("plugins update --all\n"),
         "{command_log}"
     );
+}
+
+#[test]
+fn env_set_runtime_uses_the_transactional_upgrade_path_for_existing_bindings() {
+    let root = TestDir::new("set-runtime-transactional-upgrade");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("old-openclaw"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("new-openclaw"));
+
+    let mut env = ocm_env(&root);
+    for (name, runtime) in [("old-local", &old_runtime), ("new-local", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                name,
+                "--path",
+                &runtime.display().to_string(),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "old-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    env.insert("OCM_TEST_FAIL_UPDATE_FINALIZE".to_string(), "1".to_string());
+    let bind = run_ocm(&cwd, &env, &["env", "set-runtime", "demo", "new-local"]);
+    assert!(!bind.status.success(), "{}", stdout(&bind));
+    assert!(
+        stderr(&bind).contains("restored the pre-upgrade snapshot"),
+        "{}",
+        stderr(&bind)
+    );
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(env_json["defaultRuntime"], "old-local");
 }
 
 #[test]


### PR DESCRIPTION
## Problem

OCM published a replacement runtime binding before running that runtime's `openclaw update finalize`. A live supervisor could therefore reload the replacement before doctor migrated newly retired config, turning an otherwise migratable update into a gateway outage. `ocm env set-runtime` also bypassed the snapshot-backed upgrade transaction entirely.

## Change

- run update finalization through an explicit replacement-runtime override while the previous binding remains published
- defer supervisor refresh while an official or manifest-backed runtime is being prepared, then publish one coherent state after finalization succeeds
- restore runtime bytes and metadata before restoring the environment snapshot and supervisor state
- route replacements made through `env set-runtime` through the same snapshot-backed transaction while preserving direct initial binding and the command's existing output shape
- document the transactional replacement behavior in CLI help

## Evidence

- Red on pristine `origin/main` (`1047e741cc8f553fbac1d3ed53f5d9f42a90beaf`): the replacement runtime observed itself in `defaultRuntime` during `update finalize`.
- Green on this head: the same fixture observed the previous runtime during finalization, then the replacement became active.
- Failure probe: an intentional finalizer error exited non-zero and retained the previous runtime binding.
- Focused tests: 62 passed across `upgrade_command_tests`, `runtime_binding_tests`, and `launcher_help_tests`.
- Source-blind behavior validation: all five migration, rollback, and initial-binding clauses passed.
- Autoreview: clean, no accepted/actionable findings.
