### PR TITLE
fix: verify OpenClaw gateway readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ running service cannot be restarted or started after the change, OCM restores
 the snapshot and previous runtime by default. When an environment moves to a new
 runtime, OCM runs OpenClaw's update finalization path inside that environment
 before service restart. A running managed service is considered recovered only
-after its HTTP health endpoint responds and OpenClaw's gateway status reports a
-reachable RPC endpoint; otherwise the upgrade follows the normal rollback path.
+after its HTTP health endpoint responds and OpenClaw's gateway status proves the
+gateway is reachable; otherwise the upgrade follows the normal rollback path.
 Snapshots preserve managed path, npm, and Git plugin payloads together with
 their package metadata and symlinks, while generated plugin dependency caches
 and live runtime residue stay out of the archive.

--- a/README.md
+++ b/README.md
@@ -136,9 +136,12 @@ ocm upgrade simulate mira --to ./openclaw
 running service cannot be restarted or started after the change, OCM restores
 the snapshot and previous runtime by default. When an environment moves to a new
 runtime, OCM runs OpenClaw's update finalization path inside that environment
-before service restart. Snapshots preserve managed path, npm, and Git plugin
-payloads together with their package metadata and symlinks, while generated
-plugin dependency caches and live runtime residue stay out of the archive.
+before service restart. A running managed service is considered recovered only
+after its HTTP health endpoint responds and OpenClaw's gateway status reports a
+reachable RPC endpoint; otherwise the upgrade follows the normal rollback path.
+Snapshots preserve managed path, npm, and Git plugin payloads together with
+their package metadata and symlinks, while generated plugin dependency caches
+and live runtime residue stay out of the archive.
 When both OpenClaw versions are known, `upgrade` rejects an older target before
 creating a snapshot, downloading the target, or changing runtime metadata.
 Switching only the binary cannot reverse newer OpenClaw config or SQLite state

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -585,7 +585,7 @@ pub fn upgrade_help(cmd: &str) -> String {
             "An env upgrade will not replace runtime bytes shared with another env; use --runtime to reuse those bytes or an exact --version for an isolated target.",
             "Upgrades create a pre-upgrade snapshot before changing env state.",
             "When an env moves to a new runtime, upgrade runs OpenClaw update finalization inside the env before service restart.",
-            "Managed-service upgrades require both HTTP health and OpenClaw gateway RPC readiness before reporting success.",
+            "Managed-service upgrades require both HTTP health and OpenClaw gateway reachability before reporting success.",
             "If service restart/start fails, ocm restores the snapshot and previous runtime unless --no-rollback is set.",
             "Pinned runtimes stay pinned unless you pass --version, --channel, or --runtime explicitly.",
             "Local-command environments are reported clearly instead of being changed behind your back.",

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -585,6 +585,7 @@ pub fn upgrade_help(cmd: &str) -> String {
             "An env upgrade will not replace runtime bytes shared with another env; use --runtime to reuse those bytes or an exact --version for an isolated target.",
             "Upgrades create a pre-upgrade snapshot before changing env state.",
             "When an env moves to a new runtime, upgrade runs OpenClaw update finalization inside the env before service restart.",
+            "Managed-service upgrades require both HTTP health and OpenClaw gateway RPC readiness before reporting success.",
             "If service restart/start fails, ocm restores the snapshot and previous runtime unless --no-rollback is set.",
             "Pinned runtimes stay pinned unless you pass --version, --channel, or --runtime explicitly.",
             "Local-command environments are reported clearly instead of being changed behind your back.",

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2050,12 +2050,18 @@ impl Cli {
         }
 
         if verify_gateway {
-            let gateway_status = self.run_openclaw_command(
+            let gateway_status = self.capture_openclaw_command(
                 env_name,
                 "openclaw gateway status",
                 &["gateway", "status", "--deep", "--json"],
             )?;
-            verify_gateway_status_readiness(&gateway_status.stdout)?;
+            if let Err(error) = verify_gateway_status_readiness(&gateway_status.stdout) {
+                return if gateway_status.status.success() {
+                    Err(error)
+                } else {
+                    Err(format!("{error}; {}", gateway_status.failure_summary()))
+                };
+            }
         }
 
         Ok(Some(format!(
@@ -2070,16 +2076,27 @@ impl Cli {
         name: &str,
         args: &[&str],
     ) -> Result<SimulationCommandOutput, String> {
+        let output = self.capture_openclaw_command(env_name, name, args)?;
+        if output.status.success() {
+            Ok(output)
+        } else {
+            Err(format!("{name} failed: {}", output.failure_summary()))
+        }
+    }
+
+    fn capture_openclaw_command(
+        &self,
+        env_name: &str,
+        name: &str,
+        args: &[&str],
+    ) -> Result<SimulationCommandOutput, String> {
         let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
         let resolved = self
             .environment_service()
             .resolve(env_name, None, None, &args)
             .map_err(|error| format!("{name} failed: {error}"))?;
-        match self.run_resolved_for_simulation(resolved, &[]) {
-            Ok(output) if output.status.success() => Ok(output),
-            Ok(output) => Err(format!("{name} failed: {}", output.failure_summary())),
-            Err(error) => Err(format!("{name} failed: {error}")),
-        }
+        self.run_resolved_for_simulation(resolved, &[])
+            .map_err(|error| format!("{name} failed: {error}"))
     }
 
     fn run_post_core_update(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2897,6 +2897,15 @@ fn gateway_readiness_result(ready: bool, status: &Value) -> Result<(), String> {
     if rpc_error.is_some_and(gateway_auth_failure_proves_reachable) {
         return Ok(());
     }
+    let target_error = status
+        .get("targets")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .find_map(|target| target.pointer("/connect/error").and_then(Value::as_str));
+    if target_error.is_some_and(gateway_auth_failure_proves_reachable) {
+        return Ok(());
+    }
 
     let detail = rpc_error
         .or_else(|| {
@@ -2907,14 +2916,7 @@ fn gateway_readiness_result(ready: bool, status: &Value) -> Result<(), String> {
                 .and_then(|warning| warning.get("message"))
                 .and_then(Value::as_str)
         })
-        .or_else(|| {
-            status
-                .get("targets")
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-                .find_map(|target| target.pointer("/connect/error").and_then(Value::as_str))
-        })
+        .or(target_error)
         .unwrap_or("OpenClaw reported that no gateway RPC endpoint was reachable");
 
     Err(format!("post-upgrade gateway readiness failed: {detail}"))

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2914,15 +2914,22 @@ fn gateway_readiness_result(ready: bool, status: &Value) -> Result<(), String> {
     if rpc_error.is_some_and(gateway_auth_failure_proves_reachable) {
         return Ok(());
     }
+    let target_auth_reachable = status
+        .get("targets")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|target| target.pointer("/connect/error").and_then(Value::as_str))
+        .any(gateway_auth_failure_proves_reachable);
+    if target_auth_reachable {
+        return Ok(());
+    }
     let target_error = status
         .get("targets")
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
         .find_map(|target| target.pointer("/connect/error").and_then(Value::as_str));
-    if target_error.is_some_and(gateway_auth_failure_proves_reachable) {
-        return Ok(());
-    }
 
     let detail = rpc_error
         .or_else(|| {
@@ -3060,6 +3067,12 @@ mod tests {
         assert!(
             verify_gateway_status_readiness(
                 r#"{"ok":false,"targets":[{"connect":{"ok":false,"error":"gateway closed (1008): device identity required"}}]}"#
+            )
+            .is_ok()
+        );
+        assert!(
+            verify_gateway_status_readiness(
+                r#"{"targets":[{"connect":{"ok":false,"error":"connect ECONNREFUSED 127.0.0.1:18789"}},{"connect":{"ok":false,"error":"gateway closed (1008): pairing required"}}]}"#
             )
             .is_ok()
         );

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2893,9 +2893,12 @@ fn gateway_readiness_result(ready: bool, status: &Value) -> Result<(), String> {
         return Ok(());
     }
 
-    let detail = status
-        .pointer("/rpc/error")
-        .and_then(Value::as_str)
+    let rpc_error = status.pointer("/rpc/error").and_then(Value::as_str);
+    if rpc_error.is_some_and(gateway_auth_failure_proves_reachable) {
+        return Ok(());
+    }
+
+    let detail = rpc_error
         .or_else(|| {
             status
                 .get("warnings")
@@ -2915,6 +2918,38 @@ fn gateway_readiness_result(ready: bool, status: &Value) -> Result<(), String> {
         .unwrap_or("OpenClaw reported that no gateway RPC endpoint was reachable");
 
     Err(format!("post-upgrade gateway readiness failed: {detail}"))
+}
+
+fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
+    let normalized = error.trim().to_ascii_lowercase();
+    let reason = normalized
+        .strip_prefix("gateway closed (1008):")
+        .map(str::trim)
+        .unwrap_or(normalized.as_str());
+
+    matches!(
+        reason,
+        "auth required"
+            | "owner auth required"
+            | "connect failed"
+            | "device required"
+            | "device identity required"
+            | "pairing required"
+    ) || reason.starts_with("pairing required:")
+        || reason.starts_with("unauthorized: gateway token missing")
+        || reason.starts_with("unauthorized: gateway token mismatch")
+        || reason.starts_with("unauthorized: gateway token not configured")
+        || reason.starts_with("unauthorized: gateway password missing")
+        || reason.starts_with("unauthorized: gateway password mismatch")
+        || reason.starts_with("unauthorized: gateway password not configured")
+        || reason.starts_with("unauthorized: bootstrap token invalid or expired")
+        || reason.starts_with("unauthorized: tailscale identity missing")
+        || reason.starts_with("unauthorized: tailscale proxy headers missing")
+        || reason.starts_with("unauthorized: tailscale identity check failed")
+        || reason.starts_with("unauthorized: tailscale identity mismatch")
+        || reason.starts_with("unauthorized: too many failed authentication attempts")
+        || reason.starts_with("unauthorized: device token mismatch")
+        || reason.starts_with("unauthorized: device token rejected")
 }
 
 #[cfg(test)]

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -3024,6 +3024,18 @@ mod tests {
             )
             .is_ok()
         );
+        assert!(
+            verify_gateway_status_readiness(
+                r#"{"rpc":{"ok":false,"error":"device identity required"}}"#
+            )
+            .is_ok()
+        );
+        assert!(
+            verify_gateway_status_readiness(
+                r#"{"rpc":{"ok":false,"error":"gateway closed (1008): unauthorized: gateway token mismatch"}}"#
+            )
+            .is_ok()
+        );
     }
 
     #[test]
@@ -3044,6 +3056,15 @@ mod tests {
         assert!(
             current.contains("No gateway answered any probe"),
             "{current}"
+        );
+
+        let arbitrary_auth_error = verify_gateway_status_readiness(
+            r#"{"rpc":{"ok":false,"error":"authentication backend unavailable"}}"#,
+        )
+        .unwrap_err();
+        assert!(
+            arbitrary_auth_error.contains("authentication backend unavailable"),
+            "{arbitrary_auth_error}"
         );
     }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2924,10 +2924,12 @@ fn gateway_readiness_result(ready: bool, status: &Value) -> Result<(), String> {
 
 fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
     let normalized = error.trim().to_ascii_lowercase();
-    let reason = normalized
+    let Some(reason) = normalized
         .strip_prefix("gateway closed (1008):")
         .map(str::trim)
-        .unwrap_or(normalized.as_str());
+    else {
+        return normalized == "device identity required";
+    };
 
     matches!(
         reason,
@@ -2935,7 +2937,6 @@ fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
             | "owner auth required"
             | "connect failed"
             | "device required"
-            | "device identity required"
             | "pairing required"
     ) || reason.starts_with("pairing required:")
         || reason.starts_with("unauthorized: gateway token missing")

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -3038,6 +3038,12 @@ mod tests {
             )
             .is_ok()
         );
+        assert!(
+            verify_gateway_status_readiness(
+                r#"{"ok":false,"targets":[{"connect":{"ok":false,"error":"gateway closed (1008): device identity required"}}]}"#
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2050,11 +2050,12 @@ impl Cli {
         }
 
         if verify_gateway {
-            self.run_openclaw_command(
+            let gateway_status = self.run_openclaw_command(
                 env_name,
                 "openclaw gateway status",
                 &["gateway", "status", "--deep", "--json"],
             )?;
+            verify_gateway_status_readiness(&gateway_status.stdout)?;
         }
 
         Ok(Some(format!(
@@ -2858,6 +2859,62 @@ fn gateway_health_ok(port: u32) -> bool {
     };
     let text = String::from_utf8_lossy(&response[..read]);
     text.starts_with("HTTP/1.1 200") || text.starts_with("HTTP/1.0 200")
+}
+
+fn verify_gateway_status_readiness(stdout: &str) -> Result<(), String> {
+    let status: Value = serde_json::from_str(stdout.trim()).map_err(|error| {
+        format!("post-upgrade gateway readiness failed: invalid status JSON ({error})")
+    })?;
+
+    if let Some(ready) = status.pointer("/rpc/ok").and_then(Value::as_bool) {
+        return gateway_readiness_result(ready, &status);
+    }
+    if let Some(ready) = status.get("ok").and_then(Value::as_bool) {
+        return gateway_readiness_result(ready, &status);
+    }
+    if let Some(targets) = status.get("targets").and_then(Value::as_array) {
+        let ready = targets.iter().any(|target| {
+            target
+                .pointer("/connect/ok")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        });
+        return gateway_readiness_result(ready, &status);
+    }
+
+    Err(
+        "post-upgrade gateway readiness failed: status JSON did not report RPC reachability"
+            .to_string(),
+    )
+}
+
+fn gateway_readiness_result(ready: bool, status: &Value) -> Result<(), String> {
+    if ready {
+        return Ok(());
+    }
+
+    let detail = status
+        .pointer("/rpc/error")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            status
+                .get("warnings")
+                .and_then(Value::as_array)
+                .and_then(|warnings| warnings.first())
+                .and_then(|warning| warning.get("message"))
+                .and_then(Value::as_str)
+        })
+        .or_else(|| {
+            status
+                .get("targets")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .find_map(|target| target.pointer("/connect/error").and_then(Value::as_str))
+        })
+        .unwrap_or("OpenClaw reported that no gateway RPC endpoint was reachable");
+
+    Err(format!("post-upgrade gateway readiness failed: {detail}"))
 }
 
 #[cfg(test)]

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2936,6 +2936,7 @@ fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
         "auth required"
             | "owner auth required"
             | "connect failed"
+            | "device identity required"
             | "device required"
             | "pairing required"
     ) || reason.starts_with("pairing required:")
@@ -3074,6 +3075,14 @@ mod tests {
         assert!(
             arbitrary_auth_error.contains("authentication backend unavailable"),
             "{arbitrary_auth_error}"
+        );
+
+        let bare_connect_failure =
+            verify_gateway_status_readiness(r#"{"rpc":{"ok":false,"error":"connect failed"}}"#)
+                .unwrap_err();
+        assert!(
+            bare_connect_failure.contains("connect failed"),
+            "{bare_connect_failure}"
         );
     }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2921,7 +2921,7 @@ fn gateway_readiness_result(ready: bool, status: &Value) -> Result<(), String> {
 mod tests {
     use super::{
         command_output_reports_unsupported_command, release_version_from_output,
-        version_output_matches_expected,
+        verify_gateway_status_readiness, version_output_matches_expected,
     };
 
     #[test]
@@ -2966,6 +2966,61 @@ mod tests {
         assert_eq!(
             release_version_from_output("OpenClaw current-main", Some("2026.7.2")).as_deref(),
             None
+        );
+    }
+
+    #[test]
+    fn gateway_readiness_accepts_historical_and_current_payloads() {
+        assert!(
+            verify_gateway_status_readiness(
+                r#"{"rpc":{"ok":true,"server":{"version":"2026.6.11"}}}"#
+            )
+            .is_ok()
+        );
+        assert!(
+            verify_gateway_status_readiness(
+                r#"{"ok":true,"targets":[{"connect":{"ok":true,"rpcOk":true}}]}"#
+            )
+            .is_ok()
+        );
+        assert!(
+            verify_gateway_status_readiness(
+                r#"{"targets":[{"connect":{"ok":false}},{"connect":{"ok":true}}]}"#
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn gateway_readiness_rejects_unreachable_payloads_with_diagnostics() {
+        let historical = verify_gateway_status_readiness(
+            r#"{"rpc":{"ok":false,"error":"connect ECONNREFUSED 127.0.0.1:18789"}}"#,
+        )
+        .unwrap_err();
+        assert!(
+            historical.contains("connect ECONNREFUSED 127.0.0.1:18789"),
+            "{historical}"
+        );
+
+        let current = verify_gateway_status_readiness(
+            r#"{"ok":false,"warnings":[{"message":"No gateway answered any probe"}],"targets":[]}"#,
+        )
+        .unwrap_err();
+        assert!(
+            current.contains("No gateway answered any probe"),
+            "{current}"
+        );
+    }
+
+    #[test]
+    fn gateway_readiness_rejects_invalid_or_unknown_json() {
+        let invalid = verify_gateway_status_readiness("not-json").unwrap_err();
+        assert!(invalid.contains("invalid status JSON"), "{invalid}");
+
+        let unknown = verify_gateway_status_readiness(r#"{"gatewayState":"running"}"#).unwrap_err();
+        assert!(
+            unknown.contains("did not report RPC reachability"),
+            "{unknown}"
         );
     }
 

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -279,6 +279,7 @@ fn upgrade_help_is_available_from_help_and_flag() {
     assert!(output.contains("Simulations clone the source env"));
     assert!(output.contains("Channel-tracked runtimes move forward automatically."));
     assert!(output.contains("older targets are rejected before snapshot creation"));
+    assert!(output.contains("require both HTTP health and OpenClaw gateway RPC readiness"));
     assert!(
         output.contains("An env upgrade will not replace runtime bytes shared with another env")
     );

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -279,7 +279,7 @@ fn upgrade_help_is_available_from_help_and_flag() {
     assert!(output.contains("Simulations clone the source env"));
     assert!(output.contains("Channel-tracked runtimes move forward automatically."));
     assert!(output.contains("older targets are rejected before snapshot creation"));
-    assert!(output.contains("require both HTTP health and OpenClaw gateway RPC readiness"));
+    assert!(output.contains("require both HTTP health and OpenClaw gateway reachability"));
     assert!(
         output.contains("An env upgrade will not replace runtime bytes shared with another env")
     );

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -153,7 +153,11 @@ case "$1" in
       echo "missing gateway status flags" >&2
       exit 1
     }}
-    printf '{{"gatewayState":"simulation-ok"}}\n'
+    if [ "${{OCM_TEST_GATEWAY_UNREADY:-}}" = "1" ]; then
+      printf '{{"rpc":{{"ok":false,"error":"gateway RPC is not ready"}}}}\n'
+    else
+      printf '{{"rpc":{{"ok":true}}}}\n'
+    fi
     exit 0
     ;;
 esac
@@ -239,7 +243,7 @@ case "$1" in
     exit 0
     ;;
   gateway)
-    printf '{{"gatewayState":"simulation-ok"}}\n'
+    printf '{{"rpc":{{"ok":true}}}}\n'
     exit 0
     ;;
 esac

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -201,7 +201,9 @@ case "$1" in
       echo "missing gateway status flags" >&2
       exit 1
     }}
-    if [ "${{OCM_TEST_GATEWAY_UNREADY:-}}" = "1" ]; then
+    if [ "${{OCM_TEST_GATEWAY_AUTH_HANDSHAKE:-}}" = "1" ]; then
+      printf '{{"rpc":{{"ok":false,"error":"device identity required"}}}}\n'
+    elif [ "${{OCM_TEST_GATEWAY_UNREADY:-}}" = "1" ]; then
       printf '{{"rpc":{{"ok":false,"error":"gateway RPC is not ready"}}}}\n'
     else
       printf '{{"rpc":{{"ok":true}}}}\n'
@@ -509,6 +511,10 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     let start = run_ocm(&cwd, &env, &["start", "demo"]);
     assert!(start.status.success(), "{}", stderr(&start));
 
+    env.insert(
+        "OCM_TEST_GATEWAY_AUTH_HANDSHAKE".to_string(),
+        "1".to_string(),
+    );
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
     assert!(upgrade.status.success(), "{}", stderr(&upgrade));
     let output = stdout(&upgrade);

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -203,6 +203,7 @@ case "$1" in
     }}
     if [ "${{OCM_TEST_GATEWAY_AUTH_HANDSHAKE:-}}" = "1" ]; then
       printf '{{"rpc":{{"ok":false,"error":"device identity required"}}}}\n'
+      exit "${{OCM_TEST_GATEWAY_STATUS_EXIT_CODE:-0}}"
     elif [ "${{OCM_TEST_GATEWAY_UNREADY:-}}" = "1" ]; then
       printf '{{"rpc":{{"ok":false,"error":"gateway RPC is not ready"}}}}\n'
     else
@@ -513,6 +514,10 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
 
     env.insert(
         "OCM_TEST_GATEWAY_AUTH_HANDSHAKE".to_string(),
+        "1".to_string(),
+    );
+    env.insert(
+        "OCM_TEST_GATEWAY_STATUS_EXIT_CODE".to_string(),
         "1".to_string(),
     );
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -3,9 +3,13 @@ mod support;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::thread::{self, sleep};
+use std::time::Duration;
 
 use base64::Engine;
 use flate2::{Compression, write::GzEncoder};
+use ocm::store::{now_utc, supervisor_runtime_path, supervisor_state_path};
+use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
 use serde_json::Value;
 use sha2::{Digest, Sha512};
 use tar::{Builder, Header};
@@ -50,6 +54,50 @@ fn openclaw_package_tarball(script_body: &str, version: &str) -> Vec<u8> {
         builder.finish().unwrap();
     }
     encoder.finish().unwrap()
+}
+
+fn write_running_supervisor_runtime(
+    runtime_path: &Path,
+    ocm_home: &str,
+    binding_name: &str,
+    pid: u32,
+    child_port: u32,
+) {
+    let log_root = runtime_path.parent().unwrap();
+    let stdout_path = path_string(&log_root.join("demo.stdout.log"));
+    let stderr_path = path_string(&log_root.join("demo.stderr.log"));
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: ocm_home.to_string(),
+        updated_at: now_utc(),
+        services: vec![SupervisorRuntimeService {
+            env_name: "demo".to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: binding_name.to_string(),
+            gateway_state: "running".to_string(),
+            restart_handoff: Some("none".to_string()),
+            restart_count: 0,
+            child_port,
+            pid: Some(pid),
+            stdout_path: stdout_path.clone(),
+            stderr_path: stderr_path.clone(),
+            last_exit_code: None,
+            last_error: None,
+            last_event_at: None,
+            next_retry_at: None,
+        }],
+        children: vec![SupervisorRuntimeChild {
+            env_name: "demo".to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: binding_name.to_string(),
+            pid,
+            restart_count: 0,
+            child_port,
+            stdout_path,
+            stderr_path,
+        }],
+    };
+    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
 }
 
 fn recording_openclaw_script(version: &str) -> String {
@@ -498,6 +546,126 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     let snapshot_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
     assert_eq!(snapshot_json.as_array().unwrap().len(), 1);
     assert_eq!(snapshot_json[0]["label"], "pre-upgrade");
+}
+
+#[test]
+fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
+    let root = TestDir::new("upgrade-gateway-readiness-rollback");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let health_server =
+        TestHttpServer::serve_bytes_times("/health", "application/json", br#"{"ok":true}"#, 8);
+    let health_url = health_server.url();
+    let health_port = health_url
+        .split(':')
+        .nth(2)
+        .and_then(|value| value.split('/').next())
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap();
+
+    let old_tarball =
+        openclaw_package_tarball(&recording_openclaw_script("2026.3.24"), "2026.3.24");
+    let old_integrity = sha512_integrity(&old_tarball);
+    let old_tarball_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.3.24.tgz",
+        "application/octet-stream",
+        &old_tarball,
+        10,
+    );
+    let new_tarball =
+        openclaw_package_tarball(&recording_openclaw_script("2026.3.25"), "2026.3.25");
+    let new_integrity = sha512_integrity(&new_tarball);
+    let new_tarball_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.3.25.tgz",
+        "application/octet-stream",
+        &new_tarball,
+        10,
+    );
+
+    let initial_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.24\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.3.24\":\"2026-03-25T16:35:52.000Z\"}}}}",
+        old_tarball_server.url(),
+        old_integrity
+    );
+    let updated_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.25\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}},\"2026.3.25\":{{\"version\":\"2026.3.25\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.3.24\":\"2026-03-25T16:35:52.000Z\",\"2026.3.25\":\"2026-03-26T09:00:00.000Z\"}}}}",
+        old_tarball_server.url(),
+        old_integrity,
+        new_tarball_server.url(),
+        new_integrity
+    );
+    let packument_server = TestHttpServer::serve_bytes_sequence(
+        "/openclaw",
+        "application/json",
+        vec![
+            initial_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+        ],
+    );
+
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+
+    let port = health_port.to_string();
+    let start = run_ocm(&cwd, &env, &["start", "demo", "--port", port.as_str()]);
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "stable", 4242, health_port);
+
+    let state_path = supervisor_state_path(&env, &cwd).unwrap();
+    let replacement_runtime_path = runtime_path.clone();
+    let replacement_ocm_home = ocm_home.clone();
+    let restart_observer = thread::spawn(move || {
+        for _ in 0..200 {
+            let state = fs::read_to_string(&state_path).unwrap_or_default();
+            if state.contains("restartRequests") && state.contains("\"envName\": \"demo\"") {
+                write_running_supervisor_runtime(
+                    &replacement_runtime_path,
+                    &replacement_ocm_home,
+                    "stable",
+                    4243,
+                    health_port,
+                );
+                return;
+            }
+            sleep(Duration::from_millis(25));
+        }
+        panic!("upgrade did not request a supervised gateway restart");
+    });
+
+    env.insert("OCM_TEST_GATEWAY_UNREADY".to_string(), "1".to_string());
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
+    restart_observer.join().unwrap();
+
+    assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
+    let output = stdout(&upgrade);
+    assert!(output.contains("outcome=rolled-back"), "{output}");
+    assert!(output.contains("rollback=restored"), "{output}");
+    assert!(
+        output.contains("post-upgrade gateway readiness failed: gateway RPC is not ready"),
+        "{output}"
+    );
+    assert!(!health_server.requests().is_empty());
+
+    let runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(runtime.status.success(), "{}", stderr(&runtime));
+    let runtime_json: Value = serde_json::from_str(&stdout(&runtime)).unwrap();
+    assert_eq!(runtime_json["releaseVersion"], "2026.3.24");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- require OpenClaw gateway reachability after managed-service upgrades
- accept historical and current gateway status payloads, including authenticated handshakes
- roll back upgrades when HTTP is healthy but the gateway remains unreachable
- document and test the managed-service readiness contract

## Verification

- `cargo test --lib gateway_readiness_` on retained AWS Crabbox lease
- `cargo test --test upgrade_command_tests` on a fresh exact-HEAD AWS workspace
- live gateway smokes across selected OpenClaw 2026.6.x, 2026.7.x, and frozen source `ec8f957f`
- `cargo check --all-targets` and Windows cross-check completed earlier in the branch gate