### PR TITLE
fix: protect bound runtime mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ runtime, OCM runs OpenClaw's update finalization path inside that environment
 before service restart. Snapshots preserve managed path, npm, and Git plugin
 payloads together with their package metadata and symlinks, while generated
 plugin dependency caches and live runtime residue stay out of the archive.
+Once an environment is bound to a runtime, direct `runtime update`,
+`runtime install --force`, `runtime build-local --force`, and `runtime remove`
+operations reject that runtime. Use `ocm upgrade <env>` so the environment gets
+the snapshot, OpenClaw migration, rollback, and verification path, or clear the
+binding first when intentionally managing an unused runtime.
 
 `upgrade simulate` clones the source env, leaves the real env untouched, and
 cleans temporary simulation envs and runtimes when the run finishes. For

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1470,7 +1470,7 @@ pub fn release_command_help(cmd: &str, action: &str) -> Option<String> {
                 ("--description <text>", "Optional human description"),
                 (
                     "--force",
-                    "Replace an existing managed runtime of the same name",
+                    "Replace an existing unbound managed runtime of the same name",
                 ),
                 (
                     "--raw",
@@ -1485,6 +1485,7 @@ pub fn release_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "Official installs use canonical runtime names derived from the selector.",
+                "Bound runtimes are reused only when the selected release already matches. Use `ocm upgrade <env>` when OpenClaw bytes must change.",
                 "Official release installs prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm.",
                 "On supported platforms, OCM can manage a private copy when they are missing.",
                 "Use `ocm doctor host` only if you want a full machine check or an explicit host-tool fix like git.",
@@ -1795,7 +1796,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 ("--description <text>", "Optional human description"),
                 (
                     "--force",
-                    "Replace an existing managed runtime of the same name",
+                    "Replace an existing unbound managed runtime of the same name",
                 ),
                 (
                     "--raw",
@@ -1816,6 +1817,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
             &[
                 "Exactly one install source must be provided.",
                 "Official installs use canonical runtime names unless you reuse the same canonical name explicitly.",
+                "Bound runtimes are reused only when the selected release already matches. Use `ocm upgrade <env>` when OpenClaw bytes must change.",
                 "Official release installs prefer host Node.js 22.22.3+, 24.15.0+, or 25.9.0+ and npm.",
                 "On supported platforms, OCM can manage a private copy when they are missing.",
                 "Use `ocm doctor host` only if you want a full machine check or an explicit host-tool fix like git.",
@@ -1835,7 +1837,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 ("--description <text>", "Optional human description"),
                 (
                     "--force",
-                    "Replace an existing managed runtime of the same name after the package is built",
+                    "Replace an existing unbound managed runtime of the same name",
                 ),
                 (
                     "--raw",
@@ -1850,6 +1852,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 "`build-local` uses `npm pack` so OpenClaw's prepack script performs the release-style build, UI build, package inventory, and built entry smoke checks.",
                 "The resulting runtime is installed under OCM's package runtime layout: files/node_modules/openclaw/openclaw.mjs.",
                 "Use this when testing release and upgrade behavior from a local checkout without source/Jiti execution paths.",
+                "A runtime bound to an environment cannot be replaced directly. Clear the binding first or use `ocm upgrade <env>` for published OpenClaw releases.",
             ],
         ),
         "update" => render_leaf(
@@ -1879,7 +1882,10 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 format!("{cmd} runtime update stable --version 0.3.0"),
                 format!("{cmd} runtime update --all"),
             ],
-            &[],
+            &[
+                "Direct updates are limited to unbound runtimes because they do not snapshot or migrate environment state.",
+                "Use `ocm upgrade <env>` to update OpenClaw for a bound environment. `--all` reports bound runtimes as failed without changing them.",
+            ],
         ),
         "releases" => render_leaf(
             "Inspect OpenClaw releases",
@@ -1978,7 +1984,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
         ),
         "remove" | "rm" => render_leaf(
             "Remove a runtime",
-            "Delete a runtime record.",
+            "Delete an unbound runtime record and its managed files.",
             vec![format!("{cmd} runtime remove <name> [--raw] [--json]")],
             &[
                 (
@@ -1988,7 +1994,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 ("--json", "Print the removed runtime record as JSON"),
             ],
             vec![format!("{cmd} runtime remove stable")],
-            &[],
+            &["Clear every environment binding before removing a runtime."],
         ),
         _ => return None,
     })

--- a/src/env/binding.rs
+++ b/src/env/binding.rs
@@ -1,7 +1,7 @@
 use super::{EnvMeta, EnvironmentService};
 use crate::store::{
-    get_environment, get_runtime_verified, save_environment,
-    save_environment_with_validated_launcher,
+    get_environment, save_environment, save_environment_with_validated_launcher,
+    save_environment_with_validated_runtime,
 };
 use crate::supervisor::sync_supervisor_if_present;
 
@@ -26,11 +26,14 @@ impl<'a> EnvironmentService<'a> {
         if runtime_name.eq_ignore_ascii_case("none") {
             meta.default_runtime = None;
         } else {
-            get_runtime_verified(runtime_name, self.env, self.cwd)?;
             meta.default_runtime = Some(runtime_name.to_string());
             meta.default_launcher = None;
         }
-        let meta = save_environment(meta, self.env, self.cwd)?;
+        let meta = if meta.default_runtime.is_some() {
+            save_environment_with_validated_runtime(meta, self.env, self.cwd)?
+        } else {
+            save_environment(meta, self.env, self.cwd)?
+        };
         sync_supervisor_if_present(self.env, self.cwd)?;
         Ok(meta)
     }

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -6,10 +6,10 @@ use super::EnvironmentService;
 use crate::runtime::RuntimeService;
 use crate::store::{
     EnvironmentOperationLock, clone_environment, clone_environment_for_simulation,
-    create_environment, export_environment, get_environment, get_runtime_verified,
-    import_environment, list_environments, lock_environment_operation, now_utc, remove_environment,
-    resolve_config_gateway_port, resolve_effective_gateway_ports, resolve_env_gateway_port,
-    save_environment, set_environment_service_policy,
+    create_environment_with_validated_runtime, export_environment, get_environment,
+    get_runtime_verified, import_environment, list_environments, lock_environment_operation,
+    now_utc, remove_environment, resolve_config_gateway_port, resolve_effective_gateway_ports,
+    resolve_env_gateway_port, save_environment, set_environment_service_policy,
 };
 use crate::supervisor::sync_supervisor_if_present;
 
@@ -227,10 +227,7 @@ impl<'a> EnvironmentService<'a> {
     }
 
     pub fn create(&self, options: CreateEnvironmentOptions) -> Result<EnvMeta, String> {
-        if let Some(runtime_name) = options.default_runtime.as_deref() {
-            get_runtime_verified(runtime_name, self.env, self.cwd)?;
-        }
-        let meta = create_environment(options, self.env, self.cwd)?;
+        let meta = create_environment_with_validated_runtime(options, self.env, self.cwd)?;
         sync_supervisor_if_present(self.env, self.cwd)?;
         Ok(meta)
     }

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -143,7 +143,7 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: InstallRuntimeFromOfficialReleaseOptions,
     ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
-        self.prepare_official_openclaw_runtime_with_refresh(options, true)
+        self.prepare_official_openclaw_runtime_with_refresh(options, true, true)
     }
 
     pub(crate) fn prepare_official_openclaw_runtime_deferred(
@@ -152,13 +152,14 @@ impl<'a> RuntimeService<'a> {
     ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
         // Upgrade finalization must run before changed runtime metadata reaches the live
         // supervisor; the upgrade transaction publishes one coherent state afterward.
-        self.prepare_official_openclaw_runtime_with_refresh(options, false)
+        self.prepare_official_openclaw_runtime_with_refresh(options, false, false)
     }
 
     fn prepare_official_openclaw_runtime_with_refresh(
         &self,
         options: InstallRuntimeFromOfficialReleaseOptions,
         refresh_supervisor: bool,
+        require_unbound: bool,
     ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
         let version = options
             .version
@@ -240,29 +241,36 @@ impl<'a> RuntimeService<'a> {
                 .as_ref()
                 .and_then(|meta| meta.description.clone())
         });
-        let install = install_runtime_from_selected_official_openclaw_release(
-            runtime_name.clone(),
-            options.force || existing_meta.is_some(),
-            releases_url,
-            selected_release,
-            RuntimeReleaseDetails::with_selector(
-                match (version.as_deref(), channel.as_deref()) {
-                    (Some(_), None) => Some(RuntimeReleaseSelectorKind::Version),
-                    (None, Some(_)) => Some(RuntimeReleaseSelectorKind::Channel),
-                    _ => None,
+        let install = || {
+            install_runtime_from_selected_official_openclaw_release(
+                runtime_name.clone(),
+                options.force || existing_meta.is_some(),
+                releases_url,
+                selected_release,
+                RuntimeReleaseDetails::with_selector(
+                    match (version.as_deref(), channel.as_deref()) {
+                        (Some(_), None) => Some(RuntimeReleaseSelectorKind::Version),
+                        (None, Some(_)) => Some(RuntimeReleaseSelectorKind::Channel),
+                        _ => None,
+                    },
+                    match (version, channel) {
+                        (Some(version), None) => Some(version),
+                        (None, Some(channel)) => Some(channel),
+                        _ => None,
+                    },
+                ),
+                description,
+                InstallContext {
+                    env: self.env,
+                    cwd: self.cwd,
                 },
-                match (version, channel) {
-                    (Some(version), None) => Some(version),
-                    (None, Some(channel)) => Some(channel),
-                    _ => None,
-                },
-            ),
-            description,
-            InstallContext {
-                env: self.env,
-                cwd: self.cwd,
-            },
-        )?;
+            )
+        };
+        let install = if require_unbound {
+            self.with_unbound_runtime(&runtime_name, install)?
+        } else {
+            install()?
+        };
         let action = if install.reused {
             OfficialRuntimePrepareAction::Reused
         } else if existing_meta.is_some() {
@@ -277,7 +285,9 @@ impl<'a> RuntimeService<'a> {
     }
 
     pub fn install(&self, options: InstallRuntimeOptions) -> Result<RuntimeMeta, String> {
-        let meta = install_runtime(options, self.env, self.cwd)?;
+        let name = options.name.clone();
+        let meta =
+            self.with_unbound_runtime(&name, || install_runtime(options, self.env, self.cwd))?;
         self.refresh_supervisor_if_present()?;
         Ok(meta)
     }
@@ -286,7 +296,10 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: InstallRuntimeFromUrlOptions,
     ) -> Result<RuntimeMeta, String> {
-        let meta = install_runtime_from_url(options, self.env, self.cwd)?;
+        let name = options.name.clone();
+        let meta = self.with_unbound_runtime(&name, || {
+            install_runtime_from_url(options, self.env, self.cwd)
+        })?;
         self.refresh_supervisor_if_present()?;
         Ok(meta)
     }
@@ -295,7 +308,10 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: InstallRuntimeFromReleaseOptions,
     ) -> Result<RuntimeMeta, String> {
-        let meta = install_runtime_from_release(options, self.env, self.cwd)?;
+        let name = options.name.clone();
+        let meta = self.with_unbound_runtime(&name, || {
+            install_runtime_from_release(options, self.env, self.cwd)
+        })?;
         self.refresh_supervisor_if_present()?;
         Ok(meta)
     }
@@ -304,24 +320,30 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: InstallRuntimeFromOfficialReleaseOptions,
     ) -> Result<RuntimeMeta, String> {
-        let meta = install_runtime_from_official_openclaw_release(options, self.env, self.cwd)?;
+        let name = options.name.clone();
+        let meta = self.with_unbound_runtime(&name, || {
+            install_runtime_from_official_openclaw_release(options, self.env, self.cwd)
+        })?;
         self.refresh_supervisor_if_present()?;
         Ok(meta)
     }
 
     pub fn build_local(&self, options: BuildLocalRuntimeOptions) -> Result<RuntimeMeta, String> {
-        let meta = install_runtime_from_local_openclaw_build(
-            StoreBuildLocalRuntimeOptions {
-                name: options.name,
-                repo: options.repo,
-                description: options.description,
-                force: options.force,
-            },
-            InstallContext {
-                env: self.env,
-                cwd: self.cwd,
-            },
-        )?;
+        let name = options.name.clone();
+        let meta = self.with_unbound_runtime(&name, || {
+            install_runtime_from_local_openclaw_build(
+                StoreBuildLocalRuntimeOptions {
+                    name: options.name,
+                    repo: options.repo,
+                    description: options.description,
+                    force: options.force,
+                },
+                InstallContext {
+                    env: self.env,
+                    cwd: self.cwd,
+                },
+            )
+        })?;
         self.refresh_supervisor_if_present()?;
         Ok(meta)
     }
