### PR TITLE
fix(release): require exact-SHA CI before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - "v*"
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -39,6 +40,9 @@ jobs:
               --repo "$RELEASE_REPO" \
               --tag "$RELEASE_TAG"
           )"
+          ./scripts/verify-release-ci.sh \
+            --repo "$RELEASE_REPO" \
+            --commit "$verified_commit"
           printf 'commit=%s\n' "$verified_commit" >>"$GITHUB_OUTPUT"
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to OCM are documented here.
 
 ## Unreleased
 
+- Require successful exact-SHA `main` CI before signed release tags can be created or packaged.
+
 ## 0.2.30 - 2026-07-23
 
 ### Added

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -360,6 +360,10 @@ case "$branch" in
         echo "error: ${version} is on main, but HEAD is not the expected squash-merged release commit" >&2
         exit 1
       fi
+      run_step "Verifying exact-SHA main CI" \
+        "${script_dir}/verify-release-ci.sh" \
+        --repo "$(github_repository)" \
+        --commit "$head_sha"
 
       if git show-ref --verify --quiet "refs/tags/${tag}"; then
         log_step "Using existing local tag ${tag}"
@@ -450,5 +454,6 @@ Release pull request ready: ${pr_url}
 Next:
   1. Squash-merge ${release_branch} into main.
   2. Update local main to the merged commit.
-  3. Rerun: scripts/release.sh ${version} --remote ${remote}
+  3. Wait for the exact main-branch CI run to pass.
+  4. Rerun: scripts/release.sh ${version} --remote ${remote}
 EOF

