### PR TITLE
fix: isolate shared runtime upgrades

### DIFF
--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -581,6 +581,7 @@ pub fn upgrade_help(cmd: &str) -> String {
             "Local-repo simulations validate deps/build/UI build before post-update checks.",
             "Post-update checks run update-mode doctor, plugin update dry-run, and gateway status.",
             "Channel-tracked runtimes move forward automatically.",
+            "An env upgrade will not replace runtime bytes shared with another env; use --runtime to reuse those bytes or an exact --version for an isolated target.",
             "Upgrades create a pre-upgrade snapshot before changing env state.",
             "When an env moves to a new runtime, upgrade runs OpenClaw update finalization inside the env before service restart.",
             "If service restart/start fails, ocm restores the snapshot and previous runtime unless --no-rollback is set.",

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -28,8 +28,9 @@ use crate::service::ServiceSummary;
 use crate::store::{
     InstallContext, RuntimeReleaseDetails, clean_path, copy_dir_recursive, derive_env_paths,
     display_path, ensure_minimum_local_openclaw_config, ensure_store, get_runtime,
-    install_runtime_from_selected_official_openclaw_release, remove_runtime, resolve_absolute_path,
-    runtime_install_root, runtime_integrity_issue, runtime_meta_path, save_environment, write_json,
+    install_runtime_from_selected_official_openclaw_release, lock_env_registry, remove_runtime,
+    resolve_absolute_path, runtime_install_root, runtime_integrity_issue, runtime_meta_path,
+    save_environment, write_json,
 };
 
 #[derive(Clone, Debug, Serialize)]
@@ -1097,7 +1098,7 @@ impl Cli {
                 &[current.name.clone(), target_runtime_name.clone()],
                 options.rollback_enabled,
             )?;
-            let prepared = match self.prepare_upgrade_target(env_name, target) {
+            let prepared = match self.prepare_isolated_upgrade_target(env_name, target) {
                 Ok(prepared) => prepared,
                 Err(error) => {
                     return self.rollback_failed_upgrade(
@@ -1295,7 +1296,7 @@ impl Cli {
                 &[current.name.clone(), target_runtime_name.clone()],
                 options.rollback_enabled,
             )?;
-            let prepared = match self.prepare_upgrade_target(env_name, &target) {
+            let prepared = match self.prepare_isolated_upgrade_target(env_name, &target) {
                 Ok(prepared) => prepared,
                 Err(error) => {
                     return self.rollback_failed_upgrade(
@@ -1417,13 +1418,15 @@ impl Cli {
             options.rollback_enabled,
         )?;
         let updated = match self.with_progress(format!("Updating runtime {}", current.name), || {
-            self.runtime_service().update_from_release_deferred(
-                crate::runtime::UpdateRuntimeFromReleaseOptions {
-                    name: current.name.clone(),
-                    version: None,
-                    channel: None,
-                },
-            )
+            self.with_isolated_runtime_mutation(env_name, &current.name, || {
+                self.runtime_service().update_from_release_deferred(
+                    crate::runtime::UpdateRuntimeFromReleaseOptions {
+                        name: current.name.clone(),
+                        version: None,
+                        channel: None,
+                    },
+                )
+            })
         }) {
             Ok(updated) => updated,
             Err(error) => {
@@ -1611,7 +1614,7 @@ impl Cli {
             std::slice::from_ref(&target_runtime_name),
             options.rollback_enabled,
         )?;
-        let prepared = match self.prepare_upgrade_target(env_name, target) {
+        let prepared = match self.prepare_isolated_upgrade_target(env_name, target) {
             Ok(prepared) => prepared,
             Err(error) => {
                 return self.rollback_failed_upgrade(
@@ -1767,6 +1770,31 @@ impl Cli {
             meta,
             action,
         })
+    }
+
+    fn prepare_isolated_upgrade_target(
+        &self,
+        env_name: &str,
+        target: &UpgradeTarget,
+    ) -> Result<PreparedUpgradeTarget, String> {
+        if target.is_named_runtime() {
+            return self.prepare_upgrade_target(env_name, target);
+        }
+        let runtime_name = target.canonical_runtime_name()?;
+        self.with_isolated_runtime_mutation(env_name, &runtime_name, || {
+            self.prepare_upgrade_target(env_name, target)
+        })
+    }
+
+    fn with_isolated_runtime_mutation<T>(
+        &self,
+        env_name: &str,
+        runtime_name: &str,
+        operation: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        let _registry_lock = lock_env_registry(&self.env, &self.cwd)?;
+        self.ensure_runtime_upgrade_isolated(env_name, runtime_name)?;
+        operation()
     }
 
     fn reconcile_upgraded_service(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1260,6 +1260,8 @@ impl Cli {
             });
         }
 
+        self.ensure_runtime_upgrade_isolated(env_name, &current.name)?;
+
         if options.dry_run {
             let service = self.upgrade_service_status(env_name)?;
             return Ok(UpgradeEnvSummary {
@@ -1522,6 +1524,35 @@ impl Cli {
         };
         transaction.cleanup();
         Ok(summary)
+    }
+
+    fn ensure_runtime_upgrade_isolated(
+        &self,
+        env_name: &str,
+        runtime_name: &str,
+    ) -> Result<(), String> {
+        let mut siblings = self
+            .environment_service()
+            .list()?
+            .into_iter()
+            .filter(|env| {
+                env.name != env_name && env.default_runtime.as_deref() == Some(runtime_name)
+            })
+            .map(|env| env.name)
+            .collect::<Vec<_>>();
+        if siblings.is_empty() {
+            return Ok(());
+        }
+
+        siblings.sort();
+        let siblings = siblings
+            .iter()
+            .map(|name| format!("\"{name}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Err(format!(
+            "runtime \"{runtime_name}\" is shared with {siblings}; upgrading env \"{env_name}\" would replace their OpenClaw runtime before their config and state are migrated. Use --runtime {runtime_name} to reuse the installed runtime without updating it, or --version <version> to move this env to an isolated exact release"
+        ))
     }
 
     fn upgrade_launcher_bound_env(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1060,16 +1060,19 @@ impl Cli {
         let previous_binding_name = current.name.clone();
 
         if target.is_explicit() {
+            let target_runtime_name = target.canonical_runtime_name()?;
+            if !target.is_named_runtime() {
+                self.ensure_runtime_upgrade_isolated(env_name, &target_runtime_name)?;
+            }
             let service = self.upgrade_service_status(env_name)?;
             if options.dry_run {
-                let target_runtime = target.canonical_runtime_name()?;
-                let binding_changed = target_runtime != current.name;
+                let binding_changed = target_runtime_name != current.name;
                 return Ok(UpgradeEnvSummary {
                     env_name: env_name.to_string(),
                     previous_binding_kind: "runtime".to_string(),
                     previous_binding_name,
                     binding_kind: "runtime".to_string(),
-                    binding_name: target_runtime,
+                    binding_name: target_runtime_name,
                     outcome: if binding_changed {
                         "would-switch".to_string()
                     } else {
@@ -1089,7 +1092,6 @@ impl Cli {
                     ),
                 });
             }
-            let target_runtime_name = target.canonical_runtime_name()?;
             let transaction = self.begin_upgrade_transaction(
                 env_name,
                 &[current.name.clone(), target_runtime_name.clone()],
@@ -1582,6 +1584,10 @@ impl Cli {
             });
         }
 
+        let target_runtime_name = target.canonical_runtime_name()?;
+        if !target.is_named_runtime() {
+            self.ensure_runtime_upgrade_isolated(env_name, &target_runtime_name)?;
+        }
         let service = self.upgrade_service_status(env_name)?;
         if options.dry_run {
             return Ok(UpgradeEnvSummary {
@@ -1589,7 +1595,7 @@ impl Cli {
                 previous_binding_kind: "launcher".to_string(),
                 previous_binding_name: launcher_name.to_string(),
                 binding_kind: "runtime".to_string(),
-                binding_name: target.canonical_runtime_name()?,
+                binding_name: target_runtime_name,
                 outcome: "would-switch".to_string(),
                 runtime_release_version: None,
                 runtime_release_channel: target.release_channel_hint(),
@@ -1600,7 +1606,6 @@ impl Cli {
             });
         }
 
-        let target_runtime_name = target.canonical_runtime_name()?;
         let transaction = self.begin_upgrade_transaction(
             env_name,
             std::slice::from_ref(&target_runtime_name),

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -94,7 +94,7 @@ fn write_env_registry(
     write_json(&path, &registry)
 }
 
-struct EnvRegistryLock {
+pub(crate) struct EnvRegistryLock {
     file: File,
 }
 
@@ -149,7 +149,7 @@ pub(crate) fn lock_environment_operation(
     Ok(EnvironmentOperationLock { file })
 }
 
-fn lock_env_registry(
+pub(crate) fn lock_env_registry(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvRegistryLock, String> {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use common::{
     ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, write_json,
 };
 pub(crate) use envs::save_environment_with_validated_launcher;
-pub(crate) use envs::{EnvironmentOperationLock, lock_environment_operation};
+pub(crate) use envs::{EnvironmentOperationLock, lock_env_registry, lock_environment_operation};
 pub(crate) use envs::{
     EnvironmentServicePolicyChange, restore_environment_service_policy,
     set_environment_service_policy,

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -278,6 +278,9 @@ fn upgrade_help_is_available_from_help_and_flag() {
     assert!(output.contains("ocm upgrade --all"));
     assert!(output.contains("Simulations clone the source env"));
     assert!(output.contains("Channel-tracked runtimes move forward automatically."));
+    assert!(
+        output.contains("An env upgrade will not replace runtime bytes shared with another env")
+    );
     assert!(output.contains("pre-upgrade snapshot"));
     assert!(output.contains("OpenClaw update finalization"));
 }

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -496,6 +496,88 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     assert_eq!(snapshot_json[0]["label"], "pre-upgrade");
 }
 
+#[test]
+fn upgrade_rejects_mutating_a_runtime_shared_with_another_env() {
+    let root = TestDir::new("upgrade-shared-runtime");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_tarball =
+        openclaw_package_tarball(&recording_openclaw_script("2026.3.24"), "2026.3.24");
+    let old_integrity = sha512_integrity(&old_tarball);
+    let old_tarball_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.3.24.tgz",
+        "application/octet-stream",
+        &old_tarball,
+        10,
+    );
+    let new_tarball =
+        openclaw_package_tarball(&recording_openclaw_script("2026.3.25"), "2026.3.25");
+    let new_integrity = sha512_integrity(&new_tarball);
+    let new_tarball_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.3.25.tgz",
+        "application/octet-stream",
+        &new_tarball,
+        10,
+    );
+    let initial_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.24\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.3.24\":\"2026-03-25T16:35:52.000Z\"}}}}",
+        old_tarball_server.url(),
+        old_integrity
+    );
+    let updated_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.25\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}},\"2026.3.25\":{{\"version\":\"2026.3.25\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.3.24\":\"2026-03-25T16:35:52.000Z\",\"2026.3.25\":\"2026-03-26T09:00:00.000Z\"}}}}",
+        old_tarball_server.url(),
+        old_integrity,
+        new_tarball_server.url(),
+        new_integrity
+    );
+    let packument_server = TestHttpServer::serve_bytes_sequence(
+        "/openclaw",
+        "application/json",
+        vec![
+            initial_packument.as_bytes().to_vec(),
+            initial_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+        ],
+    );
+
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+
+    for name in ["primary", "sibling"] {
+        let start = run_ocm(&cwd, &env, &["start", name, "--no-service"]);
+        assert!(start.status.success(), "{}", stderr(&start));
+    }
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "primary"]);
+    assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
+    let error = stderr(&upgrade);
+    assert!(error.contains("runtime \"stable\" is shared"), "{error}");
+    assert!(error.contains("\"sibling\""), "{error}");
+
+    let runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(runtime.status.success(), "{}", stderr(&runtime));
+    let runtime_json: Value = serde_json::from_str(&stdout(&runtime)).unwrap();
+    assert_eq!(runtime_json["releaseVersion"], "2026.3.24");
+
+    for name in ["primary", "sibling"] {
+        let version = run_ocm(&cwd, &env, &["env", "run", name, "--", "--version"]);
+        assert!(version.status.success(), "{}", stderr(&version));
+        assert_eq!(stdout(&version).trim(), "2026.3.24");
+
+        let snapshots = run_ocm(&cwd, &env, &["env", "snapshot", "list", name, "--json"]);
+        assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+        let snapshot_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+        assert!(snapshot_json.as_array().unwrap().is_empty());
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn upgrade_switches_across_versions_from_runtime_with_broken_package_bin_symlink() {

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -578,6 +578,108 @@ fn upgrade_rejects_mutating_a_runtime_shared_with_another_env() {
     }
 }
 
+#[test]
+fn upgrade_rejects_mutating_a_target_runtime_bound_to_another_env() {
+    let root = TestDir::new("upgrade-shared-target-runtime");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_tarball =
+        openclaw_package_tarball(&recording_openclaw_script("2026.3.24"), "2026.3.24");
+    let old_integrity = sha512_integrity(&old_tarball);
+    let old_tarball_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.3.24.tgz",
+        "application/octet-stream",
+        &old_tarball,
+        10,
+    );
+    let new_tarball =
+        openclaw_package_tarball(&recording_openclaw_script("2026.3.25"), "2026.3.25");
+    let new_integrity = sha512_integrity(&new_tarball);
+    let new_tarball_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.3.25.tgz",
+        "application/octet-stream",
+        &new_tarball,
+        10,
+    );
+    let initial_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.24\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.3.24\":\"2026-03-25T16:35:52.000Z\"}}}}",
+        old_tarball_server.url(),
+        old_integrity
+    );
+    let updated_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.25\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}},\"2026.3.25\":{{\"version\":\"2026.3.25\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.3.24\":\"2026-03-25T16:35:52.000Z\",\"2026.3.25\":\"2026-03-26T09:00:00.000Z\"}}}}",
+        old_tarball_server.url(),
+        old_integrity,
+        new_tarball_server.url(),
+        new_integrity
+    );
+    let packument_server = TestHttpServer::serve_bytes_sequence(
+        "/openclaw",
+        "application/json",
+        vec![
+            initial_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+        ],
+    );
+
+    let source_runtime = root.child("source-openclaw");
+    write_executable_script(&source_runtime, &recording_openclaw_script("source-local"));
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+
+    let add_source = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "add",
+            "source-local",
+            "--path",
+            &source_runtime.display().to_string(),
+        ],
+    );
+    assert!(add_source.status.success(), "{}", stderr(&add_source));
+    let create_source = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "primary", "--runtime", "source-local"],
+    );
+    assert!(create_source.status.success(), "{}", stderr(&create_source));
+    let start_sibling = run_ocm(&cwd, &env, &["start", "sibling", "--no-service"]);
+    assert!(start_sibling.status.success(), "{}", stderr(&start_sibling));
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "primary", "--channel", "stable"]);
+    assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
+    let error = stderr(&upgrade);
+    assert!(error.contains("runtime \"stable\" is shared"), "{error}");
+    assert!(error.contains("\"sibling\""), "{error}");
+
+    let runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(runtime.status.success(), "{}", stderr(&runtime));
+    let runtime_json: Value = serde_json::from_str(&stdout(&runtime)).unwrap();
+    assert_eq!(runtime_json["releaseVersion"], "2026.3.24");
+
+    let source = run_ocm(&cwd, &env, &["env", "show", "primary", "--json"]);
+    assert!(source.status.success(), "{}", stderr(&source));
+    let source_json: Value = serde_json::from_str(&stdout(&source)).unwrap();
+    assert_eq!(source_json["defaultRuntime"], "source-local");
+
+    let snapshots = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "list", "primary", "--json"],
+    );
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshot_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert!(snapshot_json.as_array().unwrap().is_empty());
+}
+
 #[cfg(unix)]
 #[test]
 fn upgrade_switches_across_versions_from_runtime_with_broken_package_bin_symlink() {


### PR DESCRIPTION
## Summary

- reject environment upgrades that would replace runtime bytes used by sibling environments
- serialize the final sibling check with runtime preparation to close the registry race
- preserve named runtime reuse and document exact-version isolation guidance

## Verification

- real OpenClaw `2026.6.11`, `2026.6.33`, and `2026.7.1` shared-runtime command flows
- complete 25-test upgrade suite
- full `cargo test`
- `cargo check --all-targets`
- Windows GNU cross-check
- `cargo fmt --check`
- `git diff --check`
- real `ocm help upgrade` output
