### PR TITLE
fix: retry busy service manager executables

### DIFF
--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -986,20 +986,29 @@ fn run_launchctl<const N: usize>(
     env: &BTreeMap<String, String>,
     args: [&str; N],
 ) -> Result<Output, String> {
-    Command::new(service_manager_binary(env, ServiceManagerKind::Launchd))
-        .args(args)
-        .output()
-        .map_err(|error| format!("failed to run \"launchctl\": {error}"))
+    run_service_manager_command(
+        service_manager_binary(env, ServiceManagerKind::Launchd),
+        args,
+    )
+    .map_err(|error| format!("failed to run \"launchctl\": {error}"))
 }
 
 fn run_systemctl<const N: usize>(
     env: &BTreeMap<String, String>,
     args: [&str; N],
 ) -> Result<Output, String> {
-    Command::new(service_manager_binary(env, ServiceManagerKind::SystemdUser))
-        .args(args)
-        .output()
-        .map_err(|error| format!("failed to run \"systemctl\": {error}"))
+    run_service_manager_command(
+        service_manager_binary(env, ServiceManagerKind::SystemdUser),
+        args,
+    )
+    .map_err(|error| format!("failed to run \"systemctl\": {error}"))
+}
+
+fn run_service_manager_command<const N: usize>(
+    binary: &str,
+    args: [&str; N],
+) -> std::io::Result<Output> {
+    Command::new(binary).args(args).output()
 }
 
 fn launchctl_detail(output: &Output) -> String {

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -21,6 +21,8 @@ const SERVICE_DIR_MODE: u32 = 0o700;
 const SERVICE_FILE_MODE: u32 = 0o600;
 const LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS: u32 = 1;
 const LAUNCH_AGENT_UMASK_DECIMAL: u32 = 0o077;
+const SERVICE_MANAGER_BUSY_ATTEMPTS: usize = 3;
+const SERVICE_MANAGER_BUSY_RETRY_MS: u64 = 10;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ManagedServiceIdentity {
@@ -1008,7 +1010,25 @@ fn run_service_manager_command<const N: usize>(
     binary: &str,
     args: [&str; N],
 ) -> std::io::Result<Output> {
-    Command::new(binary).args(args).output()
+    retry_service_manager_executable_busy(|| Command::new(binary).args(args).output())
+}
+
+fn retry_service_manager_executable_busy<T>(
+    mut operation: impl FnMut() -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    for attempt in 0..SERVICE_MANAGER_BUSY_ATTEMPTS {
+        match operation() {
+            Ok(output) => return Ok(output),
+            Err(error)
+                if error.kind() == std::io::ErrorKind::ExecutableFileBusy
+                    && attempt + 1 < SERVICE_MANAGER_BUSY_ATTEMPTS =>
+            {
+                sleep(Duration::from_millis(SERVICE_MANAGER_BUSY_RETRY_MS));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("busy retry loop always returns on its final attempt")
 }
 
 fn launchctl_detail(output: &Output) -> String {

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -1087,6 +1087,7 @@ fn validate_systemd_environment_key(key: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::collections::BTreeMap;
     use std::fs;
     #[cfg(unix)]
@@ -1098,11 +1099,62 @@ mod tests {
 
     use super::{
         ManagedServiceDefinition, ManagedServiceEnablement, ManagedServiceIdentity,
-        OCM_SERVICE_LABEL, ServiceManagerKind, gui_domain, managed_service_identity,
-        managed_service_label, restore_managed_service_registration, service_backend_support_error,
+        OCM_SERVICE_LABEL, SERVICE_MANAGER_BUSY_ATTEMPTS, ServiceManagerKind, gui_domain,
+        managed_service_identity, managed_service_label, restore_managed_service_registration,
+        retry_service_manager_executable_busy, service_backend_support_error,
         service_definition_dir, service_manager_kind, systemd_output_mode_for_version,
         write_managed_service_definition,
     };
+
+    #[test]
+    fn service_manager_execution_retries_a_busy_executable() {
+        let attempts = Cell::new(0);
+
+        let result = retry_service_manager_executable_busy(|| {
+            let attempt = attempts.get();
+            attempts.set(attempt + 1);
+            if attempt == 0 {
+                Err(std::io::Error::from(std::io::ErrorKind::ExecutableFileBusy))
+            } else {
+                Ok(())
+            }
+        });
+
+        assert!(result.is_ok());
+        assert_eq!(attempts.get(), 2);
+    }
+
+    #[test]
+    fn service_manager_execution_does_not_retry_other_errors() {
+        let attempts = Cell::new(0);
+
+        let result: std::io::Result<()> = retry_service_manager_executable_busy(|| {
+            attempts.set(attempts.get() + 1);
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+        });
+
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(attempts.get(), 1);
+    }
+
+    #[test]
+    fn service_manager_execution_stops_at_the_busy_retry_limit() {
+        let attempts = Cell::new(0);
+
+        let result: std::io::Result<()> = retry_service_manager_executable_busy(|| {
+            attempts.set(attempts.get() + 1);
+            Err(std::io::Error::from(std::io::ErrorKind::ExecutableFileBusy))
+        });
+
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::ExecutableFileBusy
+        );
+        assert_eq!(attempts.get(), SERVICE_MANAGER_BUSY_ATTEMPTS);
+    }
 
     #[test]
     fn manager_override_supports_systemd_user() {


### PR DESCRIPTION
## Summary

- share launchd and systemd service-manager command execution
- retry transient executable-busy spawn failures with a bounded delay
- preserve immediate failure for other errors and cover retry exhaustion

## Verification

- `cargo fmt --check`
- `git diff --check`
- service platform module: 22 tests passed
- prior failing service registration test: 100 consecutive passes
- full `cargo test`
- `cargo check --all-targets`
- Windows GNU cross-check