@@ -330,7 +352,10 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: UpdateRuntimeFromReleaseOptions,
     ) -> Result<RuntimeMeta, String> {
-        self.update_from_release_with_refresh(options, true)
+        let name = options.name.clone();
+        self.with_unbound_runtime(&name, || {
+            self.update_from_release_with_refresh(options, true)
+        })
     }
 
     pub(crate) fn update_from_release_deferred(

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-use crate::store::{add_runtime, get_runtime_verified, list_runtimes, remove_runtime};
+use crate::store::{
+    add_runtime, get_runtime_verified, list_runtimes, remove_runtime, with_locked_environments,
+};
 use crate::supervisor::sync_supervisor_if_present;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -91,6 +93,27 @@ pub struct RuntimeService<'a> {
 }
 
 impl<'a> RuntimeService<'a> {
+    fn with_unbound_runtime<T>(
+        &self,
+        name: &str,
+        action: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        with_locked_environments(self.env, self.cwd, |envs| {
+            let bound_envs = envs
+                .iter()
+                .filter(|environment| environment.default_runtime.as_deref() == Some(name))
+                .map(|environment| format!("\"{}\"", environment.name))
+                .collect::<Vec<_>>();
+            if !bound_envs.is_empty() {
+                return Err(format!(
+                    "runtime \"{name}\" is still used by environment(s): {}; direct runtime changes bypass per-environment snapshots and OpenClaw migration. Upgrade those environments with `ocm upgrade`, or clear their runtime bindings before changing it",
+                    bound_envs.join(", ")
+                ));
+            }
+            action()
+        })
+    }
+
     pub(crate) fn refresh_supervisor_if_present(&self) -> Result<(), String> {
         sync_supervisor_if_present(self.env, self.cwd)?;
         Ok(())
@@ -101,7 +124,8 @@ impl<'a> RuntimeService<'a> {
     }
 
     pub fn add(&self, options: AddRuntimeOptions) -> Result<RuntimeMeta, String> {
-        let meta = add_runtime(options, self.env, self.cwd)?;
+        let name = options.name.clone();
+        let meta = self.with_unbound_runtime(&name, || add_runtime(options, self.env, self.cwd))?;
         self.refresh_supervisor_if_present()?;
         Ok(meta)
     }
@@ -115,7 +139,7 @@ impl<'a> RuntimeService<'a> {
     }
 
     pub fn remove(&self, name: &str) -> Result<RuntimeMeta, String> {
-        let meta = remove_runtime(name, self.env, self.cwd)?;
+        let meta = self.with_unbound_runtime(name, || remove_runtime(name, self.env, self.cwd))?;
         self.refresh_supervisor_if_present()?;
         Ok(meta)
     }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -93,7 +93,7 @@ pub struct RuntimeService<'a> {
 }
 
 impl<'a> RuntimeService<'a> {
-    fn with_unbound_runtime<T>(
+    pub(super) fn with_unbound_runtime<T>(
         &self,
         name: &str,
         action: impl FnOnce() -> Result<T, String>,

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -367,18 +367,39 @@ pub fn create_environment(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
+    create_environment_with_runtime_validation(options, false, env, cwd)
+}
+
+pub(crate) fn create_environment_with_validated_runtime(
+    options: CreateEnvironmentOptions,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
+    create_environment_with_runtime_validation(options, true, env, cwd)
+}
+
+fn create_environment_with_runtime_validation(
+    options: CreateEnvironmentOptions,
+    validate_runtime: bool,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
     let name = validate_name(&options.name, "Environment name")?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
     if find_environment(&registry, &name).is_some() {
         return Err(format!("environment \"{name}\" already exists"));
     }
-    let default_runtime = options
-        .default_runtime
-        .as_deref()
-        .map(|runtime_name| super::runtimes::get_runtime_verified(runtime_name, env, cwd))
-        .transpose()?
-        .map(|runtime| runtime.name);
+    let default_runtime = if validate_runtime {
+        options
+            .default_runtime
+            .as_deref()
+            .map(|runtime_name| super::runtimes::get_runtime_verified(runtime_name, env, cwd))
+            .transpose()?
+            .map(|runtime| runtime.name)
+    } else {
+        options.default_runtime
+    };
     let default_launcher = options
         .default_launcher
         .as_deref()

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -276,6 +276,23 @@ pub(crate) fn save_environment_with_validated_launcher(
     Ok(meta)
 }
 
+pub(crate) fn save_environment_with_validated_runtime(
+    mut meta: EnvMeta,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
+    let _lock = lock_env_registry(env, cwd)?;
+    let mut registry = load_env_registry(env, cwd)?;
+    if let Some(runtime_name) = meta.default_runtime.as_deref() {
+        meta.default_runtime =
+            Some(super::runtimes::get_runtime_verified(runtime_name, env, cwd)?.name);
+    }
+    meta = upsert_environment(&mut registry, meta)?;
+    write_env_registry(&mut registry, env, cwd)?;
+
+    Ok(meta)
+}
+
 pub(crate) fn set_environment_service_policy(
     name: &str,
     service_enabled: Option<bool>,
@@ -356,6 +373,12 @@ pub fn create_environment(
     if find_environment(&registry, &name).is_some() {
         return Err(format!("environment \"{name}\" already exists"));
     }
+    let default_runtime = options
+        .default_runtime
+        .as_deref()
+        .map(|runtime_name| super::runtimes::get_runtime_verified(runtime_name, env, cwd))
+        .transpose()?
+        .map(|runtime| runtime.name);
     let default_launcher = options
         .default_launcher
         .as_deref()
@@ -401,7 +424,7 @@ pub fn create_environment(
         gateway_port_auto_assigned,
         service_enabled: options.service_enabled,
         service_running: options.service_running,
-        default_runtime: options.default_runtime,
+        default_runtime,
         default_launcher,
         dev: options.dev,
         protected: options.protected,
@@ -994,7 +1017,7 @@ pub fn remove_environment(
     Ok(meta)
 }
 
-pub(super) fn with_locked_environments<T>(
+pub(crate) fn with_locked_environments<T>(
     env: &BTreeMap<String, String>,
     cwd: &Path,
     action: impl FnOnce(&[EnvMeta]) -> Result<T, String>,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -19,7 +19,6 @@ use crate::env::EnvSummary;
 pub(crate) use common::{
     ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, write_json,
 };
-pub(crate) use envs::save_environment_with_validated_launcher;
 pub(crate) use envs::{EnvironmentOperationLock, lock_env_registry, lock_environment_operation};
 pub(crate) use envs::{
     EnvironmentServicePolicyChange, restore_environment_service_policy,
@@ -32,6 +31,10 @@ pub use envs::{
 pub(crate) use envs::{
     clone_environment_for_simulation, clone_environment_with_sandbox_origin,
     import_environment_with_sandbox_origin,
+};
+pub(crate) use envs::{
+    save_environment_with_validated_launcher, save_environment_with_validated_runtime,
+    with_locked_environments,
 };
 pub(crate) use gateway_ports::{
     openclaw_port_family_available, openclaw_port_family_range, resolve_config_gateway_port,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -30,7 +30,7 @@ pub use envs::{
 };
 pub(crate) use envs::{
     clone_environment_for_simulation, clone_environment_with_sandbox_origin,
-    import_environment_with_sandbox_origin,
+    create_environment_with_validated_runtime, import_environment_with_sandbox_origin,
 };
 pub(crate) use envs::{
     save_environment_with_validated_launcher, save_environment_with_validated_runtime,

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -609,12 +609,38 @@ fn runtime_and_service_leaf_help_are_command_specific() {
     assert!(output.contains(
         "Use `ocm doctor host` only if you want a full machine check or an explicit host-tool fix like git."
     ));
+    assert!(
+        output
+            .contains("Bound runtimes are reused only when the selected release already matches.")
+    );
 
     let service = run_ocm(&cwd, &env, &["service", "start", "--help"]);
     assert!(service.status.success(), "{}", stderr(&service));
     let output = stdout(&service);
     assert!(output.contains("Start an env under the background service"));
     assert!(output.contains("ocm service start <env> [--raw] [--json]"));
+}
+
+#[test]
+fn runtime_mutation_help_directs_bound_environments_to_upgrade() {
+    let root = TestDir::new("help-runtime-bound-mutations");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    for command in [
+        vec!["help", "runtime", "install"],
+        vec!["help", "runtime", "build-local"],
+        vec!["help", "runtime", "update"],
+    ] {
+        let help = run_ocm(&cwd, &env, &command);
+        assert!(help.status.success(), "{}", stderr(&help));
+        assert!(stdout(&help).contains("ocm upgrade <env>"));
+    }
+
+    let remove = run_ocm(&cwd, &env, &["help", "runtime", "remove"]);
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    assert!(stdout(&remove).contains("Clear every environment binding"));
 }
 
 #[test]
@@ -639,6 +665,10 @@ fn release_install_help_mentions_doctor_host() {
     assert!(output.contains(
         "Use `ocm doctor host` only if you want a full machine check or an explicit host-tool fix like git."
     ));
+    assert!(
+        output
+            .contains("Bound runtimes are reused only when the selected release already matches.")
+    );
 }
 
 #[test]

--- a/tests/release_command_tests.rs
+++ b/tests/release_command_tests.rs
@@ -425,6 +425,12 @@ fn release_install_reuses_a_matching_installed_runtime() {
     let first = run_ocm(&cwd, &env, &["release", "install", "--channel", "stable"]);
     assert!(first.status.success(), "{}", stderr(&first));
     assert!(stdout(&first).contains("Installed runtime stable"));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
 
     let second = run_ocm(&cwd, &env, &["release", "install", "--channel", "stable"]);
     assert!(second.status.success(), "{}", stderr(&second));

--- a/tests/runtime_binding_tests.rs
+++ b/tests/runtime_binding_tests.rs
@@ -1,10 +1,14 @@
 mod support;
 
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
 
 use base64::Engine;
 use flate2::{Compression, write::GzEncoder};
-use ocm::store::clean_path;
+use fs2::FileExt;
+use ocm::store::{clean_path, env_registry_path};
 use sha2::{Digest, Sha512};
 use tar::{Builder, Header};
 
@@ -92,6 +96,78 @@ fn env_set_runtime_updates_and_clears_the_default_runtime() {
     let show_cleared = run_ocm(&cwd, &env, &["env", "show", "demo"]);
     assert!(show_cleared.status.success(), "{}", stderr(&show_cleared));
     assert!(!stdout(&show_cleared).contains("defaultRuntime:"));
+}
+
+#[test]
+fn runtime_binding_and_removal_share_the_environment_registry_lock() {
+    let root = TestDir::new("runtime-binding-remove-lock");
+    let cwd = root.child("workspace");
+    let bin_dir = cwd.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_executable_script(&bin_dir.join("stable"), "#!/bin/sh\nexit 0\n");
+    let env = ocm_env(&root);
+
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "add", "stable", "--path", "./bin/stable"],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(&cwd, &env, &["env", "create", "demo"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let lock_path = env_registry_path(&env, &cwd)
+        .unwrap()
+        .with_extension("lock");
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(lock_path)
+        .unwrap();
+    lock.lock_exclusive().unwrap();
+
+    let mut bind = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    bind.current_dir(&cwd)
+        .args(["env", "set-runtime", "demo", "stable"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut bind = bind.spawn().unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    let mut remove = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    remove
+        .current_dir(&cwd)
+        .args(["runtime", "remove", "stable"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut remove = remove.spawn().unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    assert!(bind.try_wait().unwrap().is_none());
+    assert!(remove.try_wait().unwrap().is_none());
+    FileExt::unlock(&lock).unwrap();
+
+    let bind = bind.wait_with_output().unwrap();
+    let remove = remove.wait_with_output().unwrap();
+    assert_ne!(bind.status.success(), remove.status.success());
+
+    let environment = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(environment.status.success(), "{}", stderr(&environment));
+    let environment: serde_json::Value = serde_json::from_str(&stdout(&environment)).unwrap();
+    let runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable"]);
+    if bind.status.success() {
+        assert!(runtime.status.success(), "{}", stderr(&runtime));
+        assert_eq!(environment["defaultRuntime"], "stable");
+    } else {
+        assert!(!runtime.status.success());
+        assert!(environment["defaultRuntime"].is_null());
+    }
 }
 
 #[test]

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -517,6 +517,49 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
 }
 
 #[test]
+fn runtime_build_local_rejects_a_bound_runtime_before_repo_validation() {
+    let root = TestDir::new("runtime-build-local-bound");
+    let cwd = root.child("workspace");
+    let bin_dir = cwd.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_executable_script(&bin_dir.join("main-local"), "#!/bin/sh\nexit 0\n");
+    let env = ocm_env(&root);
+
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "add", "main-local", "--path", "./bin/main-local"],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "main-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "main-local",
+            "--repo",
+            "./missing-openclaw",
+            "--force",
+        ],
+    );
+    assert_eq!(build.status.code(), Some(1));
+    let error = stderr(&build);
+    assert!(
+        error.contains("runtime \"main-local\" is still used"),
+        "{error}"
+    );
+    assert!(!error.contains("repo path does not exist"), "{error}");
+}
+
+#[test]
 fn runtime_build_local_uses_repo_workspace_dependency_adapter() {
     let root = TestDir::new("runtime-build-local-workspace-adapter");
     let cwd = root.child("workspace");
@@ -1221,6 +1264,99 @@ fn runtime_install_refreshes_a_channel_runtime_when_the_published_release_moves(
 }
 
 #[test]
+fn bound_official_runtime_is_reused_but_not_refreshed() {
+    let root = TestDir::new("runtime-install-official-bound");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let stable_tar = openclaw_package_tarball("#!/usr/bin/env node\nconsole.log('stable-1');\n");
+    let stable_integrity = sha512_integrity(&stable_tar);
+    let next_tar = openclaw_package_tarball("#!/usr/bin/env node\nconsole.log('stable-2');\n");
+    let next_integrity = sha512_integrity(&next_tar);
+    let stable_tarball_server = TestHttpServer::serve_bytes(
+        "/openclaw-2026.3.24.tgz",
+        "application/octet-stream",
+        &stable_tar,
+    );
+    let next_tarball_server = TestHttpServer::serve_bytes(
+        "/openclaw-2026.3.25.tgz",
+        "application/octet-stream",
+        &next_tar,
+    );
+    let stable_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.24\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}}}}",
+        stable_tarball_server.url(),
+        stable_integrity
+    );
+    let moved_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.25\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}},\"2026.3.25\":{{\"version\":\"2026.3.25\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}}}}",
+        stable_tarball_server.url(),
+        stable_integrity,
+        next_tarball_server.url(),
+        next_integrity
+    );
+    let packument_server = TestHttpServer::serve_bytes_sequence(
+        "/openclaw",
+        "application/json",
+        vec![
+            stable_packument.as_bytes().to_vec(),
+            stable_packument.into_bytes(),
+            moved_packument.as_bytes().to_vec(),
+            moved_packument.into_bytes(),
+        ],
+    );
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+
+    let install = run_ocm(&cwd, &env, &["runtime", "install", "--channel", "stable"]);
+    assert!(install.status.success(), "{}", stderr(&install));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let reuse = run_ocm(&cwd, &env, &["runtime", "install", "--channel", "stable"]);
+    assert!(reuse.status.success(), "{}", stderr(&reuse));
+    assert!(stdout(&reuse).contains("Using installed runtime stable"));
+
+    let refresh = run_ocm(&cwd, &env, &["runtime", "install", "--channel", "stable"]);
+    assert_eq!(refresh.status.code(), Some(1));
+    let error = stderr(&refresh);
+    assert!(
+        error.contains("runtime \"stable\" is still used"),
+        "{error}"
+    );
+    assert!(error.contains("\"demo\""), "{error}");
+
+    let create_on_moved_channel = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "second", "--channel", "stable"],
+    );
+    assert_eq!(create_on_moved_channel.status.code(), Some(1));
+    assert!(
+        stderr(&create_on_moved_channel).contains("runtime \"stable\" is still used"),
+        "{}",
+        stderr(&create_on_moved_channel)
+    );
+    assert!(next_tarball_server.requests().is_empty());
+
+    let show = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    assert!(stdout(&show).contains("\"releaseVersion\": \"2026.3.24\""));
+    let list = run_ocm(&cwd, &env, &["env", "list", "--json"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    let environments: Value = serde_json::from_str(&stdout(&list)).unwrap();
+    assert_eq!(environments.as_array().unwrap().len(), 1);
+}
+
+#[test]
 fn runtime_releases_without_manifest_url_use_the_official_openclaw_source() {
     let root = TestDir::new("runtime-releases-official");
     let cwd = root.child("workspace");
@@ -1653,6 +1789,89 @@ fn runtime_update_reinstalls_a_manifest_backed_runtime_with_a_new_version() {
     assert!(output.contains("releaseVersion: 0.3.0"));
     assert!(output.contains("releaseChannel: stable"));
     assert!(output.contains(&format!("sourceSha256: {next_sha256}")));
+}
+
+#[test]
+fn runtime_update_rejects_a_bound_runtime_without_fetching_the_replacement() {
+    let root = TestDir::new("runtime-update-bound");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let stable_body = b"runtime-v0.2.0";
+    let stable_digest_path = root.child("sha256/openclaw-0.2.0");
+    fs::create_dir_all(stable_digest_path.parent().unwrap()).unwrap();
+    fs::write(&stable_digest_path, stable_body).unwrap();
+    let stable_sha256 = file_sha256(&stable_digest_path).unwrap();
+    let next_body = b"runtime-v0.3.0";
+    let next_digest_path = root.child("sha256/openclaw-0.3.0");
+    fs::write(&next_digest_path, next_body).unwrap();
+    let next_sha256 = file_sha256(&next_digest_path).unwrap();
+    let stable_server = TestHttpServer::serve_bytes(
+        "/artifacts/openclaw-0.2.0",
+        "application/octet-stream",
+        stable_body,
+    );
+    let next_server = TestHttpServer::serve_bytes(
+        "/artifacts/openclaw-0.3.0",
+        "application/octet-stream",
+        next_body,
+    );
+    let manifest_body = format!(
+        "{{\"releases\":[{{\"version\":\"0.2.0\",\"channel\":\"stable\",\"url\":\"{}\",\"sha256\":\"{}\"}},{{\"version\":\"0.3.0\",\"channel\":\"stable\",\"url\":\"{}\",\"sha256\":\"{}\"}}]}}",
+        stable_server.url(),
+        stable_sha256,
+        next_server.url(),
+        next_sha256
+    );
+    let manifest_server = TestHttpServer::serve_bytes(
+        "/manifests/releases.json",
+        "application/json",
+        manifest_body.as_bytes(),
+    );
+    let env = ocm_env(&root);
+
+    let install = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "install",
+            "stable",
+            "--manifest-url",
+            &manifest_server.url(),
+            "--version",
+            "0.2.0",
+        ],
+    );
+    assert!(install.status.success(), "{}", stderr(&install));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let update = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "update", "stable", "--version", "0.3.0"],
+    );
+    assert_eq!(update.status.code(), Some(1));
+    let error = stderr(&update);
+    assert!(
+        error.contains("runtime \"stable\" is still used"),
+        "{error}"
+    );
+    assert!(next_server.requests().is_empty());
+
+    let show = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    assert!(stdout(&show).contains("\"releaseVersion\": \"0.2.0\""));
+    let binary = runtime_install_root("stable", &env, &cwd).unwrap();
+    assert_eq!(
+        fs::read(binary.join("files/openclaw-0.2.0")).unwrap(),
+        stable_body
+    );
 }
 
 #[test]
@@ -2175,6 +2394,64 @@ fn runtime_install_force_replaces_an_existing_runtime_definition() {
         "\"binaryPath\": \"{}\"",
         path_string(&expected_binary)
     )));
+}
+
+#[test]
+fn runtime_install_force_rejects_replacing_a_bound_runtime() {
+    let root = TestDir::new("runtime-install-force-bound");
+    let cwd = root.child("workspace");
+    let source_dir = cwd.join("downloads");
+    fs::create_dir_all(&source_dir).unwrap();
+    let original_path = source_dir.join("openclaw-original");
+    let replacement_path = source_dir.join("openclaw-replacement");
+    write_executable_script(&original_path, "#!/bin/sh\nprintf 'original\\n'\n");
+    write_executable_script(&replacement_path, "#!/bin/sh\nprintf 'replacement\\n'\n");
+    let env = ocm_env(&root);
+
+    let install = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "install",
+            "stable",
+            "--path",
+            "./downloads/openclaw-original",
+        ],
+    );
+    assert!(install.status.success(), "{}", stderr(&install));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let replace = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "install",
+            "stable",
+            "--path",
+            "./downloads/openclaw-replacement",
+            "--force",
+        ],
+    );
+    assert_eq!(replace.status.code(), Some(1));
+    let error = stderr(&replace);
+    assert!(
+        error.contains("runtime \"stable\" is still used"),
+        "{error}"
+    );
+
+    let install_root = runtime_install_root("stable", &env, &cwd).unwrap();
+    assert_eq!(
+        fs::read_to_string(install_root.join("files/openclaw-original")).unwrap(),
+        "#!/bin/sh\nprintf 'original\\n'\n"
+    );
+    assert!(!install_root.join("files/openclaw-replacement").exists());
 }
 
 #[test]

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -2178,14 +2178,20 @@ fn runtime_update_all_uses_stored_selectors_and_skips_registered_runtimes() {
         "{}",
         stderr(&install_tracked)
     );
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "nightly"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
 
     let update = run_ocm(&cwd, &env, &["runtime", "update", "--all", "--json"]);
