### PR TITLE
fix: make snapshot removal consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ gateway is reachable; otherwise the upgrade follows the normal rollback path.
 Snapshots preserve managed path, npm, and Git plugin payloads together with
 their package metadata and symlinks, while generated plugin dependency caches
 and live runtime residue stay out of the archive.
+Snapshot removal validates that the stored environment, snapshot ID, and
+archive path match the named snapshot before deleting anything. It takes the
+live metadata and archive out of service together, then reports warnings if
+linked upgrade recovery or staged artifact cleanup still needs attention.
 When both OpenClaw versions are known, `upgrade` rejects an older target before
 creating a snapshot, downloading the target, or changing runtime metadata.
 Switching only the binary cannot reverse newer OpenClaw config or SQLite state

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -149,6 +149,8 @@ pub(crate) struct EnvDestroySummary {
     pub blockers: Vec<String>,
     pub steps: Vec<EnvDestroyStepSummary>,
     pub snapshots_removed: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
     pub service_uninstalled: bool,
     pub processes_terminated: usize,
     pub worktree_removed: bool,
@@ -381,11 +383,18 @@ impl Cli {
         // Snapshots are the recovery path if destructive cleanup fails, so
         // remove them only after the environment and worktree are gone.
         for snapshot_id in &snapshot_ids {
-            self.environment_service()
-                .remove_snapshot_locked(RemoveEnvSnapshotOptions {
-                    env_name: name.clone(),
-                    snapshot_id: snapshot_id.clone(),
-                })?;
+            let removed =
+                self.environment_service()
+                    .remove_snapshot_locked(RemoveEnvSnapshotOptions {
+                        env_name: name.clone(),
+                        snapshot_id: snapshot_id.clone(),
+                    })?;
+            summary.warnings.extend(
+                removed
+                    .warnings
+                    .into_iter()
+                    .map(|warning| format!("snapshot {snapshot_id}: {warning}")),
+            );
         }
         summary.snapshots_removed = snapshot_ids.len();
 
@@ -1114,6 +1123,7 @@ impl Cli {
             blockers,
             steps,
             snapshots_removed: 0,
+            warnings: Vec::new(),
             service_uninstalled: false,
             processes_terminated: 0,
             worktree_removed: false,

--- a/src/cli/render/env.rs
+++ b/src/cli/render/env.rs
@@ -2444,6 +2444,14 @@ pub fn env_snapshot_removed(
         rows.push(KeyValueRow::plain("Label", label));
     }
     push_card(&mut lines, "Snapshot", rows, profile.color);
+    if !removed.warnings.is_empty() {
+        let rows = removed
+            .warnings
+            .iter()
+            .map(|warning| KeyValueRow::warning("Warning", warning.clone()))
+            .collect::<Vec<_>>();
+        lines.extend(render_key_value_card("Warnings", &rows, profile.color));
+    }
     lines
 }
 
@@ -2458,6 +2466,12 @@ fn env_snapshot_removed_raw(removed: &EnvSnapshotRemoveSummary) -> Vec<String> {
     if let Some(label) = removed.label.as_deref() {
         lines.push(format!("  label: {label}"));
     }
+    lines.extend(
+        removed
+            .warnings
+            .iter()
+            .map(|warning| format!("warning: {warning}")),
+    );
     lines
 }
 
@@ -2573,6 +2587,17 @@ pub fn env_snapshot_pruned(
         &rows,
         profile.color,
     ));
+    let warnings = removed
+        .iter()
+        .flat_map(|snapshot| {
+            snapshot.warnings.iter().map(|warning| {
+                KeyValueRow::warning("Warning", format!("{}: {warning}", snapshot.snapshot_id))
+            })
+        })
+        .collect::<Vec<_>>();
+    if !warnings.is_empty() {
+        lines.extend(render_key_value_card("Warnings", &warnings, profile.color));
+    }
     lines
 }
 
@@ -2585,6 +2610,12 @@ fn env_snapshot_pruned_raw(removed: &[EnvSnapshotRemoveSummary]) -> Vec<String> 
         }
         bits.push(snapshot.archive_path.clone());
         lines.push(format!("  {}", bits.join("  ")));
+        lines.extend(
+            snapshot
+                .warnings
+                .iter()
+                .map(|warning| format!("  warning: {}: {warning}", snapshot.snapshot_id)),
+        );
     }
     lines
 }

--- a/src/cli/render/env.rs
+++ b/src/cli/render/env.rs
@@ -223,6 +223,15 @@ pub fn env_destroyed(
         profile.color,
     );
 
