### PR TITLE
feat: add transactional upgrade rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ ocm upgrade mira
 ocm upgrade --all
 ocm upgrade mira --dry-run
 ocm upgrade history mira
+ocm upgrade rollback mira --dry-run
+ocm upgrade rollback mira
 ocm upgrade simulate mira --to 2026.4.20
 ocm upgrade simulate mira --to 2026.4.20 --scenario all
 ocm upgrade simulate mira --to beta --scenario all
@@ -157,6 +159,17 @@ managed runtime retains the previous runtime files beside its transaction
 record. Removing or pruning the corresponding pre-upgrade snapshot removes
 those retained files; switching to a different runtime does not duplicate the
 source runtime.
+`ocm upgrade rollback <env>` restores the newest completed upgrade or rollback
+transition that has not already been reversed. Use `--transaction <id>` to
+select a specific transaction and `--dry-run` to validate it without mutation.
+Before creating a safety snapshot, rollback requires the current binding,
+OpenClaw version, and service policy to match the selected transaction target;
+it also verifies the recorded snapshot, source runtime or launcher, and any
+same-name retained runtime recovery. A real rollback creates a `pre-rollback`
+safety snapshot and a linked history transaction before it stops a managed
+service or replaces runtime bytes. If restore or verification fails, OCM puts
+the pre-rollback runtime and environment state back. Rolling back the linked
+transaction safely reverses the rollback.
 Once an environment is bound to a runtime, direct `runtime update`,
 `runtime install --force`, `runtime build-local --force`, and `runtime remove`
 operations reject that runtime. Use `ocm upgrade <env>` so the environment gets

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -23,6 +23,7 @@ impl Cli {
             ["dev"] => Ok(render::help::dev_help(&cmd)),
             ["start"] => Ok(render::help::start_help(&cmd)),
             ["upgrade"] => Ok(render::help::upgrade_help(&cmd)),
+            ["upgrade", "rollback"] => Ok(render::help::upgrade_rollback_help(&cmd)),
             ["doctor"] => Ok(render::help::doctor_help(&cmd)),
             ["logs"] => Ok(render::help::logs_help(&cmd)),
             ["init"] => Ok(render::help::init_help(&cmd)),
@@ -116,6 +117,11 @@ impl Cli {
             [group, flag] if group == "upgrade" && Self::is_help_flag(flag) => {
                 Some(vec!["upgrade"])
             }
+            [group, next, rest @ ..] if group == "upgrade" && Self::is_help_token(next) => {
+                let mut topic = vec!["upgrade"];
+                topic.extend(rest.iter().map(String::as_str));
+                Some(topic)
+            }
             [group, next] if group == "init" && Self::is_help_token(next) => Some(vec!["init"]),
             [group, next, rest @ ..]
                 if matches!(
@@ -160,6 +166,11 @@ impl Cli {
             }
             [group, action, flag] if group == "doctor" && Self::is_help_flag(flag) => {
                 Some(vec!["doctor", action.as_str()])
+            }
+            [group, action, flag]
+                if group == "upgrade" && action == "rollback" && Self::is_help_flag(flag) =>
+            {
+                Some(vec!["upgrade", "rollback"])
             }
             [group, subcommand] if group == "env" && subcommand == "snapshot" => {
                 Some(vec!["env", "snapshot"])

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -519,6 +519,9 @@ pub fn upgrade_help(cmd: &str) -> String {
         vec![
             format!("{cmd} upgrade history <env> [--raw] [--json]"),
             format!(
+                "{cmd} upgrade rollback <env> [--transaction <id>] [--dry-run] [--raw] [--json]"
+            ),
+            format!(
                 "{cmd} upgrade simulate <env> --to <version|channel|repo-path> [--scenario current|minimum|telegram|all] [--keep-simulations] [--raw] [--json]"
             ),
             format!(
@@ -542,7 +545,7 @@ pub fn upgrade_help(cmd: &str) -> String {
             ("--all", "Upgrade every env that can be updated safely"),
             (
                 "--dry-run",
-                "Preview what would change without writing snapshots, runtimes, envs, or services",
+                "Preview an upgrade or rollback without changing runtime, env, service, snapshot, or history state",
             ),
             (
                 "--no-rollback",
@@ -565,6 +568,8 @@ pub fn upgrade_help(cmd: &str) -> String {
         ],
         vec![
             format!("{cmd} upgrade history mira"),
+            format!("{cmd} upgrade rollback mira --dry-run"),
+            format!("{cmd} upgrade rollback mira"),
             format!("{cmd} upgrade simulate mira --to 2026.4.20"),
             format!("{cmd} upgrade simulate mira --to 2026.4.20 --scenario all"),
             format!("{cmd} upgrade simulate mira --to beta --scenario all"),
@@ -578,6 +583,9 @@ pub fn upgrade_help(cmd: &str) -> String {
         &[
             "Simulations clone the source env, leave the real env untouched, and clean temporary envs and runtimes by default.",
             "Upgrade history lists completed transaction records newest first without reading config contents or credentials.",
+            "Upgrade rollback restores the latest completed transition by default; use --transaction to select a specific unconsumed transaction.",
+            "Rollback refuses before mutation when the current binding, OpenClaw version, service policy, source binding, snapshot, or retained runtime recovery no longer matches the selected transaction.",
+            "Rollback creates a pre-rollback safety snapshot and linked history transaction. Rolling back that linked transaction safely reverses the rollback.",
             "Successful in-place managed-runtime updates retain the previous runtime files until the matching pre-upgrade snapshot is removed or pruned; runtime switches do not duplicate source runtimes.",
             "Use --scenario all to test current, clean minimum, and Telegram-configured env shapes.",
             "Use --keep-simulations only when you need retained simulation artifacts after the run.",
@@ -593,6 +601,40 @@ pub fn upgrade_help(cmd: &str) -> String {
             "If service restart/start fails, ocm restores the snapshot and previous runtime unless --no-rollback is set.",
             "Pinned runtimes stay pinned unless you pass --version, --channel, or --runtime explicitly.",
             "Local-command environments are reported clearly instead of being changed behind your back.",
+        ],
+    )
+}
+
+pub fn upgrade_rollback_help(cmd: &str) -> String {
+    render_leaf(
+        "Roll back an upgrade",
+        "Restore an environment from a completed upgrade transaction with runtime and service recovery.",
+        vec![format!(
+            "{cmd} upgrade rollback <env> [--transaction <id>] [--dry-run] [--raw] [--json]"
+        )],
+        &[
+            (
+                "--transaction <id>",
+                "Roll back one specific completed transaction instead of the latest available transition",
+            ),
+            (
+                "--dry-run",
+                "Validate rollback readiness without changing runtime, env, service, snapshot, or history state",
+            ),
+            ("--raw", "Force plain output instead of TTY cards"),
+            ("--json", "Print the rollback summary as JSON"),
+        ],
+        vec![
+            format!("{cmd} upgrade rollback mira --dry-run"),
+            format!("{cmd} upgrade rollback mira"),
+            format!("{cmd} upgrade rollback mira --transaction 1782864000-000000001 --json"),
+        ],
+        &[
+            "Without --transaction, OCM selects the newest completed upgrade or rollback transition that has not already been reversed.",
+            "Preflight requires the current binding, OpenClaw version, and service policy to match the selected transaction target.",
+            "The recorded pre-upgrade snapshot and source runtime or launcher must still be available. Same-name runtime updates also require healthy retained runtime recovery.",
+            "Rollback creates a pre-rollback safety snapshot and linked history transaction before stopping a managed service or replacing runtime bytes.",
+            "If restore or verification fails, OCM restores the pre-rollback runtime and environment state.",
         ],
     )
 }

--- a/src/cli/render/upgrade.rs
+++ b/src/cli/render/upgrade.rs
@@ -580,6 +580,9 @@ fn upgrade_history_raw_line(record: &UpgradeHistoryRecord) -> Result<String, Str
     if let Some(rollback) = record.rollback.as_deref() {
         bits.push(format!("rollback={rollback}"));
     }
+    if let Some(rollback_of) = record.rollback_of.as_deref() {
+        bits.push(format!("rollbackOf={rollback_of}"));
+    }
     Ok(bits.join("  "))
 }
 

--- a/src/cli/render/upgrade.rs
+++ b/src/cli/render/upgrade.rs
@@ -1,5 +1,6 @@
 use crate::cli::upgrade::{
-    UpgradeBatchSummary, UpgradeEnvSummary, UpgradeSimulationBatchSummary, UpgradeSimulationSummary,
+    UpgradeBatchSummary, UpgradeEnvSummary, UpgradeRollbackSummary, UpgradeSimulationBatchSummary,
+    UpgradeSimulationSummary,
 };
 use crate::infra::terminal::{
     Cell, KeyValueRow, Tone, paint, render_key_value_card, render_table, terminal_width,
@@ -138,6 +139,83 @@ pub fn upgrade_env(
         ));
     }
 
+    lines
+}
+
+pub fn upgrade_rollback(summary: &UpgradeRollbackSummary, profile: RenderProfile) -> Vec<String> {
+    if !profile.pretty {
+        return upgrade_rollback_raw(summary);
+    }
+
+    let mut lines = vec![paint(
+        &format!("Upgrade Rollback {}", summary.env_name),
+        Tone::Strong,
+        profile.color,
+    )];
+    lines.push(String::new());
+    lines.extend(render_key_value_card(
+        "Result",
+        &[
+            KeyValueRow::accent("Env", &summary.env_name),
+            KeyValueRow::plain(
+                "Was using",
+                format!(
+                    "{}:{}",
+                    summary.previous_binding_kind, summary.previous_binding_name
+                ),
+            ),
+            KeyValueRow::plain(
+                "Now using",
+                format!("{}:{}", summary.binding_kind, summary.binding_name),
+            ),
+            KeyValueRow::new("Outcome", &summary.outcome, outcome_tone(&summary.outcome)),
+            KeyValueRow::new(
+                "Service",
+                summary.service_action.as_deref().unwrap_or("unchanged"),
+                service_tone(summary.service_action.as_deref()),
+            ),
+            KeyValueRow::accent("Restored snapshot", &summary.restored_snapshot_id),
+            KeyValueRow::plain(
+                "Safety snapshot",
+                summary
+                    .safety_snapshot_id
+                    .as_deref()
+                    .unwrap_or("not created"),
+            ),
+        ],
+        profile.color,
+    ));
+    lines.push(String::new());
+    lines.extend(render_key_value_card(
+        "History",
+        &[
+            KeyValueRow::plain("Rolled back", &summary.transaction_id),
+            KeyValueRow::plain(
+                "Transaction",
+                summary
+                    .rollback_transaction_id
+                    .as_deref()
+                    .unwrap_or("not recorded"),
+            ),
+        ],
+        profile.color,
+    ));
+    if let Some(version) = summary.runtime_release_version.as_deref() {
+        lines.push(String::new());
+        lines.extend(render_key_value_card(
+            "Release",
+            &[KeyValueRow::accent("OpenClaw", version)],
+            profile.color,
+        ));
+    }
+    if let Some(note) = summary.note.as_deref() {
+        lines.push(String::new());
+        lines.extend(render_key_value_card(
+            "Details",
+            &[KeyValueRow::muted("Note", note)],
+            profile.color,
+        ));
+    }
     lines
 }
 
@@ -445,6 +523,36 @@ fn upgrade_env_raw(summary: &UpgradeEnvSummary) -> Vec<String> {
     }
     if let Some(channel) = summary.runtime_release_channel.as_deref() {
         bits.push(format!("channel={channel}"));
+    }
+    if let Some(note) = summary.note.as_deref() {
+        bits.push(format!("note={note}"));
+    }
+    vec![bits.join("  ")]
+}
+
+fn upgrade_rollback_raw(summary: &UpgradeRollbackSummary) -> Vec<String> {
+    let mut bits = vec![
+        format!("env={}", summary.env_name),
+        format!("transaction={}", summary.transaction_id),
+        format!(
+            "from={}:{}",
+            summary.previous_binding_kind, summary.previous_binding_name
+        ),
+        format!("to={}:{}", summary.binding_kind, summary.binding_name),
+        format!("outcome={}", summary.outcome),
+        format!("restoredSnapshot={}", summary.restored_snapshot_id),
+    ];
+    if let Some(transaction_id) = summary.rollback_transaction_id.as_deref() {
+        bits.push(format!("rollbackTransaction={transaction_id}"));
+    }
+    if let Some(snapshot_id) = summary.safety_snapshot_id.as_deref() {
+        bits.push(format!("safetySnapshot={snapshot_id}"));
+    }
+    if let Some(action) = summary.service_action.as_deref() {
+        bits.push(format!("service={action}"));
+    }
+    if let Some(version) = summary.runtime_release_version.as_deref() {
+        bits.push(format!("version={version}"));
     }
     if let Some(note) = summary.note.as_deref() {
         bits.push(format!("note={note}"));

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2879,10 +2879,40 @@ impl Cli {
             if !seen.insert(runtime_name.clone()) {
                 continue;
             }
-            let meta_path = runtime_meta_path(runtime_name, &self.env, &self.cwd)?;
+            let meta_path = match runtime_meta_path(runtime_name, &self.env, &self.cwd) {
+                Ok(meta_path) => meta_path,
+                Err(error) => {
+                    return Err(self.cleanup_failed_transaction_setup(
+                        env_name,
+                        &snapshot.id,
+                        runtime_backups,
+                        error,
+                    ));
+                }
+            };
             if meta_path.exists() {
-                let runtime = get_runtime(runtime_name, &self.env, &self.cwd)?;
-                runtime_backups.push(self.backup_runtime_for_upgrade(&runtime)?);
+                let runtime = match get_runtime(runtime_name, &self.env, &self.cwd) {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        return Err(self.cleanup_failed_transaction_setup(
+                            env_name,
+                            &snapshot.id,
+                            runtime_backups,
+                            error,
+                        ));
+                    }
+                };
+                match self.backup_runtime_for_upgrade(&runtime) {
+                    Ok(backup) => runtime_backups.push(backup),
+                    Err(error) => {
+                        return Err(self.cleanup_failed_transaction_setup(
+                            env_name,
+                            &snapshot.id,
+                            runtime_backups,
+                            error,
+                        ));
+                    }
+                }
             } else {
                 created_runtime_names.push(runtime_name.clone());
             }
@@ -2912,6 +2942,31 @@ impl Cli {
             runtime_mutated: false,
             rollback_of,
         })
+    }
+
+    fn cleanup_failed_transaction_setup(
+        &self,
+        env_name: &str,
+        snapshot_id: &str,
+        runtime_backups: Vec<RuntimeRollbackBackup>,
+        error: String,
+    ) -> String {
+        for backup in runtime_backups {
+            backup.cleanup();
+        }
+        match self.environment_service().remove_snapshot_locked(
+            crate::env::RemoveEnvSnapshotOptions {
+                env_name: env_name.to_string(),
+                snapshot_id: snapshot_id.to_string(),
+            },
+        ) {
+            Ok(_) => error,
+            Err(cleanup_error) => {
+                format!(
+                    "{error}; also failed to remove the incomplete transaction snapshot: {cleanup_error}"
+                )
+            }
+        }
     }
 
     fn finish_successful_upgrade(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -610,6 +610,7 @@ impl Cli {
                     let recovery = get_upgrade_runtime_recovery(
                         env_name,
                         &record.id,
+                        &record.snapshot_id,
                         &record.source.name,
                         &self.env,
                         &self.cwd,

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -32,9 +32,9 @@ use crate::store::{
     ensure_minimum_local_openclaw_config, ensure_store, get_launcher, get_runtime,
     get_upgrade_history_record, get_upgrade_runtime_recovery,
     install_runtime_from_selected_official_openclaw_release, list_upgrade_history,
-    lock_env_registry, remove_runtime, remove_upgrade_recovery, resolve_absolute_path,
-    runtime_install_root, runtime_integrity_issue, runtime_meta_path, save_environment,
-    save_upgrade_history_record, upgrade_history_recovery_dir,
+    lock_env_registry, lock_upgrade_transaction, remove_runtime, remove_upgrade_recovery,
+    resolve_absolute_path, runtime_install_root, runtime_integrity_issue, runtime_meta_path,
+    save_environment, save_upgrade_history_record, upgrade_history_recovery_dir,
     upgrade_history_runtime_recovery_dir, write_json,
 };
 
@@ -474,6 +474,7 @@ impl Cli {
             });
         }
 
+        let _transaction_lock = lock_upgrade_transaction(env_name, &self.env, &self.cwd)?;
         let _operation_lock = self.environment_service().lock_operation(env_name)?;
         let plan = self.prepare_upgrade_rollback(env_name, Some(&plan.record.id))?;
         self.execute_upgrade_rollback_locked(env_name, plan)
@@ -1594,6 +1595,16 @@ impl Cli {
     }
 
     fn upgrade_env(
+        &self,
+        name: &str,
+        target: &UpgradeTarget,
+        options: UpgradeOptions,
+    ) -> Result<UpgradeEnvSummary, String> {
+        let _transaction_lock = lock_upgrade_transaction(name, &self.env, &self.cwd)?;
+        self.upgrade_env_locked(name, target, options)
+    }
+
+    fn upgrade_env_locked(
         &self,
         name: &str,
         target: &UpgradeTarget,

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -3569,10 +3569,10 @@ fn source_binding(env: &crate::env::EnvMeta) -> (String, String) {
 }
 
 fn is_rollback_candidate(record: &UpgradeHistoryRecord) -> bool {
-    matches!(
-        record.outcome.as_str(),
-        "updated" | "switched" | "rolled-back"
-    )
+    matches!(record.outcome.as_str(), "updated" | "switched")
+        || (record.outcome == "rolled-back"
+            && record.rollback_of.is_some()
+            && record.rollback.is_none())
 }
 
 fn has_successful_rollback_child(history: &[UpgradeHistoryRecord], transaction_id: &str) -> bool {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -27,10 +27,12 @@ use crate::runtime::{
 use crate::service::ServiceSummary;
 use crate::store::{
     InstallContext, RuntimeReleaseDetails, UpgradeHistoryBinding, UpgradeHistoryRecord,
-    UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage, clean_path,
-    copy_dir_recursive, derive_env_paths, display_path, ensure_minimum_local_openclaw_config,
-    ensure_store, get_runtime, install_runtime_from_selected_official_openclaw_release,
-    list_upgrade_history, lock_env_registry, remove_runtime, resolve_absolute_path,
+    UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage,
+    UpgradeRuntimeRecovery, clean_path, copy_dir_recursive, derive_env_paths, display_path,
+    ensure_minimum_local_openclaw_config, ensure_store, get_launcher, get_runtime,
+    get_upgrade_history_record, get_upgrade_runtime_recovery,
+    install_runtime_from_selected_official_openclaw_release, list_upgrade_history,
+    lock_env_registry, remove_runtime, remove_upgrade_recovery, resolve_absolute_path,
     runtime_install_root, runtime_integrity_issue, runtime_meta_path, save_environment,
     save_upgrade_history_record, upgrade_history_recovery_dir,
     upgrade_history_runtime_recovery_dir, write_json,
@@ -63,6 +65,24 @@ pub(crate) struct UpgradeBatchSummary {
     pub restarted: usize,
     pub failed: usize,
     pub results: Vec<UpgradeEnvSummary>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UpgradeRollbackSummary {
+    pub env_name: String,
+    pub transaction_id: String,
+    pub rollback_transaction_id: Option<String>,
+    pub previous_binding_kind: String,
+    pub previous_binding_name: String,
+    pub binding_kind: String,
+    pub binding_name: String,
+    pub outcome: String,
+    pub runtime_release_version: Option<String>,
+    pub service_action: Option<String>,
+    pub restored_snapshot_id: String,
+    pub safety_snapshot_id: Option<String>,
+    pub note: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -160,6 +180,13 @@ struct UpgradeTransactionPlan {
 }
 
 #[derive(Clone, Debug)]
+struct UpgradeRollbackPlan {
+    record: UpgradeHistoryRecord,
+    recovery: Option<UpgradeRuntimeRecovery>,
+    service: Option<ServiceSummary>,
+}
+
+#[derive(Clone, Debug)]
 struct PreparedSimulationRuntime {
     name: String,
     note: String,
@@ -247,6 +274,9 @@ impl Cli {
 
     pub(super) fn handle_upgrade_command(&self, args: Vec<String>) -> Result<i32, String> {
         let (args, json_flag, profile) = self.consume_human_output_flags(args, "upgrade")?;
+        if matches!(args.first().map(String::as_str), Some("rollback")) {
+            return self.handle_upgrade_rollback(args[1..].to_vec(), json_flag, profile);
+        }
         if matches!(args.first().map(String::as_str), Some("history")) {
             let Some(env_name) = args.get(1) else {
                 return Err("upgrade history requires <env>".to_string());
@@ -390,6 +420,496 @@ impl Cli {
             &self.command_example(),
         ));
         Ok(if failed { 1 } else { 0 })
+    }
+
+    fn handle_upgrade_rollback(
+        &self,
+        args: Vec<String>,
+        json_flag: bool,
+        profile: render::RenderProfile,
+    ) -> Result<i32, String> {
+        let (args, dry_run) = Self::consume_flag(args, "--dry-run");
+        let (args, transaction_id) = Self::consume_option(args, "--transaction")?;
+        let transaction_id = Self::require_option_value(transaction_id, "--transaction")?;
+        let Some(env_name) = args.first() else {
+            return Err("upgrade rollback requires <env>".to_string());
+        };
+        Self::assert_no_extra_args(&args[1..])?;
+
+        let summary =
+            self.rollback_completed_upgrade(env_name, transaction_id.as_deref(), dry_run)?;
+        let failed = matches!(summary.outcome.as_str(), "failed" | "rollback-failed");
+        if json_flag {
+            self.print_json(&summary)?;
+        } else {
+            self.stdout_lines(render::upgrade::upgrade_rollback(&summary, profile));
+        }
+        Ok(if failed { 1 } else { 0 })
+    }
+
+    fn rollback_completed_upgrade(
+        &self,
+        env_name: &str,
+        transaction_id: Option<&str>,
+        dry_run: bool,
+    ) -> Result<UpgradeRollbackSummary, String> {
+        let plan = self.prepare_upgrade_rollback(env_name, transaction_id)?;
+        if dry_run {
+            return Ok(UpgradeRollbackSummary {
+                env_name: env_name.to_string(),
+                transaction_id: plan.record.id.clone(),
+                rollback_transaction_id: None,
+                previous_binding_kind: plan.record.target.kind.clone(),
+                previous_binding_name: plan.record.target.name.clone(),
+                binding_kind: plan.record.source.kind.clone(),
+                binding_name: plan.record.source.name.clone(),
+                outcome: "would-rollback".to_string(),
+                runtime_release_version: plan.record.source.openclaw_version.clone(),
+                service_action: rollback_service_action_for_dry_run(&plan.record),
+                restored_snapshot_id: plan.record.snapshot_id.clone(),
+                safety_snapshot_id: None,
+                note: Some(
+                    "dry run: no runtime, env, service, snapshot, or history changed".to_string(),
+                ),
+            });
+        }
+
+        let _operation_lock = self.environment_service().lock_operation(env_name)?;
+        let plan = self.prepare_upgrade_rollback(env_name, Some(&plan.record.id))?;
+        self.execute_upgrade_rollback_locked(env_name, plan)
+    }
+
+    fn prepare_upgrade_rollback(
+        &self,
+        env_name: &str,
+        transaction_id: Option<&str>,
+    ) -> Result<UpgradeRollbackPlan, String> {
+        let history = list_upgrade_history(env_name, &self.env, &self.cwd)?;
+        let record = match transaction_id {
+            Some(transaction_id) => {
+                get_upgrade_history_record(env_name, transaction_id, &self.env, &self.cwd)?
+            }
+            None => history
+                .iter()
+                .find(|record| {
+                    is_rollback_candidate(record)
+                        && !has_successful_rollback_child(&history, &record.id)
+                })
+                .cloned()
+                .ok_or_else(|| {
+                    format!(
+                        "environment \"{env_name}\" does not have a completed upgrade transaction available to roll back"
+                    )
+                })?,
+        };
+        if !is_rollback_candidate(&record) {
+            return Err(format!(
+                "upgrade transaction \"{}\" cannot be rolled back because its outcome is \"{}\"",
+                record.id, record.outcome
+            ));
+        }
+        if has_successful_rollback_child(&history, &record.id) {
+            return Err(format!(
+                "upgrade transaction \"{}\" has already been rolled back",
+                record.id
+            ));
+        }
+
+        let current = self.environment_service().get(env_name)?;
+        let current_binding = source_binding(&current);
+        if current_binding.0 != record.target.kind || current_binding.1 != record.target.name {
+            return Err(format!(
+                "refusing to roll back upgrade transaction \"{}\": env \"{env_name}\" now uses {}:{}, expected {}:{}",
+                record.id,
+                current_binding.0,
+                current_binding.1,
+                record.target.kind,
+                record.target.name
+            ));
+        }
+        if current.service_enabled != record.service_after.enabled
+            || current.service_running != record.service_after.running
+        {
+            return Err(format!(
+                "refusing to roll back upgrade transaction \"{}\": service policy changed after the transaction",
+                record.id
+            ));
+        }
+        self.environment_service()
+            .get_snapshot(env_name, &record.snapshot_id)
+            .map_err(|error| {
+                format!(
+                    "cannot roll back upgrade transaction \"{}\": {error}",
+                    record.id
+                )
+            })?;
+        self.verify_rollback_target_version(env_name, &record)?;
+        let recovery = self.verify_rollback_source(env_name, &record)?;
+        let service = if current.service_enabled && current.service_running {
+            Some(self.service_service().status(env_name)?)
+        } else {
+            None
+        };
+
+        Ok(UpgradeRollbackPlan {
+            record,
+            recovery,
+            service,
+        })
+    }
+
+    fn verify_rollback_target_version(
+        &self,
+        env_name: &str,
+        record: &UpgradeHistoryRecord,
+    ) -> Result<(), String> {
+        let Some(expected_version) = record.target.openclaw_version.as_deref() else {
+            return Ok(());
+        };
+        let version =
+            self.run_openclaw_command(env_name, "current openclaw --version", &["--version"])?;
+        if version_output_matches_expected(version.first_line().trim(), expected_version) {
+            return Ok(());
+        }
+        Err(format!(
+            "refusing to roll back upgrade transaction \"{}\": env \"{env_name}\" reports OpenClaw {}, expected {}",
+            record.id,
+            version.first_line().trim(),
+            expected_version
+        ))
+    }
+
+    fn verify_rollback_source(
+        &self,
+        env_name: &str,
+        record: &UpgradeHistoryRecord,
+    ) -> Result<Option<UpgradeRuntimeRecovery>, String> {
+        match record.source.kind.as_str() {
+            "runtime" => {
+                if record.target.kind == "runtime" && record.source.name == record.target.name {
+                    self.ensure_runtime_upgrade_isolated(env_name, &record.source.name)?;
+                    let recovery_entry = record
+                        .runtime_recovery
+                        .iter()
+                        .find(|recovery| {
+                            recovery.runtime_name == record.source.name
+                                && recovery.backup_id.is_some()
+                        })
+                        .ok_or_else(|| {
+                            format!(
+                                "cannot roll back upgrade transaction \"{}\": retained runtime recovery for \"{}\" is unavailable",
+                                record.id, record.source.name
+                            )
+                        })?;
+                    if recovery_entry.backup_id.as_deref() != Some(record.source.name.as_str()) {
+                        return Err(format!(
+                            "cannot roll back upgrade transaction \"{}\": retained runtime recovery id does not match \"{}\"",
+                            record.id, record.source.name
+                        ));
+                    }
+                    let recovery = get_upgrade_runtime_recovery(
+                        env_name,
+                        &record.id,
+                        &record.source.name,
+                        &self.env,
+                        &self.cwd,
+                    )?;
+                    if let Some(expected_version) = record.source.openclaw_version.as_deref()
+                        && recovery.meta.release_version.as_deref() != Some(expected_version)
+                    {
+                        return Err(format!(
+                            "cannot roll back upgrade transaction \"{}\": retained runtime \"{}\" is OpenClaw {}, expected {}",
+                            record.id,
+                            record.source.name,
+                            recovery
+                                .meta
+                                .release_version
+                                .as_deref()
+                                .unwrap_or("unknown"),
+                            expected_version
+                        ));
+                    }
+                    return Ok(Some(recovery));
+                }
+
+                let runtime =
+                    get_runtime(&record.source.name, &self.env, &self.cwd).map_err(|error| {
+                        format!(
+                            "cannot roll back upgrade transaction \"{}\": {error}",
+                            record.id
+                        )
+                    })?;
+                if let Some(issue) = runtime_integrity_issue(&runtime, &self.env) {
+                    return Err(format!(
+                        "cannot roll back upgrade transaction \"{}\": runtime \"{}\" is not healthy: {issue}",
+                        record.id, record.source.name
+                    ));
+                }
+                if let Some(expected_version) = record.source.openclaw_version.as_deref() {
+                    let version = self.run_update_mode_openclaw_command_output(
+                        env_name,
+                        &record.source.name,
+                        "rollback source openclaw --version",
+                        &["--version"],
+                    )?;
+                    if !version.status.success()
+                        || !version_output_matches_expected(
+                            version.first_line().trim(),
+                            expected_version,
+                        )
+                    {
+                        return Err(format!(
+                            "cannot roll back upgrade transaction \"{}\": runtime \"{}\" does not report OpenClaw {}",
+                            record.id, record.source.name, expected_version
+                        ));
+                    }
+                }
+                Ok(None)
+            }
+            "launcher" => {
+                get_launcher(&record.source.name, &self.env, &self.cwd).map_err(|error| {
+                    format!(
+                        "cannot roll back upgrade transaction \"{}\": {error}",
+                        record.id
+                    )
+                })?;
+                Ok(None)
+            }
+            source_kind => Err(format!(
+                "cannot roll back upgrade transaction \"{}\": source binding kind \"{source_kind}\" is not supported",
+                record.id
+            )),
+        }
+    }
+
+    fn execute_upgrade_rollback_locked(
+        &self,
+        env_name: &str,
+        plan: UpgradeRollbackPlan,
+    ) -> Result<UpgradeRollbackSummary, String> {
+        let runtime_names = rollback_runtime_names(&plan.record);
+        let mut transaction = self.begin_upgrade_transaction_locked(
+            env_name,
+            UpgradeTransactionPlan {
+                source: plan.record.target.clone(),
+                target: plan.record.source.clone(),
+            },
+            &runtime_names,
+            true,
+            "pre-rollback",
+            Some(plan.record.id.clone()),
+        )?;
+        let rollback_transaction_id = transaction.id.clone();
+        let safety_snapshot_id = transaction.snapshot_id.clone();
+
+        if plan
+            .service
+            .as_ref()
+            .is_some_and(|service| service.installed && service.desired_running)
+            && let Err(error) = self.service_service().stop_locked(env_name)
+        {
+            return Ok(self.fail_upgrade_rollback_locked(
+                env_name,
+                &plan,
+                transaction,
+                format!("failed to stop the managed service before rollback: {error}"),
+            ));
+        }
+
+        if let Some(recovery) = plan.recovery.as_ref() {
+            if let Err(error) = self.restore_retained_runtime(recovery) {
+                return Ok(self.fail_upgrade_rollback_locked(env_name, &plan, transaction, error));
+            }
+            transaction.mark_runtime_mutated();
+        }
+
+        if let Err(error) =
+            self.environment_service()
+                .restore_snapshot_locked(RestoreEnvSnapshotOptions {
+                    env_name: env_name.to_string(),
+                    snapshot_id: plan.record.snapshot_id.clone(),
+                })
+        {
+            return Ok(self.fail_upgrade_rollback_locked(
+                env_name,
+                &plan,
+                transaction,
+                format!("failed to restore the recorded pre-upgrade snapshot: {error}"),
+            ));
+        }
+
+        let service_action = match self.reconcile_rolled_back_service_locked(env_name, &plan.record)
+        {
+            Ok(action) => action,
+            Err(error) => {
+                return Ok(self.fail_upgrade_rollback_locked(env_name, &plan, transaction, error));
+            }
+        };
+        let verification_note = match self.verify_upgraded_openclaw(
+            env_name,
+            plan.record.source.openclaw_version.as_deref(),
+            plan.record.service_before.running,
+        ) {
+            Ok(note) => note,
+            Err(error) => {
+                return Ok(self.fail_upgrade_rollback_locked(
+                    env_name,
+                    &plan,
+                    transaction,
+                    format!("post-rollback verification failed: {error}"),
+                ));
+            }
+        };
+        transaction.mark_post_update_not_needed();
+
+        let history_summary = UpgradeEnvSummary {
+            env_name: env_name.to_string(),
+            previous_binding_kind: plan.record.target.kind.clone(),
+            previous_binding_name: plan.record.target.name.clone(),
+            binding_kind: plan.record.source.kind.clone(),
+            binding_name: plan.record.source.name.clone(),
+            outcome: "rolled-back".to_string(),
+            runtime_release_version: plan.record.source.openclaw_version.clone(),
+            runtime_release_channel: None,
+            service_action: service_action.clone(),
+            snapshot_id: Some(safety_snapshot_id.clone()),
+            rollback: None,
+            note: verification_note.clone(),
+        };
+        if let Err(error) = self.retain_required_runtime_recovery(env_name, &mut transaction) {
+            return Ok(self.fail_upgrade_rollback_locked(
+                env_name,
+                &plan,
+                transaction,
+                format!("failed to retain pre-rollback runtime recovery: {error}"),
+            ));
+        }
+        if let Err(error) = self.record_upgrade_history(&transaction, &history_summary) {
+            return Ok(self.fail_upgrade_rollback_locked(
+                env_name,
+                &plan,
+                transaction,
+                format!("failed to record rollback history: {error}"),
+            ));
+        }
+        transaction.commit();
+
+        let cleanup_note = remove_upgrade_recovery(env_name, &plan.record.id, &self.env, &self.cwd)
+            .err()
+            .map(|error| format!("Original recovery cleanup requires attention: {error}"));
+
+        Ok(UpgradeRollbackSummary {
+            env_name: env_name.to_string(),
+            transaction_id: plan.record.id,
+            rollback_transaction_id: Some(rollback_transaction_id),
+            previous_binding_kind: plan.record.target.kind,
+            previous_binding_name: plan.record.target.name,
+            binding_kind: plan.record.source.kind,
+            binding_name: plan.record.source.name,
+            outcome: "rolled-back".to_string(),
+            runtime_release_version: plan.record.source.openclaw_version,
+            service_action,
+            restored_snapshot_id: plan.record.snapshot_id,
+            safety_snapshot_id: Some(safety_snapshot_id),
+            note: join_optional_warnings(verification_note, cleanup_note),
+        })
+    }
+
+    fn restore_retained_runtime(&self, recovery: &UpgradeRuntimeRecovery) -> Result<(), String> {
+        let install_root = runtime_install_root(&recovery.meta.name, &self.env, &self.cwd)?;
+        if install_root.exists() {
+            fs::remove_dir_all(&install_root).map_err(|error| {
+                format!(
+                    "failed to remove current runtime root {}: {error}",
+                    display_path(&install_root)
+                )
+            })?;
+        }
+        copy_dir_recursive(&recovery.install_root, &install_root)?;
+        let meta_path = runtime_meta_path(&recovery.meta.name, &self.env, &self.cwd)?;
+        write_json(&meta_path, &recovery.meta)
+    }
+
+    fn reconcile_rolled_back_service_locked(
+        &self,
+        env_name: &str,
+        record: &UpgradeHistoryRecord,
+    ) -> Result<Option<String>, String> {
+        if !record.service_before.enabled || !record.service_before.running {
+            return Ok(None);
+        }
+        let started = self
+            .with_progress(format!("Starting restored service for {env_name}"), || {
+                self.service_service().start_locked(env_name)
+            })?;
+        let note = self.wait_for_restarted_gateway_health(env_name, started.running)?;
+        if let Some(note) = note {
+            return Err(note);
+        }
+        Ok(Some("started".to_string()))
+    }
+
+    fn fail_upgrade_rollback_locked(
+        &self,
+        env_name: &str,
+        plan: &UpgradeRollbackPlan,
+        transaction: UpgradeTransaction,
+        error: String,
+    ) -> UpgradeRollbackSummary {
+        let rollback_transaction_id = transaction.id.clone();
+        let safety_snapshot_id = transaction.snapshot_id.clone();
+        let restore_result = self.rollback_upgrade_locked(env_name, &transaction);
+        let (outcome, rollback, note) = match restore_result {
+            Ok(()) => (
+                "failed".to_string(),
+                "restored".to_string(),
+                format!("rollback failed, so ocm restored the pre-rollback state: {error}"),
+            ),
+            Err(restore_error) => (
+                "rollback-failed".to_string(),
+                "failed".to_string(),
+                format!(
+                    "rollback failed ({error}); restoring the pre-rollback state also failed: {restore_error}"
+                ),
+            ),
+        };
+        let history_summary = UpgradeEnvSummary {
+            env_name: env_name.to_string(),
+            previous_binding_kind: plan.record.target.kind.clone(),
+            previous_binding_name: plan.record.target.name.clone(),
+            binding_kind: plan.record.source.kind.clone(),
+            binding_name: plan.record.source.name.clone(),
+            outcome: outcome.clone(),
+            runtime_release_version: plan.record.source.openclaw_version.clone(),
+            runtime_release_channel: None,
+            service_action: None,
+            snapshot_id: Some(safety_snapshot_id.clone()),
+            rollback: Some(rollback),
+            note: Some(note.clone()),
+        };
+        let history_error = self
+            .record_upgrade_history(&transaction, &history_summary)
+            .err();
+        transaction.cleanup();
+
+        UpgradeRollbackSummary {
+            env_name: env_name.to_string(),
+            transaction_id: plan.record.id.clone(),
+            rollback_transaction_id: Some(rollback_transaction_id),
+            previous_binding_kind: plan.record.target.kind.clone(),
+            previous_binding_name: plan.record.target.name.clone(),
+            binding_kind: plan.record.source.kind.clone(),
+            binding_name: plan.record.source.name.clone(),
+            outcome,
+            runtime_release_version: plan.record.source.openclaw_version.clone(),
+            service_action: None,
+            restored_snapshot_id: plan.record.snapshot_id.clone(),
+            safety_snapshot_id: Some(safety_snapshot_id),
+            note: join_optional_warnings(
+                Some(note),
+                history_error.map(|error| format!("Rollback history was not recorded: {error}")),
+            ),
+        }
     }
 
     fn upgrade_simulate(&self, args: Vec<String>) -> Result<Vec<UpgradeSimulationSummary>, String> {
@@ -2312,6 +2832,27 @@ impl Cli {
         runtime_names: &[String],
         rollback_enabled: bool,
     ) -> Result<UpgradeTransaction, String> {
+        let _operation_lock = self.environment_service().lock_operation(env_name)?;
+        self.begin_upgrade_transaction_locked(
+            env_name,
+            plan,
+            runtime_names,
+            rollback_enabled,
+            "pre-upgrade",
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn begin_upgrade_transaction_locked(
+        &self,
+        env_name: &str,
+        plan: UpgradeTransactionPlan,
+        runtime_names: &[String],
+        rollback_enabled: bool,
+        snapshot_label: &str,
+        rollback_of: Option<String>,
+    ) -> Result<UpgradeTransaction, String> {
         let env_meta = self.environment_service().get(env_name)?;
         let started_at = time::OffsetDateTime::now_utc();
         let id = format!(
@@ -2321,12 +2862,14 @@ impl Cli {
         );
         let snapshot = self
             .environment_service()
-            .create_snapshot(CreateEnvSnapshotOptions {
+            .create_snapshot_locked(CreateEnvSnapshotOptions {
                 env_name: env_name.to_string(),
-                label: Some("pre-upgrade".to_string()),
+                label: Some(snapshot_label.to_string()),
             })
             .map_err(|error| {
-                format!("failed to create pre-upgrade snapshot for env \"{env_name}\": {error}")
+                format!(
+                    "failed to create {snapshot_label} snapshot for env \"{env_name}\": {error}"
+                )
             })?;
         let mut seen = BTreeSet::new();
         let mut runtime_backups = Vec::new();
@@ -2367,6 +2910,7 @@ impl Cli {
                 note: None,
             },
             runtime_mutated: false,
+            rollback_of,
         })
     }
 
@@ -2510,6 +3054,7 @@ impl Cli {
                 running: env_meta.service_running,
             },
             rollback: summary.rollback.clone(),
+            rollback_of: transaction.rollback_of.clone(),
             note: None,
         };
         save_upgrade_history_record(&record, &self.env, &self.cwd)
@@ -2647,6 +3192,25 @@ impl Cli {
         }
         self.environment_service()
             .restore_snapshot(RestoreEnvSnapshotOptions {
+                env_name: env_name.to_string(),
+                snapshot_id: transaction.snapshot_id.clone(),
+            })?;
+        for runtime_name in &transaction.created_runtime_names {
+            self.remove_runtime_created_during_upgrade(runtime_name)?;
+        }
+        Ok(())
+    }
+
+    fn rollback_upgrade_locked(
+        &self,
+        env_name: &str,
+        transaction: &UpgradeTransaction,
+    ) -> Result<(), String> {
+        for runtime_backup in &transaction.runtime_backups {
+            self.restore_runtime_backup(runtime_backup)?;
+        }
+        self.environment_service()
+            .restore_snapshot_locked(RestoreEnvSnapshotOptions {
                 env_name: env_name.to_string(),
                 snapshot_id: transaction.snapshot_id.clone(),
             })?;
@@ -2836,6 +3400,7 @@ struct UpgradeTransaction {
     migration: UpgradeHistoryStage,
     finalization: UpgradeHistoryStage,
     runtime_mutated: bool,
+    rollback_of: Option<String>,
 }
 
 impl UpgradeTransaction {
@@ -2940,6 +3505,39 @@ fn source_binding(env: &crate::env::EnvMeta) -> (String, String) {
         return ("dev".to_string(), "dev".to_string());
     }
     ("none".to_string(), "none".to_string())
+}
+
+fn is_rollback_candidate(record: &UpgradeHistoryRecord) -> bool {
+    matches!(
+        record.outcome.as_str(),
+        "updated" | "switched" | "rolled-back"
+    )
+}
+
+fn has_successful_rollback_child(history: &[UpgradeHistoryRecord], transaction_id: &str) -> bool {
+    history.iter().any(|record| {
+        record.rollback_of.as_deref() == Some(transaction_id) && record.outcome == "rolled-back"
+    })
+}
+
+fn rollback_runtime_names(record: &UpgradeHistoryRecord) -> Vec<String> {
+    let mut names = Vec::new();
+    for binding in [&record.target, &record.source] {
+        if binding.kind == "runtime" && !names.contains(&binding.name) {
+            names.push(binding.name.clone());
+        }
+    }
+    names
+}
+
+fn rollback_service_action_for_dry_run(record: &UpgradeHistoryRecord) -> Option<String> {
+    if record.service_before.enabled && record.service_before.running {
+        Some("would-start".to_string())
+    } else if record.service_after.enabled && record.service_after.running {
+        Some("would-stop".to_string())
+    } else {
+        None
+    }
 }
 
 fn build_simulation_batch_summary(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -29,12 +29,11 @@ use crate::store::{
     InstallContext, RuntimeReleaseDetails, UpgradeHistoryBinding, UpgradeHistoryRecord,
     UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage,
     UpgradeRuntimeRecovery, clean_path, copy_dir_recursive, derive_env_paths, display_path,
-    ensure_minimum_local_openclaw_config, ensure_store, get_launcher, get_runtime,
-    get_upgrade_history_record, get_upgrade_runtime_recovery,
-    install_runtime_from_selected_official_openclaw_release, list_upgrade_history,
-    lock_env_registry, lock_upgrade_transaction, remove_runtime, remove_upgrade_recovery,
-    resolve_absolute_path, runtime_install_root, runtime_integrity_issue, runtime_meta_path,
-    save_environment, save_upgrade_history_record, upgrade_history_recovery_dir,
+    ensure_minimum_local_openclaw_config, ensure_store, get_runtime, get_upgrade_history_record,
+    get_upgrade_runtime_recovery, install_runtime_from_selected_official_openclaw_release,
+    list_upgrade_history, lock_env_registry, lock_upgrade_transaction, remove_runtime,
+    remove_upgrade_recovery, resolve_absolute_path, runtime_install_root, runtime_integrity_issue,
+    runtime_meta_path, save_environment, save_upgrade_history_record, upgrade_history_recovery_dir,
     upgrade_history_runtime_recovery_dir, write_json,
 };
 
@@ -674,12 +673,31 @@ impl Cli {
                 Ok(None)
             }
             "launcher" => {
-                get_launcher(&record.source.name, &self.env, &self.cwd).map_err(|error| {
-                    format!(
-                        "cannot roll back upgrade transaction \"{}\": {error}",
-                        record.id
+                let version = self.run_launcher_mode_openclaw_command_output(
+                    env_name,
+                    &record.source.name,
+                    "rollback source openclaw --version",
+                    &["--version"],
+                )?;
+                if !version.status.success() {
+                    return Err(format!(
+                        "cannot roll back upgrade transaction \"{}\": launcher \"{}\" failed OpenClaw version verification: {}",
+                        record.id,
+                        record.source.name,
+                        version.failure_summary()
+                    ));
+                }
+                if let Some(expected_version) = record.source.openclaw_version.as_deref()
+                    && !version_output_matches_expected(
+                        version.first_line().trim(),
+                        expected_version,
                     )
-                })?;
+                {
+                    return Err(format!(
+                        "cannot roll back upgrade transaction \"{}\": launcher \"{}\" does not report OpenClaw {}",
+                        record.id, record.source.name, expected_version
+                    ));
+                }
                 Ok(None)
             }
             source_kind => Err(format!(
@@ -2840,6 +2858,22 @@ impl Cli {
             ],
         )
         .map_err(|error| format!("{name} failed: {error}"))
+    }
+
+    fn run_launcher_mode_openclaw_command_output(
+        &self,
+        env_name: &str,
+        launcher_name: &str,
+        name: &str,
+        args: &[&str],
+    ) -> Result<SimulationCommandOutput, String> {
+        let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+        let resolved = self
+            .environment_service()
+            .resolve(env_name, None, Some(launcher_name.to_string()), &args)
+            .map_err(|error| format!("{name} failed: {error}"))?;
+        self.run_resolved_for_simulation(resolved, &[])
+            .map_err(|error| format!("{name} failed: {error}"))
     }
 
     fn begin_upgrade_transaction(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -613,7 +613,13 @@ impl Cli {
                         &record.source.name,
                         &self.env,
                         &self.cwd,
-                    )?;
+                    )
+                    .map_err(|error| {
+                        format!(
+                            "cannot roll back upgrade transaction \"{}\": {error}",
+                            record.id
+                        )
+                    })?;
                     if let Some(expected_version) = record.source.openclaw_version.as_deref()
                         && recovery.meta.release_version.as_deref() != Some(expected_version)
                     {

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -120,6 +120,13 @@ impl<'a> EnvironmentService<'a> {
         options: CreateEnvSnapshotOptions,
     ) -> Result<EnvSnapshotSummary, String> {
         let _lock = self.lock_operation(&options.env_name)?;
+        self.create_snapshot_locked(options)
+    }
+
+    pub(crate) fn create_snapshot_locked(
+        &self,
+        options: CreateEnvSnapshotOptions,
+    ) -> Result<EnvSnapshotSummary, String> {
         let meta = create_env_snapshot(options, self.env, self.cwd)?;
         Ok(summarize_snapshot(&meta))
     }
@@ -149,6 +156,13 @@ impl<'a> EnvironmentService<'a> {
         options: RestoreEnvSnapshotOptions,
     ) -> Result<EnvSnapshotRestoreSummary, String> {
         let _lock = self.lock_operation(&options.env_name)?;
+        self.restore_snapshot_locked(options)
+    }
+
+    pub(crate) fn restore_snapshot_locked(
+        &self,
+        options: RestoreEnvSnapshotOptions,
+    ) -> Result<EnvSnapshotRestoreSummary, String> {
         let summary = restore_env_snapshot(options, self.env, self.cwd)?;
         sync_supervisor_if_present(self.env, self.cwd)?;
         Ok(summary)

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -36,16 +36,28 @@ impl<'a> ServiceService<'a> {
 
     pub fn start(&self, name: &str) -> Result<ServiceActionSummary, String> {
         let _lock = crate::env::EnvironmentService::new(self.env, self.cwd).lock_operation(name)?;
+        self.start_locked(name)
+    }
+
+    pub(crate) fn start_locked(&self, name: &str) -> Result<ServiceActionSummary, String> {
         manage::start_service(name, self.env, self.cwd)
     }
 
     pub fn stop(&self, name: &str) -> Result<ServiceActionSummary, String> {
         let _lock = crate::env::EnvironmentService::new(self.env, self.cwd).lock_operation(name)?;
+        self.stop_locked(name)
+    }
+
+    pub(crate) fn stop_locked(&self, name: &str) -> Result<ServiceActionSummary, String> {
         manage::stop_service(name, self.env, self.cwd)
     }
 
     pub fn restart(&self, name: &str) -> Result<ServiceActionSummary, String> {
         let _lock = crate::env::EnvironmentService::new(self.env, self.cwd).lock_operation(name)?;
+        self.restart_locked(name)
+    }
+
+    pub(crate) fn restart_locked(&self, name: &str) -> Result<ServiceActionSummary, String> {
         manage::restart_service(name, self.env, self.cwd)
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -88,8 +88,8 @@ pub use upgrade_history::{
     list_upgrade_history, save_upgrade_history_record,
 };
 pub(crate) use upgrade_history::{
-    UpgradeRuntimeRecovery, get_upgrade_runtime_recovery, remove_upgrade_recovery,
-    remove_upgrade_recovery_for_snapshot,
+    UpgradeRuntimeRecovery, get_upgrade_runtime_recovery, lock_upgrade_transaction,
+    remove_upgrade_recovery, remove_upgrade_recovery_for_snapshot,
 };
 
 pub fn now_utc() -> OffsetDateTime {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -82,11 +82,14 @@ pub use snapshots::{
     create_env_snapshot, get_env_snapshot, list_all_env_snapshots, list_env_snapshots,
     remove_env_snapshot, restore_env_snapshot, summarize_snapshot,
 };
-pub(crate) use upgrade_history::remove_upgrade_recovery_for_snapshot;
 pub use upgrade_history::{
     UpgradeHistoryBinding, UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery,
     UpgradeHistoryServiceState, UpgradeHistoryStage, get_upgrade_history_record,
     list_upgrade_history, save_upgrade_history_record,
+};
+pub(crate) use upgrade_history::{
+    UpgradeRuntimeRecovery, get_upgrade_runtime_recovery, remove_upgrade_recovery,
+    remove_upgrade_recovery_for_snapshot,
 };
 
 pub fn now_utc() -> OffsetDateTime {

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -9,7 +9,7 @@ use super::common::{
 };
 use super::layout::{
     display_path, runtime_install_root, upgrade_history_env_dir, upgrade_history_meta_path,
-    upgrade_history_recovery_dir, upgrade_history_runtime_recovery_dir, validate_name,
+    upgrade_history_recovery_dir, validate_name,
 };
 use super::runtime_integrity_issue;
 use crate::runtime::{RuntimeMeta, RuntimeSourceKind};
@@ -165,6 +165,7 @@ pub(crate) fn lock_upgrade_transaction(
 pub(crate) fn get_upgrade_runtime_recovery(
     env_name: &str,
     transaction_id: &str,
+    snapshot_id: &str,
     runtime_name: &str,
     env: &BTreeMap<String, String>,
     cwd: &Path,
@@ -172,8 +173,23 @@ pub(crate) fn get_upgrade_runtime_recovery(
     let env_name = validate_name(env_name, "Environment name")?;
     let transaction_id = validate_name(transaction_id, "Upgrade transaction id")?;
     let runtime_name = validate_name(runtime_name, "Runtime name")?;
-    let recovery_root =
-        upgrade_history_runtime_recovery_dir(&env_name, &transaction_id, &runtime_name, env, cwd)?;
+    let transaction_recovery_root =
+        upgrade_history_recovery_dir(&env_name, &transaction_id, env, cwd)?;
+    let recovery_snapshot_path = transaction_recovery_root.join("snapshot-id");
+    let recovery_snapshot_id =
+        std::fs::read_to_string(&recovery_snapshot_path).map_err(|error| {
+            format!(
+                "runtime recovery snapshot marker is unavailable at {}: {error}",
+                display_path(&recovery_snapshot_path)
+            )
+        })?;
+    if recovery_snapshot_id.trim() != snapshot_id {
+        return Err(format!(
+            "runtime recovery for upgrade transaction \"{transaction_id}\" belongs to snapshot \"{}\", expected \"{snapshot_id}\"",
+            recovery_snapshot_id.trim()
+        ));
+    }
+    let recovery_root = transaction_recovery_root.join(&runtime_name);
     let install_root = recovery_root.join("install-root");
     let meta_path = recovery_root.join("runtime.json");
     if !path_exists(&meta_path) || !path_exists(&install_root) {
@@ -323,9 +339,9 @@ mod tests {
         RuntimeMeta, RuntimeSourceKind, UpgradeHistoryBinding, UpgradeHistoryRecord,
         UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage,
         get_upgrade_history_record, get_upgrade_runtime_recovery, list_upgrade_history,
-        lock_upgrade_transaction, runtime_install_root, save_upgrade_history_record,
-        upgrade_history_runtime_recovery_dir, write_json,
+        lock_upgrade_transaction, runtime_install_root, save_upgrade_history_record, write_json,
     };
+    use crate::store::layout::upgrade_history_runtime_recovery_dir;
 
     fn test_env(label: &str) -> (PathBuf, BTreeMap<String, String>) {
         let root = std::env::temp_dir().join(format!(
@@ -535,17 +551,60 @@ mod tests {
             updated_at: created_at,
         };
         write_json(&recovery_root.join("runtime.json"), &meta).unwrap();
+        std::fs::write(
+            recovery_root.parent().unwrap().join("snapshot-id"),
+            "snapshot-1",
+        )
+        .unwrap();
 
-        let recovery =
-            get_upgrade_runtime_recovery("demo", transaction_id, runtime_name, &env, cwd).unwrap();
+        let recovery = get_upgrade_runtime_recovery(
+            "demo",
+            transaction_id,
+            "snapshot-1",
+            runtime_name,
+            &env,
+            cwd,
+        )
+        .unwrap();
         assert_eq!(recovery.meta.release_version.as_deref(), Some("2026.6.11"));
         assert_eq!(recovery.install_root, recovery_install_root);
+
+        std::fs::write(
+            recovery_root.parent().unwrap().join("snapshot-id"),
+            "snapshot-2",
+        )
+        .unwrap();
+        let error = get_upgrade_runtime_recovery(
+            "demo",
+            transaction_id,
+            "snapshot-1",
+            runtime_name,
+            &env,
+            cwd,
+        )
+        .unwrap_err();
+        assert!(
+            error.contains("belongs to snapshot \"snapshot-2\", expected \"snapshot-1\""),
+            "{error}"
+        );
+        std::fs::write(
+            recovery_root.parent().unwrap().join("snapshot-id"),
+            "snapshot-1",
+        )
+        .unwrap();
 
         let mut invalid = meta;
         invalid.install_root = Some(root.join("foreign").to_string_lossy().into_owned());
         write_json(&recovery_root.join("runtime.json"), &invalid).unwrap();
-        let error = get_upgrade_runtime_recovery("demo", transaction_id, runtime_name, &env, cwd)
-            .unwrap_err();
+        let error = get_upgrade_runtime_recovery(
+            "demo",
+            transaction_id,
+            "snapshot-1",
+            runtime_name,
+            &env,
+            cwd,
+        )
+        .unwrap_err();
         assert!(
             error.contains("not an installer-managed runtime"),
             "{error}"

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-use super::common::{load_json_files, path_exists, read_json, write_json};
+use super::common::{
+    ExclusiveFileLock, load_json_files, lock_file, path_exists, read_json, write_json,
+};
 use super::layout::{
     display_path, runtime_install_root, upgrade_history_env_dir, upgrade_history_meta_path,
     upgrade_history_recovery_dir, upgrade_history_runtime_recovery_dir, validate_name,
@@ -133,6 +135,20 @@ pub fn list_upgrade_history(
             .then_with(|| right.id.cmp(&left.id))
     });
     Ok(records)
+}
+
+pub(crate) fn lock_upgrade_transaction(
+    env_name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<ExclusiveFileLock, String> {
+    let env_name = validate_name(env_name, "Environment name")?;
+    let path = super::ensure_store(env, cwd)?
+        .home
+        .join("locks")
+        .join("upgrades")
+        .join(format!("{env_name}.lock"));
+    lock_file(&path, "upgrade transaction")
 }
 
 pub(crate) fn get_upgrade_runtime_recovery(
@@ -266,6 +282,9 @@ fn validate_upgrade_history_record(record: &UpgradeHistoryRecord) -> Result<(), 
 mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
 
     use time::OffsetDateTime;
 
@@ -273,8 +292,8 @@ mod tests {
         RuntimeMeta, RuntimeSourceKind, UpgradeHistoryBinding, UpgradeHistoryRecord,
         UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage,
         get_upgrade_history_record, get_upgrade_runtime_recovery, list_upgrade_history,
-        runtime_install_root, save_upgrade_history_record, upgrade_history_runtime_recovery_dir,
-        write_json,
+        lock_upgrade_transaction, runtime_install_root, save_upgrade_history_record,
+        upgrade_history_runtime_recovery_dir, write_json,
     };
 
     fn test_env(label: &str) -> (PathBuf, BTreeMap<String, String>) {
@@ -455,6 +474,32 @@ mod tests {
             error.contains("not an installer-managed runtime"),
             "{error}"
         );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn upgrade_transaction_lock_serializes_the_same_environment() {
+        let (root, env) = test_env("transaction-lock");
+        let cwd = root.as_path();
+        let first = lock_upgrade_transaction("demo", &env, cwd).unwrap();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let thread_env = env.clone();
+        let thread_cwd = root.clone();
+        let waiter = thread::spawn(move || {
+            let _second =
+                lock_upgrade_transaction("demo", &thread_env, thread_cwd.as_path()).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        assert!(
+            acquired_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err()
+        );
+        drop(first);
+        acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        waiter.join().unwrap();
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -1,11 +1,16 @@
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use super::common::{load_json_files, path_exists, read_json, write_json};
-use super::layout::{upgrade_history_env_dir, upgrade_history_meta_path, validate_name};
+use super::layout::{
+    display_path, runtime_install_root, upgrade_history_env_dir, upgrade_history_meta_path,
+    upgrade_history_recovery_dir, upgrade_history_runtime_recovery_dir, validate_name,
+};
+use super::runtime_integrity_issue;
+use crate::runtime::{RuntimeMeta, RuntimeSourceKind};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -65,7 +70,15 @@ pub struct UpgradeHistoryRecord {
     #[serde(default)]
     pub rollback: Option<String>,
     #[serde(default)]
+    pub rollback_of: Option<String>,
+    #[serde(default)]
     pub note: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct UpgradeRuntimeRecovery {
+    pub meta: RuntimeMeta,
+    pub install_root: PathBuf,
 }
 
 pub fn save_upgrade_history_record(
@@ -75,15 +88,7 @@ pub fn save_upgrade_history_record(
 ) -> Result<(), String> {
     let env_name = validate_name(&record.env_name, "Environment name")?;
     let transaction_id = validate_name(&record.id, "Upgrade transaction id")?;
-    if record.kind != "ocm-upgrade-transaction" {
-        return Err(format!("unsupported upgrade history kind: {}", record.kind));
-    }
-    if record.format_version != 1 {
-        return Err(format!(
-            "unsupported upgrade history format version: {}",
-            record.format_version
-        ));
-    }
+    validate_upgrade_history_record(record)?;
     let path = upgrade_history_meta_path(&env_name, &transaction_id, env, cwd)?;
     write_json(&path, record)
 }
@@ -102,7 +107,9 @@ pub fn get_upgrade_history_record(
             "upgrade transaction \"{transaction_id}\" does not exist for environment \"{env_name}\""
         ));
     }
-    read_json(&path)
+    let record = read_json(&path)?;
+    validate_upgrade_history_record(&record)?;
+    Ok(record)
 }
 
 pub fn list_upgrade_history(
@@ -115,7 +122,9 @@ pub fn list_upgrade_history(
     let files = load_json_files(&dir)?;
     let mut records: Vec<UpgradeHistoryRecord> = Vec::with_capacity(files.len());
     for file in files {
-        records.push(read_json(&file)?);
+        let record = read_json(&file)?;
+        validate_upgrade_history_record(&record)?;
+        records.push(record);
     }
     records.sort_by(|left, right| {
         right
@@ -124,6 +133,87 @@ pub fn list_upgrade_history(
             .then_with(|| right.id.cmp(&left.id))
     });
     Ok(records)
+}
+
+pub(crate) fn get_upgrade_runtime_recovery(
+    env_name: &str,
+    transaction_id: &str,
+    runtime_name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<UpgradeRuntimeRecovery, String> {
+    let env_name = validate_name(env_name, "Environment name")?;
+    let transaction_id = validate_name(transaction_id, "Upgrade transaction id")?;
+    let runtime_name = validate_name(runtime_name, "Runtime name")?;
+    let recovery_root =
+        upgrade_history_runtime_recovery_dir(&env_name, &transaction_id, &runtime_name, env, cwd)?;
+    let install_root = recovery_root.join("install-root");
+    let meta_path = recovery_root.join("runtime.json");
+    if !path_exists(&meta_path) || !path_exists(&install_root) {
+        return Err(format!(
+            "runtime recovery for \"{runtime_name}\" is unavailable for upgrade transaction \"{transaction_id}\""
+        ));
+    }
+
+    let meta: RuntimeMeta = read_json(&meta_path)?;
+    if meta.name != runtime_name {
+        return Err(format!(
+            "runtime recovery metadata at {} belongs to \"{}\", expected \"{runtime_name}\"",
+            display_path(&meta_path),
+            meta.name
+        ));
+    }
+    let expected_install_root = runtime_install_root(&runtime_name, env, cwd)?;
+    if meta.source_kind != RuntimeSourceKind::Installed
+        || meta
+            .install_root
+            .as_deref()
+            .map(Path::new)
+            .is_none_or(|path| path != expected_install_root)
+    {
+        return Err(format!(
+            "runtime recovery metadata for \"{runtime_name}\" is not an installer-managed runtime"
+        ));
+    }
+    let original_binary = Path::new(&meta.binary_path);
+    let relative_binary = original_binary
+        .strip_prefix(&expected_install_root)
+        .map_err(|_| {
+            format!(
+                "runtime recovery metadata for \"{runtime_name}\" points outside its managed install root"
+            )
+        })?;
+    let recovery_binary = install_root.join(relative_binary);
+    let mut relocated = meta.clone();
+    relocated.binary_path = display_path(&recovery_binary);
+    relocated.install_root = Some(display_path(&install_root));
+    if let Some(issue) = runtime_integrity_issue(&relocated, env) {
+        return Err(format!(
+            "runtime recovery for \"{runtime_name}\" is not healthy: {issue}"
+        ));
+    }
+
+    Ok(UpgradeRuntimeRecovery { meta, install_root })
+}
+
+pub(crate) fn remove_upgrade_recovery(
+    env_name: &str,
+    transaction_id: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<(), String> {
+    let env_name = validate_name(env_name, "Environment name")?;
+    let transaction_id = validate_name(transaction_id, "Upgrade transaction id")?;
+    let path = upgrade_history_recovery_dir(&env_name, &transaction_id, env, cwd)?;
+    if !path_exists(&path) {
+        return Ok(());
+    }
+    std::fs::remove_dir_all(&path).map_err(|error| {
+        format!(
+            "failed to remove upgrade recovery at {}: {error}",
+            display_path(&path)
+        )
+    })
 }
 
 pub(crate) fn remove_upgrade_recovery_for_snapshot(
@@ -159,6 +249,19 @@ pub(crate) fn remove_upgrade_recovery_for_snapshot(
     Ok(())
 }
 
+fn validate_upgrade_history_record(record: &UpgradeHistoryRecord) -> Result<(), String> {
+    if record.kind != "ocm-upgrade-transaction" {
+        return Err(format!("unsupported upgrade history kind: {}", record.kind));
+    }
+    if record.format_version != 1 {
+        return Err(format!(
+            "unsupported upgrade history format version: {}",
+            record.format_version
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -167,9 +270,11 @@ mod tests {
     use time::OffsetDateTime;
 
     use super::{
-        UpgradeHistoryBinding, UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery,
-        UpgradeHistoryServiceState, UpgradeHistoryStage, get_upgrade_history_record,
-        list_upgrade_history, save_upgrade_history_record,
+        RuntimeMeta, RuntimeSourceKind, UpgradeHistoryBinding, UpgradeHistoryRecord,
+        UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage,
+        get_upgrade_history_record, get_upgrade_runtime_recovery, list_upgrade_history,
+        runtime_install_root, save_upgrade_history_record, upgrade_history_runtime_recovery_dir,
+        write_json,
     };
 
     fn test_env(label: &str) -> (PathBuf, BTreeMap<String, String>) {
@@ -227,6 +332,7 @@ mod tests {
                 running: true,
             },
             rollback: None,
+            rollback_of: None,
             note: None,
         }
     }
@@ -252,6 +358,103 @@ mod tests {
         let loaded = get_upgrade_history_record("demo", "1700000000-000000001", &env, cwd).unwrap();
         assert_eq!(loaded.source.openclaw_version.as_deref(), Some("2026.6.11"));
         assert_eq!(loaded.target.openclaw_version.as_deref(), Some("2026.6.33"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn upgrade_history_reads_records_without_rollback_linkage() {
+        let (root, env) = test_env("legacy-rollback-linkage");
+        let cwd = root.as_path();
+        let record = serde_json::json!({
+            "kind": "ocm-upgrade-transaction",
+            "formatVersion": 1,
+            "id": "1700000000-000000001",
+            "envName": "demo",
+            "source": {
+                "kind": "runtime",
+                "name": "stable",
+                "openclawVersion": "2026.6.11"
+            },
+            "target": {
+                "kind": "runtime",
+                "name": "stable",
+                "openclawVersion": "2026.6.33"
+            },
+            "snapshotId": "snapshot-1",
+            "runtimeRecovery": [],
+            "startedAt": "2023-11-14T22:13:20Z",
+            "completedAt": "2023-11-14T22:13:20Z",
+            "outcome": "updated",
+            "migration": {"status": "validated"},
+            "finalization": {"status": "completed"},
+            "serviceBefore": {"enabled": true, "running": true},
+            "serviceAfter": {"enabled": true, "running": true}
+        });
+        let path =
+            super::upgrade_history_meta_path("demo", "1700000000-000000001", &env, cwd).unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_vec(&record).unwrap()).unwrap();
+
+        let loaded = get_upgrade_history_record("demo", "1700000000-000000001", &env, cwd).unwrap();
+        assert!(loaded.rollback_of.is_none());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn runtime_recovery_loads_only_healthy_managed_bytes() {
+        let (root, env) = test_env("runtime-recovery");
+        let cwd = root.as_path();
+        let runtime_name = "stable";
+        let transaction_id = "1700000000-000000001";
+        let expected_install_root = runtime_install_root(runtime_name, &env, cwd).unwrap();
+        let relative_binary = PathBuf::from("files/bin/openclaw");
+        let recovery_root =
+            upgrade_history_runtime_recovery_dir("demo", transaction_id, runtime_name, &env, cwd)
+                .unwrap();
+        let recovery_install_root = recovery_root.join("install-root");
+        std::fs::create_dir_all(recovery_install_root.join("files/bin")).unwrap();
+        std::fs::write(recovery_install_root.join(&relative_binary), b"openclaw").unwrap();
+        let created_at = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+        let meta = RuntimeMeta {
+            kind: "ocm-runtime".to_string(),
+            name: runtime_name.to_string(),
+            binary_path: expected_install_root
+                .join(&relative_binary)
+                .to_string_lossy()
+                .into_owned(),
+            source_kind: RuntimeSourceKind::Installed,
+            source_path: None,
+            source_url: Some("https://example.invalid/openclaw.tgz".to_string()),
+            source_manifest_url: Some("https://example.invalid/openclaw".to_string()),
+            source_sha256: None,
+            source_integrity: None,
+            release_version: Some("2026.6.11".to_string()),
+            release_channel: Some("stable".to_string()),
+            release_selector_kind: None,
+            release_selector_value: None,
+            install_root: Some(expected_install_root.to_string_lossy().into_owned()),
+            description: None,
+            created_at,
+            updated_at: created_at,
+        };
+        write_json(&recovery_root.join("runtime.json"), &meta).unwrap();
+
+        let recovery =
+            get_upgrade_runtime_recovery("demo", transaction_id, runtime_name, &env, cwd).unwrap();
+        assert_eq!(recovery.meta.release_version.as_deref(), Some("2026.6.11"));
+        assert_eq!(recovery.install_root, recovery_install_root);
+
+        let mut invalid = meta;
+        invalid.install_root = Some(root.join("foreign").to_string_lossy().into_owned());
+        write_json(&recovery_root.join("runtime.json"), &invalid).unwrap();
+        let error = get_upgrade_runtime_recovery("demo", transaction_id, runtime_name, &env, cwd)
+            .unwrap_err();
+        assert!(
+            error.contains("not an installer-managed runtime"),
+            "{error}"
+        );
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -111,6 +111,7 @@ pub fn get_upgrade_history_record(
     }
     let record = read_json(&path)?;
     validate_upgrade_history_record(&record)?;
+    validate_upgrade_history_identity(&record, &env_name, &transaction_id)?;
     Ok(record)
 }
 
@@ -126,6 +127,16 @@ pub fn list_upgrade_history(
     for file in files {
         let record = read_json(&file)?;
         validate_upgrade_history_record(&record)?;
+        let transaction_id = file
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| {
+                format!(
+                    "upgrade history path has an invalid transaction id: {}",
+                    display_path(&file)
+                )
+            })?;
+        validate_upgrade_history_identity(&record, &env_name, transaction_id)?;
         records.push(record);
     }
     records.sort_by(|left, right| {
@@ -278,6 +289,26 @@ fn validate_upgrade_history_record(record: &UpgradeHistoryRecord) -> Result<(), 
     Ok(())
 }
 
+fn validate_upgrade_history_identity(
+    record: &UpgradeHistoryRecord,
+    env_name: &str,
+    transaction_id: &str,
+) -> Result<(), String> {
+    if record.env_name != env_name {
+        return Err(format!(
+            "upgrade transaction \"{transaction_id}\" belongs to environment \"{}\", expected \"{env_name}\"",
+            record.env_name
+        ));
+    }
+    if record.id != transaction_id {
+        return Err(format!(
+            "upgrade history entry \"{transaction_id}\" contains transaction id \"{}\"",
+            record.id
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -417,6 +448,51 @@ mod tests {
 
         let loaded = get_upgrade_history_record("demo", "1700000000-000000001", &env, cwd).unwrap();
         assert!(loaded.rollback_of.is_none());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn upgrade_history_rejects_records_with_mismatched_identity() {
+        let (root, env) = test_env("mismatched-identity");
+        let cwd = root.as_path();
+        let transaction_id = "1700000000-000000001";
+        let path = super::upgrade_history_meta_path("demo", transaction_id, &env, cwd).unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let started_at = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+        let mut mismatched = record(transaction_id, started_at);
+        mismatched.env_name = "other".to_string();
+        write_json(&path, &mismatched).unwrap();
+
+        let error = get_upgrade_history_record("demo", transaction_id, &env, cwd).unwrap_err();
+        assert!(
+            error.contains("belongs to environment \"other\", expected \"demo\""),
+            "{error}"
+        );
+        let error = list_upgrade_history("demo", &env, cwd).unwrap_err();
+        assert!(
+            error.contains("belongs to environment \"other\", expected \"demo\""),
+            "{error}"
+        );
+
+        mismatched.env_name = "demo".to_string();
+        mismatched.id = "1700000000-000000002".to_string();
+        write_json(&path, &mismatched).unwrap();
+        let error = get_upgrade_history_record("demo", transaction_id, &env, cwd).unwrap_err();
+        assert!(
+            error.contains(
+                "upgrade history entry \"1700000000-000000001\" contains transaction id \"1700000000-000000002\""
+            ),
+            "{error}"
+        );
+        let error = list_upgrade_history("demo", &env, cwd).unwrap_err();
+        assert!(
+            error.contains(
+                "upgrade history entry \"1700000000-000000001\" contains transaction id \"1700000000-000000002\""
+            ),
+            "{error}"
+        );
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -281,11 +281,34 @@ fn upgrade_help_is_available_from_help_and_flag() {
     assert!(output.contains("older targets are rejected before snapshot creation"));
     assert!(output.contains("require both HTTP health and OpenClaw gateway reachability"));
     assert!(output.contains("upgrade history <env>"));
+    assert!(output.contains("upgrade rollback <env>"));
     assert!(
         output.contains("An env upgrade will not replace runtime bytes shared with another env")
     );
     assert!(output.contains("pre-upgrade snapshot"));
     assert!(output.contains("OpenClaw update finalization"));
+}
+
+#[test]
+fn upgrade_rollback_help_is_available_from_help_and_flag() {
+    let root = TestDir::new("help-upgrade-rollback");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let via_help = run_ocm(&cwd, &env, &["help", "upgrade", "rollback"]);
+    let via_flag = run_ocm(&cwd, &env, &["upgrade", "rollback", "--help"]);
+    assert!(via_help.status.success(), "{}", stderr(&via_help));
+    assert!(via_flag.status.success(), "{}", stderr(&via_flag));
+
+    let output = stdout(&via_help);
+    assert_eq!(output, stdout(&via_flag));
+    assert!(output.contains("Roll back an upgrade"));
+    assert!(output.contains("upgrade rollback <env>"));
+    assert!(output.contains("--transaction <id>"));
+    assert!(output.contains("--dry-run"));
+    assert!(output.contains("pre-rollback safety snapshot"));
+    assert!(output.contains("restores the pre-rollback runtime and environment state"));
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2749,6 +2749,149 @@ fn upgrade_rollback_cleans_snapshot_when_transaction_setup_fails() {
 }
 
 #[test]
+fn upgrade_rollback_refuses_missing_in_place_recovery_before_mutation() {
+    let root = TestDir::new("upgrade-explicit-rollback-missing-recovery");
+    let fixture = seed_in_place_rollback(&root, "2026.6.11");
+    fs::remove_dir_all(&fixture.original_recovery_root).unwrap();
+
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(!rollback.status.success());
+    assert!(
+        stderr(&rollback).contains("runtime recovery"),
+        "{}",
+        stderr(&rollback)
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "after-upgrade"
+    );
+
+    let snapshots = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["env", "snapshot", "list", "demo", "--json"],
+    );
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert_eq!(snapshots_json.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn upgrade_rollback_refuses_drifted_target_version_before_mutation() {
+    let root = TestDir::new("upgrade-explicit-rollback-target-drift");
+    let fixture = seed_in_place_rollback(&root, "2026.6.11");
+    let runtime_binary =
+        Path::new(fixture.env.get("OCM_HOME").unwrap()).join("runtimes/stable/files/bin/openclaw");
+    write_executable_script(&runtime_binary, &recording_openclaw_script("2026.7.1"));
+
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(!rollback.status.success());
+    assert!(
+        stderr(&rollback).contains("reports OpenClaw 2026.7.1, expected 2026.6.33"),
+        "{}",
+        stderr(&rollback)
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "after-upgrade"
+    );
+    assert!(fixture.original_recovery_root.exists());
+
+    let history = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "history", "demo", "--json"],
+    );
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn upgrade_rollback_refuses_to_replace_a_runtime_shared_after_upgrade() {
+    let root = TestDir::new("upgrade-explicit-rollback-shared-runtime");
+    let fixture = seed_in_place_rollback(&root, "2026.6.11");
+    let sibling = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["env", "create", "sibling", "--runtime", "stable"],
+    );
+    assert!(sibling.status.success(), "{}", stderr(&sibling));
+
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(!rollback.status.success());
+    assert!(
+        stderr(&rollback).contains("runtime \"stable\" is shared with \"sibling\""),
+        "{}",
+        stderr(&rollback)
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "after-upgrade"
+    );
+
+    let version = run_ocm(&fixture.cwd, &fixture.env, &["@demo", "--", "--version"]);
+    assert!(version.status.success(), "{}", stderr(&version));
+    assert_eq!(stdout(&version).trim(), "2026.6.33");
+}
+
+#[test]
+fn upgrade_rollback_refuses_a_transaction_with_a_successful_child() {
+    let root = TestDir::new("upgrade-explicit-rollback-already-used");
+    let fixture = seed_in_place_rollback(&root, "2026.6.11");
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(rollback.status.success(), "{}", stderr(&rollback));
+
+    let repeated = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &[
+            "upgrade",
+            "rollback",
+            "demo",
+            "--transaction",
+            &fixture.transaction_id,
+            "--json",
+        ],
+    );
+    assert!(!repeated.status.success());
+    assert!(
+        stderr(&repeated).contains("has already been rolled back"),
+        "{}",
+        stderr(&repeated)
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "before-upgrade"
+    );
+
+    let history = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "history", "demo", "--json"],
+    );
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 2);
+}
+
+#[test]
 fn upgrade_repairs_target_config_before_finalization() {
     let root = TestDir::new("upgrade-target-config-repair");
     let cwd = root.child("workspace");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2882,6 +2882,52 @@ fn upgrade_rollback_refuses_missing_in_place_recovery_before_mutation() {
 }
 
 #[test]
+fn upgrade_rollback_refuses_recovery_from_a_different_snapshot_before_mutation() {
+    let root = TestDir::new("upgrade-explicit-rollback-mismatched-recovery-snapshot");
+    let fixture = seed_in_place_rollback(&root, "2026.6.11");
+    fs::write(
+        fixture.original_recovery_root.join("snapshot-id"),
+        "different-snapshot",
+    )
+    .unwrap();
+
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(!rollback.status.success());
+    assert!(
+        stderr(&rollback).contains("belongs to snapshot \"different-snapshot\", expected"),
+        "{}",
+        stderr(&rollback)
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "after-upgrade"
+    );
+    assert!(fixture.original_recovery_root.exists());
+
+    let snapshots = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["env", "snapshot", "list", "demo", "--json"],
+    );
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert_eq!(snapshots_json.as_array().unwrap().len(), 1);
+
+    let history = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "history", "demo", "--json"],
+    );
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 1);
+}
+
+#[test]
 fn upgrade_rollback_refuses_drifted_target_version_before_mutation() {
     let root = TestDir::new("upgrade-explicit-rollback-target-drift");
     let fixture = seed_in_place_rollback(&root, "2026.6.11");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -101,6 +101,17 @@ fn write_running_supervisor_runtime(
     fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
 }
 
+fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: ocm_home.to_string(),
+        updated_at: now_utc(),
+        services: Vec::new(),
+        children: Vec::new(),
+    };
+    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+}
+
 fn recording_openclaw_script(version: &str) -> String {
     format!(
         r#"#!/bin/sh
@@ -2889,6 +2900,162 @@ fn upgrade_rollback_refuses_a_transaction_with_a_successful_child() {
     assert!(history.status.success(), "{}", stderr(&history));
     let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
     assert_eq!(history_json.as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn upgrade_rollback_restarts_and_verifies_a_managed_service() {
+    let root = TestDir::new("upgrade-explicit-rollback-service");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let health_server =
+        TestHttpServer::serve_bytes_times("/health", "application/json", br#"{"ok":true}"#, 20);
+    let health_port = health_server
+        .url()
+        .split(':')
+        .nth(2)
+        .and_then(|value| value.split('/').next())
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("2026.6.11"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("2026.6.33"));
+
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    for (name, runtime) in [("old", &old_runtime), ("new", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                name,
+                "--path",
+                &runtime.display().to_string(),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "start",
+            "demo",
+            "--runtime",
+            "old",
+            "--port",
+            &health_port.to_string(),
+        ],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+    let env_show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(env_show.status.success(), "{}", stderr(&env_show));
+    let env_json: Value = serde_json::from_str(&stdout(&env_show)).unwrap();
+    let marker =
+        Path::new(env_json["root"].as_str().unwrap()).join(".openclaw/workspace/rollback-marker");
+    fs::create_dir_all(marker.parent().unwrap()).unwrap();
+    fs::write(&marker, "before-upgrade").unwrap();
+
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "demo", "--json"]);
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    let snapshot_id = snapshot_json["id"].as_str().unwrap();
+    let bind = run_ocm(&cwd, &env, &["env", "set-runtime", "demo", "new"]);
+    assert!(bind.status.success(), "{}", stderr(&bind));
+    fs::write(&marker, "after-upgrade").unwrap();
+
+    let transaction_id = "1782864000-000000001";
+    let history = serde_json::json!({
+        "kind": "ocm-upgrade-transaction",
+        "formatVersion": 1,
+        "id": transaction_id,
+        "envName": "demo",
+        "source": {
+            "kind": "runtime",
+            "name": "old",
+            "openclawVersion": "2026.6.11"
+        },
+        "target": {
+            "kind": "runtime",
+            "name": "new",
+            "openclawVersion": "2026.6.33"
+        },
+        "snapshotId": snapshot_id,
+        "runtimeRecovery": [],
+        "startedAt": "2026-07-01T00:00:00Z",
+        "completedAt": "2026-07-01T00:01:00Z",
+        "outcome": "switched",
+        "migration": {"status": "validated"},
+        "finalization": {"status": "completed"},
+        "serviceBefore": {"enabled": true, "running": true},
+        "serviceAfter": {"enabled": true, "running": true}
+    });
+    let history_dir = Path::new(env.get("OCM_HOME").unwrap()).join("upgrade-history/demo");
+    fs::create_dir_all(&history_dir).unwrap();
+    fs::write(
+        history_dir.join(format!("{transaction_id}.json")),
+        serde_json::to_vec(&history).unwrap(),
+    )
+    .unwrap();
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "new", 4242, health_port);
+    let state_path = supervisor_state_path(&env, &cwd).unwrap();
+    let observed_runtime_path = runtime_path.clone();
+    let observed_ocm_home = ocm_home.clone();
+    let service_observer = thread::spawn(move || {
+        let mut saw_stop = false;
+        for _ in 0..400 {
+            let state = fs::read_to_string(&state_path).unwrap_or_default();
+            let parsed: Value = serde_json::from_str(&state).unwrap_or(Value::Null);
+            let children = parsed["children"].as_array().cloned().unwrap_or_default();
+            if !saw_stop && children.is_empty() {
+                write_empty_supervisor_runtime(&observed_runtime_path, &observed_ocm_home);
+                saw_stop = true;
+            } else if saw_stop
+                && children
+                    .iter()
+                    .any(|child| child["envName"] == "demo" && child["bindingName"] == "old")
+            {
+                write_running_supervisor_runtime(
+                    &observed_runtime_path,
+                    &observed_ocm_home,
+                    "old",
+                    4243,
+                    health_port,
+                );
+                return;
+            }
+            sleep(Duration::from_millis(25));
+        }
+        panic!("rollback did not stop and restart the managed service");
+    });
+
+    let rollback = run_ocm(&cwd, &env, &["upgrade", "rollback", "demo", "--raw"]);
+    service_observer.join().unwrap();
+    assert!(rollback.status.success(), "{}", stderr(&rollback));
+    let output = stdout(&rollback);
+    assert!(output.contains("outcome=rolled-back"), "{output}");
+    assert!(output.contains("service=started"), "{output}");
+    assert!(output.contains("to=runtime:old"), "{output}");
+    assert_eq!(fs::read_to_string(&marker).unwrap(), "before-upgrade");
+    assert!(!health_server.requests().is_empty());
+
+    let service = run_ocm(&cwd, &env, &["service", "status", "demo", "--json"]);
+    assert!(service.status.success(), "{}", stderr(&service));
+    let service_json: Value = serde_json::from_str(&stdout(&service)).unwrap();
+    assert_eq!(service_json["running"], true);
+    assert_eq!(service_json["bindingName"], "old");
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -216,6 +217,149 @@ echo "unexpected args: $*" >&2
 exit 1
 "#
     )
+}
+
+struct SeededInPlaceRollback {
+    cwd: PathBuf,
+    env: BTreeMap<String, String>,
+    marker: PathBuf,
+    transaction_id: String,
+    original_recovery_root: PathBuf,
+}
+
+fn seed_in_place_rollback(root: &TestDir, recovery_binary_version: &str) -> SeededInPlaceRollback {
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(root);
+    let ocm_home = PathBuf::from(env.get("OCM_HOME").unwrap());
+    let runtime_name = "stable";
+    let runtime_root = ocm_home.join("runtimes").join(runtime_name);
+    let runtime_binary = runtime_root.join("files/bin/openclaw");
+    fs::create_dir_all(runtime_binary.parent().unwrap()).unwrap();
+    write_executable_script(&runtime_binary, &recording_openclaw_script("2026.6.33"));
+    fs::create_dir_all(ocm_home.join("runtimes")).unwrap();
+    let runtime_meta = |version: &str| {
+        serde_json::json!({
+            "kind": "ocm-runtime",
+            "name": runtime_name,
+            "binaryPath": path_string(&runtime_binary),
+            "sourceKind": "installed",
+            "sourceUrl": "https://example.invalid/openclaw.tgz",
+            "sourceManifestUrl": "https://example.invalid/openclaw",
+            "releaseVersion": version,
+            "releaseChannel": "stable",
+            "installRoot": path_string(&runtime_root),
+            "description": null,
+            "createdAt": "2026-06-11T00:00:00Z",
+            "updatedAt": "2026-06-30T00:00:00Z"
+        })
+    };
+    fs::write(
+        ocm_home.join("runtimes/stable.json"),
+        serde_json::to_vec(&runtime_meta("2026.6.33")).unwrap(),
+    )
+    .unwrap();
+
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", runtime_name],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let env_show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(env_show.status.success(), "{}", stderr(&env_show));
+    let env_json: Value = serde_json::from_str(&stdout(&env_show)).unwrap();
+    let marker =
+        Path::new(env_json["root"].as_str().unwrap()).join(".openclaw/workspace/rollback-marker");
+    fs::create_dir_all(marker.parent().unwrap()).unwrap();
+    fs::write(&marker, "before-upgrade").unwrap();
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "snapshot",
+            "create",
+            "demo",
+            "--label",
+            "pre-upgrade",
+            "--json",
+        ],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    let snapshot_id = snapshot_json["id"].as_str().unwrap();
+    fs::write(&marker, "after-upgrade").unwrap();
+
+    let transaction_id = "1782864000-000000001".to_string();
+    let original_recovery_root = ocm_home
+        .join("upgrade-history/demo")
+        .join(format!("{transaction_id}.recovery"));
+    let recovery_runtime_root = original_recovery_root.join(runtime_name);
+    let recovery_binary = recovery_runtime_root.join("install-root/files/bin/openclaw");
+    fs::create_dir_all(recovery_binary.parent().unwrap()).unwrap();
+    write_executable_script(
+        &recovery_binary,
+        &recording_openclaw_script(recovery_binary_version),
+    );
+    fs::write(
+        recovery_runtime_root.join("runtime.json"),
+        serde_json::to_vec(&runtime_meta("2026.6.11")).unwrap(),
+    )
+    .unwrap();
+    fs::write(original_recovery_root.join("snapshot-id"), snapshot_id).unwrap();
+    let history = serde_json::json!({
+        "kind": "ocm-upgrade-transaction",
+        "formatVersion": 1,
+        "id": transaction_id.clone(),
+        "envName": "demo",
+        "source": {
+            "kind": "runtime",
+            "name": runtime_name,
+            "openclawVersion": "2026.6.11"
+        },
+        "target": {
+            "kind": "runtime",
+            "name": runtime_name,
+            "openclawVersion": "2026.6.33"
+        },
+        "snapshotId": snapshot_id,
+        "runtimeRecovery": [{
+            "runtimeName": runtime_name,
+            "releaseVersion": "2026.6.11",
+            "backupId": runtime_name
+        }],
+        "startedAt": "2026-06-30T00:00:00Z",
+        "completedAt": "2026-06-30T00:01:00Z",
+        "outcome": "updated",
+        "migration": {"status": "validated"},
+        "finalization": {"status": "completed"},
+        "serviceBefore": {
+            "enabled": env_json["serviceEnabled"],
+            "running": env_json["serviceRunning"]
+        },
+        "serviceAfter": {
+            "enabled": env_json["serviceEnabled"],
+            "running": env_json["serviceRunning"]
+        }
+    });
+    fs::create_dir_all(ocm_home.join("upgrade-history/demo")).unwrap();
+    fs::write(
+        ocm_home
+            .join("upgrade-history/demo")
+            .join(format!("{transaction_id}.json")),
+        serde_json::to_vec(&history).unwrap(),
+    )
+    .unwrap();
+
+    SeededInPlaceRollback {
+        cwd,
+        env,
+        marker,
+        transaction_id,
+        original_recovery_root,
+    }
 }
 
 fn destructive_finalize_openclaw_script(version: &str) -> String {
@@ -2442,6 +2586,121 @@ fn upgrade_rollback_restores_and_reverses_a_runtime_switch() {
         final_history_json[0]["rollbackOf"],
         rollback_json["rollbackTransactionId"]
     );
+}
+
+#[test]
+fn upgrade_rollback_restores_retained_in_place_runtime_bytes() {
+    let root = TestDir::new("upgrade-explicit-rollback-in-place");
+    let fixture = seed_in_place_rollback(&root, "2026.6.11");
+
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(rollback.status.success(), "{}", stderr(&rollback));
+    let rollback_json: Value = serde_json::from_str(&stdout(&rollback)).unwrap();
+    assert_eq!(rollback_json["transactionId"], fixture.transaction_id);
+    assert_eq!(rollback_json["outcome"], "rolled-back");
+    assert_eq!(rollback_json["bindingName"], "stable");
+    assert_eq!(rollback_json["runtimeReleaseVersion"], "2026.6.11");
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "before-upgrade"
+    );
+    assert!(!fixture.original_recovery_root.exists());
+
+    let version = run_ocm(&fixture.cwd, &fixture.env, &["@demo", "--", "--version"]);
+    assert!(version.status.success(), "{}", stderr(&version));
+    assert_eq!(stdout(&version).trim(), "2026.6.11");
+
+    let history = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "history", "demo", "--json"],
+    );
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 2);
+    let rollback_record = &history_json[0];
+    assert_eq!(rollback_record["rollbackOf"], fixture.transaction_id);
+    assert_eq!(
+        rollback_record["runtimeRecovery"][0]["runtimeName"],
+        "stable"
+    );
+    assert_eq!(
+        rollback_record["runtimeRecovery"][0]["releaseVersion"],
+        "2026.6.33"
+    );
+    assert_eq!(rollback_record["runtimeRecovery"][0]["backupId"], "stable");
+    let reverse_recovery = Path::new(fixture.env.get("OCM_HOME").unwrap())
+        .join("upgrade-history/demo")
+        .join(format!(
+            "{}.recovery/stable/install-root/files/bin/openclaw",
+            rollback_record["id"].as_str().unwrap()
+        ));
+    assert!(reverse_recovery.is_file());
+
+    let reverse = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(reverse.status.success(), "{}", stderr(&reverse));
+    let reverse_json: Value = serde_json::from_str(&stdout(&reverse)).unwrap();
+    assert_eq!(reverse_json["outcome"], "rolled-back");
+    assert_eq!(reverse_json["runtimeReleaseVersion"], "2026.6.33");
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "after-upgrade"
+    );
+
+    let version = run_ocm(&fixture.cwd, &fixture.env, &["@demo", "--", "--version"]);
+    assert!(version.status.success(), "{}", stderr(&version));
+    assert_eq!(stdout(&version).trim(), "2026.6.33");
+}
+
+#[test]
+fn upgrade_rollback_failure_restores_the_pre_rollback_state() {
+    let root = TestDir::new("upgrade-explicit-rollback-failure");
+    let fixture = seed_in_place_rollback(&root, "broken-recovery");
+
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(!rollback.status.success());
+    let rollback_json: Value = serde_json::from_str(&stdout(&rollback)).unwrap();
+    assert_eq!(rollback_json["transactionId"], fixture.transaction_id);
+    assert_eq!(rollback_json["outcome"], "failed");
+    assert!(
+        rollback_json["note"]
+            .as_str()
+            .unwrap()
+            .contains("restored the pre-rollback state")
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "after-upgrade"
+    );
+    assert!(fixture.original_recovery_root.exists());
+
+    let version = run_ocm(&fixture.cwd, &fixture.env, &["@demo", "--", "--version"]);
+    assert!(version.status.success(), "{}", stderr(&version));
+    assert_eq!(stdout(&version).trim(), "2026.6.33");
+
+    let history = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "history", "demo", "--json"],
+    );
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 2);
+    assert_eq!(history_json[0]["outcome"], "failed");
+    assert_eq!(history_json[0]["rollback"], "restored");
+    assert_eq!(history_json[0]["rollbackOf"], fixture.transaction_id);
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2903,6 +2903,73 @@ fn upgrade_rollback_refuses_a_transaction_with_a_successful_child() {
 }
 
 #[test]
+fn upgrade_rollback_skips_newer_automatic_failure_rollback_history() {
+    let root = TestDir::new("upgrade-explicit-rollback-skips-automatic");
+    let fixture = seed_in_place_rollback(&root, "2026.6.11");
+    let automatic_id = "1783728000-000000001";
+    let automatic = serde_json::json!({
+        "kind": "ocm-upgrade-transaction",
+        "formatVersion": 1,
+        "id": automatic_id,
+        "envName": "demo",
+        "source": {
+            "kind": "runtime",
+            "name": "stable",
+            "openclawVersion": "2026.6.33"
+        },
+        "target": {
+            "kind": "runtime",
+            "name": "stable",
+            "openclawVersion": "2026.7.1"
+        },
+        "snapshotId": "failed-upgrade-snapshot",
+        "runtimeRecovery": [],
+        "startedAt": "2026-07-11T00:00:00Z",
+        "completedAt": "2026-07-11T00:01:00Z",
+        "outcome": "rolled-back",
+        "migration": {"status": "failed"},
+        "finalization": {"status": "not-run"},
+        "serviceBefore": {"enabled": false, "running": false},
+        "serviceAfter": {"enabled": false, "running": false},
+        "rollback": "restored"
+    });
+    let history_dir = Path::new(fixture.env.get("OCM_HOME").unwrap()).join("upgrade-history/demo");
+    fs::write(
+        history_dir.join(format!("{automatic_id}.json")),
+        serde_json::to_vec(&automatic).unwrap(),
+    )
+    .unwrap();
+
+    let dry_run = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--dry-run", "--json"],
+    );
+    assert!(dry_run.status.success(), "{}", stderr(&dry_run));
+    let dry_run_json: Value = serde_json::from_str(&stdout(&dry_run)).unwrap();
+    assert_eq!(dry_run_json["transactionId"], fixture.transaction_id);
+
+    let explicit = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &[
+            "upgrade",
+            "rollback",
+            "demo",
+            "--transaction",
+            automatic_id,
+            "--json",
+        ],
+    );
+    assert!(!explicit.status.success());
+    assert!(
+        stderr(&explicit).contains("cannot be rolled back because its outcome is \"rolled-back\""),
+        "{}",
+        stderr(&explicit)
+    );
+}
+
+#[test]
 fn upgrade_rollback_restarts_and_verifies_a_managed_service() {
     let root = TestDir::new("upgrade-explicit-rollback-service");
     let cwd = root.child("workspace");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2353,6 +2353,96 @@ fn upgrade_can_switch_a_local_launcher_env_to_a_published_runtime() {
 }
 
 #[test]
+fn upgrade_rollback_refuses_a_broken_source_launcher_before_mutation() {
+    let root = TestDir::new("upgrade-rollback-broken-source-launcher");
+    let cwd = root.child("workspace");
+    let project_dir = cwd.join("openclaw");
+    fs::create_dir_all(&project_dir).unwrap();
+    let launcher_binary = root.child("launcher-openclaw");
+    write_executable_script(&launcher_binary, &recording_openclaw_script("2026.3.23"));
+
+    let tarball = openclaw_package_tarball(&recording_openclaw_script("2026.3.24"), "2026.3.24");
+    let integrity = sha512_integrity(&tarball);
+    let tarball_server = TestHttpServer::serve_bytes(
+        "/openclaw-2026.3.24.tgz",
+        "application/octet-stream",
+        &tarball,
+    );
+    let packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.3.24\"}},\"versions\":{{\"2026.3.24\":{{\"version\":\"2026.3.24\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.3.24\":\"2026-03-25T16:35:52.000Z\"}}}}",
+        tarball_server.url(),
+        integrity
+    );
+    let packument_server =
+        TestHttpServer::serve_bytes_times("/openclaw", "application/json", packument.as_bytes(), 2);
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "start",
+            "hacking",
+            "--command",
+            &path_string(&launcher_binary),
+            "--cwd",
+            &path_string(&project_dir),
+            "--no-service",
+        ],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "hacking", "--channel", "stable"]);
+    assert!(upgrade.status.success(), "{}", stderr(&upgrade));
+    assert!(stdout(&upgrade).contains("outcome=switched"));
+
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "hacking", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 1);
+    assert_eq!(history_json[0]["source"]["kind"], "launcher");
+    assert_eq!(history_json[0]["source"]["openclawVersion"], "2026.3.23");
+
+    fs::remove_dir_all(&project_dir).unwrap();
+    let rollback = run_ocm(
+        &cwd,
+        &env,
+        &["upgrade", "rollback", "hacking", "--dry-run", "--json"],
+    );
+    assert!(!rollback.status.success());
+    assert!(
+        stderr(&rollback).contains("rollback source openclaw --version failed"),
+        "{}",
+        stderr(&rollback)
+    );
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "hacking", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(env_json["defaultRuntime"], "stable");
+    assert!(env_json["defaultLauncher"].is_null());
+
+    let snapshots = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "list", "hacking", "--json"],
+    );
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert_eq!(snapshots_json.as_array().unwrap().len(), 1);
+
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "hacking", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 1);
+}
+
+#[test]
 fn upgrade_can_switch_env_to_an_installed_runtime() {
     let root = TestDir::new("upgrade-installed-runtime");
     let cwd = root.child("workspace");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2320,6 +2320,131 @@ fn upgrade_reuses_the_bound_named_runtime_without_retaining_recovery_bytes() {
 }
 
 #[test]
+fn upgrade_rollback_restores_and_reverses_a_runtime_switch() {
+    let root = TestDir::new("upgrade-explicit-rollback-switch");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("2026.6.11"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("2026.6.33"));
+
+    let env = ocm_env(&root);
+    for (name, runtime) in [("old", &old_runtime), ("new", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                name,
+                "--path",
+                &runtime.display().to_string(),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+    let create = run_ocm(&cwd, &env, &["env", "create", "demo", "--runtime", "old"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+    let env_show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(env_show.status.success(), "{}", stderr(&env_show));
+    let env_json: Value = serde_json::from_str(&stdout(&env_show)).unwrap();
+    let marker = Path::new(env_json["root"].as_str().unwrap())
+        .join(".openclaw")
+        .join("workspace")
+        .join("rollback-marker");
+    fs::create_dir_all(marker.parent().unwrap()).unwrap();
+    fs::write(&marker, "before-upgrade").unwrap();
+
+    let upgrade = run_ocm(
+        &cwd,
+        &env,
+        &["upgrade", "demo", "--runtime", "new", "--raw"],
+    );
+    assert!(upgrade.status.success(), "{}", stderr(&upgrade));
+    assert!(stdout(&upgrade).contains("outcome=switched"));
+    fs::write(&marker, "after-upgrade").unwrap();
+
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    let original_id = history_json[0]["id"].as_str().unwrap().to_string();
+
+    let dry_run = run_ocm(
+        &cwd,
+        &env,
+        &["upgrade", "rollback", "demo", "--dry-run", "--json"],
+    );
+    assert!(dry_run.status.success(), "{}", stderr(&dry_run));
+    let dry_run_json: Value = serde_json::from_str(&stdout(&dry_run)).unwrap();
+    assert_eq!(dry_run_json["transactionId"], original_id);
+    assert_eq!(dry_run_json["outcome"], "would-rollback");
+    assert_eq!(dry_run_json["bindingName"], "old");
+    assert!(dry_run_json["safetySnapshotId"].is_null());
+    assert_eq!(fs::read_to_string(&marker).unwrap(), "after-upgrade");
+
+    let rollback = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "rollback",
+            "demo",
+            "--transaction",
+            &original_id,
+            "--json",
+        ],
+    );
+    assert!(rollback.status.success(), "{}", stderr(&rollback));
+    let rollback_json: Value = serde_json::from_str(&stdout(&rollback)).unwrap();
+    assert_eq!(rollback_json["transactionId"], original_id);
+    assert_eq!(rollback_json["outcome"], "rolled-back");
+    assert_eq!(rollback_json["previousBindingName"], "new");
+    assert_eq!(rollback_json["bindingName"], "old");
+    assert_eq!(rollback_json["runtimeReleaseVersion"], "2026.6.11");
+    assert!(rollback_json["rollbackTransactionId"].is_string());
+    assert!(rollback_json["safetySnapshotId"].is_string());
+    assert_eq!(fs::read_to_string(&marker).unwrap(), "before-upgrade");
+
+    let version = run_ocm(&cwd, &env, &["@demo", "--", "--version"]);
+    assert!(version.status.success(), "{}", stderr(&version));
+    assert_eq!(stdout(&version).trim(), "2026.6.11");
+
+    let rollback_history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(
+        rollback_history.status.success(),
+        "{}",
+        stderr(&rollback_history)
+    );
+    let rollback_history_json: Value = serde_json::from_str(&stdout(&rollback_history)).unwrap();
+    assert_eq!(rollback_history_json.as_array().unwrap().len(), 2);
+    assert_eq!(rollback_history_json[0]["outcome"], "rolled-back");
+    assert_eq!(rollback_history_json[0]["rollbackOf"], original_id);
+    assert_eq!(rollback_history_json[0]["source"]["name"], "new");
+    assert_eq!(rollback_history_json[0]["target"]["name"], "old");
+
+    let reverse = run_ocm(&cwd, &env, &["upgrade", "rollback", "demo", "--raw"]);
+    assert!(reverse.status.success(), "{}", stderr(&reverse));
+    assert!(stdout(&reverse).contains("outcome=rolled-back"));
+    assert!(stdout(&reverse).contains("to=runtime:new"));
+    assert_eq!(fs::read_to_string(&marker).unwrap(), "after-upgrade");
+
+    let version = run_ocm(&cwd, &env, &["@demo", "--", "--version"]);
+    assert!(version.status.success(), "{}", stderr(&version));
+    assert_eq!(stdout(&version).trim(), "2026.6.33");
+
+    let final_history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(final_history.status.success(), "{}", stderr(&final_history));
+    let final_history_json: Value = serde_json::from_str(&stdout(&final_history)).unwrap();
+    assert_eq!(final_history_json.as_array().unwrap().len(), 3);
+    assert_eq!(
+        final_history_json[0]["rollbackOf"],
+        rollback_json["rollbackTransactionId"]
+    );
+}
+
+#[test]
 fn upgrade_repairs_target_config_before_finalization() {
     let root = TestDir::new("upgrade-target-config-repair");
     let cwd = root.child("workspace");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2704,6 +2704,51 @@ fn upgrade_rollback_failure_restores_the_pre_rollback_state() {
 }
 
 #[test]
+fn upgrade_rollback_cleans_snapshot_when_transaction_setup_fails() {
+    let root = TestDir::new("upgrade-explicit-rollback-setup-failure");
+    let fixture = seed_in_place_rollback(&root, "2026.6.11");
+    let ocm_home = Path::new(fixture.env.get("OCM_HOME").unwrap());
+    fs::write(ocm_home.join("tmp"), "block transaction backup directory").unwrap();
+
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+    assert!(!rollback.status.success());
+    assert!(
+        stderr(&rollback).contains("failed to create transaction runtime backup directory")
+            || stderr(&rollback).contains("Not a directory")
+            || stderr(&rollback).contains("File exists"),
+        "{}",
+        stderr(&rollback)
+    );
+
+    let snapshots = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["env", "snapshot", "list", "demo", "--json"],
+    );
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert_eq!(snapshots_json.as_array().unwrap().len(), 1);
+
+    let history = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "history", "demo", "--json"],
+    );
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 1);
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "after-upgrade"
+    );
+    assert!(fixture.original_recovery_root.exists());
+}
+
+#[test]
 fn upgrade_repairs_target_config_before_finalization() {
     let root = TestDir::new("upgrade-target-config-repair");
     let cwd = root.child("workspace");


### PR DESCRIPTION
## Summary

- add `ocm upgrade rollback` for explicit, transactional restoration of the runtime, environment snapshot, binding, and managed service state captured before an upgrade
- reject stale, incomplete, shared, drifted, tampered, or already-reversed transactions before mutation, including unsafe runtime-only downgrades
- serialize upgrade-family operations, preserve backward-compatible history, and expose linked rollback records through human, raw, and JSON output
- document the command and cover success, reversal, refusal, cleanup, launcher, runtime, service, and history paths

## Verification

- AWS Crabbox `cbx_a55a7013c2d7`: `cargo test --locked`
- AWS Crabbox `cbx_a55a7013c2d7`: `cargo check --locked --all-targets`
- AWS Crabbox `cbx_a55a7013c2d7`: `cargo check --locked --target x86_64-pc-windows-gnu`
- real OpenClaw upgrade, rollback, durable-state comparison, and re-upgrade across `2026.6.11`, `2026.6.33`, `2026.7.1`, `2026.7.1-2`, `2026.7.2-beta.3`, and frozen source `ec8f957f` reporting `2026.7.2`
- unsafe `2026.7.2` to `2026.7.2-beta.3` runtime-only downgrade rejected before state, snapshot, or history mutation

## Follow-up

Separate compatibility-hardening PRs will extend the general environment operation lock across the complete normal-upgrade path and make failed-rollback audit-record cleanup resilient if history persistence itself fails. The explicit rollback path in this PR already holds its operation lock for the full rollback and restores state before recording a rollback failure.