### PR TITLE
fix: preserve managed plugin payloads in env recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ ocm upgrade simulate mira --to ./openclaw
 running service cannot be restarted or started after the change, OCM restores
 the snapshot and previous runtime by default. When an environment moves to a new
 runtime, OCM runs OpenClaw's update finalization path inside that environment
-before service restart.
+before service restart. Snapshots preserve managed path, npm, and Git plugin
+payloads together with their package metadata and symlinks, while generated
+plugin dependency caches and live runtime residue stay out of the archive.
 
 `upgrade simulate` clones the source env, leaves the real env untouched, and
 cleans temporary simulation envs and runtimes when the run finishes. For
@@ -178,6 +180,11 @@ ocm adopt plan --name mira
 `migrate` is the simple front door for existing OpenClaw users. It imports a plain OpenClaw home into a managed env in one step.
 
 `migrate` preserves config, auth, sessions, logs, and other durable user state, rewrites env-scoped paths for the new managed root, and clears only live runtime residue like locks, pid files, and sockets. If `openclaw` is already available on `PATH`, it also binds the imported env to an env-local migrated launcher so you can keep using it through OCM immediately.
+
+Environment clone, export, and import flows preserve managed OpenClaw plugin
+payloads under the legacy, extension, npm, and Git install roots. Clone and
+import still clear live sessions, logs, backups, and process residue so the new
+environment does not share active runtime state with its source.
 
 Clone, import, and migration give the target environment a new local gateway and MCP app sandbox listener. They do not copy a public `mcp.apps.sandboxOrigin` because that URL belongs to the source environment's external routing and may still reach the source sandbox. Direct connections derive the target sandbox port automatically. For a target behind a reverse proxy or tunnel, pass its dedicated public origin explicitly:
 

