### PR TITLE
chore(release): bump version to 0.2.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.29"
+version = "0.2.30"
 edition = "2024"
 rust-version = "1.88"
 description = "OpenClaw Manager: the local control plane for isolated OpenClaw environments, launchers, runtimes, and services."


### PR DESCRIPTION
Prepare v0.2.30. Squash-merge this pull request, update local main, then rerun `scripts/release.sh 0.2.30` to sign and push the release tag.