+    if !summary.warnings.is_empty() {
+        let rows = summary
+            .warnings
+            .iter()
+            .map(|warning| KeyValueRow::warning("Warning", warning.clone()))
+            .collect::<Vec<_>>();
+        lines.extend(render_key_value_card("Warnings", &rows, profile.color));
+    }
+
     push_card(
         &mut lines,
         "Next",
@@ -260,6 +269,12 @@ fn env_destroyed_raw(summary: &EnvDestroySummary, command_example: &str) -> Vec<
     if summary.service_uninstalled {
         lines.push(format!("  service removed: {}", summary.service_label));
     }
+    lines.extend(
+        summary
+            .warnings
+            .iter()
+            .map(|warning| format!("warning: {warning}")),
+    );
     lines.push(format!("  list: {command_example} env list"));
     lines
 }
@@ -1760,6 +1775,7 @@ mod tests {
                 },
             ],
             snapshots_removed: 0,
+            warnings: Vec::new(),
             service_uninstalled: false,
             processes_terminated: 0,
             worktree_removed: false,

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1691,7 +1691,10 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
             vec![format!(
                 "{cmd} env snapshot remove mira 1742922000-123456789"
             )],
-            &[],
+            &[
+                "OCM validates the stored environment, snapshot ID, and archive path before removal.",
+                "Metadata and archive content leave their live paths together; later cleanup failures are reported as warnings.",
+            ],
         ),
         "prune" => render_leaf(
             "Prune environment snapshots",
@@ -1721,7 +1724,10 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
                 format!("{cmd} env snapshot prune mira --keep 5 --yes"),
                 format!("{cmd} env snapshot prune --all --older-than 30 --json"),
             ],
