### PR TITLE
fix: preserve live OpenClaw SQLite state in snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.2.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -286,11 +286,26 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "foldhash",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -419,7 +434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -439,16 +454,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "js-sys"
-version = "0.3.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "json5"
@@ -481,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -627,7 +632,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -714,27 +719,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsqlite-vfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
-dependencies = [
- "hashbrown",
- "thiserror",
-]
-
-[[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
- "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -786,12 +781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,7 +819,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -896,18 +885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
-dependencies = [
- "cc",
- "js-sys",
- "rsqlite-vfs",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,17 +908,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +915,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -971,26 +937,6 @@ checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -1153,51 +1099,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,7 +1252,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -1372,7 +1273,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -1412,7 +1313,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +288,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -581,6 +598,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tar",
+ "tempfile",
  "terminal_size",
  "time",
  "unicode-width",
@@ -696,6 +714,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "redox_syscall"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,7 +736,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -927,6 +951,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -197,6 +197,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "filetime"
@@ -225,6 +237,12 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -271,6 +289,9 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "http"
@@ -420,6 +441,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "json5"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +477,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -527,6 +569,7 @@ dependencies = [
  "indicatif",
  "json5",
  "libc",
+ "rusqlite",
  "semver",
  "serde",
  "serde_json",
@@ -584,7 +627,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -595,6 +638,12 @@ checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -665,6 +714,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,7 +830,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -817,6 +896,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +931,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,7 +949,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -869,6 +971,26 @@ checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1013,6 +1135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1151,51 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -1178,7 +1351,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1199,7 +1372,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1239,7 +1412,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ base64 = "0.22"
 flate2 = "1.1"
 fs2 = "0.4"
 tar = "0.4"
+tempfile = "3.27"
 time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 ureq = { version = "3.3", default-features = false, features = ["rustls"] }
 indicatif = { version = "0.18", default-features = false, features = ["unicode-width"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ zip = { version = "8.5", default-features = false, features = ["deflate"] }
 ctrlc = { version = "3.4", features = ["termination"] }
 url = "2.5"
 libc = "0.2"
-rusqlite = { version = "0.39", default-features = false, features = ["backup", "bundled"] }
+rusqlite = { version = "0.37", default-features = false, features = ["backup", "bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ zip = { version = "8.5", default-features = false, features = ["deflate"] }
 ctrlc = { version = "3.4", features = ["termination"] }
 url = "2.5"
 libc = "0.2"
+rusqlite = { version = "0.39", default-features = false, features = ["backup", "bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/infra/archive.rs
+++ b/src/infra/archive.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 use std::fs::{self, File};
 use std::io::{self, Cursor};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use flate2::read::GzDecoder;
 use serde::de::DeserializeOwned;
@@ -18,7 +17,6 @@ pub const ENV_ARCHIVE_METADATA_PATH: &str = "meta/env.json";
 pub const ENV_ARCHIVE_ROOT_DIR: &str = "root";
 const MAX_ENV_ARCHIVE_WRITE_ATTEMPTS: usize = 2;
 const SQLITE_SIDECAR_SUFFIXES: [&str; 3] = ["-wal", "-shm", "-journal"];
-static NEXT_SQLITE_STAGING_ID: AtomicU64 = AtomicU64::new(0);
 
 enum EnvArchiveWriteError {
     EntryDisappeared(String),
@@ -200,10 +198,6 @@ fn append_env_root(
     source_root: &Path,
     options: &EnvArchiveOptions,
 ) -> Result<(), EnvArchiveWriteError> {
-    let mut sqlite_staging = options
-        .snapshot_sqlite_files
-        .then(SqliteArchiveStaging::create)
-        .transpose()?;
     builder
         .append_dir(ENV_ARCHIVE_ROOT_DIR, source_root)
         .map_err(|error| {
@@ -265,21 +259,25 @@ fn append_env_root(
                     path.display()
                 )));
             }
-            let snapshot_path = sqlite_staging
-                .as_mut()
-                .expect("SQLite staging exists when snapshots are enabled")
-                .next_snapshot_path();
-            create_sqlite_snapshot(&path, &snapshot_path).map_err(EnvArchiveWriteError::Fatal)?;
-            fs::set_permissions(&snapshot_path, source_metadata.permissions()).map_err(
-                |error| {
-                    EnvArchiveWriteError::Fatal(format!(
-                        "failed to preserve SQLite permissions for {}: {error}",
-                        path.display()
-                    ))
-                },
-            )?;
+            let snapshot = create_sqlite_snapshot(&path).map_err(EnvArchiveWriteError::Fatal)?;
+            let snapshot_metadata = fs::metadata(snapshot.path()).map_err(|error| {
+                EnvArchiveWriteError::Fatal(format!(
+                    "failed to inspect SQLite snapshot for {}: {error}",
+                    path.display()
+                ))
+            })?;
+            let mut header = Header::new_gnu();
+            header.set_metadata(&source_metadata);
+            header.set_size(snapshot_metadata.len());
+            header.set_cksum();
+            let mut snapshot_file = File::open(snapshot.path()).map_err(|error| {
+                EnvArchiveWriteError::Fatal(format!(
+                    "failed to open SQLite snapshot for {}: {error}",
+                    path.display()
+                ))
+            })?;
             builder
-                .append_path_with_name(&snapshot_path, &archive_path)
+                .append_data(&mut header, &archive_path, &mut snapshot_file)
                 .map_err(|error| {
                     EnvArchiveWriteError::Fatal(format!(
                         "failed to archive SQLite database {}: {error}",
@@ -300,39 +298,6 @@ fn append_env_root(
     }
 
     Ok(())
-}
-
-struct SqliteArchiveStaging {
-    root: PathBuf,
-    next_id: u64,
-}
-
-impl SqliteArchiveStaging {
-    fn create() -> Result<Self, EnvArchiveWriteError> {
-        let id = NEXT_SQLITE_STAGING_ID.fetch_add(1, Ordering::Relaxed);
-        let root = std::env::temp_dir()
-            .join("ocm-sqlite-archive")
-            .join(format!("{}-{id}", std::process::id()));
-        if root.exists() {
-            fs::remove_dir_all(&root)
-                .map_err(|error| EnvArchiveWriteError::Fatal(error.to_string()))?;
-        }
-        fs::create_dir_all(&root)
-            .map_err(|error| EnvArchiveWriteError::Fatal(error.to_string()))?;
-        Ok(Self { root, next_id: 0 })
-    }
-
-    fn next_snapshot_path(&mut self) -> PathBuf {
-        let id = self.next_id;
-        self.next_id += 1;
-        self.root.join(format!("{id}.sqlite"))
-    }
-}
-
-impl Drop for SqliteArchiveStaging {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.root);
-    }
 }
 
 fn is_sqlite_database_path(path: &Path) -> bool {
@@ -652,6 +617,12 @@ mod tests {
         fs::create_dir_all(database_path.parent().unwrap()).unwrap();
 
         let connection = Connection::open(&database_path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            fs::set_permissions(&database_path, fs::Permissions::from_mode(0o640)).unwrap();
+        }
         connection
             .pragma_update(None, "journal_mode", "WAL")
             .unwrap();
@@ -681,6 +652,17 @@ mod tests {
             extract_env_archive::<serde_json::Value>(&archive_path, &extract_dir).unwrap();
         let restored_database = extracted.root_dir.join(".openclaw/state/openclaw.sqlite");
         assert!(restored_database.exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mode = fs::metadata(&restored_database)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o640);
+        }
         assert!(!restored_database.with_extension("sqlite-wal").exists());
         assert!(!restored_database.with_extension("sqlite-shm").exists());
         assert!(!restored_database.with_extension("sqlite-journal").exists());

--- a/src/infra/archive.rs
+++ b/src/infra/archive.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::fs::{self, File};
 use std::io::{self, Cursor};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use flate2::read::GzDecoder;
 use serde::de::DeserializeOwned;
@@ -11,10 +12,13 @@ use time::OffsetDateTime;
 use zip::ZipArchive;
 
 use crate::env::{default_service_enabled, default_service_running};
+use crate::infra::sqlite_snapshot::create_sqlite_snapshot;
 
 pub const ENV_ARCHIVE_METADATA_PATH: &str = "meta/env.json";
 pub const ENV_ARCHIVE_ROOT_DIR: &str = "root";
 const MAX_ENV_ARCHIVE_WRITE_ATTEMPTS: usize = 2;
+const SQLITE_SIDECAR_SUFFIXES: [&str; 3] = ["-wal", "-shm", "-journal"];
+static NEXT_SQLITE_STAGING_ID: AtomicU64 = AtomicU64::new(0);
 
 enum EnvArchiveWriteError {
     EntryDisappeared(String),
@@ -89,6 +93,7 @@ pub struct EnvArchiveOptions {
     pub should_skip_path: fn(&Path, EnvArchiveEntryKind) -> bool,
     pub included_path_roots: BTreeSet<PathBuf>,
     pub excluded_path_roots: BTreeSet<PathBuf>,
+    pub snapshot_sqlite_files: bool,
 }
 
 impl Default for EnvArchiveOptions {
@@ -97,6 +102,7 @@ impl Default for EnvArchiveOptions {
             should_skip_path: include_env_archive_path,
             included_path_roots: BTreeSet::new(),
             excluded_path_roots: BTreeSet::new(),
+            snapshot_sqlite_files: false,
         }
     }
 }
@@ -194,6 +200,10 @@ fn append_env_root(
     source_root: &Path,
     options: &EnvArchiveOptions,
 ) -> Result<(), EnvArchiveWriteError> {
+    let mut sqlite_staging = options
+        .snapshot_sqlite_files
+        .then(SqliteArchiveStaging::create)
+        .transpose()?;
     builder
         .append_dir(ENV_ARCHIVE_ROOT_DIR, source_root)
         .map_err(|error| {
@@ -222,6 +232,11 @@ fn append_env_root(
         if options.should_skip(relative_path, entry_kind) {
             continue;
         }
+        if options.snapshot_sqlite_files
+            && sqlite_database_path_for_sidecar(relative_path).is_some()
+        {
+            continue;
+        }
 
         let archive_path = Path::new(ENV_ARCHIVE_ROOT_DIR).join(relative_path);
         if metadata.is_dir() {
@@ -237,6 +252,43 @@ fn append_env_root(
             continue;
         }
 
+        if options.snapshot_sqlite_files && is_sqlite_database_path(relative_path) {
+            let source_metadata = fs::metadata(&path).map_err(|error| {
+                EnvArchiveWriteError::from_entry_io(io_error_with_context(
+                    error,
+                    format!("failed to inspect SQLite database {}", path.display()),
+                ))
+            })?;
+            if !source_metadata.is_file() {
+                return Err(EnvArchiveWriteError::Fatal(format!(
+                    "SQLite archive source is not a regular file: {}",
+                    path.display()
+                )));
+            }
+            let snapshot_path = sqlite_staging
+                .as_mut()
+                .expect("SQLite staging exists when snapshots are enabled")
+                .next_snapshot_path();
+            create_sqlite_snapshot(&path, &snapshot_path).map_err(EnvArchiveWriteError::Fatal)?;
+            fs::set_permissions(&snapshot_path, source_metadata.permissions()).map_err(
+                |error| {
+                    EnvArchiveWriteError::Fatal(format!(
+                        "failed to preserve SQLite permissions for {}: {error}",
+                        path.display()
+                    ))
+                },
+            )?;
+            builder
+                .append_path_with_name(&snapshot_path, &archive_path)
+                .map_err(|error| {
+                    EnvArchiveWriteError::Fatal(format!(
+                        "failed to archive SQLite database {}: {error}",
+                        path.display()
+                    ))
+                })?;
+            continue;
+        }
+
         builder
             .append_path_with_name(&path, &archive_path)
             .map_err(|error| {
@@ -248,6 +300,57 @@ fn append_env_root(
     }
 
     Ok(())
+}
+
+struct SqliteArchiveStaging {
+    root: PathBuf,
+    next_id: u64,
+}
+
+impl SqliteArchiveStaging {
+    fn create() -> Result<Self, EnvArchiveWriteError> {
+        let id = NEXT_SQLITE_STAGING_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join("ocm-sqlite-archive")
+            .join(format!("{}-{id}", std::process::id()));
+        if root.exists() {
+            fs::remove_dir_all(&root)
+                .map_err(|error| EnvArchiveWriteError::Fatal(error.to_string()))?;
+        }
+        fs::create_dir_all(&root)
+            .map_err(|error| EnvArchiveWriteError::Fatal(error.to_string()))?;
+        Ok(Self { root, next_id: 0 })
+    }
+
+    fn next_snapshot_path(&mut self) -> PathBuf {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.root.join(format!("{id}.sqlite"))
+    }
+}
+
+impl Drop for SqliteArchiveStaging {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn is_sqlite_database_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".sqlite"))
+}
+
+fn sqlite_database_path_for_sidecar(path: &Path) -> Option<PathBuf> {
+    let name = path.file_name()?.to_str()?;
+    for suffix in SQLITE_SIDECAR_SUFFIXES {
+        if let Some(database_name) = name.strip_suffix(suffix)
+            && database_name.ends_with(".sqlite")
+        {
+            return Some(path.with_file_name(database_name));
+        }
+    }
+    None
 }
 
 fn sorted_child_paths(path: &Path) -> io::Result<Vec<PathBuf>> {
@@ -377,6 +480,8 @@ mod tests {
     };
     use std::{fs, io};
 
+    use rusqlite::{Connection, OpenFlags};
+
     use super::{
         ArchivedEnvMeta, EnvArchiveEntryKind, EnvArchiveMetadata, EnvArchiveOptions,
         EnvArchiveWriteError, extract_env_archive, write_env_archive,
@@ -419,6 +524,7 @@ mod tests {
             should_skip_path: skip_openclaw_paths,
             included_path_roots: BTreeSet::from([PathBuf::from(".openclaw/team/ops")]),
             excluded_path_roots: BTreeSet::new(),
+            snapshot_sqlite_files: false,
         };
 
         for path in [
@@ -446,6 +552,7 @@ mod tests {
             excluded_path_roots: BTreeSet::from([PathBuf::from(
                 ".openclaw/extensions/demo/node_modules",
             )]),
+            snapshot_sqlite_files: false,
         };
 
         assert!(!options.should_skip(
@@ -534,6 +641,93 @@ mod tests {
         ));
 
         assert!(matches!(error, EnvArchiveWriteError::Fatal(_)));
+    }
+
+    #[test]
+    fn env_archive_snapshots_live_sqlite_state_without_sidecars() {
+        let source_root = temp_path("sqlite-source-root");
+        let archive_path = temp_path("sqlite-archives").join("demo.ocm-env.tar");
+        let extract_dir = temp_path("sqlite-extract");
+        let database_path = source_root.join(".openclaw/state/openclaw.sqlite");
+        fs::create_dir_all(database_path.parent().unwrap()).unwrap();
+
+        let connection = Connection::open(&database_path).unwrap();
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .unwrap();
+        connection
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE durable_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO durable_state VALUES ('sentinel', 'must survive');",
+            )
+            .unwrap();
+        assert!(database_path.with_extension("sqlite-wal").exists());
+
+        write_env_archive_with_options(
+            &serde_json::json!({ "kind": "test-archive" }),
+            &source_root,
+            &archive_path,
+            EnvArchiveOptions {
+                snapshot_sqlite_files: true,
+                ..EnvArchiveOptions::default()
+            },
+        )
+        .unwrap();
+
+        let extracted =
+            extract_env_archive::<serde_json::Value>(&archive_path, &extract_dir).unwrap();
+        let restored_database = extracted.root_dir.join(".openclaw/state/openclaw.sqlite");
+        assert!(restored_database.exists());
+        assert!(!restored_database.with_extension("sqlite-wal").exists());
+        assert!(!restored_database.with_extension("sqlite-shm").exists());
+        assert!(!restored_database.with_extension("sqlite-journal").exists());
+
+        let restored = Connection::open_with_flags(
+            restored_database,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .unwrap();
+        let value: String = restored
+            .query_row(
+                "SELECT value FROM durable_state WHERE key = 'sentinel'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, "must survive");
+
+        drop(restored);
+        drop(connection);
+        let _ = fs::remove_dir_all(source_root);
+        let _ = fs::remove_dir_all(extract_dir);
+        let _ = fs::remove_file(archive_path);
+    }
+
+    #[test]
+    fn env_archive_refuses_to_raw_copy_malformed_sqlite_state() {
+        let source_root = temp_path("malformed-sqlite-source-root");
+        let archive_path = temp_path("malformed-sqlite-archives").join("demo.ocm-env.tar");
+        let database_path = source_root.join(".openclaw/state/openclaw.sqlite");
+        fs::create_dir_all(database_path.parent().unwrap()).unwrap();
+        fs::write(&database_path, "not a sqlite database").unwrap();
+
+        let error = write_env_archive_with_options(
+            &serde_json::json!({ "kind": "test-archive" }),
+            &source_root,
+            &archive_path,
+            EnvArchiveOptions {
+                snapshot_sqlite_files: true,
+                ..EnvArchiveOptions::default()
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.contains("SQLite"), "{error}");
+        let _ = fs::remove_dir_all(source_root);
+        let _ = fs::remove_file(archive_path);
     }
 
     #[test]

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -2,4 +2,5 @@ pub mod archive;
 pub mod download;
 pub mod process;
 pub mod shell;
+mod sqlite_snapshot;
 pub mod terminal;

--- a/src/infra/sqlite_snapshot.rs
+++ b/src/infra/sqlite_snapshot.rs
@@ -1,31 +1,33 @@
-use std::fs::{self, File};
+use std::fs::File;
 use std::path::Path;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use rusqlite::backup::{Backup, StepResult};
 use rusqlite::{Connection, OpenFlags};
+use tempfile::NamedTempFile;
 
 const SQLITE_BACKUP_PAGES_PER_STEP: i32 = 256;
 const SQLITE_BACKUP_RETRY_DELAY: Duration = Duration::from_millis(10);
 const SQLITE_BACKUP_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub(super) fn create_sqlite_snapshot(source: &Path, target: &Path) -> Result<(), String> {
-    if target.exists() {
-        return Err(format!(
-            "SQLite snapshot target already exists: {}",
-            target.display()
-        ));
-    }
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
-    }
+pub(super) struct SqliteSnapshot {
+    file: NamedTempFile,
+}
 
-    let result = create_sqlite_snapshot_inner(source, target);
-    if result.is_err() {
-        let _ = fs::remove_file(target);
+impl SqliteSnapshot {
+    pub(super) fn path(&self) -> &Path {
+        self.file.path()
     }
-    result
+}
+
+pub(super) fn create_sqlite_snapshot(source: &Path) -> Result<SqliteSnapshot, String> {
+    let snapshot = SqliteSnapshot {
+        file: NamedTempFile::new()
+            .map_err(|error| format!("failed to create private SQLite snapshot: {error}"))?,
+    };
+    create_sqlite_snapshot_inner(source, snapshot.path())?;
+    Ok(snapshot)
 }
 
 fn create_sqlite_snapshot_inner(source: &Path, target: &Path) -> Result<(), String> {
@@ -50,9 +52,7 @@ fn create_sqlite_snapshot_inner(source: &Path, target: &Path) -> Result<(), Stri
 
     let mut target_db = Connection::open_with_flags(
         target,
-        OpenFlags::SQLITE_OPEN_READ_WRITE
-            | OpenFlags::SQLITE_OPEN_CREATE
-            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
     .map_err(|error| {
         format!(
@@ -136,4 +136,34 @@ fn create_sqlite_snapshot_inner(source: &Path, target: &Path) -> Result<(), Stri
                 target.display()
             )
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[cfg(unix)]
+    #[test]
+    fn sqlite_snapshot_is_private_and_removed_on_drop() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let source = NamedTempFile::new().unwrap();
+        let connection = Connection::open(source.path()).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE durable_state (value TEXT NOT NULL);
+                 INSERT INTO durable_state VALUES ('private');",
+            )
+            .unwrap();
+        drop(connection);
+
+        let snapshot = create_sqlite_snapshot(source.path()).unwrap();
+        let snapshot_path = snapshot.path().to_path_buf();
+        let mode = fs::metadata(&snapshot_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        drop(snapshot);
+        assert!(!snapshot_path.exists());
+    }
 }

--- a/src/infra/sqlite_snapshot.rs
+++ b/src/infra/sqlite_snapshot.rs
@@ -42,7 +42,7 @@ fn create_sqlite_snapshot_inner(source: &Path, target: &Path) -> Result<(), Stri
         )
     })?;
     source_db
-        .busy_timeout(SQLITE_BACKUP_TIMEOUT)
+        .busy_timeout(SQLITE_BACKUP_RETRY_DELAY)
         .map_err(|error| {
             format!(
                 "failed to configure SQLite snapshot timeout for {}: {error}",
@@ -61,7 +61,7 @@ fn create_sqlite_snapshot_inner(source: &Path, target: &Path) -> Result<(), Stri
         )
     })?;
     target_db
-        .busy_timeout(SQLITE_BACKUP_TIMEOUT)
+        .busy_timeout(SQLITE_BACKUP_RETRY_DELAY)
         .map_err(|error| {
             format!(
                 "failed to configure SQLite snapshot target {}: {error}",

--- a/src/infra/sqlite_snapshot.rs
+++ b/src/infra/sqlite_snapshot.rs
@@ -1,0 +1,139 @@
+use std::fs::{self, File};
+use std::path::Path;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use rusqlite::backup::{Backup, StepResult};
+use rusqlite::{Connection, OpenFlags};
+
+const SQLITE_BACKUP_PAGES_PER_STEP: i32 = 256;
+const SQLITE_BACKUP_RETRY_DELAY: Duration = Duration::from_millis(10);
+const SQLITE_BACKUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(super) fn create_sqlite_snapshot(source: &Path, target: &Path) -> Result<(), String> {
+    if target.exists() {
+        return Err(format!(
+            "SQLite snapshot target already exists: {}",
+            target.display()
+        ));
+    }
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+
+    let result = create_sqlite_snapshot_inner(source, target);
+    if result.is_err() {
+        let _ = fs::remove_file(target);
+    }
+    result
+}
+
+fn create_sqlite_snapshot_inner(source: &Path, target: &Path) -> Result<(), String> {
+    let source_db = Connection::open_with_flags(
+        source,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|error| {
+        format!(
+            "failed to open SQLite database {} for snapshot: {error}",
+            source.display()
+        )
+    })?;
+    source_db
+        .busy_timeout(SQLITE_BACKUP_TIMEOUT)
+        .map_err(|error| {
+            format!(
+                "failed to configure SQLite snapshot timeout for {}: {error}",
+                source.display()
+            )
+        })?;
+
+    let mut target_db = Connection::open_with_flags(
+        target,
+        OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|error| {
+        format!(
+            "failed to create SQLite snapshot {}: {error}",
+            target.display()
+        )
+    })?;
+    target_db
+        .busy_timeout(SQLITE_BACKUP_TIMEOUT)
+        .map_err(|error| {
+            format!(
+                "failed to configure SQLite snapshot target {}: {error}",
+                target.display()
+            )
+        })?;
+
+    let backup = Backup::new(&source_db, &mut target_db).map_err(|error| {
+        format!(
+            "failed to initialize SQLite snapshot for {}: {error}",
+            source.display()
+        )
+    })?;
+    let deadline = Instant::now() + SQLITE_BACKUP_TIMEOUT;
+    loop {
+        let status = backup.step(SQLITE_BACKUP_PAGES_PER_STEP).map_err(|error| {
+            format!(
+                "failed to copy SQLite database {}: {error}",
+                source.display()
+            )
+        })?;
+        match status {
+            StepResult::Done => break,
+            StepResult::More => {}
+            StepResult::Busy | StepResult::Locked => sleep(SQLITE_BACKUP_RETRY_DELAY),
+            _ => {
+                return Err(format!(
+                    "SQLite backup returned an unsupported status for {}",
+                    source.display()
+                ));
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out snapshotting SQLite database {}",
+                source.display()
+            ));
+        }
+    }
+    drop(backup);
+
+    let mut quick_check = target_db
+        .prepare("PRAGMA quick_check")
+        .map_err(|error| format!("failed to verify SQLite snapshot: {error}"))?;
+    let rows = quick_check
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|error| format!("failed to verify SQLite snapshot: {error}"))?;
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row.map_err(|error| format!("failed to verify SQLite snapshot: {error}"))?);
+    }
+    if results.as_slice() != ["ok"] {
+        return Err(format!(
+            "SQLite snapshot integrity check failed for {}: {}",
+            source.display(),
+            results.join("; ")
+        ));
+    }
+    drop(quick_check);
+    target_db
+        .close()
+        .map_err(|(_, error)| format!("failed to close SQLite snapshot: {error}"))?;
+    source_db
+        .close()
+        .map_err(|(_, error)| format!("failed to close SQLite source: {error}"))?;
+
+    File::open(target)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| {
+            format!(
+                "failed to sync SQLite snapshot {}: {error}",
+                target.display()
+            )
+        })
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -58,7 +58,8 @@ pub(crate) use openclaw_config::{
 };
 pub(crate) use openclaw_state::{
     OpenClawStateAudit, audit_openclaw_state, clear_nonportable_runtime_state,
-    openclaw_env_archive_options, prepare_migrated_runtime_state, repair_openclaw_runtime_state,
+    openclaw_env_archive_options, openclaw_env_snapshot_archive_options,
+    prepare_migrated_runtime_state, repair_openclaw_runtime_state,
 };
 pub(crate) use openclaw_workspaces::{
     OpenClawWorkspaceRuntime, resolve_env_openclaw_workspaces, resolve_plain_openclaw_workspaces,

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -109,6 +109,7 @@ pub(crate) fn openclaw_env_archive_options(
         should_skip_path: should_skip_openclaw_env_archive_path,
         included_path_roots: workspaces.archive_relative_roots(&paths.root)?,
         excluded_path_roots: openclaw_archive_excluded_path_roots(paths)?,
+        snapshot_sqlite_files: false,
     })
 }
 

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -113,6 +113,18 @@ pub(crate) fn openclaw_env_archive_options(
     })
 }
 
+pub(crate) fn openclaw_env_snapshot_archive_options(
+    paths: &EnvPaths,
+    env: &BTreeMap<String, String>,
+    runtime: OpenClawWorkspaceRuntime<'_>,
+) -> Result<EnvArchiveOptions, String> {
+    let mut options = openclaw_env_archive_options(paths, env, runtime)?;
+    options
+        .included_path_roots
+        .insert(Path::new(".openclaw/state").to_path_buf());
+    Ok(options)
+}
+
 pub(crate) fn should_skip_openclaw_env_archive_path(
     relative_path: &Path,
     _kind: EnvArchiveEntryKind,
@@ -437,7 +449,6 @@ fn is_durable_openclaw_archive_path(components: &[&str]) -> bool {
             | [".openclaw", "devices", ..]
             | [".openclaw", "identity", ..]
             | [".openclaw", "memory", ..]
-            | [".openclaw", "state", ..]
             | [".openclaw", "plugins", ..]
             | [".openclaw", "extensions", ..]
             | [".openclaw", "npm", ..]
@@ -896,7 +907,13 @@ mod tests {
         )
         .unwrap();
 
-        let options = openclaw_env_archive_options(
+        let export_options = openclaw_env_archive_options(
+            &paths,
+            &BTreeMap::new(),
+            OpenClawWorkspaceRuntime::default(),
+        )
+        .unwrap();
+        let options = openclaw_env_snapshot_archive_options(
             &paths,
             &BTreeMap::new(),
             OpenClawWorkspaceRuntime::default(),
@@ -912,14 +929,28 @@ mod tests {
                 .included_path_roots
                 .contains(Path::new(".openclaw/workspace"))
         );
+        assert!(
+            options
+                .included_path_roots
+                .contains(Path::new(".openclaw/state"))
+        );
         assert!(options.excluded_path_roots.is_empty());
         assert!(options.snapshot_sqlite_files);
+        assert!(export_options.snapshot_sqlite_files);
+        assert!(
+            !export_options
+                .included_path_roots
+                .contains(Path::new(".openclaw/state"))
+        );
+        assert!(should_skip_openclaw_env_archive_path(
+            Path::new(".openclaw/state/openclaw.sqlite"),
+            EnvArchiveEntryKind::File
+        ));
         assert!(!should_skip_openclaw_env_archive_path(
             Path::new(".openclaw/workspace/notes.txt"),
             EnvArchiveEntryKind::File
         ));
         for path in [
-            ".openclaw/state/openclaw.sqlite",
             ".openclaw/plugins/installs.json",
             ".openclaw/extensions/demo/package.json",
             ".openclaw/npm/projects/demo/package-lock.json",

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -109,7 +109,7 @@ pub(crate) fn openclaw_env_archive_options(
         should_skip_path: should_skip_openclaw_env_archive_path,
         included_path_roots: workspaces.archive_relative_roots(&paths.root)?,
         excluded_path_roots: openclaw_archive_excluded_path_roots(paths)?,
-        snapshot_sqlite_files: false,
+        snapshot_sqlite_files: true,
     })
 }
 
@@ -437,6 +437,7 @@ fn is_durable_openclaw_archive_path(components: &[&str]) -> bool {
             | [".openclaw", "devices", ..]
             | [".openclaw", "identity", ..]
             | [".openclaw", "memory", ..]
+            | [".openclaw", "state", ..]
             | [".openclaw", "plugins", ..]
             | [".openclaw", "extensions", ..]
             | [".openclaw", "npm", ..]
@@ -912,11 +913,13 @@ mod tests {
                 .contains(Path::new(".openclaw/workspace"))
         );
         assert!(options.excluded_path_roots.is_empty());
+        assert!(options.snapshot_sqlite_files);
         assert!(!should_skip_openclaw_env_archive_path(
             Path::new(".openclaw/workspace/notes.txt"),
             EnvArchiveEntryKind::File
         ));
         for path in [
+            ".openclaw/state/openclaw.sqlite",
             ".openclaw/plugins/installs.json",
             ".openclaw/extensions/demo/package.json",
             ".openclaw/npm/projects/demo/package-lock.json",

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -21,7 +21,7 @@ use super::layout::{
 };
 use super::{
     OpenClawWorkspaceRuntime, audit_openclaw_state, clear_nonportable_runtime_state,
-    get_environment, list_environments, now_utc, openclaw_env_archive_options,
+    get_environment, list_environments, now_utc, openclaw_env_snapshot_archive_options,
     rewrite_openclaw_config_for_target, save_environment,
 };
 
@@ -114,7 +114,7 @@ pub fn create_env_snapshot(
             &metadata,
             &env_paths.root,
             &archive_path,
-            openclaw_env_archive_options(
+            openclaw_env_snapshot_archive_options(
                 &env_paths,
                 env,
                 OpenClawWorkspaceRuntime::for_env(&meta.name, meta.gateway_port),

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -127,6 +127,9 @@ pub fn create_env_snapshot(
     if result.is_err() {
         let _ = fs::remove_file(&archive_path);
         let _ = fs::remove_file(&meta_path);
+        if let Some(snapshot_dir) = archive_path.parent() {
+            let _ = fs::remove_dir(snapshot_dir);
+        }
     }
 
     result

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -691,6 +691,32 @@ fn env_snapshot_rejects_external_workspaces_before_writing_an_archive() {
 }
 
 #[test]
+fn env_snapshot_removes_partial_artifacts_when_sqlite_snapshot_fails() {
+    let root = TestDir::new("env-snapshot-invalid-sqlite");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+    let database = root.child("ocm-home/envs/source/.openclaw/state/openclaw.sqlite");
+    write_text(&database, "not a sqlite database\n");
+
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
+    assert_eq!(snapshot.status.code(), Some(1));
+    assert!(
+        stderr(&snapshot).contains("SQLite"),
+        "{}",
+        stderr(&snapshot)
+    );
+    assert_eq!(
+        fs::read_to_string(&database).unwrap(),
+        "not a sqlite database\n"
+    );
+    assert!(!root.child("ocm-home/snapshots/source").exists());
+}
+
+#[test]
 fn env_snapshot_restore_json_reports_the_restored_binding_shape() {
     let root = TestDir::new("env-snapshot-restore-json");
     let cwd = root.child("workspace");

--- a/tests/store_flow_tests.rs
+++ b/tests/store_flow_tests.rs
@@ -745,6 +745,10 @@ fn environment_export_writes_a_portable_archive() {
         &source_root.join(".openclaw/workspace/notes.txt"),
         "hello export",
     );
+    write_text(
+        &source_root.join(".openclaw/state/openclaw.sqlite"),
+        "nonportable runtime state",
+    );
 
     let summary = export_environment(
         ExportEnvironmentOptions {
@@ -775,6 +779,7 @@ fn environment_export_writes_a_portable_archive() {
         fs::read_to_string(extracted.root_dir.join(".openclaw/workspace/notes.txt")).unwrap(),
         "hello export"
     );
+    assert!(!extracted.root_dir.join(".openclaw/state").exists());
 }
 
 #[test]

--- a/tests/store_flow_tests.rs
+++ b/tests/store_flow_tests.rs
@@ -21,6 +21,7 @@ use ocm::store::{
     remove_environment, remove_launcher, remove_runtime, restore_env_snapshot,
     runtime_install_root, runtime_meta_path,
 };
+use rusqlite::{Connection, OpenFlags};
 
 use crate::support::{TestDir, ocm_env, path_string, write_executable_script, write_text};
 
@@ -1106,6 +1107,112 @@ fn environment_snapshot_captures_a_named_point_in_time() {
         fs::read_to_string(extracted.root_dir.join(".openclaw/workspace/notes.txt")).unwrap(),
         "hello snapshot"
     );
+}
+
+#[test]
+fn environment_snapshot_restores_live_global_and_agent_sqlite_state() {
+    let root = TestDir::new("store-env-snapshot-sqlite");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let created = create_environment(
+        CreateEnvironmentOptions {
+            name: "source".to_string(),
+            root: None,
+            gateway_port: Some(19789),
+            service_enabled: false,
+            service_running: false,
+            default_runtime: None,
+            default_launcher: None,
+            dev: None,
+            protected: true,
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+    let source_root = Path::new(&created.root);
+    let global_database = source_root.join(".openclaw/state/openclaw.sqlite");
+    let agent_database = source_root.join(".openclaw/agents/main/agent/openclaw-agent.sqlite");
+
+    for database in [&global_database, &agent_database] {
+        fs::create_dir_all(database.parent().unwrap()).unwrap();
+    }
+    let global = Connection::open(&global_database).unwrap();
+    let agent = Connection::open(&agent_database).unwrap();
+    for connection in [&global, &agent] {
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .unwrap();
+        connection
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE durable_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO durable_state VALUES ('sentinel', 'before-upgrade');",
+            )
+            .unwrap();
+    }
+    assert!(global_database.with_extension("sqlite-wal").exists());
+    assert!(agent_database.with_extension("sqlite-wal").exists());
+
+    let snapshot = create_env_snapshot(
+        CreateEnvSnapshotOptions {
+            env_name: "source".to_string(),
+            label: Some("before-upgrade".to_string()),
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+
+    drop(global);
+    drop(agent);
+    for database in [&global_database, &agent_database] {
+        let connection = Connection::open(database).unwrap();
+        connection
+            .execute(
+                "UPDATE durable_state SET value = 'after-upgrade' WHERE key = 'sentinel'",
+                [],
+            )
+            .unwrap();
+    }
+
+    restore_env_snapshot(
+        RestoreEnvSnapshotOptions {
+            env_name: "source".to_string(),
+            snapshot_id: snapshot.id,
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+
+    for database in [&global_database, &agent_database] {
+        assert!(database.exists());
+        assert!(!database.with_extension("sqlite-wal").exists());
+        assert!(!database.with_extension("sqlite-shm").exists());
+        assert!(!database.with_extension("sqlite-journal").exists());
+        let restored = Connection::open_with_flags(
+            database,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .unwrap();
+        let value: String = restored
+            .query_row(
+                "SELECT value FROM durable_state WHERE key = 'sentinel'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, "before-upgrade");
+        let integrity: String = restored
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(integrity, "ok");
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- snapshot live OpenClaw SQLite databases through SQLite's online backup API
- preserve global runtime state only in rollback snapshots while keeping exports portable
- omit SQLite sidecars, verify copied database integrity, and clean failed snapshot artifacts
- keep temporary database copies private and bound lock waits to the archive deadline

## Verification

- `cargo test`
- `cargo check --all-targets`
- `cargo check --target x86_64-pc-windows-gnu`
- real live-WAL snapshot and restore on OpenClaw `2026.6.11`, `2026.6.33`, `2026.7.1`, `2026.7.1-2`, `2026.7.2-beta.3`, and current source `4c5e8f3b`
- real beta-to-current upgrade failure with rollback restoring the SQLite sentinel, runtime binding, database integrity, default agent, and stopped service state

Crabbox AWS lease: `cbx_a55a7013c2d7`
