### PR TITLE
fix: keep managed Node compatible with OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Inside this repo, use the development wrapper:
 ./bin/ocm help
 ```
 
-Published OpenClaw release flows in `ocm` prefer host Node.js `22.14.0` or newer and `npm`.
+Published OpenClaw release flows in `ocm` prefer host Node.js `22.22.3+`,
+`24.15.0+`, or `25.9.0+` and `npm`.
 On supported platforms, `ocm` can manage a private copy for official release installs when those tools are missing.
 Interactive release setup can also offer to install `git` for repo-aware coding workflows when it is missing.
 Local checkout flows keep using whatever command and toolchain you choose.

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -1296,14 +1296,17 @@ impl Cli {
                 env,
                 program,
                 program_args,
+                path_prepend,
                 run_dir,
                 ..
-            } => run_direct(
-                &program,
-                &program_args,
-                &build_openclaw_env(&env, &self.env),
-                &run_dir,
-            ),
+            } => {
+                let mut process_env = build_openclaw_env(&env, &self.env);
+                crate::managed_node::apply_path_prepend_to_environment(
+                    &mut process_env,
+                    path_prepend.as_deref(),
+                )?;
+                run_direct(&program, &program_args, &process_env, &run_dir)
+            }
             crate::env::ResolvedExecution::Dev {
                 env,
                 worktree_root,

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -196,7 +196,7 @@ pub fn setup_help(cmd: &str) -> String {
         vec![format!("{cmd} setup")],
         &[
             "Setup asks a few questions, then runs the same env-first flow as `start`.",
-            "Official release choices prefer host Node.js >= 22.14.0 and npm, and OCM can manage a private copy on supported platforms when they are missing.",
+            "Official release choices prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm, and OCM can manage a private copy on supported platforms when they are missing.",
             "If git is missing, setup can offer to install it for repo-aware coding workflows.",
             "When run inside an OpenClaw checkout, local mode defaults to `pnpm openclaw` in that folder.",
             "If OCM detects an existing plain OpenClaw home, setup points you at `migrate` so you can bring that state under OCM instead of starting fresh.",
@@ -504,7 +504,7 @@ pub fn start_help(cmd: &str) -> String {
             "Start writes the minimum local config by default so the env can boot immediately. Use `--onboard` for the interactive setup flow.",
             "Start installs and starts the env service by default. Use `--no-service` when you do not want a background process.",
             "Managed services currently support launchd on macOS and systemd --user on Linux.",
-            "Official release selectors prefer host Node.js >= 22.14.0 and npm, and OCM can manage a private copy on supported platforms when they are missing.",
+            "Official release selectors prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm, and OCM can manage a private copy on supported platforms when they are missing.",
             "When start creates a new official-release env interactively, it can offer to install git for repo-aware coding workflows.",
             "If OCM detects an existing plain OpenClaw home, start keeps the new env fresh and points you at `migrate` if you want to bring that older state under OCM.",
             "`--json` cannot be combined with `--onboard` because onboarding is interactive.",
@@ -935,7 +935,7 @@ pub fn doctor_command_help(cmd: &str, action: &str) -> Option<String> {
                 format!("{cmd} doctor host --fix git --yes"),
             ],
             &[
-                "Official release installs prefer host Node.js >= 22.14.0 and npm.",
+                "Official release installs prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm.",
                 "On supported platforms, OCM can manage a private copy when they are missing.",
                 "Git is the first supported host fix target; OCM will not install Homebrew automatically.",
                 "Recommended tools are advisory; they do not block local-command or launcher flows.",
@@ -1484,7 +1484,7 @@ pub fn release_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "Official installs use canonical runtime names derived from the selector.",
-                "Official release installs prefer host Node.js >= 22.14.0 and npm.",
+                "Official release installs prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm.",
                 "On supported platforms, OCM can manage a private copy when they are missing.",
                 "Use `ocm doctor host` only if you want a full machine check or an explicit host-tool fix like git.",
             ],
@@ -1815,7 +1815,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
             &[
                 "Exactly one install source must be provided.",
                 "Official installs use canonical runtime names unless you reuse the same canonical name explicitly.",
-                "Official release installs prefer host Node.js >= 22.14.0 and npm.",
+                "Official release installs prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm.",
                 "On supported platforms, OCM can manage a private copy when they are missing.",
                 "Use `ocm doctor host` only if you want a full machine check or an explicit host-tool fix like git.",
             ],

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -859,7 +859,7 @@ impl Cli {
         resolved: crate::env::ResolvedExecution,
         extra_env: &[(&str, &str)],
     ) -> Result<SimulationCommandOutput, String> {
-        let (mut command, env_meta, source_root) = match resolved {
+        let (mut command, env_meta, source_root, path_prepend) = match resolved {
             crate::env::ResolvedExecution::Launcher {
                 env,
                 command,
@@ -868,18 +868,19 @@ impl Cli {
             } => {
                 let mut process = shell_command(&command);
                 process.current_dir(run_dir);
-                (process, env, None)
+                (process, env, None, None)
             }
             crate::env::ResolvedExecution::Runtime {
                 env,
                 program,
                 program_args,
+                path_prepend,
                 run_dir,
                 ..
             } => {
                 let mut process = Command::new(program);
                 process.args(program_args).current_dir(run_dir);
-                (process, env, None)
+                (process, env, None, path_prepend)
             }
             crate::env::ResolvedExecution::Dev {
                 env,
@@ -891,7 +892,7 @@ impl Cli {
             } => {
                 let mut process = Command::new(program);
                 process.args(program_args).current_dir(run_dir);
-                (process, env, Some(PathBuf::from(worktree_root)))
+                (process, env, Some(PathBuf::from(worktree_root)), None)
             }
             crate::env::ResolvedExecution::SourceWatch {
                 env,
@@ -903,13 +904,17 @@ impl Cli {
             } => {
                 let mut process = Command::new(program);
                 process.args(program_args).current_dir(run_dir);
-                (process, env, Some(PathBuf::from(source.repo_root)))
+                (process, env, Some(PathBuf::from(source.repo_root)), None)
             }
         };
         let mut process_env = match source_root {
             Some(source_root) => build_openclaw_dev_source_env(&env_meta, &self.env, &source_root),
             None => build_openclaw_env(&env_meta, &self.env),
         };
+        crate::managed_node::apply_path_prepend_to_environment(
+            &mut process_env,
+            path_prepend.as_deref(),
+        )?;
         for (key, value) in extra_env {
             process_env.insert((*key).to_string(), (*value).to_string());
         }

--- a/src/env/execution.rs
+++ b/src/env/execution.rs
@@ -8,6 +8,7 @@ use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::launcher::{
     build_launcher_command, resolve_direct_launcher_command, resolve_launcher_run_dir,
 };
+use crate::managed_node::apply_path_prepend_to_environment;
 use crate::runtime::resolve_runtime_launch;
 use crate::store::{display_path, get_launcher, get_runtime_verified};
 
@@ -151,6 +152,8 @@ pub fn resolve_gateway_process_spec(
                 cwd,
                 bootstrap_managed_node,
             )?;
+            let mut process_env = build_openclaw_env(env_meta, process_env);
+            apply_path_prepend_to_environment(&mut process_env, launch.path_prepend.as_deref())?;
             Ok(GatewayProcessSpec {
                 env_name: env_meta.name.clone(),
                 binding_kind: "runtime".to_string(),
@@ -162,7 +165,7 @@ pub fn resolve_gateway_process_spec(
                 runtime_release_channel: runtime.release_channel.clone(),
                 args: launch.args,
                 run_dir: Path::new(&env_meta.root).to_path_buf(),
-                process_env: build_openclaw_env(env_meta, process_env),
+                process_env,
             })
         }
         ExecutionBinding::Dev => {
@@ -235,6 +238,7 @@ pub enum ResolvedExecution {
         forwarded_args: Vec<String>,
         program: String,
         program_args: Vec<String>,
+        path_prepend: Option<PathBuf>,
         run_dir: PathBuf,
     },
     Dev {
@@ -394,6 +398,7 @@ impl<'a> EnvironmentService<'a> {
                     forwarded_args: args,
                     program: launch.program,
                     program_args: launch.args,
+                    path_prepend: launch.path_prepend,
                     run_dir: resolve_runtime_run_dir(self.cwd),
                     env,
                 })

--- a/src/host.rs
+++ b/src/host.rs
@@ -5,7 +5,8 @@ use std::process::{Command, Stdio};
 use serde::Serialize;
 
 use crate::managed_node::{
-    OPENCLAW_MIN_NODE_VERSION, managed_node_fallback_detail, managed_node_fallback_supported,
+    OPENCLAW_MIN_NODE_VERSION, OPENCLAW_NODE_VERSION_REQUIREMENT, managed_node_fallback_detail,
+    managed_node_fallback_supported,
 };
 use crate::service::{ServiceManagerKind, service_manager_kind};
 use crate::store::resolve_user_home;
@@ -205,7 +206,7 @@ pub fn official_openclaw_runtime_requirement_message(
     env: &BTreeMap<String, String>,
 ) -> String {
     format!(
-        "official OpenClaw runtimes require Node.js >= {OPENCLAW_MIN_NODE_VERSION} and npm on PATH; {detail}. Run \"{} doctor host\" for a full machine check.",
+        "official OpenClaw runtimes require {OPENCLAW_NODE_VERSION_REQUIREMENT} and npm on PATH; {detail}. Run \"{} doctor host\" for a full machine check.",
         command_example(env)
     )
 }
@@ -213,14 +214,14 @@ pub fn official_openclaw_runtime_requirement_message(
 pub fn verify_official_openclaw_runtime_node(env: &BTreeMap<String, String>) -> Result<(), String> {
     let node_version = node_version(env)
         .map_err(|detail| official_openclaw_runtime_requirement_message(&detail, env))?;
-    match compare_version_like(&node_version, OPENCLAW_MIN_NODE_VERSION) {
-        Some(std::cmp::Ordering::Less) => Err(official_openclaw_runtime_requirement_message(
+    match openclaw_node_version_supported(&node_version) {
+        Some(true) => Ok(()),
+        Some(false) => Err(official_openclaw_runtime_requirement_message(
             &format!(
-                "found Node.js {node_version}; upgrade to {OPENCLAW_MIN_NODE_VERSION} or newer"
+                "found Node.js {node_version}, which is outside the supported OpenClaw ranges"
             ),
             env,
         )),
-        Some(_) => Ok(()),
         None => Err(official_openclaw_runtime_requirement_message(
             &format!("node --version returned an unreadable version: {node_version}"),
             env,
@@ -359,8 +360,8 @@ fn node_check(
         HostCheckLevel::Required
     };
     match node_version(env) {
-        Ok(version) => match compare_version_like(&version, OPENCLAW_MIN_NODE_VERSION) {
-            Some(std::cmp::Ordering::Less) => check(
+        Ok(version) => match openclaw_node_version_supported(&version) {
+            Some(false) => check(
                 "official-release",
                 "Node.js",
                 "Run published OpenClaw releases",
@@ -369,12 +370,12 @@ fn node_check(
                 HostCheckNotes::new(
                     Some(version.clone()),
                     Some(format!(
-                        "found Node.js {version}; official releases need {OPENCLAW_MIN_NODE_VERSION} or newer"
+                        "found Node.js {version}; official releases need {OPENCLAW_NODE_VERSION_REQUIREMENT}"
                     )),
                     Some(node_suggestion(managed_fallback_supported)),
                 ),
             ),
-            Some(_) => check(
+            Some(true) => check(
                 "official-release",
                 "Node.js",
                 "Run published OpenClaw releases",
@@ -455,10 +456,10 @@ fn node_detail(detail: String, managed_fallback_supported: bool) -> String {
 fn node_suggestion(managed_fallback_supported: bool) -> String {
     if managed_fallback_supported {
         format!(
-            "Install Node.js {OPENCLAW_MIN_NODE_VERSION} or newer if you want OCM to use your host toolchain; otherwise OCM can manage a private copy for official releases."
+            "Install {OPENCLAW_NODE_VERSION_REQUIREMENT} if you want OCM to use your host toolchain; otherwise OCM can manage a private copy for official releases."
         )
     } else {
-        format!("Install Node.js {OPENCLAW_MIN_NODE_VERSION} or newer.")
+        format!("Install {OPENCLAW_NODE_VERSION_REQUIREMENT}.")
     }
 }
 
@@ -1030,6 +1031,20 @@ fn parse_version_like(version: &str) -> Option<Vec<u64>> {
     Some(out)
 }
 
+fn openclaw_node_version_supported(version: &str) -> Option<bool> {
+    let parsed = parse_version_like(version)?;
+    let major = *parsed.first()?;
+    let minimum = match major {
+        22 => OPENCLAW_MIN_NODE_VERSION,
+        23 => return Some(false),
+        24 => "24.15.0",
+        25 => "25.9.0",
+        value if value > 25 => return Some(true),
+        _ => return Some(false),
+    };
+    Some(compare_version_like(version, minimum)? != std::cmp::Ordering::Less)
+}
+
 fn parse_browser_major_version(raw_version: &str) -> Option<u32> {
     raw_version
         .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '.'))
@@ -1111,23 +1126,42 @@ mod tests {
 
     use super::{
         HostPackageManager, command_exists, compare_version_like, detect_host_package_manager,
-        host_is_root, parse_browser_major_version,
+        host_is_root, openclaw_node_version_supported, parse_browser_major_version,
     };
 
     #[test]
     fn compare_version_like_orders_semverish_versions() {
         assert_eq!(
-            compare_version_like("22.14.0", "22.14.0"),
+            compare_version_like("22.22.3", "22.22.3"),
             Some(std::cmp::Ordering::Equal)
         );
         assert_eq!(
-            compare_version_like("v22.15.1", "22.14.0"),
+            compare_version_like("v22.23.1", "22.22.3"),
             Some(std::cmp::Ordering::Greater)
         );
         assert_eq!(
-            compare_version_like("20.11.0", "22.14.0"),
+            compare_version_like("20.11.0", "22.22.3"),
             Some(std::cmp::Ordering::Less)
         );
+    }
+
+    #[test]
+    fn openclaw_node_version_support_matches_current_runtime_lines() {
+        for version in ["22.22.3", "22.23.0", "24.15.0", "25.9.0", "26.0.0"] {
+            assert_eq!(
+                openclaw_node_version_supported(version),
+                Some(true),
+                "{version}"
+            );
+        }
+        for version in ["20.20.0", "22.22.2", "23.11.0", "24.14.9", "25.8.9"] {
+            assert_eq!(
+                openclaw_node_version_supported(version),
+                Some(false),
+                "{version}"
+            );
+        }
+        assert_eq!(openclaw_node_version_supported("unknown"), None);
     }
 
     #[test]

--- a/src/managed_node.rs
+++ b/src/managed_node.rs
@@ -237,8 +237,10 @@ fn apply_path_prepend_to_environment_with_platform_semantics(
     )?
     .into_string()
     .map_err(|_| "managed Node.js PATH contains non-Unicode data".to_string())?;
-    if let Some(existing_key) = environment_path_key(env, case_insensitive) {
-        env.remove(&existing_key);
+    if case_insensitive {
+        env.retain(|key, _| !key.eq_ignore_ascii_case("PATH"));
+    } else {
+        env.remove("PATH");
     }
     env.insert("PATH".to_string(), path);
     Ok(())
@@ -420,20 +422,15 @@ fn environment_path_value(
     env: &BTreeMap<String, String>,
     case_insensitive: bool,
 ) -> Option<&String> {
-    environment_path_key(env, case_insensitive).and_then(|key| env.get(&key))
-}
-
-fn environment_path_key(env: &BTreeMap<String, String>, case_insensitive: bool) -> Option<String> {
-    if env.contains_key("PATH") {
-        return Some("PATH".to_string());
+    if let Some(path) = env.get("PATH") {
+        return Some(path);
     }
-    case_insensitive
-        .then(|| {
-            env.keys()
-                .find(|key| key.eq_ignore_ascii_case("PATH"))
-                .cloned()
-        })
-        .flatten()
+    if !case_insensitive {
+        return None;
+    }
+    env.iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("PATH"))
+        .map(|(_, value)| value)
 }
 
 fn prepend_to_path(
@@ -486,7 +483,8 @@ mod tests {
     #[test]
     fn managed_node_path_replaces_windows_path_without_losing_system_entries() {
         let mut env = BTreeMap::new();
-        env.insert("Path".to_string(), path_value(&["system", "tools"]));
+        env.insert("PATH".to_string(), path_value(&["system", "tools"]));
+        env.insert("Path".to_string(), path_value(&["stale"]));
 
         apply_path_prepend_to_environment_with_platform_semantics(
             &mut env,
@@ -496,6 +494,12 @@ mod tests {
         .unwrap();
 
         assert!(!env.contains_key("Path"));
+        assert_eq!(
+            env.keys()
+                .filter(|key| key.eq_ignore_ascii_case("PATH"))
+                .count(),
+            1
+        );
         assert_eq!(
             std::env::split_paths(env.get("PATH").unwrap()).collect::<Vec<_>>(),
             vec![

--- a/src/managed_node.rs
+++ b/src/managed_node.rs
@@ -8,7 +8,8 @@ use crate::infra::archive::{extract_tar_gz, extract_zip};
 use crate::infra::download::{download_to_file, normalize_sha256, verify_file_sha256};
 use crate::store::{display_path, lock_file, resolve_store_paths};
 
-pub const OPENCLAW_MIN_NODE_VERSION: &str = "22.14.0";
+pub const OPENCLAW_MIN_NODE_VERSION: &str = "22.22.3";
+pub const OPENCLAW_NODE_VERSION_REQUIREMENT: &str = "Node.js 22.22.3+, 24.15.0+, or 25.9.0+";
 const MANAGED_NODE_VERSION: &str = "24.15.0";
 
 const INTERNAL_MANAGED_NODE_ARCHIVE_URL_ENV: &str = "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_URL";

--- a/src/managed_node.rs
+++ b/src/managed_node.rs
@@ -56,7 +56,14 @@ impl CommandSpec {
         let Some(path_prepend) = self.path_prepend.as_deref() else {
             return Ok(());
         };
-        command.env("PATH", prepend_to_path(path_prepend, env.get("PATH"))?);
+        command.env(
+            "PATH",
+            prepend_to_path(
+                path_prepend,
+                environment_path_value(env, cfg!(windows)),
+                cfg!(windows),
+            )?,
+        );
         Ok(())
     }
 }
@@ -212,12 +219,27 @@ pub(crate) fn apply_path_prepend_to_environment(
     env: &mut BTreeMap<String, String>,
     path_prepend: Option<&Path>,
 ) -> Result<(), String> {
+    apply_path_prepend_to_environment_with_platform_semantics(env, path_prepend, cfg!(windows))
+}
+
+fn apply_path_prepend_to_environment_with_platform_semantics(
+    env: &mut BTreeMap<String, String>,
+    path_prepend: Option<&Path>,
+    case_insensitive: bool,
+) -> Result<(), String> {
     let Some(path_prepend) = path_prepend else {
         return Ok(());
     };
-    let path = prepend_to_path(path_prepend, env.get("PATH"))?
-        .into_string()
-        .map_err(|_| "managed Node.js PATH contains non-Unicode data".to_string())?;
+    let path = prepend_to_path(
+        path_prepend,
+        environment_path_value(env, case_insensitive),
+        case_insensitive,
+    )?
+    .into_string()
+    .map_err(|_| "managed Node.js PATH contains non-Unicode data".to_string())?;
+    if let Some(existing_key) = environment_path_key(env, case_insensitive) {
+        env.remove(&existing_key);
+    }
     env.insert("PATH".to_string(), path);
     Ok(())
 }
@@ -394,14 +416,126 @@ fn relocate_checked_path(path: &Path, from_root: &Path, to_root: &Path) -> Resul
     Ok(to_root.join(relative))
 }
 
-fn prepend_to_path(path: &Path, current: Option<&String>) -> Result<OsString, String> {
+fn environment_path_value(
+    env: &BTreeMap<String, String>,
+    case_insensitive: bool,
+) -> Option<&String> {
+    environment_path_key(env, case_insensitive).and_then(|key| env.get(&key))
+}
+
+fn environment_path_key(env: &BTreeMap<String, String>, case_insensitive: bool) -> Option<String> {
+    if env.contains_key("PATH") {
+        return Some("PATH".to_string());
+    }
+    case_insensitive
+        .then(|| {
+            env.keys()
+                .find(|key| key.eq_ignore_ascii_case("PATH"))
+                .cloned()
+        })
+        .flatten()
+}
+
+fn prepend_to_path(
+    path: &Path,
+    current: Option<&String>,
+    case_insensitive: bool,
+) -> Result<OsString, String> {
     let mut paths = vec![path.to_path_buf()];
     if let Some(current) = current {
-        paths.extend(
-            std::env::split_paths(current)
-                .filter(|candidate| !candidate.as_os_str().is_empty() && candidate != path),
-        );
+        paths.extend(std::env::split_paths(current).filter(|candidate| {
+            !candidate.as_os_str().is_empty() && !paths_equal(candidate, path, case_insensitive)
+        }));
     }
     std::env::join_paths(paths)
         .map_err(|error| format!("failed to add managed Node.js to PATH for OpenClaw: {error}"))
+}
+
+fn paths_equal(left: &Path, right: &Path, case_insensitive: bool) -> bool {
+    left == right
+        || (case_insensitive
+            && left
+                .to_str()
+                .zip(right.to_str())
+                .is_some_and(|(left, right)| left.eq_ignore_ascii_case(right)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    use super::{
+        apply_path_prepend_to_environment_with_platform_semantics, environment_path_value,
+        prepend_to_path,
+    };
+
+    #[test]
+    fn managed_node_path_reads_windows_path_case_insensitively() {
+        let mut env = BTreeMap::new();
+        env.insert("Path".to_string(), path_value(&["system", "tools"]));
+
+        assert_eq!(
+            environment_path_value(&env, true),
+            env.get("Path"),
+            "Windows Path must remain available to npm lifecycle commands"
+        );
+        assert_eq!(environment_path_value(&env, false), None);
+    }
+
+    #[test]
+    fn managed_node_path_replaces_windows_path_without_losing_system_entries() {
+        let mut env = BTreeMap::new();
+        env.insert("Path".to_string(), path_value(&["system", "tools"]));
+
+        apply_path_prepend_to_environment_with_platform_semantics(
+            &mut env,
+            Some(Path::new("managed-node")),
+            true,
+        )
+        .unwrap();
+
+        assert!(!env.contains_key("Path"));
+        assert_eq!(
+            std::env::split_paths(env.get("PATH").unwrap()).collect::<Vec<_>>(),
+            vec![
+                PathBuf::from("managed-node"),
+                PathBuf::from("system"),
+                PathBuf::from("tools")
+            ]
+        );
+    }
+
+    #[test]
+    fn managed_node_path_preserves_system_entries_and_deduplicates_itself() {
+        let managed = PathBuf::from("managed-node");
+        let current = path_value(&["system", "managed-node", "tools"]);
+        let combined = prepend_to_path(&managed, Some(&current), false).unwrap();
+        let entries = std::env::split_paths(&combined).collect::<Vec<_>>();
+
+        assert_eq!(
+            entries,
+            vec![managed, PathBuf::from("system"), PathBuf::from("tools")]
+        );
+    }
+
+    #[test]
+    fn managed_node_path_deduplicates_windows_case_variants() {
+        let managed = PathBuf::from("Managed-Node");
+        let current = path_value(&["system", "managed-node", "tools"]);
+        let combined = prepend_to_path(&managed, Some(&current), true).unwrap();
+        let entries = std::env::split_paths(&combined).collect::<Vec<_>>();
+
+        assert_eq!(
+            entries,
+            vec![managed, PathBuf::from("system"), PathBuf::from("tools")]
+        );
+    }
+
+    fn path_value(entries: &[&str]) -> String {
+        std::env::join_paths(entries.iter().map(Path::new))
+            .unwrap()
+            .into_string()
+            .unwrap()
+    }
 }

--- a/src/managed_node.rs
+++ b/src/managed_node.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::infra::archive::{extract_tar_gz, extract_zip};
 use crate::infra::download::{download_to_file, normalize_sha256, verify_file_sha256};
@@ -41,6 +43,21 @@ enum ManagedNodeArchiveKind {
 pub(crate) struct CommandSpec {
     pub(crate) program: String,
     pub(crate) args: Vec<String>,
+    pub(crate) path_prepend: Option<PathBuf>,
+}
+
+impl CommandSpec {
+    pub(crate) fn apply_environment(
+        &self,
+        command: &mut Command,
+        env: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let Some(path_prepend) = self.path_prepend.as_deref() else {
+            return Ok(());
+        };
+        command.env("PATH", prepend_to_path(path_prepend, env.get("PATH"))?);
+        Ok(())
+    }
 }
 
 pub(crate) fn managed_node_fallback_supported() -> bool {
@@ -154,9 +171,11 @@ pub(crate) fn managed_runtime_install_command(
     cwd: &Path,
 ) -> Result<CommandSpec, String> {
     let toolchain = ensure_managed_node_toolchain(env, cwd)?;
+    let path_prepend = toolchain.node_bin.parent().map(Path::to_path_buf);
     Ok(CommandSpec {
         program: display_path(&toolchain.node_bin),
         args: vec![display_path(&toolchain.npm_cli)],
+        path_prepend,
     })
 }
 
@@ -183,6 +202,7 @@ pub(crate) fn managed_runtime_launch_command(
     Ok(CommandSpec {
         program: display_path(&toolchain.node_bin),
         args,
+        path_prepend: None,
     })
 }
 
@@ -356,4 +376,16 @@ fn relocate_checked_path(path: &Path, from_root: &Path, to_root: &Path) -> Resul
         .strip_prefix(from_root)
         .map_err(|error| error.to_string())?;
     Ok(to_root.join(relative))
+}
+
+fn prepend_to_path(path: &Path, current: Option<&String>) -> Result<OsString, String> {
+    let mut paths = vec![path.to_path_buf()];
+    if let Some(current) = current {
+        paths.extend(
+            std::env::split_paths(current)
+                .filter(|candidate| !candidate.as_os_str().is_empty() && candidate != path),
+        );
+    }
+    std::env::join_paths(paths)
+        .map_err(|error| format!("failed to add managed Node.js to PATH for OpenClaw: {error}"))
 }

--- a/src/managed_node.rs
+++ b/src/managed_node.rs
@@ -197,13 +197,28 @@ pub(crate) fn managed_runtime_launch_command(
             )
         })?
     };
+    let path_prepend = toolchain.node_bin.parent().map(Path::to_path_buf);
     let mut args = vec![binary_path.to_string()];
     args.extend(openclaw_args.iter().cloned());
     Ok(CommandSpec {
         program: display_path(&toolchain.node_bin),
         args,
-        path_prepend: None,
+        path_prepend,
     })
+}
+
+pub(crate) fn apply_path_prepend_to_environment(
+    env: &mut BTreeMap<String, String>,
+    path_prepend: Option<&Path>,
+) -> Result<(), String> {
+    let Some(path_prepend) = path_prepend else {
+        return Ok(());
+    };
+    let path = prepend_to_path(path_prepend, env.get("PATH"))?
+        .into_string()
+        .map_err(|_| "managed Node.js PATH contains non-Unicode data".to_string())?;
+    env.insert("PATH".to_string(), path);
+    Ok(())
 }
 
 fn command_example(env: &BTreeMap<String, String>) -> String {

--- a/src/managed_node.rs
+++ b/src/managed_node.rs
@@ -7,6 +7,7 @@ use crate::infra::download::{download_to_file, normalize_sha256, verify_file_sha
 use crate::store::{display_path, lock_file, resolve_store_paths};
 
 pub const OPENCLAW_MIN_NODE_VERSION: &str = "22.14.0";
+const MANAGED_NODE_VERSION: &str = "24.15.0";
 
 const INTERNAL_MANAGED_NODE_ARCHIVE_URL_ENV: &str = "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_URL";
 const INTERNAL_MANAGED_NODE_ARCHIVE_SHA256_ENV: &str = "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_SHA256";
@@ -195,7 +196,7 @@ fn command_example(env: &BTreeMap<String, String>) -> String {
 }
 
 fn managed_node_distribution() -> Result<ManagedNodeDistribution, String> {
-    let version = OPENCLAW_MIN_NODE_VERSION.to_string();
+    let version = MANAGED_NODE_VERSION.to_string();
     let arch = match std::env::consts::ARCH {
         "x86_64" => "x64",
         "aarch64" => "arm64",
@@ -246,23 +247,23 @@ fn managed_node_distribution_for(
     npm_cli_relative_path: &'static str,
 ) -> Result<ManagedNodeDistribution, String> {
     let archive_sha256 = match (version, suffix) {
-        ("22.14.0", "darwin-arm64") => {
-            "e9404633bc02a5162c5c573b1e2490f5fb44648345d64a958b17e325729a5e42"
+        ("24.15.0", "darwin-arm64") => {
+            "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
         }
-        ("22.14.0", "darwin-x64") => {
-            "6698587713ab565a94a360e091df9f6d91c8fadda6d00f0cf6526e9b40bed250"
+        ("24.15.0", "darwin-x64") => {
+            "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
         }
-        ("22.14.0", "linux-arm64") => {
-            "8cf30ff7250f9463b53c18f89c6c606dfda70378215b2c905d0a9a8b08bd45e0"
+        ("24.15.0", "linux-arm64") => {
+            "73afc234d558c24919875f51c2d1ea002a2ada4ea6f83601a383869fefa64eed"
         }
-        ("22.14.0", "linux-x64") => {
-            "9d942932535988091034dc94cc5f42b6dc8784d6366df3a36c4c9ccb3996f0c2"
+        ("24.15.0", "linux-x64") => {
+            "44836872d9aec49f1e6b52a9a922872db9a2b02d235a616a5681b6a85fec8d89"
         }
-        ("22.14.0", "win-arm64") => {
-            "2d71f5f9b2fffa33baa108c07d74b0d24e0c3dd8f441d567772ae0e3dd4b1a22"
+        ("24.15.0", "win-arm64") => {
+            "c9eb7402eda26e2ba7e44b6727fc85a8de56c5095b1f71ebd3062892211aa116"
         }
-        ("22.14.0", "win-x64") => {
-            "55b639295920b219bb2acbcfa00f90393a2789095b7323f79475c9f34795f217"
+        ("24.15.0", "win-x64") => {
+            "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
         }
         _ => {
             return Err(format!(

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -11,6 +11,7 @@ pub(crate) struct RuntimeLaunchSpec {
     pub(crate) runtime_binary_path: String,
     pub(crate) program: String,
     pub(crate) args: Vec<String>,
+    pub(crate) path_prepend: Option<PathBuf>,
 }
 
 pub(crate) fn resolve_runtime_launch(
@@ -32,6 +33,7 @@ pub(crate) fn resolve_runtime_launch(
             runtime_binary_path: meta.binary_path.clone(),
             program: managed.program,
             args: managed.args,
+            path_prepend: managed.path_prepend,
         });
     }
 
@@ -39,6 +41,7 @@ pub(crate) fn resolve_runtime_launch(
         runtime_binary_path: meta.binary_path.clone(),
         program: meta.binary_path.clone(),
         args: openclaw_args.to_vec(),
+        path_prepend: None,
     })
 }
 

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -528,6 +528,7 @@ fn local_build_npm_adapter(
         command: CommandSpec {
             program: "node".to_string(),
             args: vec![display_path(&adapter_path)],
+            path_prepend: None,
         },
         real_npm: "npm".to_string(),
         workspace_dependency_dirs: local_workspace_dependency_dirs(repo_path)?,
@@ -548,6 +549,7 @@ fn install_openclaw_package_with_npm(
         CommandSpec {
             program: npm_program(env),
             args: Vec::new(),
+            path_prepend: None,
         }
     } else {
         managed_runtime_install_command(env, cwd)?
@@ -569,6 +571,7 @@ fn install_openclaw_package_with_npm(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    install_command.apply_environment(&mut command, env)?;
     if let Some(local_adapter) = local_adapter {
         local_adapter.apply_environment(&mut command);
     }
@@ -668,6 +671,7 @@ fn pack_local_openclaw_repo(
         .unwrap_or_else(|| CommandSpec {
             program: npm_program(env),
             args: Vec::new(),
+            path_prepend: None,
         });
     let mut command = Command::new(&npm.program);
     command

--- a/tests/doctor_command_tests.rs
+++ b/tests/doctor_command_tests.rs
@@ -66,7 +66,7 @@ fn doctor_host_reports_ready_official_release_requirements() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
 
     let doctor = run_ocm(&cwd, &env, &["doctor", "host", "--json"]);
     assert!(doctor.status.success(), "{}", stderr(&doctor));

--- a/tests/env_doctor_tests.rs
+++ b/tests/env_doctor_tests.rs
@@ -114,7 +114,7 @@ fn env_doctor_keeps_official_runtime_healthy_when_managed_fallback_is_available(
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),

--- a/tests/env_resolve_tests.rs
+++ b/tests/env_resolve_tests.rs
@@ -173,7 +173,7 @@ fn env_resolve_reports_release_backed_runtime_provenance() {
     let manifest_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", manifest_body.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         manifest_server.url(),

--- a/tests/env_status_tests.rs
+++ b/tests/env_status_tests.rs
@@ -200,7 +200,7 @@ fn env_status_reports_release_backed_runtime_details() {
     let manifest_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", manifest_body.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         manifest_server.url(),
@@ -250,7 +250,7 @@ fn env_status_keeps_official_runtime_healthy_when_managed_fallback_is_available(
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -179,7 +179,9 @@ fn doctor_host_help_is_available_from_help_and_flag() {
     assert!(output.contains("ocm doctor host --fix git --yes [--json]"));
     assert!(output.contains("--fix <tool>"));
     assert!(output.contains("--yes"));
-    assert!(output.contains("Official release installs prefer host Node.js >= 22.14.0 and npm."));
+    assert!(output.contains(
+        "Official release installs prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm."
+    ));
     assert!(
         output.contains(
             "On supported platforms, OCM can manage a private copy when they are missing."
@@ -241,7 +243,7 @@ fn start_help_is_available_from_help_and_flag() {
         "Managed services currently support launchd on macOS and systemd --user on Linux."
     ));
     assert!(output.contains(
-        "Official release selectors prefer host Node.js >= 22.14.0 and npm, and OCM can manage a private copy on supported platforms when they are missing."
+        "Official release selectors prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm, and OCM can manage a private copy on supported platforms when they are missing."
     ));
     assert!(output.contains(
         "When start creates a new official-release env interactively, it can offer to install git for repo-aware coding workflows."
@@ -298,7 +300,7 @@ fn setup_help_is_available_from_help_and_flag() {
     assert!(output.contains("ocm setup"));
     assert!(output.contains("Interactive setup"));
     assert!(output.contains(
-        "Official release choices prefer host Node.js >= 22.14.0 and npm, and OCM can manage a private copy on supported platforms when they are missing."
+        "Official release choices prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm, and OCM can manage a private copy on supported platforms when they are missing."
     ));
     assert!(output.contains(
         "If git is missing, setup can offer to install it for repo-aware coding workflows."
@@ -593,7 +595,9 @@ fn runtime_and_service_leaf_help_are_command_specific() {
     assert!(output.contains("Install a managed runtime"));
     assert!(output.contains("--manifest-url <url>"));
     assert!(output.contains("Exactly one install source must be provided."));
-    assert!(output.contains("Official release installs prefer host Node.js >= 22.14.0 and npm."));
+    assert!(output.contains(
+        "Official release installs prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm."
+    ));
     assert!(
         output.contains(
             "On supported platforms, OCM can manage a private copy when they are missing."
@@ -621,7 +625,9 @@ fn release_install_help_mentions_doctor_host() {
     assert!(help.status.success(), "{}", stderr(&help));
     let output = stdout(&help);
     assert!(output.contains("ocm release install [<name>] (--version <version> | --channel <channel>) [--description <text>] [--force] [--raw] [--json]"));
-    assert!(output.contains("Official release installs prefer host Node.js >= 22.14.0 and npm."));
+    assert!(output.contains(
+        "Official release installs prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm."
+    ));
     assert!(
         output.contains(
             "On supported platforms, OCM can manage a private copy when they are missing."

--- a/tests/release_command_tests.rs
+++ b/tests/release_command_tests.rs
@@ -383,7 +383,7 @@ fn release_install_stays_quiet_when_managed_node_fallback_is_available() {
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
     );
-    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "22.14.0");
+    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
 
     let install = run_ocm(&cwd, &env, &["release", "install", "--channel", "stable"]);
     assert!(install.status.success(), "{}", stderr(&install));

--- a/tests/release_command_tests.rs
+++ b/tests/release_command_tests.rs
@@ -103,7 +103,7 @@ fn release_list_uses_the_official_openclaw_source() {
     fs::create_dir_all(&cwd).unwrap();
     let server = TestHttpServer::serve_bytes("/openclaw", "application/json", &packument_body());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         server.url(),
@@ -273,7 +273,7 @@ fn release_list_rejects_conflicting_selectors() {
     fs::create_dir_all(&cwd).unwrap();
     let server = TestHttpServer::serve_bytes("/openclaw", "application/json", &packument_body());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         server.url(),
@@ -315,7 +315,7 @@ fn release_install_uses_the_published_openclaw_source() {
     );
     let server = TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         server.url(),
@@ -416,7 +416,7 @@ fn release_install_reuses_a_matching_installed_runtime() {
     let server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         server.url(),
@@ -453,7 +453,7 @@ fn release_list_and_show_surface_installed_runtime_names() {
     let server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 3);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         server.url(),

--- a/tests/runtime_binding_tests.rs
+++ b/tests/runtime_binding_tests.rs
@@ -147,7 +147,7 @@ fn env_set_runtime_with_channel_installs_and_binds_the_official_runtime() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -326,7 +326,7 @@ fn env_create_with_channel_installs_and_binds_the_official_runtime() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -388,7 +388,7 @@ fn env_create_with_latest_channel_alias_binds_the_stable_runtime_name() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -433,7 +433,7 @@ fn env_create_with_version_installs_and_binds_the_official_runtime() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -1350,6 +1350,16 @@ fn official_runtime_install_uses_managed_node_when_npm_is_missing() {
     );
     assert!(install.status.success(), "{}", stderr(&install));
     assert!(root.child("ocm-home/runtimes/stable").exists());
+
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "managed", "--runtime", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let run = run_ocm(&cwd, &env, &["env", "run", "managed", "--", "--version"]);
+    assert!(run.status.success(), "{}", stderr(&run));
+    assert_eq!(stdout(&run), "stable\n");
 }
 
 #[test]

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -1338,6 +1338,10 @@ fn official_runtime_install_uses_managed_node_when_npm_is_missing() {
         "OCM_INTERNAL_NPM_BIN".to_string(),
         path_string(&root.child("missing-npm")),
     );
+    env.insert(
+        "OCM_TEST_REQUIRE_MANAGED_NODE_ON_PATH".to_string(),
+        "1".to_string(),
+    );
 
     let install = run_ocm(
         &cwd,

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -804,7 +804,7 @@ fn official_runtime_install_stays_quiet_when_managed_node_fallback_is_available(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
     );
-    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "22.14.0");
+    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
 
     let install = run_ocm(&cwd, &env, &["runtime", "install", "--channel", "stable"]);
     assert!(install.status.success(), "{}", stderr(&install));
@@ -1329,7 +1329,7 @@ fn official_runtime_install_uses_managed_node_when_npm_is_missing() {
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
     install_fake_node_and_npm(&root, &mut env, "22.14.0");
-    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "22.14.0");
+    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1370,7 +1370,7 @@ fn official_runtime_install_rejects_untrusted_managed_node_archive() {
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
     install_fake_node_and_npm(&root, &mut env, "20.11.0");
-    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "22.14.0");
+    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
     env.insert(
         "OCM_INTERNAL_MANAGED_NODE_ARCHIVE_SHA256".to_string(),
         "0".repeat(64),
@@ -1418,7 +1418,7 @@ fn official_runtime_install_uses_managed_node_when_host_node_is_too_old() {
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
     install_fake_node_and_npm(&root, &mut env, "20.11.0");
-    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "22.14.0");
+    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -100,7 +100,7 @@ fn install_fake_node_and_packing_npm(
     let log_path = root.child("fake-pack-npm.log");
     write_executable_script(
         &bin_dir.join("node"),
-        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'v22.14.0\\n'\n  exit 0\nfi\nif [ \"$(basename \"$1\")\" = \"ocm-npm-workspace-deps.mjs\" ]; then\n  script=\"$1\"\n  shift\n  exec \"$script\" \"$@\"\nfi\nprintf 'fake node\\n'\n",
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'v22.22.3\\n'\n  exit 0\nfi\nif [ \"$(basename \"$1\")\" = \"ocm-npm-workspace-deps.mjs\" ]; then\n  script=\"$1\"\n  shift\n  exec \"$script\" \"$@\"\nfi\nprintf 'fake node\\n'\n",
     );
     let npm_script = format!(
         r#"#!/bin/sh
@@ -625,7 +625,7 @@ fn runtime_install_from_official_release_installs_the_openclaw_package() {
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -696,7 +696,7 @@ fn runtime_install_exposes_package_dependencies_to_openclaw_package_root() {
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -755,7 +755,7 @@ fn official_runtime_install_produces_a_runnable_env_binding() {
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -823,7 +823,7 @@ fn runtime_install_rejects_non_canonical_names_for_official_releases() {
     let packument = br#"{"dist-tags":{"latest":"2026.3.24"},"versions":{"2026.3.24":{"version":"2026.3.24","dist":{"tarball":"https://registry.npmjs.org/openclaw/-/openclaw-2026.3.24.tgz"}}}}"#;
     let server = TestHttpServer::serve_bytes("/openclaw", "application/json", packument);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         server.url(),
@@ -864,7 +864,7 @@ fn runtime_install_reuses_a_matching_official_runtime() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -900,7 +900,7 @@ fn concurrent_official_runtime_installs_reuse_the_published_runtime() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -974,7 +974,7 @@ fn concurrent_official_runtime_installs_reject_changed_integrity() {
         vec![packument(&integrity), packument(&changed_integrity)],
     );
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1042,7 +1042,7 @@ fn runtime_install_refreshes_a_matching_official_runtime_with_bad_package_dep_la
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1121,7 +1121,7 @@ fn runtime_install_refreshes_a_channel_runtime_when_the_published_release_moves(
         vec![first_packument.into_bytes(), second_packument.into_bytes()],
     );
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1206,7 +1206,7 @@ fn runtime_update_reuses_the_official_release_selector() {
         vec![packument_v1.into_bytes(), packument_v2.into_bytes()],
     );
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1328,7 +1328,7 @@ fn official_runtime_install_uses_managed_node_when_npm_is_missing() {
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
@@ -1411,8 +1411,8 @@ fn official_runtime_install_rejects_untrusted_managed_node_archive() {
 }
 
 #[test]
-fn official_runtime_install_uses_managed_node_when_host_node_is_too_old() {
-    let root = TestDir::new("runtime-install-official-old-node");
+fn official_runtime_install_uses_managed_node_when_host_node_is_unsupported() {
+    let root = TestDir::new("runtime-install-official-unsupported-node");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
 
@@ -1431,7 +1431,7 @@ fn official_runtime_install_uses_managed_node_when_host_node_is_too_old() {
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "20.11.0");
+    install_fake_node_and_npm(&root, &mut env, "23.11.0");
     let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
@@ -2025,7 +2025,7 @@ fn official_runtime_install_requires_sha512_integrity_before_download() {
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),

--- a/tests/runtime_verify_tests.rs
+++ b/tests/runtime_verify_tests.rs
@@ -201,7 +201,7 @@ fn runtime_verify_keeps_official_runtimes_healthy_when_managed_fallback_is_avail
     let packument_server =
         TestHttpServer::serve_bytes("/openclaw", "application/json", packument.as_bytes());
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),

--- a/tests/setup_command_tests.rs
+++ b/tests/setup_command_tests.rs
@@ -77,7 +77,7 @@ fn setup_can_prepare_latest_stable_without_onboarding() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),

--- a/tests/setup_command_tests.rs
+++ b/tests/setup_command_tests.rs
@@ -306,7 +306,7 @@ fn setup_can_offer_git_install_before_using_managed_node_fallback() {
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
     );
-    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "22.14.0");
+    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
     let log_path = install_fake_git_package_manager(&root, &mut env, "apt-get");
 
     let setup = run_ocm_with_stdin(&cwd, &env, &["setup"], "1\ny\n\nn\nn\n");

--- a/tests/start_command_tests.rs
+++ b/tests/start_command_tests.rs
@@ -77,7 +77,7 @@ fn start_generates_an_env_name_and_uses_latest_stable_runtime() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
         "launchd".to_string(),
@@ -149,7 +149,7 @@ fn start_without_a_name_generates_a_new_env_each_time() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 4);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),

--- a/tests/start_command_tests.rs
+++ b/tests/start_command_tests.rs
@@ -389,7 +389,7 @@ fn start_uses_managed_node_fallback_without_host_doctor_noise() {
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
     );
-    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "22.14.0");
+    let _managed_node = install_fake_managed_node_archive(&root, &mut env, "24.15.0");
 
     let start = run_ocm(&cwd, &env, &["start", "--no-service"]);
     assert!(start.status.success(), "{}", stderr(&start));

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -525,6 +525,13 @@ script="$1"
 shift
 case "$script" in
   *npm-cli.js)
+    if [ "${{OCM_TEST_REQUIRE_MANAGED_NODE_ON_PATH:-}}" = "1" ]; then
+      resolved_node="$(command -v node || true)"
+      if [ "$resolved_node" != "$0" ]; then
+        echo "managed npm lifecycle PATH resolved node to ${{resolved_node:-missing}}, expected $0" >&2
+        exit 1
+      fi
+    fi
     prefix=""
     archive=""
     while [ "$#" -gt 0 ]; do

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -566,6 +566,13 @@ EOF
     exit 0
     ;;
 esac
+if [ "${{OCM_TEST_REQUIRE_MANAGED_NODE_ON_PATH:-}}" = "1" ]; then
+  resolved_node="$(command -v node || true)"
+  if [ "$resolved_node" != "$0" ]; then
+    echo "managed OpenClaw PATH resolved node to ${{resolved_node:-missing}}, expected $0" >&2
+    exit 1
+  fi
+fi
 if [ -n "$script" ] && /usr/bin/grep -q "process\.argv\.slice(2)\.join(' ')" "$script"; then
   printf '%s\n' "$*"
   exit 0

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -412,7 +412,7 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -514,7 +514,7 @@ fn upgrade_switches_across_versions_from_runtime_with_broken_package_bin_symlink
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -614,7 +614,7 @@ fn upgrade_dry_run_reports_without_changing_runtime_or_creating_snapshot() {
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 1);
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -691,7 +691,7 @@ fn upgrade_simulate_tests_a_published_version_without_changing_the_source_env() 
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -790,7 +790,7 @@ fn upgrade_simulate_errors_before_cloning_when_published_target_is_missing() {
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 4);
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -891,7 +891,7 @@ fn upgrade_simulate_runs_openclaw_update_contract_checks_for_published_targets()
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1014,7 +1014,7 @@ fn upgrade_simulate_all_scenarios_reports_plugin_specific_failures() {
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1126,7 +1126,7 @@ fn upgrade_simulate_reports_local_repo_doctor_failures() {
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 1);
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     install_fake_simulation_pnpm(&root, &mut env);
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
@@ -1210,7 +1210,7 @@ fn upgrade_rolls_back_runtime_when_service_restart_fails() {
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1300,7 +1300,7 @@ fn upgrade_restores_runtime_when_runtime_preparation_fails() {
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1373,7 +1373,7 @@ fn upgrade_rolls_back_when_post_upgrade_version_verification_fails() {
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1447,7 +1447,7 @@ fn upgrade_reports_pinned_envs_without_moving_them() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1489,7 +1489,7 @@ fn upgrade_can_switch_a_local_launcher_env_to_a_published_runtime() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
@@ -1746,7 +1746,7 @@ fn upgrade_keeps_a_stopped_installed_service_stopped() {
     let packument_server =
         TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     install_fake_launchctl(&root, &mut env);
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
@@ -1833,7 +1833,7 @@ fn upgrade_all_updates_safe_envs_and_skips_local_or_pinned_ones() {
     );
 
     let mut env = ocm_env(&root);
-    install_fake_node_and_npm(&root, &mut env, "22.14.0");
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
     env.insert(
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),


### PR DESCRIPTION
## Summary

- update OCM managed fallback to Node.js 24.15.0 with authenticated archives for macOS, Linux, and Windows
- match current OpenClaw host Node ranges instead of accepting unsupported intermediate majors
- keep managed Node first on PATH for npm lifecycle scripts, direct env runs, services, restart handoff, and upgrade simulations
- preserve existing system PATH entries, including Windows Path casing semantics
- update README and command help with the exact supported ranges

## Verification

- `cargo fmt --check`
- `cargo test --workspace --all-targets --locked`
- `cargo check --workspace --all-targets --locked`
- Windows GNU `cargo check --target x86_64-pc-windows-gnu --workspace --all-targets --locked`
- official Node.js `v24.15.0` checksum and archive-layout verification for macOS, Linux, and Windows on x64 and arm64
- isolated installs with no host Node/npm for OpenClaw `2026.6.11`, `2026.6.33`, `2026.7.1-2`, and `2026.7.2-beta.3`, including `--version` and `--help` execution
- release-shaped build, install, bind, and execution of current OpenClaw `main` at `67ef07863fbb24d751e20f022e216118924ae15d`

## Compatibility

The managed Node fallback remains compatible with the tested 2026.6.x releases while satisfying the current 2026.7.x engine contract. Launcher and local-source flows are unchanged.

Native macOS and Windows CI remain required before landing.

Follow-up to #40 and #42.