-    assert!(update.status.success(), "{}", stderr(&update));
+    assert_eq!(update.status.code(), Some(1));
     let value: Value = serde_json::from_str(&stdout(&update)).unwrap();
     assert_eq!(value["count"], 3);
-    assert_eq!(value["updated"], 2);
+    assert_eq!(value["updated"], 1);
     assert_eq!(value["skipped"], 1);
-    assert_eq!(value["failed"], 0);
+    assert_eq!(value["failed"], 1);
     let array = value["results"].as_array().unwrap();
     assert_eq!(array.len(), 3);
     assert!(array.iter().any(|item| {
@@ -2203,18 +2209,24 @@ fn runtime_update_all_uses_stored_selectors_and_skips_registered_runtimes() {
     }));
     assert!(array.iter().any(|item| {
         item["name"] == "nightly"
-            && item["outcome"] == "updated"
-            && item["releaseVersion"] == "0.3.0-dev"
+            && item["outcome"] == "failed"
+            && item["releaseVersion"] == "0.2.0-dev"
             && item["releaseChannel"] == "nightly"
+            && item["issue"]
+                .as_str()
+                .unwrap()
+                .contains("runtime \"nightly\" is still used")
     }));
+    assert!(tracked_second_server.requests().is_empty());
 
     let update_plain = run_ocm(&cwd, &env, &["runtime", "update", "--all"]);
-    assert!(update_plain.status.success(), "{}", stderr(&update_plain));
+    assert_eq!(update_plain.status.code(), Some(1));
     let plain_output = stdout(&update_plain);
-    assert!(plain_output.contains("Runtime update summary: total=3 updated=2 skipped=1 failed=0"));
+    assert!(plain_output.contains("Runtime update summary: total=3 updated=1 skipped=1 failed=1"));
     assert!(plain_output.contains("external  outcome=skipped"));
     assert!(plain_output.contains("stable-pinned  outcome=updated"));
-    assert!(plain_output.contains("nightly  outcome=updated"));
+    assert!(plain_output.contains("nightly  outcome=failed"));
+    assert!(tracked_second_server.requests().is_empty());
 }
 
 #[test]

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -267,6 +267,84 @@ fn runtime_show_and_remove_use_runtime_metadata() {
 }
 
 #[test]