--- a/scripts/verify-release-ci.sh
+++ b/scripts/verify-release-ci.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: scripts/verify-release-ci.sh --repo <owner/repo> --commit <sha>" >&2
+}
+
+github() {
+  if [[ -n "${OCM_GH_BIN:-}" ]]; then
+    "$OCM_GH_BIN" "$@"
+  elif command -v ghx >/dev/null 2>&1; then
+    ghx --no-cache "$@"
+  elif command -v gh >/dev/null 2>&1; then
+    gh "$@"
+  else
+    echo "error: ghx or gh is required to verify release CI" >&2
+    return 1
+  fi
+}
+
+repo=""
+commit=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      shift
+      [[ $# -gt 0 ]] || {
+        echo "error: --repo requires a value" >&2
+        exit 1
+      }
+      repo="$1"
+      ;;
+    --commit)
+      shift
+      [[ $# -gt 0 ]] || {
+        echo "error: --commit requires a value" >&2
+        exit 1
+      }
+      commit="$1"
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ ! "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+  echo "error: invalid GitHub repository: ${repo:-empty}" >&2
+  exit 1
+fi
+if [[ ! "$commit" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "error: invalid release commit SHA: ${commit:-empty}" >&2
+  exit 1
+fi
+
+endpoint="repos/${repo}/actions/workflows/ci.yml/runs?branch=main&event=push&head_sha=${commit}&per_page=20"
+run_data="$(
+  github api "$endpoint" \
+    --jq "(.workflow_runs | map(select(.head_sha == \"${commit}\")) | .[0]) // empty | [.id, .head_sha, .status, (.conclusion // \"\"), .html_url] | map(tostring) | join(\"|\")"
+)"
+if [[ -z "$run_data" ]]; then
+  echo "error: no main-branch CI push run exists for exact commit ${commit}" >&2
+  echo "hint: wait for CI to start and finish, then retry the release" >&2
+  exit 1
+fi
+
+IFS='|' read -r run_id run_head_sha run_status run_conclusion run_url <<<"$run_data"
+if [[ "$run_head_sha" != "$commit" ]]; then
+  echo "error: CI run ${run_id:-unknown} is for ${run_head_sha:-unknown}, not ${commit}" >&2
+  exit 1
+fi
+if [[ "$run_status" != "completed" ]]; then
+  echo "error: CI run ${run_id:-unknown} for ${commit} is still ${run_status:-unknown}" >&2
+  [[ -n "$run_url" ]] && echo "run: ${run_url}" >&2
+  exit 1
+fi
+if [[ "$run_conclusion" != "success" ]]; then
+  echo "error: CI run ${run_id:-unknown} for ${commit} concluded ${run_conclusion:-unknown}" >&2
+  [[ -n "$run_url" ]] && echo "run: ${run_url}" >&2
+  exit 1
+fi
+
+echo "Verified exact-SHA CI run ${run_id} for ${commit}"

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -410,7 +410,9 @@ fn workflows_pin_actions_lock_dependencies_and_gate_the_msrv() {
     assert!(ci.contains("cargo install --locked"));
     assert!(release.contains("cargo build --locked --release"));
     assert!(release.contains("scripts/verify-release-tag.sh"));
+    assert!(release.contains("scripts/verify-release-ci.sh"));
     assert!(release.contains("scripts/publish-release.sh"));
+    assert!(release.contains("actions: read"));
     assert!(release.contains("cp ./install.sh ./dist/install.sh"));
     assert!(release.contains("tags:"));
     assert!(release.contains("- \"v*\""));

--- a/tests/release_script_tests.rs
+++ b/tests/release_script_tests.rs
@@ -106,6 +106,16 @@ impl ReleaseRepo {
         assert!(push.status.success(), "{}", stderr(&push));
         self.git_stdout(&["rev-parse", "HEAD"]).trim().to_string()
     }
+
+    fn record_ci(&self, head_sha: &str, status: &str, conclusion: &str) {
+        fs::write(
+            self.repo.join(".git/test-ci-run"),
+            format!(
+                "12345|{head_sha}|{status}|{conclusion}|https://github.com/example/ocm/actions/runs/12345\n"
+            ),
+        )
+        .unwrap();
+    }
 }
 
 fn stdout(output: &Output) -> String {
@@ -166,6 +176,7 @@ fn init_release_repo(label: &str) -> ReleaseRepo {
         "scripts/release.sh",
         "scripts/update-version.sh",
         "scripts/validate-version.sh",
+        "scripts/verify-release-ci.sh",
     ] {
         copy_script(&repo, script);
     }
@@ -209,6 +220,11 @@ exec "$real_git" "$@"
         r#"#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>.git/test-ghx-commands
+if [[ "${1:-}" == "api" && "${2:-}" == repos/example/ocm/actions/workflows/ci.yml/runs\?* ]]; then
+  [[ -f .git/test-ci-run ]] || exit 0
+  cat .git/test-ci-run
+  exit 0
+fi
 case "${1:-} ${2:-}" in
   "pr view")
     [[ -f .git/test-pr-url ]] || exit 1
@@ -361,6 +377,7 @@ fn release_script_tags_only_after_the_release_pr_is_squash_merged() {
     let repo = init_release_repo("release-pr-tag");
     assert!(repo.run_release("0.2.8").status.success());
     let merged_head = repo.merge_release_pr("0.2.8");
+    repo.record_ci(&merged_head, "completed", "success");
 
     let output = repo.run_release("0.2.8");
     assert!(output.status.success(), "{}", stderr(&output));
@@ -374,6 +391,7 @@ fn release_script_retries_a_previously_created_local_tag() {
     let repo = init_release_repo("release-local-tag-resume");
     assert!(repo.run_release("0.2.8").status.success());
     let merged_head = repo.merge_release_pr("0.2.8");
+    repo.record_ci(&merged_head, "completed", "success");
     let tag = repo.git_output(&[
         "-c",
         "tag.gpgSign=true",
@@ -395,12 +413,51 @@ fn release_script_retries_a_previously_created_local_tag() {
 fn release_script_accepts_an_already_pushed_verified_tag() {
     let repo = init_release_repo("release-tag-idempotent");
     assert!(repo.run_release("0.2.8").status.success());
-    repo.merge_release_pr("0.2.8");
+    let merged_head = repo.merge_release_pr("0.2.8");
+    repo.record_ci(&merged_head, "completed", "success");
     assert!(repo.run_release("0.2.8").status.success());
 
     let output = repo.run_release("0.2.8");
     assert!(output.status.success(), "{}", stderr(&output));
     assert!(stdout(&output).contains("already published from verified commit"));
+}
+
+#[test]
+fn release_script_refuses_to_tag_without_exact_sha_ci() {
+    let repo = init_release_repo("release-ci-missing");
+    assert!(repo.run_release("0.2.8").status.success());
+    let merged_head = repo.merge_release_pr("0.2.8");
+
+    let output = repo.run_release("0.2.8");
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr(&output).contains(&format!(
+        "no main-branch CI push run exists for exact commit {merged_head}"
+    )));
+    assert!(repo.remote_ref("refs/tags/v0.2.8").is_empty());
+}
+
+#[test]
+fn release_script_refuses_pending_failed_and_wrong_sha_ci() {
+    let repo = init_release_repo("release-ci-invalid");
+    assert!(repo.run_release("0.2.8").status.success());
+    let merged_head = repo.merge_release_pr("0.2.8");
+
+    repo.record_ci(&merged_head, "in_progress", "");
+    let pending = repo.run_release("0.2.8");
+    assert_eq!(pending.status.code(), Some(1));
+    assert!(stderr(&pending).contains("is still in_progress"));
+
+    repo.record_ci(&merged_head, "completed", "failure");
+    let failed = repo.run_release("0.2.8");
+    assert_eq!(failed.status.code(), Some(1));
+    assert!(stderr(&failed).contains("concluded failure"));
+
+    let wrong_sha = repo.git_stdout(&["rev-parse", "HEAD^"]);
+    repo.record_ci(wrong_sha.trim(), "completed", "success");
+    let wrong = repo.run_release("0.2.8");
+    assert_eq!(wrong.status.code(), Some(1));
+    assert!(stderr(&wrong).contains(&format!("not {merged_head}")));
+    assert!(repo.remote_ref("refs/tags/v0.2.8").is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## What Problem This Solves

OCM's release script is PR-first, but signed tag creation and the tag-triggered release workflow did not require successful CI for the exact squash-merged `main` commit. A valid signed tag could therefore start packaging before that precise commit had passed the canonical push workflow.

## Why This Change Was Made

- Add one reusable `scripts/verify-release-ci.sh` gate that resolves the exact `main` push run for a full commit SHA.
- Prefer `ghx --no-cache` when available, with `gh` fallback, so release decisions never use stale cached run state.
- Require completed, successful CI before local tag creation and again inside the release workflow.
- Grant the release workflow only the additional `actions: read` permission needed for verification.
- Preserve the existing signed-tag, ancestry, package-version, PR-first, and retry contracts.

Closes #62

## User Impact

Release operators now get a clear wait/failure message instead of creating or packaging a tag before exact-SHA CI succeeds. Manually pushed tags are also blocked server-side from producing release artifacts without that proof.

## Evidence

- `cargo test --locked --test release_script_tests --test release_asset_tests` (18 passed)
- `cargo fmt --check`
- `bash -n scripts/release.sh scripts/verify-release-ci.sh`
- `shellcheck scripts/release.sh scripts/verify-release-ci.sh scripts/verify-release-tag.sh`
- `actionlint .github/workflows/release.yml .github/workflows/ci.yml`
- `git diff --check`
- Live verifier proof against successful OCM `main` run `30672032768`
- Autoreview: clean, no accepted/actionable findings
