### PR TITLE
fix: clean unrecorded rollback snapshots

### DIFF
--- a/src/cli/render/upgrade.rs
+++ b/src/cli/render/upgrade.rs
@@ -175,13 +175,7 @@ pub fn upgrade_rollback(summary: &UpgradeRollbackSummary, profile: RenderProfile
                 service_tone(summary.service_action.as_deref()),
             ),
             KeyValueRow::accent("Restored snapshot", &summary.restored_snapshot_id),
-            KeyValueRow::plain(
-                "Safety snapshot",
-                summary
-                    .safety_snapshot_id
-                    .as_deref()
-                    .unwrap_or("not created"),
-            ),
+            KeyValueRow::plain("Safety snapshot", rollback_safety_snapshot_display(summary)),
         ],
         profile.color,
     ));
@@ -560,6 +554,16 @@ fn upgrade_rollback_raw(summary: &UpgradeRollbackSummary) -> Vec<String> {
     vec![bits.join("  ")]
 }
 
+fn rollback_safety_snapshot_display(summary: &UpgradeRollbackSummary) -> &str {
+    if let Some(snapshot_id) = summary.safety_snapshot_id.as_deref() {
+        snapshot_id
+    } else if summary.outcome == "would-rollback" {
+        "not created"
+    } else {
+        "removed"
+    }
+}
+
 fn upgrade_history_raw_line(record: &UpgradeHistoryRecord) -> Result<String, String> {
     let mut bits = vec![
         format!("id={}", record.id),
@@ -703,7 +707,43 @@ fn simulation_temp_label(summary: &UpgradeSimulationSummary) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::upgrade::{UpgradeSimulationBatchSummary, UpgradeSimulationCheck};
+    use crate::cli::upgrade::{
+        UpgradeRollbackSummary, UpgradeSimulationBatchSummary, UpgradeSimulationCheck,
+    };
+
+    fn rollback_summary(outcome: &str) -> UpgradeRollbackSummary {
+        UpgradeRollbackSummary {
+            env_name: "demo".to_string(),
+            transaction_id: "upgrade-1".to_string(),
+            rollback_transaction_id: Some("rollback-1".to_string()),
+            previous_binding_kind: "runtime".to_string(),
+            previous_binding_name: "new".to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: "old".to_string(),
+            outcome: outcome.to_string(),
+            runtime_release_version: Some("2026.6.11".to_string()),
+            service_action: None,
+            restored_snapshot_id: "pre-upgrade".to_string(),
+            safety_snapshot_id: None,
+            note: None,
+        }
+    }
+
+    #[test]
+    fn rollback_pretty_distinguishes_removed_and_uncreated_safety_snapshots() {
+        let removed =
+            upgrade_rollback(&rollback_summary("failed"), RenderProfile::pretty(false)).join("\n");
+        let dry_run = upgrade_rollback(
+            &rollback_summary("would-rollback"),
+            RenderProfile::pretty(false),
+        )
+        .join("\n");
+
+        assert!(removed.contains("removed"), "{removed}");
+        assert!(!removed.contains("not created"), "{removed}");
+        assert!(dry_run.contains("not created"), "{dry_run}");
+        assert!(!dry_run.contains("removed"), "{dry_run}");
+    }
 
     #[test]
     fn upgrade_simulation_batch_pretty_surfaces_failure_details() {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -885,6 +885,7 @@ impl Cli {
         let rollback_transaction_id = transaction.id.clone();
         let safety_snapshot_id = transaction.snapshot_id.clone();
         let restore_result = self.rollback_upgrade_locked(env_name, &transaction);
+        let restored_pre_rollback_state = restore_result.is_ok();
         let (outcome, rollback, note) = match restore_result {
             Ok(()) => (
                 "failed".to_string(),
@@ -916,6 +917,29 @@ impl Cli {
         let history_error = self
             .record_upgrade_history(&transaction, &history_summary)
             .err();
+        let mut retained_safety_snapshot_id = Some(safety_snapshot_id.clone());
+        let snapshot_cleanup_note = if history_error.is_some() && restored_pre_rollback_state {
+            match self.environment_service().remove_snapshot_locked(
+                crate::env::RemoveEnvSnapshotOptions {
+                    env_name: env_name.to_string(),
+                    snapshot_id: safety_snapshot_id.clone(),
+                },
+            ) {
+                Ok(_) => {
+                    retained_safety_snapshot_id = None;
+                    Some("Unrecorded safety snapshot was removed.".to_string())
+                }
+                Err(error) => Some(format!(
+                    "Unrecorded safety snapshot cleanup failed: {error}"
+                )),
+            }
+        } else if history_error.is_some() {
+            Some(format!(
+                "Safety snapshot \"{safety_snapshot_id}\" was retained because restoring the pre-rollback state failed."
+            ))
+        } else {
+            None
+        };
         transaction.cleanup();
 
         UpgradeRollbackSummary {
@@ -930,10 +954,14 @@ impl Cli {
             runtime_release_version: plan.record.source.openclaw_version.clone(),
             service_action: None,
             restored_snapshot_id: plan.record.snapshot_id.clone(),
-            safety_snapshot_id: Some(safety_snapshot_id),
+            safety_snapshot_id: retained_safety_snapshot_id,
             note: join_optional_warnings(
-                Some(note),
-                history_error.map(|error| format!("Rollback history was not recorded: {error}")),
+                join_optional_warnings(
+                    Some(note),
+                    history_error
+                        .map(|error| format!("Rollback history was not recorded: {error}")),
+                ),
+                snapshot_cleanup_note,
             ),
         }
     }

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2959,6 +2959,12 @@ fn upgrade_rollback_removes_an_unrecorded_safety_snapshot_after_restore() {
             .unwrap()
             .contains("Rollback history was not recorded")
     );
+    assert!(
+        rollback_json["note"]
+            .as_str()
+            .unwrap()
+            .contains("Unrecorded safety snapshot was removed")
+    );
     assert_eq!(
         fs::read_to_string(&fixture.marker).unwrap(),
         "after-upgrade"

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2,6 +2,8 @@ mod support;
 
 use std::collections::BTreeMap;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::{self, sleep};
@@ -2914,6 +2916,62 @@ fn upgrade_rollback_failure_restores_the_pre_rollback_state() {
     assert_eq!(history_json[0]["outcome"], "failed");
     assert_eq!(history_json[0]["rollback"], "restored");
     assert_eq!(history_json[0]["rollbackOf"], fixture.transaction_id);
+}
+
+#[cfg(unix)]
+#[test]
+fn upgrade_rollback_removes_an_unrecorded_safety_snapshot_after_restore() {
+    let root = TestDir::new("upgrade-rollback-history-write-failure");
+    let fixture = seed_in_place_rollback(&root, "broken-recovery");
+    let history_dir = Path::new(fixture.env.get("OCM_HOME").unwrap()).join("upgrade-history/demo");
+    let mut permissions = fs::metadata(&history_dir).unwrap().permissions();
+    let original_mode = permissions.mode();
+    permissions.set_mode(0o500);
+    fs::set_permissions(&history_dir, permissions).unwrap();
+
+    let rollback = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "rollback", "demo", "--json"],
+    );
+
+    let mut permissions = fs::metadata(&history_dir).unwrap().permissions();
+    permissions.set_mode(original_mode);
+    fs::set_permissions(&history_dir, permissions).unwrap();
+
+    assert!(!rollback.status.success());
+    let rollback_json: Value = serde_json::from_str(&stdout(&rollback)).unwrap();
+    assert_eq!(rollback_json["outcome"], "failed");
+    assert!(rollback_json["safetySnapshotId"].is_null());
+    assert!(
+        rollback_json["note"]
+            .as_str()
+            .unwrap()
+            .contains("Rollback history was not recorded")
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.marker).unwrap(),
+        "after-upgrade"
+    );
+    assert!(fixture.original_recovery_root.exists());
+
+    let snapshots = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["env", "snapshot", "list", "demo", "--json"],
+    );
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert_eq!(snapshots_json.as_array().unwrap().len(), 1);
+
+    let history = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["upgrade", "history", "demo", "--json"],
+    );
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert_eq!(history_json.as_array().unwrap().len(), 1);
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2889,6 +2889,7 @@ fn upgrade_rollback_failure_restores_the_pre_rollback_state() {
     let rollback_json: Value = serde_json::from_str(&stdout(&rollback)).unwrap();
     assert_eq!(rollback_json["transactionId"], fixture.transaction_id);
     assert_eq!(rollback_json["outcome"], "failed");
+    assert!(rollback_json["safetySnapshotId"].is_string());
     assert!(
         rollback_json["note"]
             .as_str()
@@ -2916,6 +2917,15 @@ fn upgrade_rollback_failure_restores_the_pre_rollback_state() {
     assert_eq!(history_json[0]["outcome"], "failed");
     assert_eq!(history_json[0]["rollback"], "restored");
     assert_eq!(history_json[0]["rollbackOf"], fixture.transaction_id);
+
+    let snapshots = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["env", "snapshot", "list", "demo", "--json"],
+    );
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert_eq!(snapshots_json.as_array().unwrap().len(), 2);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- remove a failed rollback safety snapshot when state restoration succeeded but history persistence failed
- retain safety snapshots when history records them or restoration itself failed
- report removed snapshots accurately across pretty, raw, and JSON output

## Verification
- reproduced the orphaned-snapshot failure on AWS before the fix
- AWS Crabbox: `cargo test --locked`
- AWS Crabbox: `cargo check --locked --all-targets`
- AWS Crabbox: `cargo check --locked --target x86_64-pc-windows-gnu`
- AWS Crabbox: all explicit rollback tests plus exact-tip lifecycle and render tests
- `cargo fmt --check`
- `git diff --check`