### PR TITLE
feat: retain runtime recovery for in-place upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ migration/finalization status, service state, and rollback outcome. History is
 stored as atomic JSON metadata under `OCM_HOME`; it does not copy config
 contents, command output, or credentials. A successful in-place update of a
 managed runtime retains the previous runtime files beside its transaction
-record. Removing the corresponding pre-upgrade snapshot removes those retained
-files; switching to a different runtime does not duplicate the source runtime.
+record. Removing or pruning the corresponding pre-upgrade snapshot removes
+those retained files; switching to a different runtime does not duplicate the
+source runtime.
 Once an environment is bound to a runtime, direct `runtime update`,
 `runtime install --force`, `runtime build-local --force`, and `runtime remove`
 operations reject that runtime. Use `ocm upgrade <env>` so the environment gets

--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ while that release and its state schema were active.
 including source and target bindings and versions, the pre-upgrade snapshot,
 migration/finalization status, service state, and rollback outcome. History is
 stored as atomic JSON metadata under `OCM_HOME`; it does not copy config
-contents, command output, or credentials.
+contents, command output, or credentials. A successful in-place update of a
+managed runtime retains the previous runtime files beside its transaction
+record. Removing the corresponding pre-upgrade snapshot removes those retained
+files; switching to a different runtime does not duplicate the source runtime.
 Once an environment is bound to a runtime, direct `runtime update`,
 `runtime install --force`, `runtime build-local --force`, and `runtime remove`
 operations reject that runtime. Use `ocm upgrade <env>` so the environment gets

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -578,6 +578,7 @@ pub fn upgrade_help(cmd: &str) -> String {
         &[
             "Simulations clone the source env, leave the real env untouched, and clean temporary envs and runtimes by default.",
             "Upgrade history lists completed transaction records newest first without reading config contents or credentials.",
+            "Successful in-place managed-runtime updates retain the previous runtime files until the matching pre-upgrade snapshot is removed; runtime switches do not duplicate source runtimes.",
             "Use --scenario all to test current, clean minimum, and Telegram-configured env shapes.",
             "Use --keep-simulations only when you need retained simulation artifacts after the run.",
             "Published-target simulations run OpenClaw's update dry-run plan before switching the clone.",

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -578,7 +578,7 @@ pub fn upgrade_help(cmd: &str) -> String {
         &[
             "Simulations clone the source env, leave the real env untouched, and clean temporary envs and runtimes by default.",
             "Upgrade history lists completed transaction records newest first without reading config contents or credentials.",
-            "Successful in-place managed-runtime updates retain the previous runtime files until the matching pre-upgrade snapshot is removed; runtime switches do not duplicate source runtimes.",
+            "Successful in-place managed-runtime updates retain the previous runtime files until the matching pre-upgrade snapshot is removed or pruned; runtime switches do not duplicate source runtimes.",
             "Use --scenario all to test current, clean minimum, and Telegram-configured env shapes.",
             "Use --keep-simulations only when you need retained simulation artifacts after the run.",
             "Published-target simulations run OpenClaw's update dry-run plan before switching the clone.",

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2459,16 +2459,16 @@ impl Cli {
                 display_path(&transaction_recovery_root)
             ));
         }
-        let recovery_files = recovery_root.join("files");
-        if let Err(error) = fs::rename(&source_root, &recovery_files) {
+        let recovery_install_root = recovery_root.join("install-root");
+        if let Err(error) = fs::rename(&source_root, &recovery_install_root) {
             let _ = fs::remove_dir_all(&transaction_recovery_root);
             backup.backup_root = Some(source_root);
             return Err(format!(
                 "failed to retain runtime recovery bytes at {}: {error}",
-                display_path(&recovery_files)
+                display_path(&recovery_install_root)
             ));
         }
-        backup.backup_root = Some(recovery_files);
+        backup.backup_root = Some(recovery_install_root);
         backup.retained_root = Some(transaction_recovery_root);
         write_json(&recovery_root.join("runtime.json"), &backup.meta)?;
         backup.backup_id = Some(runtime_name);

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -32,7 +32,8 @@ use crate::store::{
     ensure_store, get_runtime, install_runtime_from_selected_official_openclaw_release,
     list_upgrade_history, lock_env_registry, remove_runtime, resolve_absolute_path,
     runtime_install_root, runtime_integrity_issue, runtime_meta_path, save_environment,
-    save_upgrade_history_record, upgrade_history_runtime_recovery_dir, write_json,
+    save_upgrade_history_record, upgrade_history_recovery_dir,
+    upgrade_history_runtime_recovery_dir, write_json,
 };
 
 #[derive(Clone, Debug, Serialize)]
@@ -2430,6 +2431,8 @@ impl Cli {
                 "runtime \"{runtime_name}\" does not have installer-managed bytes to retain"
             ));
         };
+        let transaction_recovery_root =
+            upgrade_history_recovery_dir(env_name, &transaction.id, &self.env, &self.cwd)?;
         let recovery_root = upgrade_history_runtime_recovery_dir(
             env_name,
             &transaction.id,
@@ -2437,17 +2440,28 @@ impl Cli {
             &self.env,
             &self.cwd,
         )?;
-        if recovery_root.exists() {
+        if transaction_recovery_root.exists() {
             backup.backup_root = Some(source_root);
             return Err(format!(
                 "runtime recovery path already exists: {}",
-                display_path(&recovery_root)
+                display_path(&transaction_recovery_root)
             ));
         }
         fs::create_dir_all(&recovery_root).map_err(|error| error.to_string())?;
+        if let Err(error) = fs::write(
+            transaction_recovery_root.join("snapshot-id"),
+            &transaction.snapshot_id,
+        ) {
+            let _ = fs::remove_dir_all(&transaction_recovery_root);
+            backup.backup_root = Some(source_root);
+            return Err(format!(
+                "failed to record the recovery snapshot at {}: {error}",
+                display_path(&transaction_recovery_root)
+            ));
+        }
         let recovery_files = recovery_root.join("files");
         if let Err(error) = fs::rename(&source_root, &recovery_files) {
-            let _ = fs::remove_dir_all(&recovery_root);
+            let _ = fs::remove_dir_all(&transaction_recovery_root);
             backup.backup_root = Some(source_root);
             return Err(format!(
                 "failed to retain runtime recovery bytes at {}: {error}",
@@ -2455,7 +2469,7 @@ impl Cli {
             ));
         }
         backup.backup_root = Some(recovery_files);
-        backup.retained_root = Some(recovery_root.clone());
+        backup.retained_root = Some(transaction_recovery_root);
         write_json(&recovery_root.join("runtime.json"), &backup.meta)?;
         backup.backup_id = Some(runtime_name);
         Ok(())

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -32,7 +32,7 @@ use crate::store::{
     ensure_store, get_runtime, install_runtime_from_selected_official_openclaw_release,
     list_upgrade_history, lock_env_registry, remove_runtime, resolve_absolute_path,
     runtime_install_root, runtime_integrity_issue, runtime_meta_path, save_environment,
-    save_upgrade_history_record, write_json,
+    save_upgrade_history_record, upgrade_history_runtime_recovery_dir, write_json,
 };
 
 #[derive(Clone, Debug, Serialize)]
@@ -1170,6 +1170,12 @@ impl Cli {
                     );
                 }
             };
+            if matches!(
+                prepared.action,
+                OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
+            ) {
+                transaction.mark_runtime_mutated();
+            }
             let binding_changed = prepared.name != current.name;
             let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
                 Ok(note) => {
@@ -1394,6 +1400,9 @@ impl Cli {
                 prepared.action,
                 OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
             );
+            if changed {
+                transaction.mark_runtime_mutated();
+            }
             let post_update_note = if changed {
                 match self.run_post_core_update(env_name, &prepared.name) {
                     Ok(note) => {
@@ -1561,6 +1570,7 @@ impl Cli {
                 );
             }
         };
+        transaction.mark_runtime_mutated();
         let post_update_note = match self.run_post_core_update(env_name, &updated.name) {
             Ok(note) => {
                 transaction.mark_post_update_completed(note.as_deref());
@@ -1767,6 +1777,12 @@ impl Cli {
                 );
             }
         };
+        if matches!(
+            prepared.action,
+            OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
+        ) {
+            transaction.mark_runtime_mutated();
+        }
         let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
             Ok(note) => {
                 transaction.mark_post_update_completed(note.as_deref());
@@ -2349,14 +2365,30 @@ impl Cli {
                 status: "not-run".to_string(),
                 note: None,
             },
+            runtime_mutated: false,
         })
     }
 
     fn finish_successful_upgrade(
         &self,
         summary: UpgradeEnvSummary,
-        transaction: UpgradeTransaction,
+        mut transaction: UpgradeTransaction,
     ) -> Result<UpgradeEnvSummary, String> {
+        if let Err(error) =
+            self.retain_required_runtime_recovery(&summary.env_name, &mut transaction)
+        {
+            return self.rollback_failed_upgrade(
+                &summary.env_name,
+                &summary.previous_binding_kind,
+                summary.previous_binding_name.clone(),
+                &summary.binding_kind,
+                summary.binding_name.clone(),
+                summary.runtime_release_version.clone(),
+                summary.runtime_release_channel.clone(),
+                transaction,
+                format!("failed to retain runtime recovery material: {error}"),
+            );
+        }
         if let Err(error) = self.record_upgrade_history(&transaction, &summary) {
             return self.rollback_failed_upgrade(
                 &summary.env_name,
@@ -2370,8 +2402,63 @@ impl Cli {
                 format!("failed to record upgrade history: {error}"),
             );
         }
-        transaction.cleanup();
+        transaction.commit();
         Ok(summary)
+    }
+
+    fn retain_required_runtime_recovery(
+        &self,
+        env_name: &str,
+        transaction: &mut UpgradeTransaction,
+    ) -> Result<(), String> {
+        if !transaction.runtime_mutated
+            || transaction.source.kind != "runtime"
+            || transaction.source.name != transaction.target.name
+        {
+            return Ok(());
+        }
+        let runtime_name = transaction.source.name.clone();
+        let backup = transaction
+            .runtime_backups
+            .iter_mut()
+            .find(|backup| backup.meta.name == runtime_name)
+            .ok_or_else(|| {
+                format!("runtime backup for in-place upgrade of \"{runtime_name}\" was not created")
+            })?;
+        let Some(source_root) = backup.backup_root.take() else {
+            return Err(format!(
+                "runtime \"{runtime_name}\" does not have installer-managed bytes to retain"
+            ));
+        };
+        let recovery_root = upgrade_history_runtime_recovery_dir(
+            env_name,
+            &transaction.id,
+            &runtime_name,
+            &self.env,
+            &self.cwd,
+        )?;
+        if recovery_root.exists() {
+            backup.backup_root = Some(source_root);
+            return Err(format!(
+                "runtime recovery path already exists: {}",
+                display_path(&recovery_root)
+            ));
+        }
+        fs::create_dir_all(&recovery_root).map_err(|error| error.to_string())?;
+        let recovery_files = recovery_root.join("files");
+        if let Err(error) = fs::rename(&source_root, &recovery_files) {
+            let _ = fs::remove_dir_all(&recovery_root);
+            backup.backup_root = Some(source_root);
+            return Err(format!(
+                "failed to retain runtime recovery bytes at {}: {error}",
+                display_path(&recovery_files)
+            ));
+        }
+        backup.backup_root = Some(recovery_files);
+        backup.retained_root = Some(recovery_root.clone());
+        write_json(&recovery_root.join("runtime.json"), &backup.meta)?;
+        backup.backup_id = Some(runtime_name);
+        Ok(())
     }
 
     fn record_upgrade_history(
@@ -2386,7 +2473,7 @@ impl Cli {
             .map(|backup| UpgradeHistoryRuntimeRecovery {
                 runtime_name: backup.meta.name.clone(),
                 release_version: backup.meta.release_version.clone(),
-                backup_id: None,
+                backup_id: backup.backup_id.clone(),
             })
             .collect();
         let record = UpgradeHistoryRecord {
@@ -2444,6 +2531,8 @@ impl Cli {
         Ok(RuntimeRollbackBackup {
             meta: runtime.clone(),
             backup_root,
+            retained_root: None,
+            backup_id: None,
         })
     }
 
@@ -2732,9 +2821,14 @@ struct UpgradeTransaction {
     service_before: UpgradeHistoryServiceState,
     migration: UpgradeHistoryStage,
     finalization: UpgradeHistoryStage,
+    runtime_mutated: bool,
 }
 
 impl UpgradeTransaction {
+    fn mark_runtime_mutated(&mut self) {
+        self.runtime_mutated = true;
+    }
+
     fn mark_post_update_completed(&mut self, note: Option<&str>) {
         self.migration.status = if note.is_some_and(|note| note.contains("config repair")) {
             "repaired".to_string()
@@ -2764,25 +2858,48 @@ impl UpgradeTransaction {
             runtime_backup.cleanup();
         }
     }
+
+    fn commit(self) {
+        for runtime_backup in self.runtime_backups {
+            runtime_backup.commit();
+        }
+    }
 }
 
 #[derive(Debug)]
 struct RuntimeRollbackBackup {
     meta: RuntimeMeta,
     backup_root: Option<PathBuf>,
+    retained_root: Option<PathBuf>,
+    backup_id: Option<String>,
 }
 
 impl RuntimeRollbackBackup {
     fn cleanup(mut self) {
-        if let Some(backup_root) = self.backup_root.take() {
+        if let Some(retained_root) = self.retained_root.take() {
+            self.backup_root.take();
+            let _ = fs::remove_dir_all(retained_root);
+        } else if let Some(backup_root) = self.backup_root.take() {
             let _ = fs::remove_dir_all(backup_root);
+        }
+    }
+
+    fn commit(mut self) {
+        if self.backup_id.is_some() {
+            self.backup_root.take();
+            self.retained_root.take();
+        } else {
+            self.cleanup();
         }
     }
 }
 
 impl Drop for RuntimeRollbackBackup {
     fn drop(&mut self) {
-        if let Some(backup_root) = self.backup_root.take() {
+        if let Some(retained_root) = self.retained_root.take() {
+            self.backup_root.take();
+            let _ = fs::remove_dir_all(retained_root);
+        } else if let Some(backup_root) = self.backup_root.take() {
             let _ = fs::remove_dir_all(backup_root);
         }
     }

--- a/src/store/layout.rs
+++ b/src/store/layout.rs
@@ -276,6 +276,25 @@ pub fn upgrade_history_meta_path(
     Ok(upgrade_history_env_dir(env_name, env, cwd)?.join(format!("{transaction_id}.json")))
 }
 
+pub fn upgrade_history_recovery_dir(
+    env_name: &str,
+    transaction_id: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PathBuf, String> {
+    Ok(upgrade_history_env_dir(env_name, env, cwd)?.join(format!("{transaction_id}.recovery")))
+}
+
+pub fn upgrade_history_runtime_recovery_dir(
+    env_name: &str,
+    transaction_id: &str,
+    runtime_name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PathBuf, String> {
+    Ok(upgrade_history_recovery_dir(env_name, transaction_id, env, cwd)?.join(runtime_name))
+}
+
 pub fn supervisor_state_path(
     env: &BTreeMap<String, String>,
     cwd: &Path,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -82,6 +82,7 @@ pub use snapshots::{
     create_env_snapshot, get_env_snapshot, list_all_env_snapshots, list_env_snapshots,
     remove_env_snapshot, restore_env_snapshot, summarize_snapshot,
 };
+pub(crate) use upgrade_history::remove_upgrade_recovery_for_snapshot;
 pub use upgrade_history::{
     UpgradeHistoryBinding, UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery,
     UpgradeHistoryServiceState, UpgradeHistoryStage, get_upgrade_history_record,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -48,7 +48,8 @@ pub use layout::{
     resolve_store_paths, resolve_user_home, runtime_install_files_dir, runtime_install_root,
     runtime_meta_path, snapshot_archive_path, snapshot_env_dir, snapshot_meta_path,
     source_watch_override_path, supervisor_logs_dir, supervisor_runtime_path,
-    supervisor_state_path, upgrade_history_env_dir, upgrade_history_meta_path, validate_name,
+    supervisor_state_path, upgrade_history_env_dir, upgrade_history_meta_path,
+    upgrade_history_recovery_dir, upgrade_history_runtime_recovery_dir, validate_name,
 };
 pub(crate) use openclaw_config::{
     OpenClawConfigAudit, audit_openclaw_config, clear_skip_bootstrap_for_openclaw_onboarding,

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -22,7 +22,7 @@ use super::layout::{
 use super::{
     OpenClawWorkspaceRuntime, audit_openclaw_state, clear_nonportable_runtime_state,
     get_environment, list_environments, now_utc, openclaw_env_snapshot_archive_options,
-    rewrite_openclaw_config_for_target, save_environment,
+    remove_upgrade_recovery_for_snapshot, rewrite_openclaw_config_for_target, save_environment,
 };
 
 static NEXT_RESTORE_ID: AtomicU64 = AtomicU64::new(0);
@@ -295,6 +295,7 @@ pub fn remove_env_snapshot(
     if path_exists(&archive_path) {
         fs::remove_file(&archive_path).map_err(|error| error.to_string())?;
     }
+    remove_upgrade_recovery_for_snapshot(&snapshot.env_name, &snapshot.id, env, cwd)?;
 
     remove_snapshot_parent_if_empty(&snapshot.env_name, env, cwd)?;
 

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -126,6 +126,39 @@ pub fn list_upgrade_history(
     Ok(records)
 }
 
+pub(crate) fn remove_upgrade_recovery_for_snapshot(
+    env_name: &str,
+    snapshot_id: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<(), String> {
+    let env_name = validate_name(env_name, "Environment name")?;
+    let recovery_parent = upgrade_history_env_dir(&env_name, env, cwd)?;
+    if !recovery_parent.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(&recovery_parent).map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let file_type = entry.file_type().map_err(|error| error.to_string())?;
+        let path = entry.path();
+        if !file_type.is_dir() || !entry.file_name().to_string_lossy().ends_with(".recovery") {
+            continue;
+        }
+        let Ok(recovery_snapshot_id) = std::fs::read_to_string(path.join("snapshot-id")) else {
+            continue;
+        };
+        if recovery_snapshot_id.trim() == snapshot_id {
+            std::fs::remove_dir_all(&path).map_err(|error| {
+                format!(
+                    "failed to remove upgrade recovery at {}: {error}",
+                    path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -590,6 +590,28 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     assert_eq!(recovery_meta["name"], "stable");
     assert_eq!(recovery_meta["releaseVersion"], "2026.3.24");
     assert!(recovery_root.join("files").is_dir());
+    assert_eq!(
+        fs::read_to_string(recovery_root.parent().unwrap().join("snapshot-id")).unwrap(),
+        snapshot_json[0]["id"].as_str().unwrap()
+    );
+
+    let remove_snapshot = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "snapshot",
+            "remove",
+            "demo",
+            snapshot_json[0]["id"].as_str().unwrap(),
+        ],
+    );
+    assert!(
+        remove_snapshot.status.success(),
+        "{}",
+        stderr(&remove_snapshot)
+    );
+    assert!(!recovery_root.exists());
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -589,7 +589,11 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
         serde_json::from_slice(&fs::read(recovery_root.join("runtime.json")).unwrap()).unwrap();
     assert_eq!(recovery_meta["name"], "stable");
     assert_eq!(recovery_meta["releaseVersion"], "2026.3.24");
-    assert!(recovery_root.join("files").is_dir());
+    assert!(
+        recovery_root
+            .join("install-root/files/node_modules/openclaw/openclaw.mjs")
+            .is_file()
+    );
     assert_eq!(
         fs::read_to_string(recovery_root.parent().unwrap().join("snapshot-id")).unwrap(),
         snapshot_json[0]["id"].as_str().unwrap()

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -575,6 +575,21 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     assert_eq!(record["serviceBefore"]["running"], true);
     assert_eq!(record["serviceAfter"]["running"], true);
     assert!(record["note"].is_null());
+    assert_eq!(record["runtimeRecovery"][0]["runtimeName"], "stable");
+    assert_eq!(record["runtimeRecovery"][0]["releaseVersion"], "2026.3.24");
+    assert_eq!(record["runtimeRecovery"][0]["backupId"], "stable");
+
+    let ocm_home = Path::new(env.get("OCM_HOME").unwrap());
+    let recovery_root = ocm_home
+        .join("upgrade-history")
+        .join("demo")
+        .join(format!("{}.recovery", record["id"].as_str().unwrap()))
+        .join("stable");
+    let recovery_meta: Value =
+        serde_json::from_slice(&fs::read(recovery_root.join("runtime.json")).unwrap()).unwrap();
+    assert_eq!(recovery_meta["name"], "stable");
+    assert_eq!(recovery_meta["releaseVersion"], "2026.3.24");
+    assert!(recovery_root.join("files").is_dir());
 }
 
 #[test]
@@ -708,6 +723,11 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
     assert_eq!(record["finalization"]["status"], "completed");
     assert_eq!(record["serviceAfter"]["running"], true);
     assert!(record["note"].is_null());
+    let recovery_root = Path::new(env.get("OCM_HOME").unwrap())
+        .join("upgrade-history")
+        .join("demo")
+        .join(format!("{}.recovery", record["id"].as_str().unwrap()));
+    assert!(!recovery_root.exists());
 }
 
 #[test]
@@ -2211,6 +2231,53 @@ fn upgrade_can_switch_env_to_an_installed_runtime() {
         !command_log.contains("plugins update --all\n"),
         "{command_log}"
     );
+}
+
+#[test]
+fn upgrade_reuses_the_bound_named_runtime_without_retaining_recovery_bytes() {
+    let root = TestDir::new("upgrade-reuse-bound-runtime");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let runtime_path = root.child("local-openclaw");
+    write_executable_script(&runtime_path, &recording_openclaw_script("local-openclaw"));
+
+    let env = ocm_env(&root);
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "add",
+            "local",
+            "--path",
+            &runtime_path.display().to_string(),
+        ],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "demo", "--runtime", "local"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "local"]);
+    assert!(upgrade.status.success(), "{}", stderr(&upgrade));
+    let output = stdout(&upgrade);
+    assert!(output.contains("outcome=up-to-date"), "{output}");
+
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    let record = &history_json[0];
+    assert_eq!(record["source"]["name"], "local");
+    assert_eq!(record["target"]["name"], "local");
+    assert_eq!(record["runtimeRecovery"][0]["runtimeName"], "local");
+    assert!(record["runtimeRecovery"][0]["backupId"].is_null());
+
+    let recovery_root = Path::new(env.get("OCM_HOME").unwrap())
+        .join("upgrade-history")
+        .join("demo")
+        .join(format!("{}.recovery", record["id"].as_str().unwrap()));
+    assert!(!recovery_root.exists());
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -599,22 +599,35 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
         snapshot_json[0]["id"].as_str().unwrap()
     );
 
-    let remove_snapshot = run_ocm(
+    let create_newer_snapshot = run_ocm(
         &cwd,
         &env,
         &[
             "env",
             "snapshot",
-            "remove",
+            "create",
             "demo",
-            snapshot_json[0]["id"].as_str().unwrap(),
+            "--label",
+            "after-upgrade",
         ],
     );
     assert!(
-        remove_snapshot.status.success(),
+        create_newer_snapshot.status.success(),
         "{}",
-        stderr(&remove_snapshot)
+        stderr(&create_newer_snapshot)
     );
+
+    let prune_snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "prune", "demo", "--keep", "1", "--yes"],
+    );
+    assert!(
+        prune_snapshot.status.success(),
+        "{}",
+        stderr(&prune_snapshot)
+    );
+    assert!(stdout(&prune_snapshot).contains("Pruned 1 snapshot(s)."));
     assert!(!recovery_root.exists());
 }
 


### PR DESCRIPTION
## Summary

- retain the previous installer-managed runtime after a successful in-place upgrade
- record durable recovery metadata in upgrade history without duplicating runtime switches or reused runtimes
- remove retained runtime bytes when the matching pre-upgrade snapshot is removed
- document the recovery lifetime in README and upgrade help

## Verification

- AWS Crabbox `cbx_a55a7013c2d7`: full Rust test suite
- AWS Crabbox `cbx_a55a7013c2d7`: 29/29 upgrade integration tests on the final head
- `cargo check --locked --all-targets`
- `cargo check --locked --target x86_64-pc-windows-gnu`
- real package-shaped in-place upgrade from OpenClaw `2026.6.11` to `2026.6.33`, including execution of the retained `2026.6.11` runtime and snapshot-coupled cleanup
