### PR TITLE
feat: record upgrade history

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This is the shortest path for most people.
 ocm upgrade mira
 ocm upgrade --all
 ocm upgrade mira --dry-run
+ocm upgrade history mira
 ocm upgrade simulate mira --to 2026.4.20
 ocm upgrade simulate mira --to 2026.4.20 --scenario all
 ocm upgrade simulate mira --to beta --scenario all
@@ -147,6 +148,11 @@ creating a snapshot, downloading the target, or changing runtime metadata.
 Switching only the binary cannot reverse newer OpenClaw config or SQLite state
 migrations; returning to an older release requires a complete snapshot captured
 while that release and its state schema were active.
+`ocm upgrade history <env>` lists completed upgrade transactions newest first,
+including source and target bindings and versions, the pre-upgrade snapshot,
+migration/finalization status, service state, and rollback outcome. History is
+stored as atomic JSON metadata under `OCM_HOME`; it does not copy config
+contents, command output, or credentials.
 Once an environment is bound to a runtime, direct `runtime update`,
 `runtime install --force`, `runtime build-local --force`, and `runtime remove`
 operations reject that runtime. Use `ocm upgrade <env>` so the environment gets

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -517,6 +517,7 @@ pub fn upgrade_help(cmd: &str) -> String {
         "Upgrade environments",
         "Update OpenClaw for one environment or every environment with pre-upgrade snapshots and service rollback when needed.",
         vec![
+            format!("{cmd} upgrade history <env> [--raw] [--json]"),
             format!(
                 "{cmd} upgrade simulate <env> --to <version|channel|repo-path> [--scenario current|minimum|telegram|all] [--keep-simulations] [--raw] [--json]"
             ),
@@ -563,6 +564,7 @@ pub fn upgrade_help(cmd: &str) -> String {
             ("--json", "Print upgrade summaries as JSON"),
         ],
         vec![
+            format!("{cmd} upgrade history mira"),
             format!("{cmd} upgrade simulate mira --to 2026.4.20"),
             format!("{cmd} upgrade simulate mira --to 2026.4.20 --scenario all"),
             format!("{cmd} upgrade simulate mira --to beta --scenario all"),
@@ -575,6 +577,7 @@ pub fn upgrade_help(cmd: &str) -> String {
         ],
         &[
             "Simulations clone the source env, leave the real env untouched, and clean temporary envs and runtimes by default.",
+            "Upgrade history lists completed transaction records newest first without reading config contents or credentials.",
             "Use --scenario all to test current, clean minimum, and Telegram-configured env shapes.",
             "Use --keep-simulations only when you need retained simulation artifacts after the run.",
             "Published-target simulations run OpenClaw's update dry-run plan before switching the clone.",

--- a/src/cli/render/upgrade.rs
+++ b/src/cli/render/upgrade.rs
@@ -4,8 +4,52 @@ use crate::cli::upgrade::{
 use crate::infra::terminal::{
     Cell, KeyValueRow, Tone, paint, render_key_value_card, render_table, terminal_width,
 };
+use crate::store::UpgradeHistoryRecord;
 
-use super::RenderProfile;
+use super::{RenderProfile, format_rfc3339};
+
+pub fn upgrade_history(
+    env_name: &str,
+    records: &[UpgradeHistoryRecord],
+    profile: RenderProfile,
+) -> Result<Vec<String>, String> {
+    if !profile.pretty {
+        return records
+            .iter()
+            .map(upgrade_history_raw_line)
+            .collect::<Result<Vec<_>, _>>();
+    }
+    if records.is_empty() {
+        return Ok(vec![paint(
+            &format!("No upgrade history for {env_name}."),
+            Tone::Muted,
+            profile.color,
+        )]);
+    }
+
+    let rows = records
+        .iter()
+        .map(|record| {
+            Ok(vec![
+                Cell::accent(record.id.clone()),
+                Cell::plain(format!("{}:{}", record.source.kind, record.source.name)),
+                Cell::plain(format!("{}:{}", record.target.kind, record.target.name)),
+                Cell::new(
+                    record.outcome.clone(),
+                    crate::infra::terminal::Align::Left,
+                    outcome_tone(&record.outcome),
+                ),
+                Cell::plain(format_rfc3339(record.completed_at)?),
+            ])
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    Ok(render_table(
+        &["Transaction", "From", "To", "Outcome", "Completed"],
+        &rows,
+        profile.color,
+    ))
+}
 
 pub fn upgrade_env(
     summary: &UpgradeEnvSummary,
@@ -406,6 +450,29 @@ fn upgrade_env_raw(summary: &UpgradeEnvSummary) -> Vec<String> {
         bits.push(format!("note={note}"));
     }
     vec![bits.join("  ")]
+}
+
+fn upgrade_history_raw_line(record: &UpgradeHistoryRecord) -> Result<String, String> {
+    let mut bits = vec![
+        format!("id={}", record.id),
+        format!("env={}", record.env_name),
+        format!("from={}:{}", record.source.kind, record.source.name),
+        format!("to={}:{}", record.target.kind, record.target.name),
+        format!("outcome={}", record.outcome),
+        format!("snapshot={}", record.snapshot_id),
+        format!("started={}", format_rfc3339(record.started_at)?),
+        format!("completed={}", format_rfc3339(record.completed_at)?),
+    ];
+    if let Some(version) = record.source.openclaw_version.as_deref() {
+        bits.push(format!("fromVersion={version}"));
+    }
+    if let Some(version) = record.target.openclaw_version.as_deref() {
+        bits.push(format!("toVersion={version}"));
+    }
+    if let Some(rollback) = record.rollback.as_deref() {
+        bits.push(format!("rollback={rollback}"));
+    }
+    Ok(bits.join("  "))
 }
 
 fn upgrade_batch_raw(summary: &UpgradeBatchSummary) -> Vec<String> {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1101,7 +1101,7 @@ impl Cli {
             let resolved = self.resolve_upgrade_target(target)?;
             let target_runtime_name = resolved.name.clone();
             let target_version = self.resolved_target_version(env_name, &resolved)?;
-            self.ensure_upgrade_is_not_downgrade(
+            let source_version = self.ensure_upgrade_is_not_downgrade(
                 env_name,
                 current.release_version.as_deref(),
                 target_version.as_deref(),
@@ -1143,7 +1143,7 @@ impl Cli {
                     source: UpgradeHistoryBinding {
                         kind: "runtime".to_string(),
                         name: current.name.clone(),
-                        openclaw_version: current.release_version.clone(),
+                        openclaw_version: source_version,
                     },
                     target: UpgradeHistoryBinding {
                         kind: "runtime".to_string(),
@@ -1334,7 +1334,7 @@ impl Cli {
             let resolved = self.resolve_upgrade_target(&target)?;
             let target_runtime_name = resolved.name.clone();
             let target_version = self.resolved_target_version(env_name, &resolved)?;
-            self.ensure_upgrade_is_not_downgrade(
+            let source_version = self.ensure_upgrade_is_not_downgrade(
                 env_name,
                 current.release_version.as_deref(),
                 target_version.as_deref(),
@@ -1363,7 +1363,7 @@ impl Cli {
                     source: UpgradeHistoryBinding {
                         kind: "runtime".to_string(),
                         name: current.name.clone(),
-                        openclaw_version: current.release_version.clone(),
+                        openclaw_version: source_version,
                     },
                     target: UpgradeHistoryBinding {
                         kind: "runtime".to_string(),
@@ -1501,7 +1501,7 @@ impl Cli {
             },
         )?;
         let target_version = resolved_update.release_version().to_string();
-        self.ensure_upgrade_is_not_downgrade(
+        let source_version = self.ensure_upgrade_is_not_downgrade(
             env_name,
             current.release_version.as_deref(),
             Some(&target_version),
@@ -1529,7 +1529,7 @@ impl Cli {
                 source: UpgradeHistoryBinding {
                     kind: "runtime".to_string(),
                     name: current.name.clone(),
-                    openclaw_version: current.release_version.clone(),
+                    openclaw_version: source_version,
                 },
                 target: UpgradeHistoryBinding {
                     kind: "runtime".to_string(),
@@ -1711,7 +1711,8 @@ impl Cli {
         let resolved = self.resolve_upgrade_target(target)?;
         let target_runtime_name = resolved.name.clone();
         let target_version = self.resolved_target_version(env_name, &resolved)?;
-        self.ensure_upgrade_is_not_downgrade(env_name, None, target_version.as_deref())?;
+        let source_version =
+            self.ensure_upgrade_is_not_downgrade(env_name, None, target_version.as_deref())?;
         if !target.is_named_runtime() {
             self.ensure_runtime_upgrade_isolated(env_name, &target_runtime_name)?;
         }
@@ -1739,7 +1740,7 @@ impl Cli {
                 source: UpgradeHistoryBinding {
                     kind: "launcher".to_string(),
                     name: launcher_name.to_string(),
-                    openclaw_version: None,
+                    openclaw_version: source_version,
                 },
                 target: UpgradeHistoryBinding {
                     kind: "runtime".to_string(),
@@ -1907,10 +1908,7 @@ impl Cli {
         env_name: &str,
         current_version_hint: Option<&str>,
         target_version: Option<&str>,
-    ) -> Result<(), String> {
-        let Some(target_version) = target_version else {
-            return Ok(());
-        };
+    ) -> Result<Option<String>, String> {
         let current_version_hint = current_version_hint
             .filter(|version| compare_runtime_release_versions(version, version).is_some());
         let current_version =
@@ -1922,19 +1920,22 @@ impl Cli {
                 }
                 Err(_) => current_version_hint.map(str::to_string),
             };
+        let Some(target_version) = target_version else {
+            return Ok(current_version);
+        };
         let Some(current_version) = current_version else {
-            return Ok(());
+            return Ok(None);
         };
 
         if current_version == target_version {
-            return Ok(());
+            return Ok(Some(current_version));
         }
 
         match compare_runtime_release_versions(&current_version, target_version) {
             Some(std::cmp::Ordering::Greater) => Err(format!(
                 "refusing to downgrade env \"{env_name}\" from OpenClaw {current_version} to {target_version}: OCM does not run reverse config or SQLite state migrations, and newer environment state may be unreadable by the older runtime. Restore a complete pre-upgrade snapshot captured with {target_version} instead of switching only the runtime"
             )),
-            Some(_) => Ok(()),
+            Some(_) => Ok(Some(current_version)),
             None => Err(format!(
                 "cannot safely compare current OpenClaw version \"{current_version}\" with target \"{target_version}\"; refusing to change env \"{env_name}\" without downgrade safety"
             )),

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -28,9 +28,9 @@ use crate::service::ServiceSummary;
 use crate::store::{
     InstallContext, RuntimeReleaseDetails, clean_path, copy_dir_recursive, derive_env_paths,
     display_path, ensure_minimum_local_openclaw_config, ensure_store, get_runtime,
-    install_runtime_from_selected_official_openclaw_release, lock_env_registry, remove_runtime,
-    resolve_absolute_path, runtime_install_root, runtime_integrity_issue, runtime_meta_path,
-    save_environment, write_json,
+    install_runtime_from_selected_official_openclaw_release, list_upgrade_history,
+    lock_env_registry, remove_runtime, resolve_absolute_path, runtime_install_root,
+    runtime_integrity_issue, runtime_meta_path, save_environment, write_json,
 };
 
 #[derive(Clone, Debug, Serialize)]
@@ -238,6 +238,21 @@ impl Cli {
 
     pub(super) fn handle_upgrade_command(&self, args: Vec<String>) -> Result<i32, String> {
         let (args, json_flag, profile) = self.consume_human_output_flags(args, "upgrade")?;
+        if matches!(args.first().map(String::as_str), Some("history")) {
+            let Some(env_name) = args.get(1) else {
+                return Err("upgrade history requires <env>".to_string());
+            };
+            Self::assert_no_extra_args(&args[2..])?;
+            let history = list_upgrade_history(env_name, &self.env, &self.cwd)?;
+            if json_flag {
+                self.print_json(&history)?;
+            } else {
+                self.stdout_lines(render::upgrade::upgrade_history(
+                    env_name, &history, profile,
+                )?);
+            }
+            return Ok(0);
+        }
         if matches!(args.first().map(String::as_str), Some("simulate")) {
             let summaries = self.upgrade_simulate(args[1..].to_vec())?;
             let failed = summaries.iter().any(|summary| summary.outcome == "failed");

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -26,11 +26,13 @@ use crate::runtime::{
 };
 use crate::service::ServiceSummary;
 use crate::store::{
-    InstallContext, RuntimeReleaseDetails, clean_path, copy_dir_recursive, derive_env_paths,
-    display_path, ensure_minimum_local_openclaw_config, ensure_store, get_runtime,
-    install_runtime_from_selected_official_openclaw_release, list_upgrade_history,
-    lock_env_registry, remove_runtime, resolve_absolute_path, runtime_install_root,
-    runtime_integrity_issue, runtime_meta_path, save_environment, write_json,
+    InstallContext, RuntimeReleaseDetails, UpgradeHistoryBinding, UpgradeHistoryRecord,
+    UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage, clean_path,
+    copy_dir_recursive, derive_env_paths, display_path, ensure_minimum_local_openclaw_config,
+    ensure_store, get_runtime, install_runtime_from_selected_official_openclaw_release,
+    list_upgrade_history, lock_env_registry, remove_runtime, resolve_absolute_path,
+    runtime_install_root, runtime_integrity_issue, runtime_meta_path, save_environment,
+    save_upgrade_history_record, write_json,
 };
 
 #[derive(Clone, Debug, Serialize)]
@@ -148,6 +150,12 @@ struct UpgradeOptions {
 #[derive(Clone, Copy, Debug)]
 struct UpgradeSimulationOptions {
     keep_envs: bool,
+}
+
+#[derive(Clone, Debug)]
+struct UpgradeTransactionPlan {
+    source: UpgradeHistoryBinding,
+    target: UpgradeHistoryBinding,
 }
 
 #[derive(Clone, Debug)]
@@ -1129,8 +1137,20 @@ impl Cli {
                     ),
                 });
             }
-            let transaction = self.begin_upgrade_transaction(
+            let mut transaction = self.begin_upgrade_transaction(
                 env_name,
+                UpgradeTransactionPlan {
+                    source: UpgradeHistoryBinding {
+                        kind: "runtime".to_string(),
+                        name: current.name.clone(),
+                        openclaw_version: current.release_version.clone(),
+                    },
+                    target: UpgradeHistoryBinding {
+                        kind: "runtime".to_string(),
+                        name: target_runtime_name.clone(),
+                        openclaw_version: target_version.clone(),
+                    },
+                },
                 &[current.name.clone(), target_runtime_name.clone()],
                 options.rollback_enabled,
             )?;
@@ -1152,8 +1172,12 @@ impl Cli {
             };
             let binding_changed = prepared.name != current.name;
             let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
-                Ok(note) => note,
+                Ok(note) => {
+                    transaction.mark_post_update_completed(note.as_deref());
+                    note
+                }
                 Err(error) => {
+                    transaction.mark_post_update_failed(&error);
                     return self.rollback_failed_upgrade(
                         env_name,
                         "runtime",
@@ -1255,8 +1279,7 @@ impl Cli {
                 rollback: None,
                 note,
             };
-            transaction.cleanup();
-            return Ok(summary);
+            return self.finish_successful_upgrade(summary, transaction);
         }
 
         if current.source_manifest_url.is_none() {
@@ -1334,8 +1357,20 @@ impl Cli {
                     ),
                 });
             }
-            let transaction = self.begin_upgrade_transaction(
+            let mut transaction = self.begin_upgrade_transaction(
                 env_name,
+                UpgradeTransactionPlan {
+                    source: UpgradeHistoryBinding {
+                        kind: "runtime".to_string(),
+                        name: current.name.clone(),
+                        openclaw_version: current.release_version.clone(),
+                    },
+                    target: UpgradeHistoryBinding {
+                        kind: "runtime".to_string(),
+                        name: target_runtime_name.clone(),
+                        openclaw_version: target_version.clone(),
+                    },
+                },
                 &[current.name.clone(), target_runtime_name.clone()],
                 options.rollback_enabled,
             )?;
@@ -1361,8 +1396,12 @@ impl Cli {
             );
             let post_update_note = if changed {
                 match self.run_post_core_update(env_name, &prepared.name) {
-                    Ok(note) => note,
+                    Ok(note) => {
+                        transaction.mark_post_update_completed(note.as_deref());
+                        note
+                    }
                     Err(error) => {
+                        transaction.mark_post_update_failed(&error);
                         return self.rollback_failed_upgrade(
                             env_name,
                             "runtime",
@@ -1377,6 +1416,7 @@ impl Cli {
                     }
                 }
             } else {
+                transaction.mark_post_update_not_needed();
                 None
             };
             if changed && let Err(error) = self.runtime_service().refresh_supervisor_if_present() {
@@ -1450,8 +1490,7 @@ impl Cli {
                     verification_note,
                 ),
             };
-            transaction.cleanup();
-            return Ok(summary);
+            return self.finish_successful_upgrade(summary, transaction);
         }
 
         let resolved_update = self.runtime_service().resolve_update_from_release(
@@ -1484,8 +1523,20 @@ impl Cli {
                 note: Some("dry run: no runtime, env, service, or snapshot changed".to_string()),
             });
         }
-        let transaction = self.begin_upgrade_transaction(
+        let mut transaction = self.begin_upgrade_transaction(
             env_name,
+            UpgradeTransactionPlan {
+                source: UpgradeHistoryBinding {
+                    kind: "runtime".to_string(),
+                    name: current.name.clone(),
+                    openclaw_version: current.release_version.clone(),
+                },
+                target: UpgradeHistoryBinding {
+                    kind: "runtime".to_string(),
+                    name: current.name.clone(),
+                    openclaw_version: Some(target_version.clone()),
+                },
+            },
             std::slice::from_ref(&current.name),
             options.rollback_enabled,
         )?;
@@ -1511,8 +1562,12 @@ impl Cli {
             }
         };
         let post_update_note = match self.run_post_core_update(env_name, &updated.name) {
-            Ok(note) => note,
+            Ok(note) => {
+                transaction.mark_post_update_completed(note.as_deref());
+                note
+            }
             Err(error) => {
+                transaction.mark_post_update_failed(&error);
                 return self.rollback_failed_upgrade(
                     env_name,
                     "runtime",
@@ -1594,8 +1649,7 @@ impl Cli {
                 verification_note,
             ),
         };
-        transaction.cleanup();
-        Ok(summary)
+        self.finish_successful_upgrade(summary, transaction)
     }
 
     fn ensure_runtime_upgrade_isolated(
@@ -1679,8 +1733,20 @@ impl Cli {
             });
         }
 
-        let transaction = self.begin_upgrade_transaction(
+        let mut transaction = self.begin_upgrade_transaction(
             env_name,
+            UpgradeTransactionPlan {
+                source: UpgradeHistoryBinding {
+                    kind: "launcher".to_string(),
+                    name: launcher_name.to_string(),
+                    openclaw_version: None,
+                },
+                target: UpgradeHistoryBinding {
+                    kind: "runtime".to_string(),
+                    name: target_runtime_name.clone(),
+                    openclaw_version: target_version.clone(),
+                },
+            },
             std::slice::from_ref(&target_runtime_name),
             options.rollback_enabled,
         )?;
@@ -1701,8 +1767,12 @@ impl Cli {
             }
         };
         let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
-            Ok(note) => note,
+            Ok(note) => {
+                transaction.mark_post_update_completed(note.as_deref());
+                note
+            }
             Err(error) => {
+                transaction.mark_post_update_failed(&error);
                 return self.rollback_failed_upgrade(
                     env_name,
                     "launcher",
@@ -1791,8 +1861,7 @@ impl Cli {
                 verification_note,
             ),
         };
-        transaction.cleanup();
-        Ok(summary)
+        self.finish_successful_upgrade(summary, transaction)
     }
 
     fn upgrade_service_status(&self, env_name: &str) -> Result<Option<ServiceSummary>, String> {
@@ -2221,9 +2290,17 @@ impl Cli {
     fn begin_upgrade_transaction(
         &self,
         env_name: &str,
+        plan: UpgradeTransactionPlan,
         runtime_names: &[String],
         rollback_enabled: bool,
     ) -> Result<UpgradeTransaction, String> {
+        let env_meta = self.environment_service().get(env_name)?;
+        let started_at = time::OffsetDateTime::now_utc();
+        let id = format!(
+            "{}-{:09}",
+            started_at.unix_timestamp(),
+            started_at.nanosecond()
+        );
         let snapshot = self
             .environment_service()
             .create_snapshot(CreateEnvSnapshotOptions {
@@ -2251,11 +2328,89 @@ impl Cli {
         }
 
         Ok(UpgradeTransaction {
+            id,
             snapshot_id: snapshot.id,
             runtime_backups,
             created_runtime_names,
             rollback_enabled,
+            started_at,
+            source: plan.source,
+            target: plan.target,
+            service_before: UpgradeHistoryServiceState {
+                enabled: env_meta.service_enabled,
+                running: env_meta.service_running,
+            },
+            migration: UpgradeHistoryStage {
+                status: "not-run".to_string(),
+                note: None,
+            },
+            finalization: UpgradeHistoryStage {
+                status: "not-run".to_string(),
+                note: None,
+            },
         })
+    }
+
+    fn finish_successful_upgrade(
+        &self,
+        summary: UpgradeEnvSummary,
+        transaction: UpgradeTransaction,
+    ) -> Result<UpgradeEnvSummary, String> {
+        if let Err(error) = self.record_upgrade_history(&transaction, &summary) {
+            return self.rollback_failed_upgrade(
+                &summary.env_name,
+                &summary.previous_binding_kind,
+                summary.previous_binding_name.clone(),
+                &summary.binding_kind,
+                summary.binding_name.clone(),
+                summary.runtime_release_version.clone(),
+                summary.runtime_release_channel.clone(),
+                transaction,
+                format!("failed to record upgrade history: {error}"),
+            );
+        }
+        transaction.cleanup();
+        Ok(summary)
+    }
+
+    fn record_upgrade_history(
+        &self,
+        transaction: &UpgradeTransaction,
+        summary: &UpgradeEnvSummary,
+    ) -> Result<(), String> {
+        let env_meta = self.environment_service().get(&summary.env_name)?;
+        let runtime_recovery = transaction
+            .runtime_backups
+            .iter()
+            .map(|backup| UpgradeHistoryRuntimeRecovery {
+                runtime_name: backup.meta.name.clone(),
+                release_version: backup.meta.release_version.clone(),
+                backup_id: None,
+            })
+            .collect();
+        let record = UpgradeHistoryRecord {
+            kind: "ocm-upgrade-transaction".to_string(),
+            format_version: 1,
+            id: transaction.id.clone(),
+            env_name: summary.env_name.clone(),
+            source: transaction.source.clone(),
+            target: transaction.target.clone(),
+            snapshot_id: transaction.snapshot_id.clone(),
+            runtime_recovery,
+            started_at: transaction.started_at,
+            completed_at: time::OffsetDateTime::now_utc(),
+            outcome: summary.outcome.clone(),
+            migration: transaction.migration.clone(),
+            finalization: transaction.finalization.clone(),
+            service_before: transaction.service_before.clone(),
+            service_after: UpgradeHistoryServiceState {
+                enabled: env_meta.service_enabled,
+                running: env_meta.service_running,
+            },
+            rollback: summary.rollback.clone(),
+            note: None,
+        };
+        save_upgrade_history_record(&record, &self.env, &self.cwd)
     }
 
     fn backup_runtime_for_upgrade(
@@ -2306,8 +2461,7 @@ impl Cli {
     ) -> Result<UpgradeEnvSummary, String> {
         if !transaction.rollback_enabled {
             let snapshot_id = transaction.snapshot_id.clone();
-            transaction.cleanup();
-            return Ok(UpgradeEnvSummary {
+            let mut summary = UpgradeEnvSummary {
                 env_name: env_name.to_string(),
                 previous_binding_kind: previous_binding_kind.to_string(),
                 previous_binding_name,
@@ -2320,14 +2474,21 @@ impl Cli {
                 snapshot_id: Some(snapshot_id),
                 rollback: Some("disabled".to_string()),
                 note: Some(format!("upgrade failed and rollback was disabled: {error}")),
-            });
+            };
+            if let Err(history_error) = self.record_upgrade_history(&transaction, &summary) {
+                summary.note = join_optional_warnings(
+                    summary.note,
+                    Some(format!("upgrade history was not recorded: {history_error}")),
+                );
+            }
+            transaction.cleanup();
+            return Ok(summary);
         }
 
         let rollback_result = self.rollback_upgrade(env_name, &transaction);
         let snapshot_id = transaction.snapshot_id.clone();
-        transaction.cleanup();
-        match rollback_result {
-            Ok(()) => Ok(UpgradeEnvSummary {
+        let mut summary = match rollback_result {
+            Ok(()) => UpgradeEnvSummary {
                 env_name: env_name.to_string(),
                 previous_binding_kind: previous_binding_kind.to_string(),
                 previous_binding_name,
@@ -2342,8 +2503,8 @@ impl Cli {
                 note: Some(format!(
                     "upgrade failed, so ocm restored the pre-upgrade snapshot: {error}"
                 )),
-            }),
-            Err(rollback_error) => Ok(UpgradeEnvSummary {
+            },
+            Err(rollback_error) => UpgradeEnvSummary {
                 env_name: env_name.to_string(),
                 previous_binding_kind: previous_binding_kind.to_string(),
                 previous_binding_name,
@@ -2358,8 +2519,16 @@ impl Cli {
                 note: Some(format!(
                     "upgrade failed ({error}); rollback also failed: {rollback_error}"
                 )),
-            }),
+            },
+        };
+        if let Err(history_error) = self.record_upgrade_history(&transaction, &summary) {
+            summary.note = join_optional_warnings(
+                summary.note,
+                Some(format!("upgrade history was not recorded: {history_error}")),
+            );
         }
+        transaction.cleanup();
+        Ok(summary)
     }
 
     fn rollback_upgrade(
@@ -2551,13 +2720,44 @@ impl UpgradeSimulationScenario {
 
 #[derive(Debug)]
 struct UpgradeTransaction {
+    id: String,
     snapshot_id: String,
     runtime_backups: Vec<RuntimeRollbackBackup>,
     created_runtime_names: Vec<String>,
     rollback_enabled: bool,
+    started_at: time::OffsetDateTime,
+    source: UpgradeHistoryBinding,
+    target: UpgradeHistoryBinding,
+    service_before: UpgradeHistoryServiceState,
+    migration: UpgradeHistoryStage,
+    finalization: UpgradeHistoryStage,
 }
 
 impl UpgradeTransaction {
+    fn mark_post_update_completed(&mut self, note: Option<&str>) {
+        self.migration.status = if note.is_some_and(|note| note.contains("config repair")) {
+            "repaired".to_string()
+        } else {
+            "validated".to_string()
+        };
+        self.finalization.status = "completed".to_string();
+    }
+
+    fn mark_post_update_failed(&mut self, error: &str) {
+        if error.contains("openclaw update finalize failed") {
+            self.migration.status = "validated".to_string();
+            self.finalization.status = "failed".to_string();
+        } else {
+            self.migration.status = "failed".to_string();
+            self.finalization.status = "not-run".to_string();
+        }
+    }
+
+    fn mark_post_update_not_needed(&mut self) {
+        self.migration.status = "not-needed".to_string();
+        self.finalization.status = "not-needed".to_string();
+    }
+
     fn cleanup(self) {
         for runtime_backup in self.runtime_backups {
             runtime_backup.cleanup();

--- a/src/store/layout.rs
+++ b/src/store/layout.rs
@@ -18,6 +18,7 @@ pub struct StorePaths {
     pub launchers_dir: PathBuf,
     pub runtimes_dir: PathBuf,
     pub snapshots_dir: PathBuf,
+    pub upgrade_history_dir: PathBuf,
     pub supervisor_dir: PathBuf,
 }
 
@@ -148,6 +149,7 @@ pub fn resolve_store_paths(
         launchers_dir: home.join("launchers"),
         runtimes_dir: home.join("runtimes"),
         snapshots_dir: home.join("snapshots"),
+        upgrade_history_dir: home.join("upgrade-history"),
         supervisor_dir: home.join("supervisor"),
         home,
     })
@@ -254,6 +256,24 @@ pub fn snapshot_meta_path(
     cwd: &Path,
 ) -> Result<PathBuf, String> {
     Ok(snapshot_env_dir(env_name, env, cwd)?.join(format!("{snapshot_id}.json")))
+}
+
+pub fn upgrade_history_env_dir(
+    env_name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PathBuf, String> {
+    let stores = resolve_store_paths(env, cwd)?;
+    Ok(stores.upgrade_history_dir.join(env_name))
+}
+
+pub fn upgrade_history_meta_path(
+    env_name: &str,
+    transaction_id: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PathBuf, String> {
+    Ok(upgrade_history_env_dir(env_name, env, cwd)?.join(format!("{transaction_id}.json")))
 }
 
 pub fn supervisor_state_path(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,6 +8,7 @@ mod openclaw_state;
 mod openclaw_workspaces;
 mod runtimes;
 mod snapshots;
+mod upgrade_history;
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -47,7 +48,7 @@ pub use layout::{
     resolve_store_paths, resolve_user_home, runtime_install_files_dir, runtime_install_root,
     runtime_meta_path, snapshot_archive_path, snapshot_env_dir, snapshot_meta_path,
     source_watch_override_path, supervisor_logs_dir, supervisor_runtime_path,
-    supervisor_state_path, validate_name,
+    supervisor_state_path, upgrade_history_env_dir, upgrade_history_meta_path, validate_name,
 };
 pub(crate) use openclaw_config::{
     OpenClawConfigAudit, audit_openclaw_config, clear_skip_bootstrap_for_openclaw_onboarding,
@@ -80,6 +81,11 @@ pub use snapshots::{
     create_env_snapshot, get_env_snapshot, list_all_env_snapshots, list_env_snapshots,
     remove_env_snapshot, restore_env_snapshot, summarize_snapshot,
 };
+pub use upgrade_history::{
+    UpgradeHistoryBinding, UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery,
+    UpgradeHistoryServiceState, UpgradeHistoryStage, get_upgrade_history_record,
+    list_upgrade_history, save_upgrade_history_record,
+};
 
 pub fn now_utc() -> OffsetDateTime {
     OffsetDateTime::now_utc()
@@ -92,6 +98,7 @@ pub fn ensure_store(env: &BTreeMap<String, String>, cwd: &Path) -> Result<StoreP
     ensure_dir(&stores.launchers_dir)?;
     ensure_dir(&stores.runtimes_dir)?;
     ensure_dir(&stores.snapshots_dir)?;
+    ensure_dir(&stores.upgrade_history_dir)?;
     ensure_dir(&stores.supervisor_dir)?;
     Ok(stores)
 }

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -1,0 +1,225 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use super::common::{load_json_files, path_exists, read_json, write_json};
+use super::layout::{upgrade_history_env_dir, upgrade_history_meta_path, validate_name};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeHistoryBinding {
+    pub kind: String,
+    pub name: String,
+    #[serde(default)]
+    pub openclaw_version: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeHistoryServiceState {
+    pub enabled: bool,
+    pub running: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeHistoryStage {
+    pub status: String,
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeHistoryRuntimeRecovery {
+    pub runtime_name: String,
+    #[serde(default)]
+    pub release_version: Option<String>,
+    #[serde(default)]
+    pub backup_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeHistoryRecord {
+    pub kind: String,
+    pub format_version: u32,
+    pub id: String,
+    pub env_name: String,
+    pub source: UpgradeHistoryBinding,
+    pub target: UpgradeHistoryBinding,
+    pub snapshot_id: String,
+    #[serde(default)]
+    pub runtime_recovery: Vec<UpgradeHistoryRuntimeRecovery>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub started_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub completed_at: OffsetDateTime,
+    pub outcome: String,
+    pub migration: UpgradeHistoryStage,
+    pub finalization: UpgradeHistoryStage,
+    pub service_before: UpgradeHistoryServiceState,
+    pub service_after: UpgradeHistoryServiceState,
+    #[serde(default)]
+    pub rollback: Option<String>,
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+pub fn save_upgrade_history_record(
+    record: &UpgradeHistoryRecord,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<(), String> {
+    let env_name = validate_name(&record.env_name, "Environment name")?;
+    let transaction_id = validate_name(&record.id, "Upgrade transaction id")?;
+    if record.kind != "ocm-upgrade-transaction" {
+        return Err(format!("unsupported upgrade history kind: {}", record.kind));
+    }
+    if record.format_version != 1 {
+        return Err(format!(
+            "unsupported upgrade history format version: {}",
+            record.format_version
+        ));
+    }
+    let path = upgrade_history_meta_path(&env_name, &transaction_id, env, cwd)?;
+    write_json(&path, record)
+}
+
+pub fn get_upgrade_history_record(
+    env_name: &str,
+    transaction_id: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<UpgradeHistoryRecord, String> {
+    let env_name = validate_name(env_name, "Environment name")?;
+    let transaction_id = validate_name(transaction_id, "Upgrade transaction id")?;
+    let path = upgrade_history_meta_path(&env_name, &transaction_id, env, cwd)?;
+    if !path_exists(&path) {
+        return Err(format!(
+            "upgrade transaction \"{transaction_id}\" does not exist for environment \"{env_name}\""
+        ));
+    }
+    read_json(&path)
+}
+
+pub fn list_upgrade_history(
+    env_name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<Vec<UpgradeHistoryRecord>, String> {
+    let env_name = validate_name(env_name, "Environment name")?;
+    let dir = upgrade_history_env_dir(&env_name, env, cwd)?;
+    let files = load_json_files(&dir)?;
+    let mut records: Vec<UpgradeHistoryRecord> = Vec::with_capacity(files.len());
+    for file in files {
+        records.push(read_json(&file)?);
+    }
+    records.sort_by(|left, right| {
+        right
+            .started_at
+            .cmp(&left.started_at)
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use time::OffsetDateTime;
+
+    use super::{
+        UpgradeHistoryBinding, UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery,
+        UpgradeHistoryServiceState, UpgradeHistoryStage, get_upgrade_history_record,
+        list_upgrade_history, save_upgrade_history_record,
+    };
+
+    fn test_env(label: &str) -> (PathBuf, BTreeMap<String, String>) {
+        let root = std::env::temp_dir().join(format!(
+            "ocm-upgrade-history-{label}-{}",
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        let mut env = BTreeMap::new();
+        env.insert(
+            "OCM_HOME".to_string(),
+            root.join("ocm").to_string_lossy().into_owned(),
+        );
+        (root, env)
+    }
+
+    fn record(id: &str, started_at: OffsetDateTime) -> UpgradeHistoryRecord {
+        UpgradeHistoryRecord {
+            kind: "ocm-upgrade-transaction".to_string(),
+            format_version: 1,
+            id: id.to_string(),
+            env_name: "demo".to_string(),
+            source: UpgradeHistoryBinding {
+                kind: "runtime".to_string(),
+                name: "stable".to_string(),
+                openclaw_version: Some("2026.6.11".to_string()),
+            },
+            target: UpgradeHistoryBinding {
+                kind: "runtime".to_string(),
+                name: "2026.6.33".to_string(),
+                openclaw_version: Some("2026.6.33".to_string()),
+            },
+            snapshot_id: "snapshot-1".to_string(),
+            runtime_recovery: vec![UpgradeHistoryRuntimeRecovery {
+                runtime_name: "stable".to_string(),
+                release_version: Some("2026.6.11".to_string()),
+                backup_id: None,
+            }],
+            started_at,
+            completed_at: started_at,
+            outcome: "switched".to_string(),
+            migration: UpgradeHistoryStage {
+                status: "completed".to_string(),
+                note: None,
+            },
+            finalization: UpgradeHistoryStage {
+                status: "completed".to_string(),
+                note: None,
+            },
+            service_before: UpgradeHistoryServiceState {
+                enabled: true,
+                running: true,
+            },
+            service_after: UpgradeHistoryServiceState {
+                enabled: true,
+                running: true,
+            },
+            rollback: None,
+            note: None,
+        }
+    }
+
+    #[test]
+    fn upgrade_history_round_trips_and_sorts_newest_first() {
+        let (root, env) = test_env("round-trip");
+        let cwd = root.as_path();
+        let older = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+        let newer = OffsetDateTime::from_unix_timestamp(1_800_000_000).unwrap();
+
+        save_upgrade_history_record(&record("1700000000-000000001", older), &env, cwd).unwrap();
+        save_upgrade_history_record(&record("1800000000-000000001", newer), &env, cwd).unwrap();
+
+        let records = list_upgrade_history("demo", &env, cwd).unwrap();
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1800000000-000000001", "1700000000-000000001"]
+        );
+        let loaded = get_upgrade_history_record("demo", "1700000000-000000001", &env, cwd).unwrap();
+        assert_eq!(loaded.source.openclaw_version.as_deref(), Some("2026.6.11"));
+        assert_eq!(loaded.target.openclaw_version.as_deref(), Some("2026.6.33"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -280,6 +280,7 @@ fn upgrade_help_is_available_from_help_and_flag() {
     assert!(output.contains("Channel-tracked runtimes move forward automatically."));
     assert!(output.contains("older targets are rejected before snapshot creation"));
     assert!(output.contains("require both HTTP health and OpenClaw gateway reachability"));
+    assert!(output.contains("upgrade history <env>"));
     assert!(
         output.contains("An env upgrade will not replace runtime bytes shared with another env")
     );

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -557,6 +557,24 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     let snapshot_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
     assert_eq!(snapshot_json.as_array().unwrap().len(), 1);
     assert_eq!(snapshot_json[0]["label"], "pre-upgrade");
+
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    let record = &history_json[0];
+    assert_eq!(record["kind"], "ocm-upgrade-transaction");
+    assert_eq!(record["formatVersion"], 1);
+    assert_eq!(record["source"]["name"], "stable");
+    assert_eq!(record["source"]["openclawVersion"], "2026.3.24");
+    assert_eq!(record["target"]["name"], "stable");
+    assert_eq!(record["target"]["openclawVersion"], "2026.3.25");
+    assert_eq!(record["snapshotId"], snapshot_json[0]["id"]);
+    assert_eq!(record["outcome"], "updated");
+    assert_eq!(record["migration"]["status"], "validated");
+    assert_eq!(record["finalization"]["status"], "completed");
+    assert_eq!(record["serviceBefore"]["running"], true);
+    assert_eq!(record["serviceAfter"]["running"], true);
+    assert!(record["note"].is_null());
 }
 
 #[test]
@@ -677,6 +695,19 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
     assert!(runtime.status.success(), "{}", stderr(&runtime));
     let runtime_json: Value = serde_json::from_str(&stdout(&runtime)).unwrap();
     assert_eq!(runtime_json["releaseVersion"], "2026.3.24");
+
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    let record = &history_json[0];
+    assert_eq!(record["source"]["openclawVersion"], "2026.3.24");
+    assert_eq!(record["target"]["openclawVersion"], "2026.3.25");
+    assert_eq!(record["outcome"], "rolled-back");
+    assert_eq!(record["rollback"], "restored");
+    assert_eq!(record["migration"]["status"], "validated");
+    assert_eq!(record["finalization"]["status"], "completed");
+    assert_eq!(record["serviceAfter"]["running"], true);
+    assert!(record["note"].is_null());
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -1235,6 +1235,11 @@ fn upgrade_dry_run_reports_without_changing_runtime_or_creating_snapshot() {
     assert!(snapshots.status.success(), "{}", stderr(&snapshots));
     let snapshot_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
     assert_eq!(snapshot_json.as_array().unwrap().len(), 0);
+
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- persist atomic, credential-free records for real upgrade transactions
- expose `ocm upgrade history <env>` in pretty, raw, and JSON output
- record observed source and target versions, snapshots, stages, service state, and rollback outcomes
- keep dry runs and skipped upgrades out of transaction history

## Verification

- fresh AWS Crabbox exact-head store, upgrade, and help suites
- all-target and Windows cross-compilation
- real OpenClaw `2026.6.11` to `2026.6.33` upgrade-history smoke with cleanup