+fn runtime_remove_rejects_a_runtime_bound_to_an_environment() {
+    let root = TestDir::new("runtime-remove-bound");
+    let cwd = root.child("workspace");
+    let bin_dir = cwd.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    write_executable_script(&bin_dir.join("stable"), "#!/bin/sh\nexit 0\n");
+    let env = ocm_env(&root);
+
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "add", "stable", "--path", "./bin/stable"],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let remove = run_ocm(&cwd, &env, &["runtime", "remove", "stable"]);
+    assert_eq!(remove.status.code(), Some(1));
+    let error = stderr(&remove);
+    assert!(
+        error.contains("runtime \"stable\" is still used"),
+        "{error}"
+    );
+    assert!(error.contains("\"demo\""), "{error}");
+    assert!(error.contains("ocm upgrade"), "{error}");
+
+    let show = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let environment = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(environment.status.success(), "{}", stderr(&environment));
+    assert!(stdout(&environment).contains("\"defaultRuntime\": \"stable\""));
+}
+
+#[test]
+fn runtime_add_rejects_a_name_referenced_by_a_stale_binding() {
+    let root = TestDir::new("runtime-add-stale-binding");
+    let cwd = root.child("workspace");
+    let bin_dir = cwd.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let runtime_path = bin_dir.join("stable");
+    write_executable_script(&runtime_path, "#!/bin/sh\nexit 0\n");
+    let env = ocm_env(&root);
+
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "add", "stable", "--path", "./bin/stable"],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    fs::remove_file(root.child("ocm-home/runtimes/stable.json")).unwrap();
+
+    let replacement = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "add", "stable", "--path", "./bin/stable"],
+    );
+    assert_eq!(replacement.status.code(), Some(1));
+    let error = stderr(&replacement);
+    assert!(
+        error.contains("runtime \"stable\" is still used"),
+        "{error}"
+    );
+    assert!(error.contains("\"demo\""), "{error}");
+    assert!(!root.child("ocm-home/runtimes/stable.json").exists());
+}
+
+#[test]
 fn runtime_install_and_which_use_the_managed_binary_path() {
     let root = TestDir::new("runtime-install-which");
     let cwd = root.child("workspace");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2414,12 +2414,7 @@ fn upgrade_all_json_exits_failed_when_any_env_fails() {
     );
     assert!(create.status.success(), "{}", stderr(&create));
 
-    let remove_runtime = run_ocm(&cwd, &env, &["runtime", "remove", "missing-soon"]);
-    assert!(
-        remove_runtime.status.success(),
-        "{}",
-        stderr(&remove_runtime)
-    );
+    fs::remove_file(root.child("ocm-home/runtimes/missing-soon.json")).unwrap();
 
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "--all", "--json"]);
     assert!(!upgrade.status.success(), "{}", stdout(&upgrade));


### PR DESCRIPTION
## Summary

- reject direct runtime replacement, update, build, and removal while an environment references the runtime
- keep matching official release reuse and transactional `ocm upgrade` behavior intact
- serialize environment binding changes with runtime mutation checks and preserve portable unresolved metadata flows
- document the safety rule in README and command help

## Verification

- AWS Crabbox lease `cbx_a55a7013c2d7`: targeted runtime, binding, release, upgrade, help, store, and concurrency tests
- `cargo check --all-targets`
- `cargo check --target x86_64-pc-windows-gnu`
- real OpenClaw flow: direct replacement of a bound `2026.6.33` runtime rejected; transactional upgrade to `2026.7.1` completed with snapshot, finalization, and verification
- frozen OpenClaw source reference: `ec8f957f2e7ca3125824d610a2ad5a53446d6631`
