### PR TITLE
fix: reject unsafe OpenClaw downgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ runtime, OCM runs OpenClaw's update finalization path inside that environment
 before service restart. Snapshots preserve managed path, npm, and Git plugin
 payloads together with their package metadata and symlinks, while generated
 plugin dependency caches and live runtime residue stay out of the archive.
+When both OpenClaw versions are known, `upgrade` rejects an older target before
+creating a snapshot, downloading the target, or changing runtime metadata.
+Switching only the binary cannot reverse newer OpenClaw config or SQLite state
+migrations; returning to an older release requires a complete snapshot captured
+while that release and its state schema were active.
 Once an environment is bound to a runtime, direct `runtime update`,
 `runtime install --force`, `runtime build-local --force`, and `runtime remove`
 operations reject that runtime. Use `ocm upgrade <env>` so the environment gets

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -581,6 +581,7 @@ pub fn upgrade_help(cmd: &str) -> String {
             "Local-repo simulations validate deps/build/UI build before post-update checks.",
             "Post-update checks run update-mode doctor, plugin update dry-run, and gateway status.",
             "Channel-tracked runtimes move forward automatically.",
+            "When current and target OpenClaw versions are known, older targets are rejected before snapshot creation or runtime mutation because config and SQLite state migrations cannot be reversed by switching binaries.",
             "An env upgrade will not replace runtime bytes shared with another env; use --runtime to reuse those bytes or an exact --version for an isolated target.",
             "Upgrades create a pre-upgrade snapshot before changing env state.",
             "When an env moves to a new runtime, upgrade runs OpenClaw update finalization inside the env before service restart.",

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -17,8 +17,8 @@ use crate::env::{
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::openclaw_repo::{detect_openclaw_checkout, ensure_openclaw_worktree};
 use crate::runtime::releases::{
-    OpenClawRelease, is_official_openclaw_releases_url, normalize_openclaw_channel_selector,
-    official_openclaw_releases_url,
+    OpenClawRelease, compare_runtime_release_versions, is_official_openclaw_releases_url,
+    normalize_openclaw_channel_selector, official_openclaw_releases_url,
 };
 use crate::runtime::{
     InstallRuntimeFromOfficialReleaseOptions, OfficialRuntimePrepareAction, RuntimeMeta,
@@ -104,6 +104,20 @@ struct UpgradeTarget {
     version: Option<String>,
     channel: Option<String>,
     runtime: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+enum ResolvedUpgradeTargetKind {
+    Named(RuntimeMeta),
+    Official(OpenClawRelease),
+}
+
+#[derive(Clone, Debug)]
+struct ResolvedUpgradeTarget {
+    name: String,
+    release_version: Option<String>,
+    release_channel: Option<String>,
+    kind: ResolvedUpgradeTargetKind,
 }
 
 #[derive(Clone, Debug)]
@@ -1061,7 +1075,14 @@ impl Cli {
         let previous_binding_name = current.name.clone();
 
         if target.is_explicit() {
-            let target_runtime_name = target.canonical_runtime_name()?;
+            let resolved = self.resolve_upgrade_target(target)?;
+            let target_runtime_name = resolved.name.clone();
+            let target_version = self.resolved_target_version(env_name, &resolved)?;
+            self.ensure_upgrade_is_not_downgrade(
+                env_name,
+                current.release_version.as_deref(),
+                &target_version,
+            )?;
             if !target.is_named_runtime() {
                 self.ensure_runtime_upgrade_isolated(env_name, &target_runtime_name)?;
             }
@@ -1079,8 +1100,8 @@ impl Cli {
                     } else {
                         "would-update".to_string()
                     },
-                    runtime_release_version: None,
-                    runtime_release_channel: target.release_channel_hint(),
+                    runtime_release_version: Some(target_version),
+                    runtime_release_channel: resolved.release_channel.clone(),
                     service_action: service_action_for_dry_run(
                         service.as_ref(),
                         binding_changed,
@@ -1098,7 +1119,7 @@ impl Cli {
                 &[current.name.clone(), target_runtime_name.clone()],
                 options.rollback_enabled,
             )?;
-            let prepared = match self.prepare_isolated_upgrade_target(env_name, target) {
+            let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
                 Ok(prepared) => prepared,
                 Err(error) => {
                     return self.rollback_failed_upgrade(
@@ -1107,7 +1128,7 @@ impl Cli {
                         previous_binding_name,
                         "runtime",
                         target_runtime_name,
-                        None,
+                        Some(target_version),
                         target.release_channel_hint(),
                         transaction,
                         error,
@@ -1265,24 +1286,6 @@ impl Cli {
 
         self.ensure_runtime_upgrade_isolated(env_name, &current.name)?;
 
-        if options.dry_run {
-            let service = self.upgrade_service_status(env_name)?;
-            return Ok(UpgradeEnvSummary {
-                env_name: env_name.to_string(),
-                previous_binding_kind: "runtime".to_string(),
-                previous_binding_name: previous_binding_name.clone(),
-                binding_kind: "runtime".to_string(),
-                binding_name: previous_binding_name,
-                outcome: "would-update".to_string(),
-                runtime_release_version: current.release_version.clone(),
-                runtime_release_channel: current.release_channel.clone(),
-                service_action: service_action_for_dry_run(service.as_ref(), false, true),
-                snapshot_id: None,
-                rollback: None,
-                note: Some("dry run: no runtime, env, service, or snapshot changed".to_string()),
-            });
-        }
-
         if is_official_openclaw_releases_url(current.source_manifest_url.as_deref(), &self.env) {
             let service = self.upgrade_service_status(env_name)?;
             let target = UpgradeTarget {
@@ -1290,13 +1293,38 @@ impl Cli {
                 channel: current.release_selector_value.clone(),
                 runtime: None,
             };
-            let target_runtime_name = target.canonical_runtime_name()?;
+            let resolved = self.resolve_upgrade_target(&target)?;
+            let target_runtime_name = resolved.name.clone();
+            let target_version = self.resolved_target_version(env_name, &resolved)?;
+            self.ensure_upgrade_is_not_downgrade(
+                env_name,
+                current.release_version.as_deref(),
+                &target_version,
+            )?;
+            if options.dry_run {
+                return Ok(UpgradeEnvSummary {
+                    env_name: env_name.to_string(),
+                    previous_binding_kind: "runtime".to_string(),
+                    previous_binding_name: previous_binding_name.clone(),
+                    binding_kind: "runtime".to_string(),
+                    binding_name: target_runtime_name,
+                    outcome: "would-update".to_string(),
+                    runtime_release_version: Some(target_version),
+                    runtime_release_channel: resolved.release_channel.clone(),
+                    service_action: service_action_for_dry_run(service.as_ref(), false, true),
+                    snapshot_id: None,
+                    rollback: None,
+                    note: Some(
+                        "dry run: no runtime, env, service, or snapshot changed".to_string(),
+                    ),
+                });
+            }
             let transaction = self.begin_upgrade_transaction(
                 env_name,
                 &[current.name.clone(), target_runtime_name.clone()],
                 options.rollback_enabled,
             )?;
-            let prepared = match self.prepare_isolated_upgrade_target(env_name, &target) {
+            let prepared = match self.prepare_isolated_upgrade_target(env_name, &target, resolved) {
                 Ok(prepared) => prepared,
                 Err(error) => {
                     return self.rollback_failed_upgrade(
@@ -1305,8 +1333,8 @@ impl Cli {
                         previous_binding_name,
                         "runtime",
                         target_runtime_name,
-                        current.release_version.clone(),
-                        current.release_channel.clone(),
+                        Some(target_version),
+                        target.release_channel_hint(),
                         transaction,
                         error,
                     );
@@ -1411,7 +1439,36 @@ impl Cli {
             return Ok(summary);
         }
 
+        let resolved_update = self.runtime_service().resolve_update_from_release(
+            crate::runtime::UpdateRuntimeFromReleaseOptions {
+                name: current.name.clone(),
+                version: None,
+                channel: None,
+            },
+        )?;
+        let target_version = resolved_update.release_version().to_string();
+        self.ensure_upgrade_is_not_downgrade(
+            env_name,
+            current.release_version.as_deref(),
+            &target_version,
+        )?;
         let service = self.upgrade_service_status(env_name)?;
+        if options.dry_run {
+            return Ok(UpgradeEnvSummary {
+                env_name: env_name.to_string(),
+                previous_binding_kind: "runtime".to_string(),
+                previous_binding_name: previous_binding_name.clone(),
+                binding_kind: "runtime".to_string(),
+                binding_name: previous_binding_name,
+                outcome: "would-update".to_string(),
+                runtime_release_version: Some(target_version),
+                runtime_release_channel: current.release_channel.clone(),
+                service_action: service_action_for_dry_run(service.as_ref(), false, true),
+                snapshot_id: None,
+                rollback: None,
+                note: Some("dry run: no runtime, env, service, or snapshot changed".to_string()),
+            });
+        }
         let transaction = self.begin_upgrade_transaction(
             env_name,
             std::slice::from_ref(&current.name),
@@ -1419,13 +1476,8 @@ impl Cli {
         )?;
         let updated = match self.with_progress(format!("Updating runtime {}", current.name), || {
             self.with_isolated_runtime_mutation(env_name, &current.name, || {
-                self.runtime_service().update_from_release_deferred(
-                    crate::runtime::UpdateRuntimeFromReleaseOptions {
-                        name: current.name.clone(),
-                        version: None,
-                        channel: None,
-                    },
-                )
+                self.runtime_service()
+                    .apply_resolved_update(resolved_update, false)
             })
         }) {
             Ok(updated) => updated,
@@ -1587,7 +1639,10 @@ impl Cli {
             });
         }
 
-        let target_runtime_name = target.canonical_runtime_name()?;
+        let resolved = self.resolve_upgrade_target(target)?;
+        let target_runtime_name = resolved.name.clone();
+        let target_version = self.resolved_target_version(env_name, &resolved)?;
+        self.ensure_upgrade_is_not_downgrade(env_name, None, &target_version)?;
         if !target.is_named_runtime() {
             self.ensure_runtime_upgrade_isolated(env_name, &target_runtime_name)?;
         }
@@ -1600,8 +1655,8 @@ impl Cli {
                 binding_kind: "runtime".to_string(),
                 binding_name: target_runtime_name,
                 outcome: "would-switch".to_string(),
-                runtime_release_version: None,
-                runtime_release_channel: target.release_channel_hint(),
+                runtime_release_version: Some(target_version),
+                runtime_release_channel: resolved.release_channel.clone(),
                 service_action: service_action_for_dry_run(service.as_ref(), true, true),
                 snapshot_id: None,
                 rollback: None,
@@ -1614,7 +1669,7 @@ impl Cli {
             std::slice::from_ref(&target_runtime_name),
             options.rollback_enabled,
         )?;
-        let prepared = match self.prepare_isolated_upgrade_target(env_name, target) {
+        let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
             Ok(prepared) => prepared,
             Err(error) => {
                 return self.rollback_failed_upgrade(
@@ -1623,7 +1678,7 @@ impl Cli {
                     launcher_name.to_string(),
                     "runtime",
                     target_runtime_name,
-                    None,
+                    Some(target_version),
                     target.release_channel_hint(),
                     transaction,
                     error,
@@ -1733,11 +1788,71 @@ impl Cli {
         self.service_service().status(env_name).map(Some)
     }
 
-    fn prepare_upgrade_target(
+    fn resolved_target_version(
         &self,
         env_name: &str,
+        target: &ResolvedUpgradeTarget,
+    ) -> Result<String, String> {
+        if let Some(version) = target.release_version.as_deref() {
+            return Ok(version.to_string());
+        }
+
+        let output = self.run_update_mode_openclaw_command_output(
+            env_name,
+            &target.name,
+            "target openclaw --version",
+            &["--version"],
+        )?;
+        if !output.status.success() {
+            return Err(format!(
+                "target openclaw --version failed: {}",
+                output.failure_summary()
+            ));
+        }
+        release_version_from_output(&output.first_line(), None).ok_or_else(|| {
+            format!(
+                "cannot determine the OpenClaw version provided by runtime \"{}\"",
+                target.name
+            )
+        })
+    }
+
+    fn ensure_upgrade_is_not_downgrade(
+        &self,
+        env_name: &str,
+        current_version_hint: Option<&str>,
+        target_version: &str,
+    ) -> Result<(), String> {
+        let current =
+            self.run_openclaw_command(env_name, "current openclaw --version", &["--version"])?;
+        let current_version =
+            release_version_from_output(&current.first_line(), current_version_hint).ok_or_else(
+                || {
+                    format!(
+                        "cannot determine the current OpenClaw version for env \"{env_name}\"; refusing to change its runtime without downgrade safety"
+                    )
+                },
+            )?;
+
+        if current_version == target_version {
+            return Ok(());
+        }
+
+        match compare_runtime_release_versions(&current_version, target_version) {
+            Some(std::cmp::Ordering::Greater) => Err(format!(
+                "refusing to downgrade env \"{env_name}\" from OpenClaw {current_version} to {target_version}: OCM does not run reverse config or SQLite state migrations, and newer environment state may be unreadable by the older runtime. Restore a complete pre-upgrade snapshot captured with {target_version} instead of switching only the runtime"
+            )),
+            Some(_) => Ok(()),
+            None => Err(format!(
+                "cannot safely compare current OpenClaw version \"{current_version}\" with target \"{target_version}\"; refusing to change env \"{env_name}\" without downgrade safety"
+            )),
+        }
+    }
+
+    fn resolve_upgrade_target(
+        &self,
         target: &UpgradeTarget,
-    ) -> Result<PreparedUpgradeTarget, String> {
+    ) -> Result<ResolvedUpgradeTarget, String> {
         let runtime_name = target.canonical_runtime_name()?;
         if target.is_named_runtime() {
             let meta = self.runtime_service().show(&runtime_name)?;
@@ -1746,43 +1861,78 @@ impl Cli {
                     "runtime \"{runtime_name}\" is not healthy: {issue}",
                 ));
             }
-            return Ok(PreparedUpgradeTarget {
+            return Ok(ResolvedUpgradeTarget {
                 name: runtime_name,
-                meta,
-                action: OfficialRuntimePrepareAction::Reused,
+                release_version: meta.release_version.clone(),
+                release_channel: meta.release_channel.clone(),
+                kind: ResolvedUpgradeTargetKind::Named(meta),
             });
         }
-        let (meta, action) =
-            self.with_progress(format!("Preparing OpenClaw runtime for {env_name}"), || {
-                self.runtime_service()
-                    .prepare_official_openclaw_runtime_deferred(
-                        InstallRuntimeFromOfficialReleaseOptions {
-                            name: runtime_name.clone(),
-                            version: target.version.clone(),
-                            channel: target.channel.clone(),
-                            description: None,
-                            force: false,
-                        },
-                    )
-            })?;
-        Ok(PreparedUpgradeTarget {
+
+        let release = self
+            .runtime_service()
+            .official_openclaw_releases(target.version.as_deref(), target.channel.as_deref())?
+            .into_iter()
+            .next()
+            .ok_or_else(|| "OpenClaw release was not found".to_string())?;
+        Ok(ResolvedUpgradeTarget {
             name: runtime_name,
-            meta,
-            action,
+            release_version: Some(release.version.clone()),
+            release_channel: release.channel.clone(),
+            kind: ResolvedUpgradeTargetKind::Official(release),
         })
+    }
+
+    fn prepare_resolved_upgrade_target(
+        &self,
+        env_name: &str,
+        target: &UpgradeTarget,
+        resolved: ResolvedUpgradeTarget,
+    ) -> Result<PreparedUpgradeTarget, String> {
+        match resolved.kind {
+            ResolvedUpgradeTargetKind::Named(meta) => Ok(PreparedUpgradeTarget {
+                name: resolved.name,
+                meta,
+                action: OfficialRuntimePrepareAction::Reused,
+            }),
+            ResolvedUpgradeTargetKind::Official(release) => {
+                let (meta, action) = self.with_progress(
+                    format!("Preparing OpenClaw runtime for {env_name}"),
+                    || {
+                        self.runtime_service()
+                            .prepare_selected_official_openclaw_runtime_deferred(
+                                InstallRuntimeFromOfficialReleaseOptions {
+                                    name: resolved.name.clone(),
+                                    version: target.version.clone(),
+                                    channel: target.channel.clone(),
+                                    description: None,
+                                    force: false,
+                                },
+                                release,
+                            )
+                    },
+                )?;
+                Ok(PreparedUpgradeTarget {
+                    name: resolved.name,
+                    meta,
+                    action,
+                })
+            }
+        }
     }
 
     fn prepare_isolated_upgrade_target(
         &self,
         env_name: &str,
         target: &UpgradeTarget,
+        resolved: ResolvedUpgradeTarget,
     ) -> Result<PreparedUpgradeTarget, String> {
         if target.is_named_runtime() {
-            return self.prepare_upgrade_target(env_name, target);
+            return self.prepare_resolved_upgrade_target(env_name, target, resolved);
         }
-        let runtime_name = target.canonical_runtime_name()?;
+        let runtime_name = resolved.name.clone();
         self.with_isolated_runtime_mutation(env_name, &runtime_name, || {
-            self.prepare_upgrade_target(env_name, target)
+            self.prepare_resolved_upgrade_target(env_name, target, resolved)
         })
     }
 
@@ -2479,6 +2629,19 @@ fn version_output_matches_expected(actual: &str, expected: &str) -> bool {
         .any(|token| token == expected)
 }
 
+fn release_version_from_output(actual: &str, hint: Option<&str>) -> Option<String> {
+    if let Some(hint) = hint
+        && version_output_matches_expected(actual, hint)
+    {
+        return Some(hint.to_string());
+    }
+
+    actual
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '+'))
+        .find(|token| !token.is_empty() && compare_runtime_release_versions(token, token).is_some())
+        .map(str::to_string)
+}
+
 fn simulation_env_name(source_name: &str, scenario: &str) -> String {
     format!(
         "{}-{}-sim-{}",
@@ -2690,7 +2853,10 @@ fn gateway_health_ok(port: u32) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_output_reports_unsupported_command, version_output_matches_expected};
+    use super::{
+        command_output_reports_unsupported_command, release_version_from_output,
+        version_output_matches_expected,
+    };
 
     #[test]
     fn version_output_accepts_exact_version() {
@@ -2719,6 +2885,22 @@ mod tests {
             "OpenClaw 12026.5.14",
             "2026.5.14"
         ));
+    }
+
+    #[test]
+    fn release_version_output_extracts_openclaw_and_generic_versions() {
+        assert_eq!(
+            release_version_from_output("OpenClaw 2026.7.1-2 (local)", None).as_deref(),
+            Some("2026.7.1-2")
+        );
+        assert_eq!(
+            release_version_from_output("runtime 0.3.0", None).as_deref(),
+            Some("0.3.0")
+        );
+        assert_eq!(
+            release_version_from_output("OpenClaw current-main", Some("2026.7.2")).as_deref(),
+            None
+        );
     }
 
     #[test]

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1081,7 +1081,7 @@ impl Cli {
             self.ensure_upgrade_is_not_downgrade(
                 env_name,
                 current.release_version.as_deref(),
-                &target_version,
+                target_version.as_deref(),
             )?;
             if !target.is_named_runtime() {
                 self.ensure_runtime_upgrade_isolated(env_name, &target_runtime_name)?;
@@ -1100,7 +1100,7 @@ impl Cli {
                     } else {
                         "would-update".to_string()
                     },
-                    runtime_release_version: Some(target_version),
+                    runtime_release_version: target_version.clone(),
                     runtime_release_channel: resolved.release_channel.clone(),
                     service_action: service_action_for_dry_run(
                         service.as_ref(),
@@ -1128,7 +1128,7 @@ impl Cli {
                         previous_binding_name,
                         "runtime",
                         target_runtime_name,
-                        Some(target_version),
+                        target_version.clone(),
                         target.release_channel_hint(),
                         transaction,
                         error,
@@ -1299,7 +1299,7 @@ impl Cli {
             self.ensure_upgrade_is_not_downgrade(
                 env_name,
                 current.release_version.as_deref(),
-                &target_version,
+                target_version.as_deref(),
             )?;
             if options.dry_run {
                 return Ok(UpgradeEnvSummary {
@@ -1309,7 +1309,7 @@ impl Cli {
                     binding_kind: "runtime".to_string(),
                     binding_name: target_runtime_name,
                     outcome: "would-update".to_string(),
-                    runtime_release_version: Some(target_version),
+                    runtime_release_version: target_version.clone(),
                     runtime_release_channel: resolved.release_channel.clone(),
                     service_action: service_action_for_dry_run(service.as_ref(), false, true),
                     snapshot_id: None,
@@ -1333,7 +1333,7 @@ impl Cli {
                         previous_binding_name,
                         "runtime",
                         target_runtime_name,
-                        Some(target_version),
+                        target_version.clone(),
                         target.release_channel_hint(),
                         transaction,
                         error,
@@ -1450,7 +1450,7 @@ impl Cli {
         self.ensure_upgrade_is_not_downgrade(
             env_name,
             current.release_version.as_deref(),
-            &target_version,
+            Some(&target_version),
         )?;
         let service = self.upgrade_service_status(env_name)?;
         if options.dry_run {
@@ -1642,7 +1642,7 @@ impl Cli {
         let resolved = self.resolve_upgrade_target(target)?;
         let target_runtime_name = resolved.name.clone();
         let target_version = self.resolved_target_version(env_name, &resolved)?;
-        self.ensure_upgrade_is_not_downgrade(env_name, None, &target_version)?;
+        self.ensure_upgrade_is_not_downgrade(env_name, None, target_version.as_deref())?;
         if !target.is_named_runtime() {
             self.ensure_runtime_upgrade_isolated(env_name, &target_runtime_name)?;
         }
@@ -1655,7 +1655,7 @@ impl Cli {
                 binding_kind: "runtime".to_string(),
                 binding_name: target_runtime_name,
                 outcome: "would-switch".to_string(),
-                runtime_release_version: Some(target_version),
+                runtime_release_version: target_version.clone(),
                 runtime_release_channel: resolved.release_channel.clone(),
                 service_action: service_action_for_dry_run(service.as_ref(), true, true),
                 snapshot_id: None,
@@ -1678,7 +1678,7 @@ impl Cli {
                     launcher_name.to_string(),
                     "runtime",
                     target_runtime_name,
-                    Some(target_version),
+                    target_version.clone(),
                     target.release_channel_hint(),
                     transaction,
                     error,
@@ -1792,47 +1792,54 @@ impl Cli {
         &self,
         env_name: &str,
         target: &ResolvedUpgradeTarget,
-    ) -> Result<String, String> {
-        if let Some(version) = target.release_version.as_deref() {
-            return Ok(version.to_string());
+    ) -> Result<Option<String>, String> {
+        if let Some(version) = target
+            .release_version
+            .as_deref()
+            .filter(|version| compare_runtime_release_versions(version, version).is_some())
+        {
+            return Ok(Some(version.to_string()));
         }
 
-        let output = self.run_update_mode_openclaw_command_output(
+        let Ok(output) = self.run_update_mode_openclaw_command_output(
             env_name,
             &target.name,
             "target openclaw --version",
             &["--version"],
-        )?;
+        ) else {
+            return Ok(None);
+        };
         if !output.status.success() {
-            return Err(format!(
-                "target openclaw --version failed: {}",
-                output.failure_summary()
-            ));
+            return Ok(None);
         }
-        release_version_from_output(&output.first_line(), None).ok_or_else(|| {
-            format!(
-                "cannot determine the OpenClaw version provided by runtime \"{}\"",
-                target.name
-            )
-        })
+        Ok(release_version_from_output(&output.first_line(), None))
     }
 
     fn ensure_upgrade_is_not_downgrade(
         &self,
         env_name: &str,
         current_version_hint: Option<&str>,
-        target_version: &str,
+        target_version: Option<&str>,
     ) -> Result<(), String> {
-        let current =
-            self.run_openclaw_command(env_name, "current openclaw --version", &["--version"])?;
-        let current_version =
-            release_version_from_output(&current.first_line(), current_version_hint).ok_or_else(
-                || {
-                    format!(
-                        "cannot determine the current OpenClaw version for env \"{env_name}\"; refusing to change its runtime without downgrade safety"
-                    )
-                },
-            )?;
+        let Some(target_version) = target_version else {
+            return Ok(());
+        };
+        let current_version = if let Some(current_version) = current_version_hint
+            .filter(|version| compare_runtime_release_versions(version, version).is_some())
+        {
+            current_version.to_string()
+        } else {
+            let Ok(current) =
+                self.run_openclaw_command(env_name, "current openclaw --version", &["--version"])
+            else {
+                return Ok(());
+            };
+            let Some(current_version) = release_version_from_output(&current.first_line(), None)
+            else {
+                return Ok(());
+            };
+            current_version
+        };
 
         if current_version == target_version {
             return Ok(());
@@ -2632,6 +2639,7 @@ fn version_output_matches_expected(actual: &str, expected: &str) -> bool {
 fn release_version_from_output(actual: &str, hint: Option<&str>) -> Option<String> {
     if let Some(hint) = hint
         && version_output_matches_expected(actual, hint)
+        && compare_runtime_release_versions(hint, hint).is_some()
     {
         return Some(hint.to_string());
     }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1793,12 +1793,12 @@ impl Cli {
         env_name: &str,
         target: &ResolvedUpgradeTarget,
     ) -> Result<Option<String>, String> {
-        if let Some(version) = target
+        let version_hint = target
             .release_version
             .as_deref()
-            .filter(|version| compare_runtime_release_versions(version, version).is_some())
-        {
-            return Ok(Some(version.to_string()));
+            .filter(|version| compare_runtime_release_versions(version, version).is_some());
+        if matches!(&target.kind, ResolvedUpgradeTargetKind::Official(_)) {
+            return Ok(version_hint.map(str::to_string));
         }
 
         let Ok(output) = self.run_update_mode_openclaw_command_output(
@@ -1807,12 +1807,15 @@ impl Cli {
             "target openclaw --version",
             &["--version"],
         ) else {
-            return Ok(None);
+            return Ok(version_hint.map(str::to_string));
         };
         if !output.status.success() {
-            return Ok(None);
+            return Ok(version_hint.map(str::to_string));
         }
-        Ok(release_version_from_output(&output.first_line(), None))
+        Ok(
+            release_version_from_output(&output.first_line(), version_hint)
+                .or_else(|| version_hint.map(str::to_string)),
+        )
     }
 
     fn ensure_upgrade_is_not_downgrade(
@@ -1824,21 +1827,19 @@ impl Cli {
         let Some(target_version) = target_version else {
             return Ok(());
         };
-        let current_version = if let Some(current_version) = current_version_hint
-            .filter(|version| compare_runtime_release_versions(version, version).is_some())
-        {
-            current_version.to_string()
-        } else {
-            let Ok(current) =
-                self.run_openclaw_command(env_name, "current openclaw --version", &["--version"])
-            else {
-                return Ok(());
+        let current_version_hint = current_version_hint
+            .filter(|version| compare_runtime_release_versions(version, version).is_some());
+        let current_version =
+            match self.run_openclaw_command(env_name, "current openclaw --version", &["--version"])
+            {
+                Ok(current) => {
+                    release_version_from_output(&current.first_line(), current_version_hint)
+                        .or_else(|| current_version_hint.map(str::to_string))
+                }
+                Err(_) => current_version_hint.map(str::to_string),
             };
-            let Some(current_version) = release_version_from_output(&current.first_line(), None)
-            else {
-                return Ok(());
-            };
-            current_version
+        let Some(current_version) = current_version else {
+            return Ok(());
         };
 
         if current_version == target_version {

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -79,6 +79,15 @@ pub(crate) struct ResolvedRuntimeUpdate {
     release: ResolvedRuntimeUpdateRelease,
 }
 
+impl ResolvedRuntimeUpdate {
+    pub(crate) fn release_version(&self) -> &str {
+        match &self.release {
+            ResolvedRuntimeUpdateRelease::Official(release) => &release.version,
+            ResolvedRuntimeUpdateRelease::Manifest(release) => &release.version,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeUpdateSummary {
@@ -159,16 +168,20 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: InstallRuntimeFromOfficialReleaseOptions,
     ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
-        self.prepare_official_openclaw_runtime_with_refresh(options, true, true)
+        self.prepare_official_openclaw_runtime_with_refresh(options, true, true, None)
     }
 
-    pub(crate) fn prepare_official_openclaw_runtime_deferred(
+    pub(crate) fn prepare_selected_official_openclaw_runtime_deferred(
         &self,
         options: InstallRuntimeFromOfficialReleaseOptions,
+        selected_release: OpenClawRelease,
     ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
-        // Upgrade finalization must run before changed runtime metadata reaches the live
-        // supervisor; the upgrade transaction publishes one coherent state afterward.
-        self.prepare_official_openclaw_runtime_with_refresh(options, false, false)
+        self.prepare_official_openclaw_runtime_with_refresh(
+            options,
+            false,
+            false,
+            Some(selected_release),
+        )
     }
 
     fn prepare_official_openclaw_runtime_with_refresh(
@@ -176,6 +189,7 @@ impl<'a> RuntimeService<'a> {
         options: InstallRuntimeFromOfficialReleaseOptions,
         refresh_supervisor: bool,
         require_unbound: bool,
+        selected_release: Option<OpenClawRelease>,
     ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
         let version = options
             .version
@@ -206,15 +220,39 @@ impl<'a> RuntimeService<'a> {
         }
 
         let releases_url = official_openclaw_releases_url(self.env);
-        let releases = load_official_openclaw_release_selection(&releases_url)?;
-        let selected_release = match (version.as_deref(), channel.as_deref()) {
-            (Some(version), None) => {
-                select_official_openclaw_release_by_version(&releases, version)?
+        let selected_release = match selected_release {
+            Some(selected_release) => {
+                let matches_selector = match (version.as_deref(), channel.as_deref()) {
+                    (Some(version), None) => selected_release.version == version,
+                    (None, Some(channel)) => {
+                        selected_release.channel.as_deref() == Some(channel)
+                            || selected_release
+                                .channels
+                                .iter()
+                                .any(|value| value == channel)
+                    }
+                    _ => false,
+                };
+                if !matches_selector {
+                    return Err(format!(
+                        "resolved OpenClaw release \"{}\" no longer matches the requested selector",
+                        selected_release.version
+                    ));
+                }
+                selected_release
             }
-            (None, Some(channel)) => {
-                select_official_openclaw_release_by_channel(&releases, channel)?
+            None => {
+                let releases = load_official_openclaw_release_selection(&releases_url)?;
+                match (version.as_deref(), channel.as_deref()) {
+                    (Some(version), None) => {
+                        select_official_openclaw_release_by_version(&releases, version)?
+                    }
+                    (None, Some(channel)) => {
+                        select_official_openclaw_release_by_channel(&releases, channel)?
+                    }
+                    _ => unreachable!("validated above"),
+                }
             }
-            _ => unreachable!("validated above"),
         };
 
         let mut existing_meta = None;
@@ -373,14 +411,6 @@ impl<'a> RuntimeService<'a> {
             let resolved = self.resolve_update_from_release(options)?;
             self.apply_resolved_update(resolved, true)
         })
-    }
-
-    pub(crate) fn update_from_release_deferred(
-        &self,
-        options: UpdateRuntimeFromReleaseOptions,
-    ) -> Result<RuntimeMeta, String> {
-        let resolved = self.resolve_update_from_release(options)?;
-        self.apply_resolved_update(resolved, false)
     }
 
     pub(crate) fn resolve_update_from_release(

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -1,15 +1,16 @@
 use super::{RuntimeMeta, RuntimeReleaseSelectorKind, RuntimeService};
 use crate::runtime::releases::{
-    is_official_openclaw_releases_url, load_official_openclaw_release_selection,
-    normalize_openclaw_channel_selector, official_openclaw_releases_url,
-    select_official_openclaw_release_by_channel, select_official_openclaw_release_by_version,
+    OpenClawRelease, RuntimeRelease, is_official_openclaw_releases_url,
+    load_official_openclaw_release_selection, normalize_openclaw_channel_selector,
+    official_openclaw_releases_url, select_official_openclaw_release_by_channel,
+    select_official_openclaw_release_by_version,
 };
 use crate::store::{
     BuildLocalRuntimeOptions as StoreBuildLocalRuntimeOptions, InstallContext,
     RuntimeReleaseDetails, get_runtime, install_runtime, install_runtime_from_local_openclaw_build,
     install_runtime_from_official_openclaw_release, install_runtime_from_release,
-    install_runtime_from_selected_official_openclaw_release, install_runtime_from_url,
-    list_runtimes, runtime_integrity_issue,
+    install_runtime_from_selected_official_openclaw_release, install_runtime_from_selected_release,
+    install_runtime_from_url, list_runtimes, runtime_integrity_issue,
 };
 use serde::Serialize;
 
@@ -61,6 +62,21 @@ pub struct UpdateRuntimeFromReleaseOptions {
     pub name: String,
     pub version: Option<String>,
     pub channel: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ResolvedRuntimeUpdateRelease {
+    Official(OpenClawRelease),
+    Manifest(RuntimeRelease),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedRuntimeUpdate {
+    pub(crate) existing: RuntimeMeta,
+    manifest_url: String,
+    selector_kind: RuntimeReleaseSelectorKind,
+    selector_value: String,
+    release: ResolvedRuntimeUpdateRelease,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -354,7 +370,8 @@ impl<'a> RuntimeService<'a> {
     ) -> Result<RuntimeMeta, String> {
         let name = options.name.clone();
         self.with_unbound_runtime(&name, || {
-            self.update_from_release_with_refresh(options, true)
+            let resolved = self.resolve_update_from_release(options)?;
+            self.apply_resolved_update(resolved, true)
         })
     }
 
@@ -362,22 +379,20 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: UpdateRuntimeFromReleaseOptions,
     ) -> Result<RuntimeMeta, String> {
-        // Keep the existing supervisor spec active until the replacement runtime has
-        // migrated and validated the environment it will own.
-        self.update_from_release_with_refresh(options, false)
+        let resolved = self.resolve_update_from_release(options)?;
+        self.apply_resolved_update(resolved, false)
     }
 
-    fn update_from_release_with_refresh(
+    pub(crate) fn resolve_update_from_release(
         &self,
         options: UpdateRuntimeFromReleaseOptions,
-        refresh_supervisor: bool,
-    ) -> Result<RuntimeMeta, String> {
+    ) -> Result<ResolvedRuntimeUpdate, String> {
         if options.version.is_some() && options.channel.is_some() {
             return Err("runtime update accepts only one of --version or --channel".to_string());
         }
 
         let existing = get_runtime(&options.name, self.env, self.cwd)?;
-        let manifest_url = existing.source_manifest_url.ok_or_else(|| {
+        let manifest_url = existing.source_manifest_url.clone().ok_or_else(|| {
             format!(
                 "runtime \"{}\" is not backed by a release manifest",
                 existing.name
@@ -401,38 +416,74 @@ impl<'a> RuntimeService<'a> {
             },
             _ => unreachable!("conflicting selectors are rejected above"),
         };
+        let (selector_kind, selector_value) = match (&version, &channel) {
+            (Some(version), None) => (RuntimeReleaseSelectorKind::Version, version.clone()),
+            (None, Some(channel)) => (RuntimeReleaseSelectorKind::Channel, channel.clone()),
+            _ => unreachable!("runtime update requires a resolved selector"),
+        };
 
-        if is_official_openclaw_releases_url(Some(manifest_url.as_str()), self.env) {
-            let meta = install_runtime_from_official_openclaw_release(
-                InstallRuntimeFromOfficialReleaseOptions {
-                    name: existing.name,
-                    version,
-                    channel,
-                    description: existing.description,
-                    force: true,
-                },
-                self.env,
-                self.cwd,
-            );
-            let meta = meta?;
-            if refresh_supervisor {
-                self.refresh_supervisor_if_present()?;
+        let release = if is_official_openclaw_releases_url(Some(manifest_url.as_str()), self.env) {
+            let release = self
+                .official_openclaw_releases(version.as_deref(), channel.as_deref())?
+                .into_iter()
+                .next()
+                .ok_or_else(|| "OpenClaw release was not found".to_string())?;
+            ResolvedRuntimeUpdateRelease::Official(release)
+        } else {
+            let release = self
+                .releases_from_manifest(&manifest_url, version.as_deref(), channel.as_deref())?
+                .into_iter()
+                .next()
+                .ok_or_else(|| "runtime release was not found".to_string())?;
+            ResolvedRuntimeUpdateRelease::Manifest(release)
+        };
+
+        Ok(ResolvedRuntimeUpdate {
+            existing,
+            manifest_url,
+            selector_kind,
+            selector_value,
+            release,
+        })
+    }
+
+    pub(crate) fn apply_resolved_update(
+        &self,
+        resolved: ResolvedRuntimeUpdate,
+        refresh_supervisor: bool,
+    ) -> Result<RuntimeMeta, String> {
+        let selector_kind = Some(resolved.selector_kind);
+        let selector_value = Some(resolved.selector_value);
+        let meta = match resolved.release {
+            ResolvedRuntimeUpdateRelease::Official(release) => {
+                install_runtime_from_selected_official_openclaw_release(
+                    resolved.existing.name,
+                    true,
+                    resolved.manifest_url,
+                    release,
+                    RuntimeReleaseDetails::with_selector(selector_kind, selector_value),
+                    resolved.existing.description,
+                    InstallContext {
+                        env: self.env,
+                        cwd: self.cwd,
+                    },
+                )?
+                .meta
             }
-            return Ok(meta);
-        }
-
-        let meta = install_runtime_from_release(
-            InstallRuntimeFromReleaseOptions {
-                name: existing.name,
-                manifest_url,
-                version,
-                channel,
-                description: existing.description,
-                force: true,
-            },
-            self.env,
-            self.cwd,
-        )?;
+            ResolvedRuntimeUpdateRelease::Manifest(release) => {
+                install_runtime_from_selected_release(
+                    resolved.existing.name,
+                    true,
+                    resolved.manifest_url,
+                    release,
+                    selector_kind,
+                    selector_value,
+                    resolved.existing.description,
+                    self.env,
+                    self.cwd,
+                )?
+            }
+        };
         if refresh_supervisor {
             self.refresh_supervisor_if_present()?;
         }

--- a/src/runtime/releases.rs
+++ b/src/runtime/releases.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -57,6 +58,75 @@ pub struct OpenClawReleaseCatalogEntry {
     pub release: OpenClawRelease,
     #[serde(default)]
     pub installed_runtime_names: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ParsedOpenClawReleaseVersion {
+    year: u64,
+    month: u64,
+    patch: u64,
+    channel_rank: u8,
+    sequence: u64,
+}
+
+fn parse_openclaw_release_version(value: &str) -> Option<ParsedOpenClawReleaseVersion> {
+    let value = value.trim().strip_prefix('v').unwrap_or(value.trim());
+    if value.contains('+') {
+        return None;
+    }
+
+    let (base, suffix) = value
+        .split_once('-')
+        .map_or((value, None), |(base, suffix)| (base, Some(suffix)));
+    let mut parts = base.split('.');
+    let year_raw = parts.next()?;
+    let month_raw = parts.next()?;
+    let patch_raw = parts.next()?;
+    if parts.next().is_some() || year_raw.len() != 4 {
+        return None;
+    }
+
+    let year = year_raw.parse().ok()?;
+    let month = month_raw.parse().ok()?;
+    let patch = patch_raw.parse().ok()?;
+    if !(1..=12).contains(&month) || patch == 0 {
+        return None;
+    }
+
+    let (channel_rank, sequence) = match suffix {
+        None => (2, 0),
+        Some(suffix) => {
+            if let Ok(correction) = suffix.parse::<u64>() {
+                if correction == 0 {
+                    return None;
+                }
+                (3, correction)
+            } else {
+                let (channel, sequence) = suffix.split_once('.')?;
+                let sequence = sequence.parse::<u64>().ok()?;
+                if sequence == 0 {
+                    return None;
+                }
+                match channel {
+                    "alpha" => (0, sequence),
+                    "beta" => (1, sequence),
+                    _ => return None,
+                }
+            }
+        }
+    };
+
+    Some(ParsedOpenClawReleaseVersion {
+        year,
+        month,
+        patch,
+        channel_rank,
+        sequence,
+    })
+}
+
+pub fn compare_openclaw_release_versions(left: &str, right: &str) -> Option<Ordering> {
+    Some(parse_openclaw_release_version(left)?.cmp(&parse_openclaw_release_version(right)?))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/runtime/releases.rs
+++ b/src/runtime/releases.rs
@@ -125,10 +125,6 @@ fn parse_openclaw_release_version(value: &str) -> Option<ParsedOpenClawReleaseVe
     })
 }
 
-pub fn compare_openclaw_release_versions(left: &str, right: &str) -> Option<Ordering> {
-    Some(parse_openclaw_release_version(left)?.cmp(&parse_openclaw_release_version(right)?))
-}
-
 pub(crate) fn compare_runtime_release_versions(left: &str, right: &str) -> Option<Ordering> {
     match (
         parse_openclaw_release_version(left),
@@ -540,5 +536,40 @@ fn openclaw_channel_priority(channel: &str) -> usize {
         "beta" => 1,
         "dev" => 2,
         _ => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+
+    use super::compare_runtime_release_versions;
+
+    #[test]
+    fn openclaw_release_versions_order_prereleases_stable_and_corrections() {
+        assert_eq!(
+            compare_runtime_release_versions("2026.7.1-alpha.9", "2026.7.1-beta.1"),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            compare_runtime_release_versions("2026.7.1-beta.3", "2026.7.1"),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            compare_runtime_release_versions("2026.7.1-2", "2026.7.1"),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            compare_runtime_release_versions("2026.7.2-beta.3", "2026.7.1-2"),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            compare_runtime_release_versions("2026.7.1-2", "2026.7.1-1"),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            compare_runtime_release_versions("2026.7.1-dev.1", "2026.7.1"),
+            None
+        );
     }
 }

--- a/src/runtime/releases.rs
+++ b/src/runtime/releases.rs
@@ -129,6 +129,24 @@ pub fn compare_openclaw_release_versions(left: &str, right: &str) -> Option<Orde
     Some(parse_openclaw_release_version(left)?.cmp(&parse_openclaw_release_version(right)?))
 }
 
+pub(crate) fn compare_runtime_release_versions(left: &str, right: &str) -> Option<Ordering> {
+    match (
+        parse_openclaw_release_version(left),
+        parse_openclaw_release_version(right),
+    ) {
+        (Some(left), Some(right)) => Some(left.cmp(&right)),
+        (None, None) => {
+            let left = semver::Version::parse(left.trim().strip_prefix('v').unwrap_or(left.trim()))
+                .ok()?;
+            let right =
+                semver::Version::parse(right.trim().strip_prefix('v').unwrap_or(right.trim()))
+                    .ok()?;
+            Some(left.cmp_precedence(&right))
+        }
+        _ => None,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct OpenClawPackageManifest {
     #[serde(rename = "dist-tags", default)]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -69,6 +69,7 @@ pub(crate) use openclaw_workspaces::{
 };
 pub(crate) use runtimes::install_runtime_from_local_openclaw_build;
 pub(crate) use runtimes::install_runtime_from_selected_official_openclaw_release;
+pub(crate) use runtimes::install_runtime_from_selected_release;
 pub(crate) use runtimes::{BuildLocalRuntimeOptions, InstallContext, RuntimeReleaseDetails};
 pub use runtimes::{
     add_runtime, get_runtime, get_runtime_verified, install_runtime,

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -13,8 +13,8 @@ use crate::infra::download::{
 };
 use crate::managed_node::{CommandSpec, managed_runtime_install_command};
 use crate::runtime::releases::{
-    OpenClawRelease, load_official_openclaw_release_selection, load_release_manifest,
-    normalize_openclaw_channel_selector, official_openclaw_releases_url,
+    OpenClawRelease, RuntimeRelease, load_official_openclaw_release_selection,
+    load_release_manifest, normalize_openclaw_channel_selector, official_openclaw_releases_url,
     select_official_openclaw_release_by_channel, select_official_openclaw_release_by_version,
     select_release,
 };
@@ -1334,25 +1334,12 @@ pub fn install_runtime_from_release(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<RuntimeMeta, String> {
-    let name = validate_name(&options.name, "Runtime name")?;
-
     let manifest = load_release_manifest(&options.manifest_url)?;
     let release = select_release(
         &manifest,
         options.version.as_deref(),
         options.channel.as_deref(),
     )?;
-    let source_sha256 = release
-        .sha256
-        .as_deref()
-        .ok_or_else(|| {
-            format!(
-                "runtime release \"{}\" is missing required sha256 integrity",
-                release.version
-            )
-        })
-        .and_then(normalize_sha256)?;
-    let target = prepare_runtime_install_target(name, options.force, env, cwd)?;
     let (selector_kind, selector_value) =
         match (options.version.as_deref(), options.channel.as_deref()) {
             (Some(version), None) => (
@@ -1365,6 +1352,42 @@ pub fn install_runtime_from_release(
             ),
             _ => (None, None),
         };
+    install_runtime_from_selected_release(
+        options.name,
+        options.force,
+        options.manifest_url,
+        release,
+        selector_kind,
+        selector_value,
+        options.description,
+        env,
+        cwd,
+    )
+}
+
+pub(crate) fn install_runtime_from_selected_release(
+    name: String,
+    force: bool,
+    manifest_url: String,
+    release: RuntimeRelease,
+    selector_kind: Option<RuntimeReleaseSelectorKind>,
+    selector_value: Option<String>,
+    description: Option<String>,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<RuntimeMeta, String> {
+    let name = validate_name(&name, "Runtime name")?;
+    let source_sha256 = release
+        .sha256
+        .as_deref()
+        .ok_or_else(|| {
+            format!(
+                "runtime release \"{}\" is missing required sha256 integrity",
+                release.version
+            )
+        })
+        .and_then(normalize_sha256)?;
+    let target = prepare_runtime_install_target(name, force, env, cwd)?;
     let release_details = RuntimeReleaseDetails {
         version: Some(release.version.clone()),
         channel: release.channel.clone(),
@@ -1372,7 +1395,7 @@ pub fn install_runtime_from_release(
         selector_value,
     };
     let description =
-        trim_description(options.description).or_else(|| trim_description(release.description));
+        trim_description(description).or_else(|| trim_description(release.description));
 
     let file_name = artifact_file_name_from_url(&release.url)?;
     install_runtime_at_path(
@@ -1380,7 +1403,7 @@ pub fn install_runtime_from_release(
         Path::new(&file_name),
         RuntimeSourceDetails {
             url: Some(release.url),
-            manifest_url: Some(options.manifest_url),
+            manifest_url: Some(manifest_url),
             sha256: Some(source_sha256),
             ..RuntimeSourceDetails::default()
         },

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -278,6 +278,7 @@ fn upgrade_help_is_available_from_help_and_flag() {
     assert!(output.contains("ocm upgrade --all"));
     assert!(output.contains("Simulations clone the source env"));
     assert!(output.contains("Channel-tracked runtimes move forward automatically."));
+    assert!(output.contains("older targets are rejected before snapshot creation"));
     assert!(
         output.contains("An env upgrade will not replace runtime bytes shared with another env")
     );

--- a/tests/release_manifest_tests.rs
+++ b/tests/release_manifest_tests.rs
@@ -3,43 +3,13 @@ mod support;
 use serde_json::json;
 
 use ocm::runtime::releases::{
-    compare_openclaw_release_versions, load_official_openclaw_releases, load_release_manifest,
-    query_official_openclaw_releases, query_releases, select_official_openclaw_release_by_channel,
+    load_official_openclaw_releases, load_release_manifest, query_official_openclaw_releases,
+    query_releases, select_official_openclaw_release_by_channel,
     select_official_openclaw_release_by_version, select_release, select_release_by_channel,
     select_release_by_version,
 };
 
 use crate::support::TestHttpServer;
-
-#[test]
-fn openclaw_release_versions_order_prereleases_stable_and_corrections() {
-    use std::cmp::Ordering;
-
-    assert_eq!(
-        compare_openclaw_release_versions("2026.7.1-alpha.9", "2026.7.1-beta.1"),
-        Some(Ordering::Less)
-    );
-    assert_eq!(
-        compare_openclaw_release_versions("2026.7.1-beta.3", "2026.7.1"),
-        Some(Ordering::Less)
-    );
-    assert_eq!(
-        compare_openclaw_release_versions("2026.7.1-2", "2026.7.1"),
-        Some(Ordering::Greater)
-    );
-    assert_eq!(
-        compare_openclaw_release_versions("2026.7.2-beta.3", "2026.7.1-2"),
-        Some(Ordering::Greater)
-    );
-    assert_eq!(
-        compare_openclaw_release_versions("2026.7.1-2", "2026.7.1-1"),
-        Some(Ordering::Greater)
-    );
-    assert_eq!(
-        compare_openclaw_release_versions("2026.7.1-dev.1", "2026.7.1"),
-        None
-    );
-}
 
 #[test]
 fn load_release_manifest_fetches_and_validates_remote_json() {

--- a/tests/release_manifest_tests.rs
+++ b/tests/release_manifest_tests.rs
@@ -3,13 +3,43 @@ mod support;
 use serde_json::json;
 
 use ocm::runtime::releases::{
-    load_official_openclaw_releases, load_release_manifest, query_official_openclaw_releases,
-    query_releases, select_official_openclaw_release_by_channel,
+    compare_openclaw_release_versions, load_official_openclaw_releases, load_release_manifest,
+    query_official_openclaw_releases, query_releases, select_official_openclaw_release_by_channel,
     select_official_openclaw_release_by_version, select_release, select_release_by_channel,
     select_release_by_version,
 };
 
 use crate::support::TestHttpServer;
+
+#[test]
+fn openclaw_release_versions_order_prereleases_stable_and_corrections() {
+    use std::cmp::Ordering;
+
+    assert_eq!(
+        compare_openclaw_release_versions("2026.7.1-alpha.9", "2026.7.1-beta.1"),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        compare_openclaw_release_versions("2026.7.1-beta.3", "2026.7.1"),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        compare_openclaw_release_versions("2026.7.1-2", "2026.7.1"),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        compare_openclaw_release_versions("2026.7.2-beta.3", "2026.7.1-2"),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        compare_openclaw_release_versions("2026.7.1-2", "2026.7.1-1"),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        compare_openclaw_release_versions("2026.7.1-dev.1", "2026.7.1"),
+        None
+    );
+}
 
 #[test]
 fn load_release_manifest_fetches_and_validates_remote_json() {

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -870,6 +870,32 @@ fn upgrade_rejects_downgrade_before_snapshot_or_target_download() {
 
     let target = run_ocm(&cwd, &env, &["runtime", "show", older_version]);
     assert!(!target.status.success());
+
+    let install_target = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "install", "--version", older_version],
+    );
+    assert!(
+        install_target.status.success(),
+        "{}",
+        stderr(&install_target)
+    );
+    let older_requests_before_named_target = older_server.requests().len();
+    let named_upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", older_version]);
+    assert_eq!(named_upgrade.status.code(), Some(1));
+    assert!(
+        stderr(&named_upgrade).contains(&format!(
+            "refusing to downgrade env \"demo\" from OpenClaw {newer_version} to {older_version}"
+        )),
+        "{}",
+        stderr(&named_upgrade)
+    );
+    assert_eq!(
+        older_server.requests().len(),
+        older_requests_before_named_target
+    );
+
     let snapshots = run_ocm(&cwd, &env, &["env", "snapshot", "list", "demo", "--json"]);
     assert!(snapshots.status.success(), "{}", stderr(&snapshots));
     let snapshots: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -804,6 +804,147 @@ fn upgrade_switches_across_versions_from_runtime_with_broken_package_bin_symlink
 }
 
 #[test]
+fn upgrade_rejects_downgrade_before_snapshot_or_target_download() {
+    let root = TestDir::new("upgrade-reject-downgrade");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let older_version = "2026.7.1-2";
+    let newer_version = "2026.7.2-beta.3";
+    let older_tarball =
+        openclaw_package_tarball(&recording_openclaw_script(older_version), older_version);
+    let older_integrity = sha512_integrity(&older_tarball);
+    let older_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.7.1-2.tgz",
+        "application/octet-stream",
+        &older_tarball,
+        4,
+    );
+    let newer_tarball =
+        openclaw_package_tarball(&recording_openclaw_script(newer_version), newer_version);
+    let newer_integrity = sha512_integrity(&newer_tarball);
+    let newer_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.7.2-beta.3.tgz",
+        "application/octet-stream",
+        &newer_tarball,
+        4,
+    );
+    let packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"{newer_version}\",\"beta\":\"{newer_version}\"}},\"versions\":{{\"{older_version}\":{{\"version\":\"{older_version}\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{older_integrity}\"}}}},\"{newer_version}\":{{\"version\":\"{newer_version}\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{newer_integrity}\"}}}}}},\"time\":{{\"{older_version}\":\"2026-07-18T03:53:48.967Z\",\"{newer_version}\":\"2026-07-18T23:15:12.160Z\"}}}}",
+        older_server.url(),
+        newer_server.url()
+    );
+    let packument_server =
+        TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 8);
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &["start", "demo", "--version", newer_version, "--no-service"],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+    assert!(older_server.requests().is_empty());
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--version", older_version]);
+    assert_eq!(upgrade.status.code(), Some(1));
+    let error = stderr(&upgrade);
+    assert!(
+        error.contains(&format!(
+            "refusing to downgrade env \"demo\" from OpenClaw {newer_version} to {older_version}"
+        )),
+        "{error}"
+    );
+    assert!(error.contains("SQLite state"), "{error}");
+    assert!(older_server.requests().is_empty());
+
+    let environment = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(environment.status.success(), "{}", stderr(&environment));
+    let environment: Value = serde_json::from_str(&stdout(&environment)).unwrap();
+    assert_eq!(environment["defaultRuntime"], newer_version);
+
+    let target = run_ocm(&cwd, &env, &["runtime", "show", older_version]);
+    assert!(!target.status.success());
+    let snapshots = run_ocm(&cwd, &env, &["env", "snapshot", "list", "demo", "--json"]);
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert!(snapshots.as_array().unwrap().is_empty());
+}
+
+#[test]
+fn upgrade_accepts_correction_release_and_freezes_channel_selection() {
+    let root = TestDir::new("upgrade-correction-release");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let stable_version = "2026.7.1";
+    let correction_version = "2026.7.1-2";
+    let stable_tarball =
+        openclaw_package_tarball(&recording_openclaw_script(stable_version), stable_version);
+    let stable_integrity = sha512_integrity(&stable_tarball);
+    let stable_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.7.1.tgz",
+        "application/octet-stream",
+        &stable_tarball,
+        4,
+    );
+    let correction_tarball = openclaw_package_tarball(
+        &recording_openclaw_script(correction_version),
+        correction_version,
+    );
+    let correction_integrity = sha512_integrity(&correction_tarball);
+    let correction_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.7.1-2.tgz",
+        "application/octet-stream",
+        &correction_tarball,
+        4,
+    );
+    let packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"{correction_version}\"}},\"versions\":{{\"{stable_version}\":{{\"version\":\"{stable_version}\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{stable_integrity}\"}}}},\"{correction_version}\":{{\"version\":\"{correction_version}\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{correction_integrity}\"}}}}}},\"time\":{{\"{stable_version}\":\"2026-07-13T17:58:18.920Z\",\"{correction_version}\":\"2026-07-18T03:53:48.967Z\"}}}}",
+        stable_server.url(),
+        correction_server.url()
+    );
+    let packument_server =
+        TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 8);
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &["start", "demo", "--version", stable_version, "--no-service"],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+    let requests_before_upgrade = packument_server.requests().len();
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--channel", "stable"]);
+    assert!(upgrade.status.success(), "{}", stderr(&upgrade));
+    assert_eq!(
+        packument_server.requests().len() - requests_before_upgrade,
+        1
+    );
+    assert_eq!(correction_server.requests().len(), 1);
+
+    let environment = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(environment.status.success(), "{}", stderr(&environment));
+    let environment: Value = serde_json::from_str(&stdout(&environment)).unwrap();
+    assert_eq!(environment["defaultRuntime"], "stable");
+    let runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(runtime.status.success(), "{}", stderr(&runtime));
+    let runtime: Value = serde_json::from_str(&stdout(&runtime)).unwrap();
+    assert_eq!(runtime["releaseVersion"], correction_version);
+}
+
+#[test]
 fn upgrade_dry_run_reports_without_changing_runtime_or_creating_snapshot() {
     let root = TestDir::new("upgrade-dry-run");
     let cwd = root.child("workspace");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -967,7 +967,7 @@ fn upgrade_dry_run_reports_without_changing_runtime_or_creating_snapshot() {
         old_integrity
     );
     let packument_server =
-        TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 1);
+        TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
 
     let mut env = ocm_env(&root);
     install_fake_node_and_npm(&root, &mut env, "22.22.3");
@@ -1589,7 +1589,11 @@ fn upgrade_rolls_back_runtime_when_service_restart_fails() {
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--version", "2026.3.25"]);
     assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
     let output = stdout(&upgrade);
-    assert!(output.contains("outcome=rolled-back"), "{output}");
+    assert!(
+        output.contains("outcome=rolled-back"),
+        "stdout:\n{output}\nstderr:\n{}",
+        stderr(&upgrade)
+    );
     assert!(output.contains("rollback=restored"), "{output}");
     assert!(output.contains("snapshot="), "{output}");
 
@@ -1666,9 +1670,18 @@ fn upgrade_restores_runtime_when_runtime_preparation_fails() {
     assert!(start.status.success(), "{}", stderr(&start));
 
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
-    assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
+    assert!(
+        !upgrade.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&upgrade),
+        stderr(&upgrade)
+    );
     let output = stdout(&upgrade);
-    assert!(output.contains("outcome=rolled-back"), "{output}");
+    assert!(
+        output.contains("outcome=rolled-back"),
+        "stdout:\n{output}\nstderr:\n{}",
+        stderr(&upgrade)
+    );
     assert!(output.contains("rollback=restored"), "{output}");
     assert!(
         output.contains("runtime artifact integrity is invalid"),


### PR DESCRIPTION
## Summary

- resolve and freeze runtime release selections before upgrade mutation
- reject known OpenClaw downgrades before snapshots, downloads, bindings, or services change
- preserve existing behavior for manual and unversioned runtimes
- document the downgrade safety boundary and recovery path

## Verification

- AWS Crabbox: `cargo test --test upgrade_command_tests`
- AWS Crabbox: `cargo test --test runtime_command_tests`
- AWS Crabbox: `cargo test --test release_manifest_tests`
- AWS Crabbox: `cargo test --test launcher_help_tests`
- AWS Crabbox: `cargo check --all-targets`
- AWS Crabbox: `cargo check --target x86_64-pc-windows-gnu`
- real OpenClaw downgrade rejection: `2026.7.2-beta.3` to `2026.7.1-2`
- real forward upgrade: `2026.7.2-beta.3` to frozen source `ec8f957f2e7ca3125824d610a2ad5a53446d6631`