--- a/src/infra/archive.rs
+++ b/src/infra/archive.rs
@@ -88,6 +88,7 @@ pub enum EnvArchiveEntryKind {
 pub struct EnvArchiveOptions {
     pub should_skip_path: fn(&Path, EnvArchiveEntryKind) -> bool,
     pub included_path_roots: BTreeSet<PathBuf>,
+    pub excluded_path_roots: BTreeSet<PathBuf>,
 }
 
 impl Default for EnvArchiveOptions {
@@ -95,12 +96,20 @@ impl Default for EnvArchiveOptions {
         Self {
             should_skip_path: include_env_archive_path,
             included_path_roots: BTreeSet::new(),
+            excluded_path_roots: BTreeSet::new(),
         }
     }
 }
 
 impl EnvArchiveOptions {
     fn should_skip(&self, relative_path: &Path, kind: EnvArchiveEntryKind) -> bool {
+        if self
+            .excluded_path_roots
+            .iter()
+            .any(|root| relative_path == root || relative_path.starts_with(root))
+        {
+            return true;
+        }
         let explicitly_included = self.included_path_roots.iter().any(|root| {
             relative_path == root
                 || relative_path.starts_with(root)
@@ -409,6 +418,7 @@ mod tests {
         let options = EnvArchiveOptions {
             should_skip_path: skip_openclaw_paths,
             included_path_roots: BTreeSet::from([PathBuf::from(".openclaw/team/ops")]),
+            excluded_path_roots: BTreeSet::new(),
         };
 
         for path in [
@@ -425,6 +435,26 @@ mod tests {
         assert!(options.should_skip(
             Path::new(".openclaw/team/cache"),
             EnvArchiveEntryKind::Directory
+        ));
+    }
+
+    #[test]
+    fn archive_options_exclusions_override_selected_path_branches() {
+        let options = EnvArchiveOptions {
+            should_skip_path: skip_openclaw_paths,
+            included_path_roots: BTreeSet::from([PathBuf::from(".openclaw/extensions")]),
+            excluded_path_roots: BTreeSet::from([PathBuf::from(
+                ".openclaw/extensions/demo/node_modules",
+            )]),
+        };
+
+        assert!(!options.should_skip(
+            Path::new(".openclaw/extensions/demo/package.json"),
+            EnvArchiveEntryKind::File
+        ));
+        assert!(options.should_skip(
+            Path::new(".openclaw/extensions/demo/node_modules/package/index.js"),
+            EnvArchiveEntryKind::File
         ));
     }
 

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -163,7 +163,10 @@ pub(crate) fn clear_nonportable_runtime_state(
         let entry = entry.map_err(|error| error.to_string())?;
         let path = entry.path();
         let name = entry.file_name();
-        if name == OsStr::new("openclaw.json") || workspaces.contains(&path) {
+        if name == OsStr::new("openclaw.json")
+            || is_managed_plugin_state_root(&name)
+            || workspaces.contains(&path)
+        {
             continue;
         }
         if name == OsStr::new("agents") {
@@ -182,6 +185,13 @@ pub(crate) fn clear_nonportable_runtime_state(
     }
 
     Ok(changed)
+}
+
+fn is_managed_plugin_state_root(name: &OsStr) -> bool {
+    matches!(
+        name.to_str(),
+        Some("plugins") | Some("extensions") | Some("npm") | Some("git")
+    )
 }
 
 fn rewrite_runtime_state_root_refs(
@@ -675,7 +685,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_nonportable_runtime_state_preserves_config_workspace_and_agent_auth() {
+    fn clear_nonportable_runtime_state_preserves_config_workspaces_auth_and_plugin_payloads() {
         let temp =
             std::env::temp_dir().join(format!("ocm-openclaw-state-clear-{}", std::process::id()));
         let _ = fs::remove_dir_all(&temp);
@@ -694,6 +704,16 @@ mod tests {
             "{}\n",
         )
         .unwrap();
+        for path in [
+            "plugins/installs.json",
+            "extensions/demo/openclaw.plugin.json",
+            "npm/projects/demo/package-lock.json",
+            "git/git-demo/repo/.git/HEAD",
+        ] {
+            let path = paths.state_dir.join(path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, "keep\n").unwrap();
+        }
         fs::write(paths.state_dir.join("logs.txt"), "log\n").unwrap();
         fs::write(paths.workspace_dir.join("notes/todo.txt"), "keep\n").unwrap();
         fs::write(
@@ -723,6 +743,14 @@ mod tests {
                 .join("agents/main/agent/auth-profiles.json")
                 .exists()
         );
+        for path in [
+            "plugins/installs.json",
+            "extensions/demo/openclaw.plugin.json",
+            "npm/projects/demo/package-lock.json",
+            "git/git-demo/repo/.git/HEAD",
+        ] {
+            assert!(paths.state_dir.join(path).exists(), "{path}");
+        }
         assert!(!paths.state_dir.join("agents/main/sessions").exists());
         assert!(!paths.state_dir.join("logs.txt").exists());
 

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -108,6 +108,7 @@ pub(crate) fn openclaw_env_archive_options(
     Ok(EnvArchiveOptions {
         should_skip_path: should_skip_openclaw_env_archive_path,
         included_path_roots: workspaces.archive_relative_roots(&paths.root)?,
+        excluded_path_roots: openclaw_archive_excluded_path_roots(paths)?,
     })
 }
 
@@ -422,7 +423,67 @@ fn is_durable_openclaw_archive_path(components: &[&str]) -> bool {
             | [".openclaw", "identity", ..]
             | [".openclaw", "memory", ..]
             | [".openclaw", "plugins", ..]
+            | [".openclaw", "extensions", ..]
+            | [".openclaw", "npm", ..]
+            | [".openclaw", "git", ..]
     )
+}
+
+fn openclaw_archive_excluded_path_roots(paths: &EnvPaths) -> Result<BTreeSet<PathBuf>, String> {
+    let extensions_root = paths.state_dir.join("extensions");
+    let entries = match fs::read_dir(&extensions_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeSet::new()),
+        Err(error) => return Err(error.to_string()),
+    };
+    let mut excluded = BTreeSet::new();
+
+    for entry in entries {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let plugin_root = entry.path();
+        let metadata = fs::symlink_metadata(&plugin_root).map_err(|error| error.to_string())?;
+        if !metadata.is_dir() {
+            continue;
+        }
+        let children = fs::read_dir(&plugin_root)
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        let has_runtime_deps_marker = children
+            .iter()
+            .any(|child| is_openclaw_runtime_dependency_marker(&child.file_name()));
+        let plugin_relative_root = Path::new(".openclaw")
+            .join("extensions")
+            .join(entry.file_name());
+
+        for child in children {
+            let name = child.file_name();
+            if is_openclaw_legacy_dependency_debris(&name)
+                || (name == OsStr::new("node_modules") && has_runtime_deps_marker)
+            {
+                excluded.insert(plugin_relative_root.join(name));
+            }
+        }
+    }
+
+    Ok(excluded)
+}
+
+fn is_openclaw_runtime_dependency_marker(name: &OsStr) -> bool {
+    name.to_str().is_some_and(|name| {
+        name == ".openclaw-runtime-deps.json"
+            || name == ".openclaw-runtime-deps-stamp.json"
+            || name.starts_with(".openclaw-runtime-deps-")
+    })
+}
+
+fn is_openclaw_legacy_dependency_debris(name: &OsStr) -> bool {
+    is_openclaw_runtime_dependency_marker(name)
+        || name == OsStr::new(".openclaw-pnpm-store")
+        || name == OsStr::new(".openclaw-install-backups")
+        || name
+            .to_str()
+            .is_some_and(|name| name.starts_with(".openclaw-install-stage"))
 }
 
 fn collect_runtime_state_path_refs(
@@ -792,10 +853,35 @@ mod tests {
                 .included_path_roots
                 .contains(Path::new(".openclaw/workspace"))
         );
+        assert!(options.excluded_path_roots.is_empty());
         assert!(!should_skip_openclaw_env_archive_path(
             Path::new(".openclaw/workspace/notes.txt"),
             EnvArchiveEntryKind::File
         ));
+        for path in [
+            ".openclaw/plugins/installs.json",
+            ".openclaw/extensions/demo/package.json",
+            ".openclaw/npm/projects/demo/package-lock.json",
+            ".openclaw/npm/projects/demo/node_modules/demo/index.js",
+            ".openclaw/git/git-demo/repo/.git/HEAD",
+            ".openclaw/git/git-demo/repo/openclaw.plugin.json",
+        ] {
+            assert!(
+                !should_skip_openclaw_env_archive_path(Path::new(path), EnvArchiveEntryKind::File),
+                "{path} should be archived"
+            );
+        }
+        for path in [
+            ".openclaw/plugin-runtime-deps/node_modules/demo/index.js",
+            ".openclaw/bundled-plugin-runtime-deps/node_modules/demo/index.js",
+            ".openclaw/.openclaw-pnpm-store/v3/files/cache",
+            ".openclaw/.openclaw-npm-cache/_cacache/index",
+        ] {
+            assert!(
+                should_skip_openclaw_env_archive_path(Path::new(path), EnvArchiveEntryKind::File),
+                "{path} should not be archived"
+            );
+        }
         assert!(should_skip_openclaw_env_archive_path(
             Path::new(".openclaw/workspace-attestations/manifest.json"),
             EnvArchiveEntryKind::File

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -158,6 +158,10 @@ pub(crate) fn clear_nonportable_runtime_state(
     let workspaces = resolve_archivable_workspaces(paths, env, runtime)?;
 
     let mut changed = false;
+    for relative_path in openclaw_extension_runtime_debris_roots(&paths.state_dir)? {
+        remove_path(&paths.state_dir.join(relative_path))?;
+        changed = true;
+    }
     let entries = fs::read_dir(&paths.state_dir).map_err(|error| error.to_string())?;
     for entry in entries {
         let entry = entry.map_err(|error| error.to_string())?;
@@ -440,7 +444,14 @@ fn is_durable_openclaw_archive_path(components: &[&str]) -> bool {
 }
 
 fn openclaw_archive_excluded_path_roots(paths: &EnvPaths) -> Result<BTreeSet<PathBuf>, String> {
-    let extensions_root = paths.state_dir.join("extensions");
+    Ok(openclaw_extension_runtime_debris_roots(&paths.state_dir)?
+        .into_iter()
+        .map(|path| Path::new(".openclaw").join(path))
+        .collect())
+}
+
+fn openclaw_extension_runtime_debris_roots(state_dir: &Path) -> Result<BTreeSet<PathBuf>, String> {
+    let extensions_root = state_dir.join("extensions");
     let entries = match fs::read_dir(&extensions_root) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeSet::new()),
@@ -462,9 +473,7 @@ fn openclaw_archive_excluded_path_roots(paths: &EnvPaths) -> Result<BTreeSet<Pat
         let has_runtime_deps_marker = children
             .iter()
             .any(|child| is_openclaw_runtime_dependency_marker(&child.file_name()));
-        let plugin_relative_root = Path::new(".openclaw")
-            .join("extensions")
-            .join(entry.file_name());
+        let plugin_relative_root = Path::new("extensions").join(entry.file_name());
 
         for child in children {
             let name = child.file_name();
@@ -707,12 +716,23 @@ mod tests {
         for path in [
             "plugins/installs.json",
             "extensions/demo/openclaw.plugin.json",
+            "extensions/demo/node_modules/package/index.js",
+            "extensions/generated/openclaw.plugin.json",
             "npm/projects/demo/package-lock.json",
             "git/git-demo/repo/.git/HEAD",
         ] {
             let path = paths.state_dir.join(path);
             fs::create_dir_all(path.parent().unwrap()).unwrap();
             fs::write(path, "keep\n").unwrap();
+        }
+        for path in [
+            "extensions/generated/.openclaw-runtime-deps.json",
+            "extensions/generated/.openclaw-install-backups/backup.json",
+            "extensions/generated/node_modules/package/index.js",
+        ] {
+            let path = paths.state_dir.join(path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, "remove\n").unwrap();
         }
         fs::write(paths.state_dir.join("logs.txt"), "log\n").unwrap();
         fs::write(paths.workspace_dir.join("notes/todo.txt"), "keep\n").unwrap();
@@ -746,10 +766,19 @@ mod tests {
         for path in [
             "plugins/installs.json",
             "extensions/demo/openclaw.plugin.json",
+            "extensions/demo/node_modules/package/index.js",
+            "extensions/generated/openclaw.plugin.json",
             "npm/projects/demo/package-lock.json",
             "git/git-demo/repo/.git/HEAD",
         ] {
             assert!(paths.state_dir.join(path).exists(), "{path}");
+        }
+        for path in [
+            "extensions/generated/.openclaw-runtime-deps.json",
+            "extensions/generated/.openclaw-install-backups",
+            "extensions/generated/node_modules",
+        ] {
+            assert!(!paths.state_dir.join(path).exists(), "{path}");
         }
         assert!(!paths.state_dir.join("agents/main/sessions").exists());
         assert!(!paths.state_dir.join("logs.txt").exists());

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -53,6 +53,64 @@ fn env_clone_copies_state_into_a_new_environment() {
 }
 
 #[test]
+fn env_clone_preserves_plugin_payloads_while_clearing_live_runtime_state() {
+    let root = TestDir::new("env-clone-plugin-payloads");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let source_state = root.child("ocm-home/envs/source/.openclaw");
+    let payloads = [
+        (
+            "plugins/installs.json",
+            "{\"legacy\":{\"source\":\"path\"}}\n",
+        ),
+        (
+            "extensions/path-demo/openclaw.plugin.json",
+            "{\"id\":\"path-demo\"}\n",
+        ),
+        (
+            "npm/projects/npm-demo/package-lock.json",
+            "{\"lockfileVersion\":3}\n",
+        ),
+        (
+            "npm/projects/npm-demo/node_modules/npm-demo/index.js",
+            "module.exports = 'npm-demo';\n",
+        ),
+        ("git/git-demo/repo/.git/HEAD", "ref: refs/heads/main\n"),
+        (
+            "git/git-demo/repo/openclaw.plugin.json",
+            "{\"id\":\"git-demo\"}\n",
+        ),
+    ];
+    for (path, contents) in payloads {
+        write_text(&source_state.join(path), contents);
+    }
+    write_text(
+        &source_state.join("agents/main/sessions/session.jsonl"),
+        "{\"message\":\"do not copy\"}\n",
+    );
+    write_text(&source_state.join("logs/gateway.log"), "do not copy\n");
+
+    let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
+    assert!(clone.status.success(), "{}", stderr(&clone));
+
+    let target_state = root.child("ocm-home/envs/target/.openclaw");
+    for (path, contents) in payloads {
+        assert_eq!(
+            fs::read_to_string(target_state.join(path)).unwrap(),
+            contents,
+            "{path}"
+        );
+    }
+    assert!(!target_state.join("agents/main/sessions").exists());
+    assert!(!target_state.join("logs").exists());
+}
+
+#[test]
 fn env_clone_rewrites_openclaw_config_for_the_new_env_root() {
     let root = TestDir::new("env-clone-config-rewrite");
     let cwd = root.child("workspace");

--- a/tests/env_clone_tests.rs
+++ b/tests/env_clone_tests.rs
@@ -73,6 +73,14 @@ fn env_clone_preserves_plugin_payloads_while_clearing_live_runtime_state() {
             "{\"id\":\"path-demo\"}\n",
         ),
         (
+            "extensions/path-demo/node_modules/path-dependency/index.js",
+            "module.exports = 'path-dependency';\n",
+        ),
+        (
+            "extensions/generated/openclaw.plugin.json",
+            "{\"id\":\"generated\"}\n",
+        ),
+        (
             "npm/projects/npm-demo/package-lock.json",
             "{\"lockfileVersion\":3}\n",
         ),
@@ -94,6 +102,18 @@ fn env_clone_preserves_plugin_payloads_while_clearing_live_runtime_state() {
         "{\"message\":\"do not copy\"}\n",
     );
     write_text(&source_state.join("logs/gateway.log"), "do not copy\n");
+    write_text(
+        &source_state.join("extensions/generated/.openclaw-runtime-deps.json"),
+        "{}\n",
+    );
+    write_text(
+        &source_state.join("extensions/generated/.openclaw-install-backups/backup.json"),
+        "{}\n",
+    );
+    write_text(
+        &source_state.join("extensions/generated/node_modules/generated/index.js"),
+        "module.exports = 'generated';\n",
+    );
 
     let clone = run_ocm(&cwd, &env, &["env", "clone", "source", "target"]);
     assert!(clone.status.success(), "{}", stderr(&clone));
@@ -108,6 +128,13 @@ fn env_clone_preserves_plugin_payloads_while_clearing_live_runtime_state() {
     }
     assert!(!target_state.join("agents/main/sessions").exists());
     assert!(!target_state.join("logs").exists());
+    for path in [
+        "extensions/generated/.openclaw-runtime-deps.json",
+        "extensions/generated/.openclaw-install-backups",
+        "extensions/generated/node_modules",
+    ] {
+        assert!(!target_state.join(path).exists(), "{path}");
+    }
 }
 
 #[test]

--- a/tests/env_import_tests.rs
+++ b/tests/env_import_tests.rs
@@ -101,6 +101,89 @@ fn env_import_restores_an_archive_with_a_new_name_and_root() {
 }
 
 #[test]
+fn env_import_restores_managed_plugin_payloads_without_runtime_debris() {
+    let root = TestDir::new("env-import-plugin-payloads");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let source_state = root.child("ocm-home/envs/source/.openclaw");
+    let payloads = [
+        (
+            "plugins/installs.json",
+            "{\"legacy\":{\"source\":\"path\"}}\n",
+        ),
+        (
+            "extensions/path-demo/openclaw.plugin.json",
+            "{\"id\":\"path-demo\"}\n",
+        ),
+        (
+            "npm/projects/npm-demo/package-lock.json",
+            "{\"lockfileVersion\":3}\n",
+        ),
+        (
+            "npm/projects/npm-demo/node_modules/npm-demo/index.js",
+            "module.exports = 'npm-demo';\n",
+        ),
+        ("git/git-demo/repo/.git/HEAD", "ref: refs/heads/main\n"),
+        (
+            "git/git-demo/repo/openclaw.plugin.json",
+            "{\"id\":\"git-demo\"}\n",
+        ),
+    ];
+    for (path, contents) in payloads {
+        write_text(&source_state.join(path), contents);
+    }
+    write_text(
+        &source_state.join("plugin-runtime-deps/demo/node_modules/demo/index.js"),
+        "generated runtime dependency\n",
+    );
+
+    let archive = root.child("source.ocm-env.tar");
+    let export = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "export",
+            "source",
+            "--output",
+            archive.to_string_lossy().as_ref(),
+        ],
+    );
+    assert!(export.status.success(), "{}", stderr(&export));
+
+    let target_root = root.child("imports/target");
+    let import = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "import",
+            archive.to_string_lossy().as_ref(),
+            "--name",
+            "target",
+            "--root",
+            target_root.to_string_lossy().as_ref(),
+        ],
+    );
+    assert!(import.status.success(), "{}", stderr(&import));
+
+    let target_state = target_root.join(".openclaw");
+    for (path, contents) in payloads {
+        assert_eq!(
+            fs::read_to_string(target_state.join(path)).unwrap(),
+            contents,
+            "{path}"
+        );
+    }
+    assert!(!target_state.join("plugin-runtime-deps").exists());
+}
+
+#[test]
 fn env_import_rewrites_identity_bound_workspaces_to_the_imported_data_path() {
     let root = TestDir::new("env-import-runtime-identity");
     let cwd = root.child("workspace");

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -269,6 +269,75 @@ fn env_snapshot_restore_reverts_state_from_the_selected_snapshot() {
 }
 
 #[test]
+fn env_snapshot_restore_recovers_managed_plugin_payloads() {
+    let root = TestDir::new("env-snapshot-plugin-payloads");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let state_root = root.child("ocm-home/envs/source/.openclaw");
+    let payloads = [
+        (
+            "plugins/installs.json",
+            "{\"legacy\":{\"source\":\"path\"}}\n",
+        ),
+        (
+            "extensions/path-demo/openclaw.plugin.json",
+            "{\"id\":\"path-demo\"}\n",
+        ),
+        (
+            "npm/projects/npm-demo/package-lock.json",
+            "{\"lockfileVersion\":3}\n",
+        ),
+        (
+            "npm/projects/npm-demo/node_modules/npm-demo/index.js",
+            "module.exports = 'npm-demo';\n",
+        ),
+        ("git/git-demo/repo/.git/HEAD", "ref: refs/heads/main\n"),
+        (
+            "git/git-demo/repo/openclaw.plugin.json",
+            "{\"id\":\"git-demo\"}\n",
+        ),
+    ];
+    for (path, contents) in payloads {
+        write_text(&state_root.join(path), contents);
+    }
+
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source", "--json"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    let snapshot_id = stdout(&list)
+        .split("\"id\": \"")
+        .nth(1)
+        .and_then(|rest| rest.split('"').next())
+        .unwrap()
+        .to_string();
+
+    for root_name in ["plugins", "extensions", "npm", "git"] {
+        fs::remove_dir_all(state_root.join(root_name)).unwrap();
+    }
+
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", &snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+
+    for (path, contents) in payloads {
+        assert_eq!(
+            fs::read_to_string(state_root.join(path)).unwrap(),
+            contents,
+            "{path}"
+        );
+    }
+}
+
+#[test]
 fn env_snapshot_restore_preserves_configured_agent_workspaces_and_includes() {
     let root = TestDir::new("env-snapshot-secondary-workspaces");
     let cwd = root.child("workspace");

--- a/tests/store_flow_tests.rs
+++ b/tests/store_flow_tests.rs
@@ -1110,7 +1110,7 @@ fn environment_snapshot_captures_a_named_point_in_time() {
 
 #[cfg(unix)]
 #[test]
-fn environment_snapshot_skips_legacy_plugin_dependency_state_and_preserves_symlinks() {
+fn environment_snapshot_preserves_managed_plugin_payloads_and_skips_runtime_debris() {
     let root = TestDir::new("store-env-snapshot-legacy-plugin-deps");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -1174,6 +1174,39 @@ fn environment_snapshot_skips_legacy_plugin_dependency_state_and_preserves_symli
         &source_root.join(".openclaw/plugins/installed.json"),
         "{\"plugins\":[]}\n",
     );
+    write_text(
+        &source_root.join(".openclaw/extensions/current/openclaw.plugin.json"),
+        "{\"id\":\"current\"}\n",
+    );
+    write_text(
+        &source_root.join(".openclaw/extensions/current/node_modules/package/index.js"),
+        "module.exports = true;\n",
+    );
+    write_text(
+        &source_root.join(".openclaw/npm/projects/demo/package.json"),
+        "{\"name\":\"demo\"}\n",
+    );
+    write_text(
+        &source_root.join(".openclaw/npm/projects/demo/package-lock.json"),
+        "{\"lockfileVersion\":3}\n",
+    );
+    write_text(
+        &source_root.join(".openclaw/npm/projects/demo/node_modules/demo/index.js"),
+        "module.exports = 'npm';\n",
+    );
+    write_text(
+        &source_root.join(".openclaw/git/git-demo/repo/.git/HEAD"),
+        "ref: refs/heads/main\n",
+    );
+    write_text(
+        &source_root.join(".openclaw/git/git-demo/repo/openclaw.plugin.json"),
+        "{\"id\":\"git-demo\"}\n",
+    );
+    std::os::unix::fs::symlink(
+        "../demo",
+        source_root.join(".openclaw/npm/projects/demo/node_modules/demo-link"),
+    )
+    .unwrap();
     std::os::unix::fs::symlink(
         "../missing-workspace-target.txt",
         source_root.join(".openclaw/workspace/missing-link"),
@@ -1262,6 +1295,13 @@ fn environment_snapshot_skips_legacy_plugin_dependency_state_and_preserves_symli
         ".openclaw/identity/profile.json",
         ".openclaw/memory/store.json",
         ".openclaw/plugins/installed.json",
+        ".openclaw/extensions/current/openclaw.plugin.json",
+        ".openclaw/extensions/current/node_modules/package/index.js",
+        ".openclaw/npm/projects/demo/package.json",
+        ".openclaw/npm/projects/demo/package-lock.json",
+        ".openclaw/npm/projects/demo/node_modules/demo/index.js",
+        ".openclaw/git/git-demo/repo/.git/HEAD",
+        ".openclaw/git/git-demo/repo/openclaw.plugin.json",
     ] {
         assert!(extracted.root_dir.join(path).exists(), "{path}");
     }
@@ -1270,6 +1310,16 @@ fn environment_snapshot_skips_legacy_plugin_dependency_state_and_preserves_symli
             .unwrap()
             .file_type()
             .is_symlink()
+    );
+    assert!(
+        fs::symlink_metadata(
+            extracted
+                .root_dir
+                .join(".openclaw/npm/projects/demo/node_modules/demo-link")
+        )
+        .unwrap()
+        .file_type()
+        .is_symlink()
     );
     assert!(
         !extracted

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -132,6 +132,29 @@ exit 1
     )
 }
 
+fn destructive_finalize_openclaw_script(version: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+home="${{OPENCLAW_HOME:-$PWD}}"
+case "$1" in
+  --version)
+    printf '{version}\n'
+    exit 0
+    ;;
+  update)
+    if [ "$2" = "finalize" ]; then
+      rm -rf "$home/.openclaw/npm"
+      printf '{{"status":"ok","mode":"finalize"}}\n'
+      exit 0
+    fi
+    ;;
+esac
+echo "unexpected args: $*" >&2
+exit 1
+"#
+    )
+}
+
 fn prebinding_guard_openclaw_script(version: &str, expected_runtime: &str) -> String {
     format!(
         r#"#!/bin/sh
@@ -1317,8 +1340,10 @@ fn upgrade_rolls_back_when_post_upgrade_version_verification_fails() {
         &old_tarball,
     );
 
-    let wrong_version_tarball =
-        openclaw_package_tarball(&recording_openclaw_script("2026.3.24"), "2026.3.25");
+    let wrong_version_tarball = openclaw_package_tarball(
+        &destructive_finalize_openclaw_script("2026.3.24"),
+        "2026.3.25",
+    );
     let wrong_version_integrity = sha512_integrity(&wrong_version_tarball);
     let wrong_version_tarball_server = TestHttpServer::serve_bytes(
         "/openclaw-2026.3.25.tgz",
@@ -1357,6 +1382,27 @@ fn upgrade_rolls_back_when_post_upgrade_version_verification_fails() {
     let start = run_ocm(&cwd, &env, &["start", "demo", "--no-service"]);
     assert!(start.status.success(), "{}", stderr(&start));
 
+    let state_root = root.child("ocm-home/envs/demo/.openclaw");
+    let plugin_payloads = [
+        (
+            "npm/projects/demo/package.json",
+            "{\"name\":\"@example/demo\"}\n",
+        ),
+        (
+            "npm/projects/demo/package-lock.json",
+            "{\"lockfileVersion\":3}\n",
+        ),
+        (
+            "npm/projects/demo/node_modules/demo/index.js",
+            "module.exports = 'restored';\n",
+        ),
+    ];
+    for (path, contents) in plugin_payloads {
+        let path = state_root.join(path);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
     assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
     let output = stdout(&upgrade);
@@ -1371,6 +1417,13 @@ fn upgrade_rolls_back_when_post_upgrade_version_verification_fails() {
     assert!(runtime.status.success(), "{}", stderr(&runtime));
     let runtime_json: Value = serde_json::from_str(&stdout(&runtime)).unwrap();
     assert_eq!(runtime_json["releaseVersion"], "2026.3.24");
+    for (path, contents) in plugin_payloads {
+        assert_eq!(
+            fs::read_to_string(state_root.join(path)).unwrap(),
+            contents,
+            "{path}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve legacy, path, npm, and Git plugin payload roots in environment snapshots and portable archives
- retain plugin payloads through clone and import while clearing sessions, logs, process residue, and generated extension dependencies
- prove automatic failed-upgrade rollback restores package manifests, lockfiles, and installed plugin code
- document the payload portability contract

## Verification

- `cargo fmt --check`
- Rust 1.88 `cargo check --workspace --all-targets --locked`
- `cargo test --locked`
- Windows GNU `cargo check --workspace --all-targets --locked --target x86_64-pc-windows-gnu`
- clean `cargo install --locked --path .` smoke
- real OpenClaw `2026.7.1-2` npm-plugin snapshot/restore with `@openclaw/irc@2026.7.1`, including byte-for-byte package-tree verification and `openclaw plugins list --json` after restore

## Follow-up

Current OpenClaw SQLite state requires a separate quiesced/checkpointed snapshot contract, and OCM managed-Node compatibility requires its own runtime-toolchain fix. Those changes are intentionally not mixed into this payload-focused PR.

Progresses #35.