-            &["TTY output renders tables for preview and applied removals by default."],
+            &[
+                "TTY output renders tables for preview and applied removals by default.",
+                "Applied prune output preserves cleanup warnings for each removed snapshot.",
+            ],
         ),
         _ => return None,
     })

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -925,9 +925,14 @@ impl Cli {
                     snapshot_id: safety_snapshot_id.clone(),
                 },
             ) {
-                Ok(_) => {
+                Ok(removed) => {
                     retained_safety_snapshot_id = None;
-                    Some("Unrecorded safety snapshot was removed.".to_string())
+                    join_optional_warnings(
+                        Some("Unrecorded safety snapshot was removed.".to_string()),
+                        join_warnings(&removed.warnings).map(|warning| {
+                            format!("Snapshot cleanup requires attention: {warning}")
+                        }),
+                    )
                 }
                 Err(error) => Some(format!(
                     "Unrecorded safety snapshot cleanup failed: {error}"

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -54,6 +54,8 @@ pub struct EnvSnapshotRemoveSummary {
     pub snapshot_id: String,
     pub label: Option<String>,
     pub archive_path: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -142,19 +142,18 @@ pub fn get_env_snapshot(
     cwd: &Path,
 ) -> Result<EnvSnapshotMeta, String> {
     let safe_env_name = validate_name(env_name, "Environment name")?;
-    let safe_snapshot_id = snapshot_id.trim();
-    if safe_snapshot_id.is_empty() {
-        return Err("snapshot id is required".to_string());
-    }
+    let safe_snapshot_id = validate_name(snapshot_id, "Snapshot id")?;
 
-    let path = snapshot_meta_path(&safe_env_name, safe_snapshot_id, env, cwd)?;
+    let path = snapshot_meta_path(&safe_env_name, &safe_snapshot_id, env, cwd)?;
     if !path_exists(&path) {
         return Err(format!(
             "snapshot \"{}\" does not exist for environment \"{}\"",
             safe_snapshot_id, safe_env_name
         ));
     }
-    read_json(&path)
+    let snapshot = read_json(&path)?;
+    validate_env_snapshot_identity(&snapshot, &safe_env_name, &safe_snapshot_id, env, cwd)?;
+    Ok(snapshot)
 }
 
 pub fn summarize_snapshot(meta: &EnvSnapshotMeta) -> EnvSnapshotSummary {
@@ -317,7 +316,13 @@ pub fn list_env_snapshots(
     let files = load_json_files(&dir)?;
     let mut out = Vec::with_capacity(files.len());
     for file in files {
-        out.push(read_json(&file)?);
+        let snapshot_id = file
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| format!("snapshot path has an invalid id: {}", display_path(&file)))?;
+        let snapshot = read_json(&file)?;
+        validate_env_snapshot_identity(&snapshot, &safe_env_name, snapshot_id, env, cwd)?;
+        out.push(snapshot);
     }
     sort_snapshots(&mut out);
     Ok(out)
@@ -336,13 +341,64 @@ pub fn list_all_env_snapshots(
         if !path.is_dir() {
             continue;
         }
+        let env_name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| {
+                format!(
+                    "snapshot directory has an invalid environment name: {}",
+                    display_path(&path)
+                )
+            })?;
+        let env_name = validate_name(env_name, "Environment name")?;
         let files = load_json_files(&path)?;
         for file in files {
-            out.push(read_json(&file)?);
+            let snapshot_id = file
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| {
+                    format!("snapshot path has an invalid id: {}", display_path(&file))
+                })?;
+            let snapshot = read_json(&file)?;
+            validate_env_snapshot_identity(&snapshot, &env_name, snapshot_id, env, cwd)?;
+            out.push(snapshot);
         }
     }
     sort_snapshots(&mut out);
     Ok(out)
+}
+
+fn validate_env_snapshot_identity(
+    snapshot: &EnvSnapshotMeta,
+    env_name: &str,
+    snapshot_id: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<(), String> {
+    if snapshot.kind != "ocm-env-snapshot" {
+        return Err(format!("unsupported snapshot kind: {}", snapshot.kind));
+    }
+    if snapshot.env_name != env_name {
+        return Err(format!(
+            "snapshot \"{snapshot_id}\" belongs to environment \"{}\", expected \"{env_name}\"",
+            snapshot.env_name
+        ));
+    }
+    if snapshot.id != snapshot_id {
+        return Err(format!(
+            "snapshot entry \"{snapshot_id}\" contains snapshot id \"{}\"",
+            snapshot.id
+        ));
+    }
+    let expected_archive = snapshot_archive_path(env_name, snapshot_id, env, cwd)?;
+    if Path::new(&snapshot.archive_path) != expected_archive {
+        return Err(format!(
+            "snapshot \"{snapshot_id}\" archive path is {}, expected {}",
+            snapshot.archive_path,
+            display_path(&expected_archive)
+        ));
+    }
+    Ok(())
 }
 
 fn sort_snapshots(snapshots: &mut [EnvSnapshotMeta]) {

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -299,34 +299,29 @@ pub fn remove_env_snapshot(
         )
     })?;
 
-    let archive_staged = if path_exists(&archive_path) {
-        if let Err(error) = fs::rename(&archive_path, &staged_archive_path) {
-            let _ = fs::remove_dir(&staging_dir);
-            return Err(format!(
-                "failed to stage snapshot archive {} for removal: {error}",
-                display_path(&archive_path)
-            ));
-        }
-        true
-    } else {
-        false
-    };
-
     if let Err(error) = fs::rename(&meta_path, &staged_meta_path) {
-        let restore_error = if archive_staged {
-            fs::rename(&staged_archive_path, &archive_path)
-                .err()
-                .map(|restore_error| {
-                    format!("; restoring the staged archive also failed: {restore_error}")
-                })
-        } else {
-            None
-        };
         let _ = fs::remove_dir(&staging_dir);
         return Err(format!(
-            "failed to stage snapshot metadata {} for removal: {error}{}",
+            "failed to stage snapshot metadata {} for removal: {error}",
             display_path(&meta_path),
-            restore_error.unwrap_or_default()
+        ));
+    }
+
+    if path_exists(&archive_path)
+        && let Err(error) = fs::rename(&archive_path, &staged_archive_path)
+    {
+        let restore_error = fs::rename(&staged_meta_path, &meta_path).err();
+        if restore_error.is_none() {
+            let _ = fs::remove_dir(&staging_dir);
+        }
+        return Err(format!(
+            "failed to stage snapshot archive {} for removal: {error}{}",
+            display_path(&archive_path),
+            restore_error
+                .map(|restore_error| {
+                    format!("; restoring the staged metadata also failed: {restore_error}")
+                })
+                .unwrap_or_default()
         ));
     }
 

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -26,6 +26,7 @@ use super::{
 };
 
 static NEXT_RESTORE_ID: AtomicU64 = AtomicU64::new(0);
+static NEXT_REMOVAL_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -287,22 +288,74 @@ pub fn remove_env_snapshot(
     let snapshot = get_env_snapshot(&options.env_name, &options.snapshot_id, env, cwd)?;
     let meta_path = snapshot_meta_path(&snapshot.env_name, &snapshot.id, env, cwd)?;
     let archive_path = PathBuf::from(&snapshot.archive_path);
+    let staging_dir = snapshot_removal_staging_dir(&snapshot.env_name, &snapshot.id, env, cwd)?;
+    let staged_meta_path = staging_dir.join("snapshot.json");
+    let staged_archive_path = staging_dir.join("snapshot.tar");
 
-    if path_exists(&meta_path) {
-        fs::remove_file(&meta_path).map_err(|error| error.to_string())?;
-    }
-    if path_exists(&archive_path) {
-        fs::remove_file(&archive_path).map_err(|error| error.to_string())?;
-    }
-    remove_upgrade_recovery_for_snapshot(&snapshot.env_name, &snapshot.id, env, cwd)?;
+    fs::create_dir(&staging_dir).map_err(|error| {
+        format!(
+            "failed to create snapshot removal staging directory {}: {error}",
+            display_path(&staging_dir)
+        )
+    })?;
 
-    remove_snapshot_parent_if_empty(&snapshot.env_name, env, cwd)?;
+    let archive_staged = if path_exists(&archive_path) {
+        if let Err(error) = fs::rename(&archive_path, &staged_archive_path) {
+            let _ = fs::remove_dir(&staging_dir);
+            return Err(format!(
+                "failed to stage snapshot archive {} for removal: {error}",
+                display_path(&archive_path)
+            ));
+        }
+        true
+    } else {
+        false
+    };
+
+    if let Err(error) = fs::rename(&meta_path, &staged_meta_path) {
+        let restore_error = if archive_staged {
+            fs::rename(&staged_archive_path, &archive_path)
+                .err()
+                .map(|restore_error| {
+                    format!("; restoring the staged archive also failed: {restore_error}")
+                })
+        } else {
+            None
+        };
+        let _ = fs::remove_dir(&staging_dir);
+        return Err(format!(
+            "failed to stage snapshot metadata {} for removal: {error}{}",
+            display_path(&meta_path),
+            restore_error.unwrap_or_default()
+        ));
+    }
+
+    let mut warnings = Vec::new();
+    if let Err(error) =
+        remove_upgrade_recovery_for_snapshot(&snapshot.env_name, &snapshot.id, env, cwd)
+    {
+        warnings.push(format!(
+            "linked upgrade recovery cleanup failed after snapshot removal: {error}"
+        ));
+    }
+    if let Err(error) = fs::remove_dir_all(&staging_dir) {
+        warnings.push(format!(
+            "staged snapshot artifact cleanup failed at {}: {error}",
+            display_path(&staging_dir)
+        ));
+    }
+    if let Err(error) = remove_snapshot_parent_if_empty(&snapshot.env_name, env, cwd) {
+        warnings.push(format!(
+            "snapshot directory cleanup failed after removal: {error}"
+        ));
+    }
 
     Ok(EnvSnapshotRemoveSummary {
         env_name: snapshot.env_name,
         snapshot_id: snapshot.id,
         label: snapshot.label,
         archive_path: snapshot.archive_path,
+        warnings,
     })
 }
 
@@ -415,6 +468,17 @@ fn restore_staging_dir() -> PathBuf {
     std::env::temp_dir()
         .join("ocm-snapshot-restores")
         .join(format!("{}-{id}", std::process::id()))
+}
+
+fn snapshot_removal_staging_dir(
+    env_name: &str,
+    snapshot_id: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PathBuf, String> {
+    let id = NEXT_REMOVAL_ID.fetch_add(1, Ordering::Relaxed);
+    Ok(snapshot_env_dir(env_name, env, cwd)?
+        .join(format!(".remove-{snapshot_id}-{}-{id}", std::process::id())))
 }
 
 fn restore_backup_root(root: &Path) -> PathBuf {

--- a/tests/env_destroy_tests.rs
+++ b/tests/env_destroy_tests.rs
@@ -456,6 +456,9 @@ fn env_destroy_yes_uninstalls_service_removes_snapshots_and_deletes_env() {
         ],
     );
     assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let history_root = root.child("ocm-home/upgrade-history");
+    fs::create_dir_all(&history_root).unwrap();
+    fs::write(history_root.join("demo"), "block linked recovery traversal").unwrap();
 
     let install = run_ocm(&cwd, &env, &["service", "install", "demo"]);
     assert!(install.status.success(), "{}", stderr(&install));
@@ -467,6 +470,11 @@ fn env_destroy_yes_uninstalls_service_removes_snapshots_and_deletes_env() {
     assert!(output.contains("Destroyed env demo"));
     assert!(output.contains("snapshots removed: 1"));
     assert!(output.contains("service removed: ocm"));
+    assert!(
+        output.contains("warning: snapshot")
+            && output.contains("linked upgrade recovery cleanup failed"),
+        "{output}"
+    );
 
     let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
     assert!(!show.status.success());

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -1044,6 +1044,50 @@ fn env_snapshot_remove_json_reports_removed_snapshot_metadata() {
 }
 
 #[test]
+fn env_snapshot_remove_reports_cleanup_warnings_after_logical_removal() {
+    let root = TestDir::new("env-snapshot-remove-warning");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--json"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot_json: serde_json::Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    let snapshot_id = snapshot_json["id"].as_str().unwrap();
+
+    let history_root = root.child("ocm-home/upgrade-history");
+    fs::create_dir_all(&history_root).unwrap();
+    fs::write(
+        history_root.join("source"),
+        "block linked recovery traversal",
+    )
+    .unwrap();
+
+    let remove = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "remove", "source", snapshot_id],
+    );
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    assert!(
+        stdout(&remove).contains("warning: linked upgrade recovery cleanup failed"),
+        "{}",
+        stdout(&remove)
+    );
+
+    let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    assert!(stdout(&list).contains("No snapshots."));
+}
+
+#[test]
 fn env_snapshot_prune_previews_candidates_without_removing_them() {
     let root = TestDir::new("env-snapshot-prune-preview");
     let cwd = root.child("workspace");

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -600,6 +600,13 @@ fn nested_snapshot_help_is_available() {
     assert!(output.contains("ocm env snapshot list <name> [--raw] [--json]"));
     assert!(output.contains("TTY output renders a table by default."));
 
+    let remove = run_ocm(&cwd, &env, &["help", "env", "snapshot", "remove"]);
+    assert!(remove.status.success(), "{}", stderr(&remove));
+    let output = stdout(&remove);
+    assert!(output.contains("ocm env snapshot remove <name> <snapshot> [--raw] [--json]"));
+    assert!(output.contains("validates the stored environment, snapshot ID, and archive path"));
+    assert!(output.contains("later cleanup failures are reported as warnings"));
+
     let prune = run_ocm(&cwd, &env, &["help", "env", "snapshot", "prune"]);
     assert!(prune.status.success(), "{}", stderr(&prune));
     let output = stdout(&prune);
@@ -609,6 +616,7 @@ fn nested_snapshot_help_is_available() {
     assert!(
         output.contains("TTY output renders tables for preview and applied removals by default.")
     );
+    assert!(output.contains("preserves cleanup warnings for each removed snapshot"));
 }
 
 #[test]

--- a/tests/store_flow_tests.rs
+++ b/tests/store_flow_tests.rs
@@ -1786,7 +1786,71 @@ fn environment_snapshot_remove_deletes_snapshot_artifacts_and_metadata() {
     assert_eq!(removed.env_name, "source");
     assert_eq!(removed.snapshot_id, snapshot.id);
     assert_eq!(removed.label.as_deref(), Some("before-cleanup"));
+    assert!(removed.warnings.is_empty());
     assert!(!std::path::Path::new(&removed.archive_path).exists());
+    assert!(list_env_snapshots("source", &env, &cwd).unwrap().is_empty());
+    assert!(!root.child("ocm-home/snapshots/source").exists());
+}
+
+#[test]
+fn environment_snapshot_remove_reports_post_removal_cleanup_warnings() {
+    let root = TestDir::new("store-env-snapshot-remove-warning");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    create_environment(
+        CreateEnvironmentOptions {
+            name: "source".to_string(),
+            root: None,
+            gateway_port: None,
+            service_enabled: false,
+            service_running: false,
+            default_runtime: None,
+            default_launcher: None,
+            dev: None,
+            protected: false,
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+
+    let snapshot = create_env_snapshot(
+        CreateEnvSnapshotOptions {
+            env_name: "source".to_string(),
+            label: None,
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+    let history_root = root.child("ocm-home/upgrade-history");
+    fs::create_dir_all(&history_root).unwrap();
+    fs::write(
+        history_root.join("source"),
+        "block linked recovery traversal",
+    )
+    .unwrap();
+
+    let removed = remove_env_snapshot(
+        RemoveEnvSnapshotOptions {
+            env_name: "source".to_string(),
+            snapshot_id: snapshot.id.clone(),
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+
+    assert_eq!(removed.snapshot_id, snapshot.id);
+    assert_eq!(removed.warnings.len(), 1);
+    assert!(
+        removed.warnings[0].contains("linked upgrade recovery cleanup failed"),
+        "{:?}",
+        removed.warnings
+    );
+    assert!(!Path::new(&removed.archive_path).exists());
     assert!(list_env_snapshots("source", &env, &cwd).unwrap().is_empty());
     assert!(!root.child("ocm-home/snapshots/source").exists());
 }

--- a/tests/store_flow_tests.rs
+++ b/tests/store_flow_tests.rs
@@ -1792,6 +1792,86 @@ fn environment_snapshot_remove_deletes_snapshot_artifacts_and_metadata() {
 }
 
 #[test]
+fn environment_snapshot_reads_reject_mismatched_identity_and_archive_paths() {
+    let root = TestDir::new("store-env-snapshot-identity");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    create_environment(
+        CreateEnvironmentOptions {
+            name: "source".to_string(),
+            root: None,
+            gateway_port: None,
+            service_enabled: false,
+            service_running: false,
+            default_runtime: None,
+            default_launcher: None,
+            dev: None,
+            protected: false,
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+
+    let snapshot = create_env_snapshot(
+        CreateEnvSnapshotOptions {
+            env_name: "source".to_string(),
+            label: None,
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+    let meta_path = root
+        .child("ocm-home/snapshots/source")
+        .join(format!("{}.json", snapshot.id));
+    let original = fs::read(&meta_path).unwrap();
+    let mut metadata: serde_json::Value = serde_json::from_slice(&original).unwrap();
+
+    metadata["envName"] = serde_json::Value::String("other".to_string());
+    fs::write(&meta_path, serde_json::to_vec(&metadata).unwrap()).unwrap();
+    let error = get_env_snapshot("source", &snapshot.id, &env, &cwd).unwrap_err();
+    assert!(
+        error.contains("belongs to environment \"other\", expected \"source\""),
+        "{error}"
+    );
+
+    fs::write(&meta_path, &original).unwrap();
+    metadata = serde_json::from_slice(&original).unwrap();
+    metadata["id"] = serde_json::Value::String("different".to_string());
+    fs::write(&meta_path, serde_json::to_vec(&metadata).unwrap()).unwrap();
+    let error = list_env_snapshots("source", &env, &cwd).unwrap_err();
+    assert!(
+        error.contains("contains snapshot id \"different\""),
+        "{error}"
+    );
+
+    fs::write(&meta_path, &original).unwrap();
+    metadata = serde_json::from_slice(&original).unwrap();
+    let foreign_archive = root.child("do-not-remove.tar");
+    fs::write(&foreign_archive, "foreign").unwrap();
+    metadata["archivePath"] =
+        serde_json::Value::String(foreign_archive.to_string_lossy().into_owned());
+    fs::write(&meta_path, serde_json::to_vec(&metadata).unwrap()).unwrap();
+    let error = remove_env_snapshot(
+        RemoveEnvSnapshotOptions {
+            env_name: "source".to_string(),
+            snapshot_id: snapshot.id.clone(),
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap_err();
+    assert!(error.contains("archive path is"), "{error}");
+    assert!(foreign_archive.exists());
+
+    let error = get_env_snapshot("source", "../outside", &env, &cwd).unwrap_err();
+    assert!(error.contains("Snapshot id must use letters"), "{error}");
+}
+
+#[test]
 fn environment_snapshot_prune_keeps_the_newest_snapshot_in_scope() {
     let root = TestDir::new("store-env-snapshot-prune");
     let cwd = root.child("workspace");


### PR DESCRIPTION
## Summary
- validate snapshot identity and managed archive paths before removal
- tombstone snapshot metadata before staging archive content out of live paths
- preserve post-removal cleanup warnings through direct removal, pruning, rollback, and environment destruction

## Why
A linked recovery cleanup failure could occur after snapshot metadata and archive content were already removed. Callers could then report a safety snapshot as retained even though it was unavailable.

## Verification
- AWS Crabbox: `cargo test --locked`
- AWS Crabbox: `cargo check --locked --all-targets`
- AWS Crabbox: `cargo check --locked --target x86_64-pc-windows-gnu`
- frozen OpenClaw 2026.6.11 through 2026.7.2 compatibility evidence remains applicable because runtime and version execution paths are unchanged