### PR TITLE
fix: repair legacy config before OpenClaw finalization

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1903,6 +1903,9 @@ impl Cli {
         if validation.status.success() {
             return Ok(false);
         }
+        if command_output_reports_unsupported_command(&validation.stdout, &validation.stderr) {
+            return Ok(false);
+        }
 
         self.run_update_mode_openclaw_command(
             env_name,
@@ -2508,6 +2511,20 @@ fn summarize_command_output(stdout: &[u8], stderr: &[u8]) -> String {
     summarize_command_text(&stderr, &stdout).unwrap_or_else(|| "no output".to_string())
 }
 
+fn command_output_reports_unsupported_command(stdout: &str, stderr: &str) -> bool {
+    [stdout, stderr].iter().any(|text| {
+        let normalized = text.to_ascii_lowercase();
+        [
+            "unknown command",
+            "unrecognized command",
+            "command not found",
+            "unexpected args:",
+        ]
+        .iter()
+        .any(|marker| normalized.contains(marker))
+    })
+}
+
 fn shell_command(command: &str) -> Command {
     if cfg!(windows) {
         let mut process = Command::new("cmd");
@@ -2609,7 +2626,7 @@ fn gateway_health_ok(port: u32) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::version_output_matches_expected;
+    use super::{command_output_reports_unsupported_command, version_output_matches_expected};
 
     #[test]
     fn version_output_accepts_exact_version() {
@@ -2637,6 +2654,26 @@ mod tests {
         assert!(!version_output_matches_expected(
             "OpenClaw 12026.5.14",
             "2026.5.14"
+        ));
+    }
+
+    #[test]
+    fn config_probe_recognizes_unsupported_commands() {
+        assert!(command_output_reports_unsupported_command(
+            "",
+            "error: unknown command 'config'"
+        ));
+        assert!(command_output_reports_unsupported_command(
+            "",
+            "unexpected args: config validate"
+        ));
+    }
+
+    #[test]
+    fn config_probe_keeps_invalid_config_failures_actionable() {
+        assert!(!command_output_reports_unsupported_command(
+            "",
+            "OpenClaw config is invalid\nProblem: meta: Unrecognized key: lastTouchedAt"
         ));
     }
 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1952,6 +1952,9 @@ impl Cli {
             &[
                 ("OPENCLAW_UPDATE_IN_PROGRESS", "1"),
                 ("OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE", "1"),
+                ("OPENCLAW_UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART", "1"),
+                ("OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR", "0"),
+                ("OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION", "0"),
             ],
         )
         .map_err(|error| format!("{name} failed: {error}"))

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1866,13 +1866,57 @@ impl Cli {
     ) -> Result<Option<String>, String> {
         // Resolve the replacement explicitly while the previous binding remains published.
         // A failed finalizer can then roll back without ever activating the replacement.
+        let config_repaired = self.repair_target_openclaw_config(env_name, runtime_name)?;
         self.run_update_mode_openclaw_command(
             env_name,
             runtime_name,
             "openclaw update finalize",
             &["update", "finalize", "--json", "--yes", "--no-restart"],
         )?;
-        Ok(Some("OpenClaw update finalization completed".to_string()))
+        Ok(Some(if config_repaired {
+            "OpenClaw config repair and update finalization completed".to_string()
+        } else {
+            "OpenClaw update finalization completed".to_string()
+        }))
+    }
+
+    fn repair_target_openclaw_config(
+        &self,
+        env_name: &str,
+        runtime_name: &str,
+    ) -> Result<bool, String> {
+        let env = self
+            .environment_service()
+            .get(env_name)
+            .map_err(|error| format!("failed to inspect OpenClaw config: {error}"))?;
+        let config_path = derive_env_paths(Path::new(&env.root)).config_path;
+        if !config_path.exists() {
+            return Ok(false);
+        }
+
+        let validation = self.run_update_mode_openclaw_command_output(
+            env_name,
+            runtime_name,
+            "openclaw config validate",
+            &["config", "validate"],
+        )?;
+        if validation.status.success() {
+            return Ok(false);
+        }
+
+        self.run_update_mode_openclaw_command(
+            env_name,
+            runtime_name,
+            "openclaw doctor",
+            &["doctor", "--non-interactive", "--fix"],
+        )?;
+        self.run_update_mode_openclaw_command(
+            env_name,
+            runtime_name,
+            "openclaw config validate after doctor",
+            &["config", "validate"],
+        )?;
+        Ok(true)
     }
 
     fn run_update_mode_openclaw_command(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1882,22 +1882,35 @@ impl Cli {
         name: &str,
         args: &[&str],
     ) -> Result<(), String> {
+        let output =
+            self.run_update_mode_openclaw_command_output(env_name, runtime_name, name, args)?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(format!("{name} failed: {}", output.failure_summary()))
+        }
+    }
+
+    fn run_update_mode_openclaw_command_output(
+        &self,
+        env_name: &str,
+        runtime_name: &str,
+        name: &str,
+        args: &[&str],
+    ) -> Result<SimulationCommandOutput, String> {
         let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
         let resolved = self
             .environment_service()
             .resolve(env_name, Some(runtime_name.to_string()), None, &args)
             .map_err(|error| format!("{name} failed: {error}"))?;
-        match self.run_resolved_for_simulation(
+        self.run_resolved_for_simulation(
             resolved,
             &[
                 ("OPENCLAW_UPDATE_IN_PROGRESS", "1"),
                 ("OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE", "1"),
             ],
-        ) {
-            Ok(output) if output.status.success() => Ok(()),
-            Ok(output) => Err(format!("{name} failed: {}", output.failure_summary())),
-            Err(error) => Err(format!("{name} failed: {error}")),
-        }
+        )
+        .map_err(|error| format!("{name} failed: {error}"))
     }
 
     fn begin_upgrade_transaction(

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -134,7 +134,9 @@ case "$1" in
       exit 29
     fi
     mkdir -p "$home/.openclaw"
-    touch "$home/.openclaw/config-repaired"
+    if [ "${{OCM_TEST_DOCTOR_LEAVES_CONFIG_INVALID:-}}" != "1" ]; then
+      touch "$home/.openclaw/config-repaired"
+    fi
     echo "doctor ok"
     exit 0
     ;;
@@ -1764,6 +1766,85 @@ fn upgrade_rolls_back_when_target_config_doctor_fails() {
 
     let command_log = fs::read_to_string(command_log_path).unwrap();
     assert!(command_log.contains("config validate"), "{command_log}");
+    assert!(
+        command_log.contains("doctor --non-interactive --fix"),
+        "{command_log}"
+    );
+    assert!(
+        !command_log.contains("update finalize --json --yes --no-restart"),
+        "{command_log}"
+    );
+}
+
+#[test]
+fn upgrade_rolls_back_when_doctor_does_not_repair_target_config() {
+    let root = TestDir::new("upgrade-target-config-revalidation-failure");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("old-openclaw"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("new-openclaw"));
+
+    let mut env = ocm_env(&root);
+    for (name, runtime) in [("old-local", &old_runtime), ("new-local", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                name,
+                "--path",
+                &runtime.display().to_string(),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "old-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let env_root = root.child("ocm-home/envs/demo");
+    let config_path = env_root.join(".openclaw/openclaw.json");
+    let original_config = "{\"meta\":{\"lastTouchedAt\":\"legacy\"}}\n";
+    fs::write(&config_path, original_config).unwrap();
+
+    env.insert(
+        "OCM_TEST_INVALID_CONFIG_UNTIL_DOCTOR".to_string(),
+        "1".to_string(),
+    );
+    env.insert(
+        "OCM_TEST_DOCTOR_LEAVES_CONFIG_INVALID".to_string(),
+        "1".to_string(),
+    );
+    let command_log_path = root.child("revalidation-failure-commands.log");
+    env.insert(
+        "OCM_TEST_COMMAND_LOG".to_string(),
+        path_string(&command_log_path),
+    );
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
+    assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
+    let output = stdout(&upgrade);
+    assert!(output.contains("outcome=rolled-back"), "{output}");
+    assert!(output.contains("rollback=restored"), "{output}");
+    assert!(
+        output.contains("openclaw config validate after doctor failed"),
+        "{output}"
+    );
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(env_json["defaultRuntime"], "old-local");
+    assert_eq!(fs::read_to_string(config_path).unwrap(), original_config);
+
+    let command_log = fs::read_to_string(command_log_path).unwrap();
+    assert_eq!(command_log.matches("config validate").count(), 2);
     assert!(
         command_log.contains("doctor --non-interactive --fix"),
         "{command_log}"

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -119,6 +119,15 @@ case "$1" in
       echo "missing OPENCLAW_UPDATE_IN_PROGRESS" >&2
       exit 1
     fi
+    if [ "${{OCM_TEST_REQUIRE_DOCTOR_OWNERSHIP_FLAGS:-}}" = "1" ]; then
+      if [ "${{OPENCLAW_UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART:-}}" != "1" ] ||
+         [ "${{OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR:-}}" != "0" ] ||
+         [ "${{OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION:-}}" != "0" ] ||
+         [ "${{OPENCLAW_SERVICE_REPAIR_POLICY:-}}" != "external" ]; then
+        echo "missing doctor service ownership flags" >&2
+        exit 1
+      fi
+    fi
     mkdir -p "$home/.openclaw"
     touch "$home/.openclaw/config-repaired"
     echo "doctor ok"
@@ -1656,6 +1665,10 @@ fn upgrade_repairs_target_config_before_finalization() {
 
     env.insert(
         "OCM_TEST_INVALID_CONFIG_UNTIL_DOCTOR".to_string(),
+        "1".to_string(),
+    );
+    env.insert(
+        "OCM_TEST_REQUIRE_DOCTOR_OWNERSHIP_FLAGS".to_string(),
         "1".to_string(),
     );
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -97,6 +97,19 @@ case "$1" in
     printf '{{"dryRun":true}}\n'
     exit 0
     ;;
+  config)
+    [ "$2" = "validate" ] || {{
+      echo "unexpected config args: $*" >&2
+      exit 1
+    }}
+    if [ "${{OCM_TEST_INVALID_CONFIG_UNTIL_DOCTOR:-}}" = "1" ] &&
+       [ ! -f "$home/.openclaw/config-repaired" ]; then
+      echo "OpenClaw config is invalid" >&2
+      exit 1
+    fi
+    echo "Config valid"
+    exit 0
+    ;;
   doctor)
     has_arg "--non-interactive" "$@" && has_arg "--fix" "$@" || {{
       echo "missing doctor update flags" >&2
@@ -106,6 +119,8 @@ case "$1" in
       echo "missing OPENCLAW_UPDATE_IN_PROGRESS" >&2
       exit 1
     fi
+    mkdir -p "$home/.openclaw"
+    touch "$home/.openclaw/config-repaired"
     echo "doctor ok"
     exit 0
     ;;
@@ -1597,6 +1612,74 @@ fn upgrade_can_switch_env_to_an_installed_runtime() {
         !command_log.contains("plugins update --all\n"),
         "{command_log}"
     );
+}
+
+#[test]
+fn upgrade_repairs_target_config_before_finalization() {
+    let root = TestDir::new("upgrade-target-config-repair");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("old-openclaw"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("new-openclaw"));
+
+    let mut env = ocm_env(&root);
+    for (name, runtime) in [("old-local", &old_runtime), ("new-local", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                name,
+                "--path",
+                &runtime.display().to_string(),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "old-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let env_root = root.child("ocm-home/envs/demo");
+    fs::write(
+        env_root.join(".openclaw/openclaw.json"),
+        "{\"meta\":{\"lastTouchedAt\":\"legacy\"}}\n",
+    )
+    .unwrap();
+
+    env.insert(
+        "OCM_TEST_INVALID_CONFIG_UNTIL_DOCTOR".to_string(),
+        "1".to_string(),
+    );
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
+    assert!(upgrade.status.success(), "{}", stderr(&upgrade));
+    let output = stdout(&upgrade);
+    assert!(output.contains("outcome=switched"), "{output}");
+    assert!(output.contains("config repair"), "{output}");
+
+    let command_log = fs::read_to_string(env_root.join("sim-commands.log")).unwrap();
+    let validate_before = command_log.find("config validate").unwrap();
+    let doctor = command_log.find("doctor --non-interactive --fix").unwrap();
+    let validate_after = command_log.rfind("config validate").unwrap();
+    let finalize = command_log
+        .find("update finalize --json --yes --no-restart")
+        .unwrap();
+    assert!(validate_before < doctor, "{command_log}");
+    assert!(doctor < validate_after, "{command_log}");
+    assert!(validate_after < finalize, "{command_log}");
+    assert!(env_root.join(".openclaw/config-repaired").exists());
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(env_json["defaultRuntime"], "new-local");
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -1856,6 +1856,67 @@ fn upgrade_rolls_back_when_doctor_does_not_repair_target_config() {
 }
 
 #[test]
+fn upgrade_skips_config_repair_when_openclaw_config_is_missing() {
+    let root = TestDir::new("upgrade-missing-config");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("old-openclaw"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("new-openclaw"));
+
+    let env = ocm_env(&root);
+    for (name, runtime) in [("old-local", &old_runtime), ("new-local", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                name,
+                "--path",
+                &runtime.display().to_string(),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "old-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let env_root = root.child("ocm-home/envs/demo");
+    let config_path = env_root.join(".openclaw/openclaw.json");
+    assert!(!config_path.exists());
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
+    assert!(upgrade.status.success(), "{}", stderr(&upgrade));
+    let output = stdout(&upgrade);
+    assert!(output.contains("outcome=switched"), "{output}");
+    assert!(!output.contains("config repair"), "{output}");
+
+    let command_log = fs::read_to_string(env_root.join("sim-commands.log")).unwrap();
+    assert!(!command_log.contains("config validate"), "{command_log}");
+    assert!(
+        !command_log.contains("doctor --non-interactive --fix"),
+        "{command_log}"
+    );
+    assert!(
+        command_log.contains("update finalize --json --yes --no-restart"),
+        "{command_log}"
+    );
+    assert!(!config_path.exists());
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(env_json["defaultRuntime"], "new-local");
+}
+
+#[test]
 fn env_set_runtime_uses_the_transactional_upgrade_path_for_existing_bindings() {
     let root = TestDir::new("set-runtime-transactional-upgrade");
     let cwd = root.child("workspace");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -57,7 +57,8 @@ fn recording_openclaw_script(version: &str) -> String {
         r#"#!/bin/sh
 home="${{OPENCLAW_HOME:-$PWD}}"
 mkdir -p "$home"
-printf '%s\n' "$*" >> "$home/sim-commands.log"
+command_log="${{OCM_TEST_COMMAND_LOG:-$home/sim-commands.log}}"
+printf '%s\n' "$*" >> "$command_log"
 has_arg() {{
   needle="$1"
   shift
@@ -127,6 +128,10 @@ case "$1" in
         echo "missing doctor service ownership flags" >&2
         exit 1
       fi
+    fi
+    if [ "${{OCM_TEST_FAIL_DOCTOR:-}}" = "1" ]; then
+      echo "forced doctor failure" >&2
+      exit 29
     fi
     mkdir -p "$home/.openclaw"
     touch "$home/.openclaw/config-repaired"
@@ -1693,6 +1698,80 @@ fn upgrade_repairs_target_config_before_finalization() {
     assert!(show.status.success(), "{}", stderr(&show));
     let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     assert_eq!(env_json["defaultRuntime"], "new-local");
+}
+
+#[test]
+fn upgrade_rolls_back_when_target_config_doctor_fails() {
+    let root = TestDir::new("upgrade-target-config-doctor-failure");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("old-openclaw"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("new-openclaw"));
+
+    let mut env = ocm_env(&root);
+    for (name, runtime) in [("old-local", &old_runtime), ("new-local", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                name,
+                "--path",
+                &runtime.display().to_string(),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "old-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let env_root = root.child("ocm-home/envs/demo");
+    let config_path = env_root.join(".openclaw/openclaw.json");
+    let original_config = "{\"meta\":{\"lastTouchedAt\":\"legacy\"}}\n";
+    fs::write(&config_path, original_config).unwrap();
+
+    env.insert(
+        "OCM_TEST_INVALID_CONFIG_UNTIL_DOCTOR".to_string(),
+        "1".to_string(),
+    );
+    env.insert("OCM_TEST_FAIL_DOCTOR".to_string(), "1".to_string());
+    let command_log_path = root.child("doctor-failure-commands.log");
+    env.insert(
+        "OCM_TEST_COMMAND_LOG".to_string(),
+        path_string(&command_log_path),
+    );
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
+    assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
+    let output = stdout(&upgrade);
+    assert!(output.contains("outcome=rolled-back"), "{output}");
+    assert!(output.contains("rollback=restored"), "{output}");
+    assert!(output.contains("openclaw doctor failed"), "{output}");
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(env_json["defaultRuntime"], "old-local");
+    assert_eq!(fs::read_to_string(config_path).unwrap(), original_config);
+    assert!(!env_root.join(".openclaw/config-repaired").exists());
+
+    let command_log = fs::read_to_string(command_log_path).unwrap();
+    assert!(command_log.contains("config validate"), "{command_log}");
+    assert!(
+        command_log.contains("doctor --non-interactive --fix"),
+        "{command_log}"
+    );
+    assert!(
+        !command_log.contains("update finalize --json --yes --no-restart"),
+        "{command_log}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- validate an existing environment config with the replacement OpenClaw runtime before update finalization
- repair invalid legacy config with target-runtime doctor, revalidate it, and retain OCM ownership of gateway service activation and repair
- preserve upgrades for missing configs and older OpenClaw runtimes that do not support `config validate`

## Verification

- AWS Crabbox `cbx_a55a7013c2d7`: `cargo test`
- AWS Crabbox `cbx_a55a7013c2d7`: `cargo check --all-targets`
- AWS Crabbox `cbx_a55a7013c2d7`: `cargo check --target x86_64-pc-windows-gnu`
- package-shaped upgrade chain: OpenClaw `2026.6.11`, `2026.6.33`, `2026.7.1`, `2026.7.1-2`, `2026.7.2-beta.3`, and current source
- frozen OpenClaw source `ec8f957f2e7ca3125824d610a2ad5a53446d6631`: `pnpm check`, local package runtime build/verify, config repair, update finalization, service-state verification, live SQLite WAL preservation, and snapshot sidecar exclusion
