### PR TITLE
fix(upgrade): quiesce runtime rollback mutations

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -182,7 +182,6 @@ struct UpgradeTransactionPlan {
 struct UpgradeRollbackPlan {
     record: UpgradeHistoryRecord,
     recovery: Option<UpgradeRuntimeRecovery>,
-    service: Option<ServiceSummary>,
 }
 
 #[derive(Clone, Debug)]
@@ -545,17 +544,7 @@ impl Cli {
             })?;
         self.verify_rollback_target_version(env_name, &record)?;
         let recovery = self.verify_rollback_source(env_name, &record)?;
-        let service = if current.service_enabled && current.service_running {
-            Some(self.service_service().status(env_name)?)
-        } else {
-            None
-        };
-
-        Ok(UpgradeRollbackPlan {
-            record,
-            recovery,
-            service,
-        })
+        Ok(UpgradeRollbackPlan { record, recovery })
     }
 
     fn verify_rollback_target_version(
@@ -713,7 +702,11 @@ impl Cli {
         env_name: &str,
         plan: UpgradeRollbackPlan,
     ) -> Result<UpgradeRollbackSummary, String> {
-        let runtime_names = rollback_runtime_names(&plan.record);
+        let runtime_names = plan
+            .recovery
+            .as_ref()
+            .map(|recovery| vec![recovery.meta.name.clone()])
+            .unwrap_or_default();
         let mut transaction = self.begin_upgrade_transaction_locked(
             env_name,
             UpgradeTransactionPlan {
@@ -728,25 +721,25 @@ impl Cli {
         let rollback_transaction_id = transaction.id.clone();
         let safety_snapshot_id = transaction.snapshot_id.clone();
 
-        if plan
-            .service
-            .as_ref()
-            .is_some_and(|service| service.installed && service.desired_running)
-            && let Err(error) = self.service_service().stop_locked(env_name)
+        if plan.record.service_after.enabled
+            && plan.record.service_after.running
+            && let Err(error) = self
+                .service_service()
+                .quiesce_for_runtime_mutation_locked(env_name)
         {
             return Ok(self.fail_upgrade_rollback_locked(
                 env_name,
                 &plan,
                 transaction,
-                format!("failed to stop the managed service before rollback: {error}"),
+                format!("failed to quiesce the managed service before rollback: {error}"),
             ));
         }
 
         if let Some(recovery) = plan.recovery.as_ref() {
+            transaction.mark_runtime_mutated(&recovery.meta.name);
             if let Err(error) = self.restore_retained_runtime(recovery) {
                 return Ok(self.fail_upgrade_rollback_locked(env_name, &plan, transaction, error));
             }
-            transaction.mark_runtime_mutated();
         }
 
         if let Err(error) =
@@ -1728,6 +1721,11 @@ impl Cli {
                     ),
                 });
             }
+            let runtime_names = if target.is_named_runtime() {
+                Vec::new()
+            } else {
+                vec![target_runtime_name.clone()]
+            };
             let mut transaction = self.begin_upgrade_transaction_locked(
                 env_name,
                 UpgradeTransactionPlan {
@@ -1742,11 +1740,14 @@ impl Cli {
                         openclaw_version: target_version.clone(),
                     },
                 },
-                &[current.name.clone(), target_runtime_name.clone()],
+                &runtime_names,
                 options.rollback_enabled,
                 "pre-upgrade",
                 None,
             )?;
+            if !target.is_named_runtime() {
+                transaction.mark_runtime_mutated(&target_runtime_name);
+            }
             let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
                 Ok(prepared) => prepared,
                 Err(error) => {
@@ -1763,11 +1764,8 @@ impl Cli {
                     );
                 }
             };
-            if matches!(
-                prepared.action,
-                OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
-            ) {
-                transaction.mark_runtime_mutated();
+            if matches!(prepared.action, OfficialRuntimePrepareAction::Reused) {
+                transaction.unmark_runtime_mutated(&prepared.name);
             }
             let binding_changed = prepared.name != current.name;
             let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
@@ -1974,11 +1972,12 @@ impl Cli {
                         openclaw_version: target_version.clone(),
                     },
                 },
-                &[current.name.clone(), target_runtime_name.clone()],
+                std::slice::from_ref(&target_runtime_name),
                 options.rollback_enabled,
                 "pre-upgrade",
                 None,
             )?;
+            transaction.mark_runtime_mutated(&target_runtime_name);
             let prepared = match self.prepare_isolated_upgrade_target(env_name, &target, resolved) {
                 Ok(prepared) => prepared,
                 Err(error) => {
@@ -1999,8 +1998,8 @@ impl Cli {
                 prepared.action,
                 OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
             );
-            if changed {
-                transaction.mark_runtime_mutated();
+            if !changed {
+                transaction.unmark_runtime_mutated(&prepared.name);
             }
             let post_update_note = if changed {
                 match self.run_post_core_update(env_name, &prepared.name) {
@@ -2040,8 +2039,12 @@ impl Cli {
                     format!("failed to publish upgraded runtime: {error}"),
                 );
             }
-            let service_result =
-                self.reconcile_upgraded_service_locked(env_name, service.as_ref(), false, changed);
+            let service_result = self.reconcile_upgraded_service_locked(
+                env_name,
+                service.as_ref(),
+                false,
+                changed || transaction.service_quiesced,
+            );
             let (service_action, service_note) = match service_result {
                 Ok(result) => result,
                 Err(error) => {
@@ -2150,6 +2153,7 @@ impl Cli {
             "pre-upgrade",
             None,
         )?;
+        transaction.mark_runtime_mutated(&current.name);
         let updated = match self.with_progress(format!("Updating runtime {}", current.name), || {
             self.with_isolated_runtime_mutation(env_name, &current.name, || {
                 self.runtime_service()
@@ -2171,7 +2175,6 @@ impl Cli {
                 );
             }
         };
-        transaction.mark_runtime_mutated();
         let post_update_note = match self.run_post_core_update(env_name, &updated.name) {
             Ok(note) => {
                 transaction.mark_post_update_completed(note.as_deref());
@@ -2364,6 +2367,9 @@ impl Cli {
             "pre-upgrade",
             None,
         )?;
+        if !target.is_named_runtime() {
+            transaction.mark_runtime_mutated(&target_runtime_name);
+        }
         let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
             Ok(prepared) => prepared,
             Err(error) => {
@@ -2380,11 +2386,8 @@ impl Cli {
                 );
             }
         };
-        if matches!(
-            prepared.action,
-            OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
-        ) {
-            transaction.mark_runtime_mutated();
+        if matches!(prepared.action, OfficialRuntimePrepareAction::Reused) {
+            transaction.unmark_runtime_mutated(&prepared.name);
         }
         let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
             Ok(note) => {
@@ -2998,6 +3001,27 @@ impl Cli {
             }
         }
 
+        let service_quiesced = if runtime_names.is_empty() {
+            false
+        } else {
+            match self
+                .service_service()
+                .quiesce_for_runtime_mutation_locked(env_name)
+            {
+                Ok(quiesced) => quiesced,
+                Err(error) => {
+                    return Err(self.cleanup_failed_transaction_setup(
+                        env_name,
+                        &snapshot.id,
+                        runtime_backups,
+                        format!(
+                            "failed to quiesce managed service before runtime mutation: {error}"
+                        ),
+                    ));
+                }
+            }
+        };
+
         Ok(UpgradeTransaction {
             id,
             snapshot_id: snapshot.id,
@@ -3019,7 +3043,8 @@ impl Cli {
                 status: "not-run".to_string(),
                 note: None,
             },
-            runtime_mutated: false,
+            service_quiesced,
+            mutated_runtime_names: BTreeSet::new(),
             rollback_of,
         })
     }
@@ -3091,20 +3116,24 @@ impl Cli {
         env_name: &str,
         transaction: &mut UpgradeTransaction,
     ) -> Result<(), String> {
-        if !transaction.runtime_mutated
-            || transaction.source.kind != "runtime"
+        if transaction.source.kind != "runtime"
             || transaction.source.name != transaction.target.name
         {
             return Ok(());
         }
         let runtime_name = transaction.source.name.clone();
-        let backup = transaction
+        if !transaction.mutated_runtime_names.contains(&runtime_name) {
+            return Ok(());
+        }
+        let Some(backup) = transaction
             .runtime_backups
             .iter_mut()
             .find(|backup| backup.meta.name == runtime_name)
-            .ok_or_else(|| {
-                format!("runtime backup for in-place upgrade of \"{runtime_name}\" was not created")
-            })?;
+        else {
+            return Err(format!(
+                "runtime backup for in-place upgrade of \"{runtime_name}\" was not created"
+            ));
+        };
         let Some(source_root) = backup.backup_root.take() else {
             return Err(format!(
                 "runtime \"{runtime_name}\" does not have installer-managed bytes to retain"
@@ -3163,6 +3192,11 @@ impl Cli {
         let runtime_recovery = transaction
             .runtime_backups
             .iter()
+            .filter(|backup| {
+                transaction
+                    .mutated_runtime_names
+                    .contains(&backup.meta.name)
+            })
             .map(|backup| UpgradeHistoryRuntimeRecovery {
                 runtime_name: backup.meta.name.clone(),
                 release_version: backup.meta.release_version.clone(),
@@ -3245,6 +3279,18 @@ impl Cli {
     ) -> Result<UpgradeEnvSummary, String> {
         if !transaction.rollback_enabled {
             let snapshot_id = transaction.snapshot_id.clone();
+            let service_restore_warning = if transaction.service_before.enabled
+                && transaction.service_before.running
+            {
+                self.service_service()
+                    .start_locked(env_name)
+                    .err()
+                    .map(|restore_error| {
+                        format!("failed to restore the pre-upgrade service state: {restore_error}")
+                    })
+            } else {
+                None
+            };
             let mut summary = UpgradeEnvSummary {
                 env_name: env_name.to_string(),
                 previous_binding_kind: previous_binding_kind.to_string(),
@@ -3257,7 +3303,10 @@ impl Cli {
                 service_action: None,
                 snapshot_id: Some(snapshot_id),
                 rollback: Some("disabled".to_string()),
-                note: Some(format!("upgrade failed and rollback was disabled: {error}")),
+                note: join_optional_warnings(
+                    Some(format!("upgrade failed and rollback was disabled: {error}")),
+                    service_restore_warning,
+                ),
             };
             if let Err(history_error) = self.record_upgrade_history(&transaction, &summary) {
                 summary.note = join_optional_warnings(
@@ -3320,9 +3369,19 @@ impl Cli {
         env_name: &str,
         transaction: &UpgradeTransaction,
     ) -> Result<(), String> {
-        // Restore runtime bytes and metadata before the snapshot republishes supervisor
-        // state; otherwise rollback can briefly advertise the failed runtime revision.
-        for runtime_backup in &transaction.runtime_backups {
+        let changes_runtime_trees = !transaction.mutated_runtime_names.is_empty();
+        if changes_runtime_trees {
+            self.service_service()
+                .quiesce_for_runtime_mutation_locked(env_name)
+                .map_err(|error| {
+                    format!("failed to quiesce the failed target before runtime rollback: {error}")
+                })?;
+        }
+        for runtime_backup in transaction.runtime_backups.iter().filter(|backup| {
+            transaction
+                .mutated_runtime_names
+                .contains(&backup.meta.name)
+        }) {
             self.restore_runtime_backup(runtime_backup)?;
         }
         self.environment_service()
@@ -3330,8 +3389,25 @@ impl Cli {
                 env_name: env_name.to_string(),
                 snapshot_id: transaction.snapshot_id.clone(),
             })?;
-        for runtime_name in &transaction.created_runtime_names {
+        if changes_runtime_trees {
+            self.service_service().wait_for_binding_convergence_locked(
+                env_name,
+                &transaction.source.kind,
+                &transaction.source.name,
+            )?;
+        }
+        for runtime_name in transaction
+            .created_runtime_names
+            .iter()
+            .filter(|runtime_name| transaction.mutated_runtime_names.contains(*runtime_name))
+        {
             self.remove_runtime_created_during_upgrade(runtime_name)?;
+        }
+        if transaction.service_before.enabled && transaction.service_before.running {
+            self.service_service()
+                .start_locked(env_name)
+                .map(|_| ())
+                .map_err(|error| format!("failed to restart the restored service: {error}"))?;
         }
         Ok(())
     }
@@ -3515,13 +3591,18 @@ struct UpgradeTransaction {
     service_before: UpgradeHistoryServiceState,
     migration: UpgradeHistoryStage,
     finalization: UpgradeHistoryStage,
-    runtime_mutated: bool,
+    service_quiesced: bool,
+    mutated_runtime_names: BTreeSet<String>,
     rollback_of: Option<String>,
 }
 
 impl UpgradeTransaction {
-    fn mark_runtime_mutated(&mut self) {
-        self.runtime_mutated = true;
+    fn mark_runtime_mutated(&mut self, runtime_name: &str) {
+        self.mutated_runtime_names.insert(runtime_name.to_string());
+    }
+
+    fn unmark_runtime_mutated(&mut self, runtime_name: &str) {
+        self.mutated_runtime_names.remove(runtime_name);
     }
 
     fn mark_post_update_completed(&mut self, note: Option<&str>) {
@@ -3634,16 +3715,6 @@ fn has_successful_rollback_child(history: &[UpgradeHistoryRecord], transaction_i
     history.iter().any(|record| {
         record.rollback_of.as_deref() == Some(transaction_id) && record.outcome == "rolled-back"
     })
-}
-
-fn rollback_runtime_names(record: &UpgradeHistoryRecord) -> Vec<String> {
-    let mut names = Vec::new();
-    for binding in [&record.target, &record.source] {
-        if binding.kind == "runtime" && !names.contains(&binding.name) {
-            names.push(binding.name.clone());
-        }
-    }
-    names
 }
 
 fn rollback_service_action_for_dry_run(record: &UpgradeHistoryRecord) -> Option<String> {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -4,6 +4,8 @@ pub(crate) mod platform;
 
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 
 pub use inspect::{ServiceSummary, ServiceSummaryList};
 pub use manage::{ServiceActionSummary, ServiceInstallSummary};
@@ -50,6 +52,102 @@ impl<'a> ServiceService<'a> {
 
     pub(crate) fn stop_locked(&self, name: &str) -> Result<ServiceActionSummary, String> {
         manage::stop_service(name, self.env, self.cwd)
+    }
+
+    pub(crate) fn quiesce_for_runtime_mutation_locked(&self, name: &str) -> Result<bool, String> {
+        let meta = crate::env::EnvironmentService::new(self.env, self.cwd).get(name)?;
+        if !meta.service_enabled || !meta.service_running {
+            return Ok(false);
+        }
+        self.stop_locked(name)?;
+        if let Err(error) = self.wait_for_runtime_mutation_quiescence_locked(name) {
+            return match self.start_locked(name) {
+                Ok(_) => Err(error),
+                Err(restore_error) => Err(format!(
+                    "{error}; also failed to restore the pre-maintenance service state: {restore_error}"
+                )),
+            };
+        }
+        Ok(true)
+    }
+
+    pub(crate) fn wait_for_binding_convergence_locked(
+        &self,
+        name: &str,
+        expected_kind: &str,
+        expected_name: &str,
+    ) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let meta = crate::env::EnvironmentService::new(self.env, self.cwd).get(name)?;
+            let meta_matches = match expected_kind {
+                "runtime" => meta.default_runtime.as_deref() == Some(expected_name),
+                "launcher" => meta.default_launcher.as_deref() == Some(expected_name),
+                _ => false,
+            };
+            let inspection =
+                crate::supervisor::SupervisorService::new(self.env, self.cwd).inspect()?;
+            let planned_matches = inspection
+                .planned_children
+                .iter()
+                .filter(|child| child.env_name == name)
+                .all(|child| {
+                    child.binding_kind == expected_kind && child.binding_name == expected_name
+                });
+            let runtime_matches = inspection
+                .runtime_children
+                .iter()
+                .filter(|child| child.env_name == name)
+                .all(|child| {
+                    child.binding_kind == expected_kind && child.binding_name == expected_name
+                })
+                && inspection
+                    .runtime_services
+                    .iter()
+                    .filter(|service| service.env_name == name)
+                    .all(|service| {
+                        service.binding_kind == expected_kind
+                            && service.binding_name == expected_name
+                    });
+            if meta_matches && planned_matches && runtime_matches {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "supervisor did not acknowledge restored {expected_kind} binding \"{expected_name}\" for env \"{name}\" before runtime cleanup"
+                ));
+            }
+            sleep(Duration::from_millis(25));
+        }
+    }
+
+    fn wait_for_runtime_mutation_quiescence_locked(&self, name: &str) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let inspection =
+                crate::supervisor::SupervisorService::new(self.env, self.cwd).inspect()?;
+            let acknowledged = !inspection
+                .planned_children
+                .iter()
+                .any(|child| child.env_name == name)
+                && !inspection
+                    .runtime_children
+                    .iter()
+                    .any(|child| child.env_name == name)
+                && !inspection
+                    .runtime_services
+                    .iter()
+                    .any(|service| service.env_name == name);
+            if acknowledged {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "supervisor did not acknowledge quiescence for env \"{name}\" before runtime mutation"
+                ));
+            }
+            sleep(Duration::from_millis(25));
+        }
     }
 
     pub fn restart(&self, name: &str) -> Result<ServiceActionSummary, String> {

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -6,12 +6,16 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::thread::{self, sleep};
 use std::time::Duration;
 
 use base64::Engine;
 use flate2::{Compression, write::GzEncoder};
-use ocm::store::{now_utc, supervisor_runtime_path, supervisor_state_path};
+use ocm::store::{env_registry_path, now_utc, supervisor_runtime_path, supervisor_state_path};
 use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
 use serde_json::Value;
 use sha2::{Digest, Sha512};
@@ -109,6 +113,38 @@ fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
         ocm_home: ocm_home.to_string(),
         updated_at: now_utc(),
         services: Vec::new(),
+        children: Vec::new(),
+    };
+    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+}
+
+fn write_backoff_supervisor_runtime(
+    runtime_path: &Path,
+    ocm_home: &str,
+    binding_name: &str,
+    child_port: u32,
+) {
+    let log_root = runtime_path.parent().unwrap();
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: ocm_home.to_string(),
+        updated_at: now_utc(),
+        services: vec![SupervisorRuntimeService {
+            env_name: "demo".to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: binding_name.to_string(),
+            gateway_state: "backoff".to_string(),
+            restart_handoff: Some("none".to_string()),
+            restart_count: 1,
+            child_port,
+            pid: None,
+            stdout_path: path_string(&log_root.join("demo.stdout.log")),
+            stderr_path: path_string(&log_root.join("demo.stderr.log")),
+            last_exit_code: Some(1),
+            last_error: Some("fixture target failed".to_string()),
+            last_event_at: Some(now_utc()),
+            next_retry_at: Some(now_utc()),
+        }],
         children: Vec::new(),
     };
     fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
@@ -223,6 +259,14 @@ case "$1" in
       echo "missing gateway status flags" >&2
       exit 1
     }}
+    if [ -n "${{OCM_TEST_GATEWAY_STATUS_STARTED:-}}" ]; then
+      : > "$OCM_TEST_GATEWAY_STATUS_STARTED"
+    fi
+    if [ -n "${{OCM_TEST_GATEWAY_STATUS_RELEASE:-}}" ]; then
+      while [ ! -e "$OCM_TEST_GATEWAY_STATUS_RELEASE" ]; do
+        sleep 0.01
+      done
+    fi
     if [ "${{OCM_TEST_GATEWAY_AUTH_HANDSHAKE:-}}" = "1" ]; then
       printf '{{"rpc":{{"ok":false,"error":"device identity required"}}}}\n'
       exit "${{OCM_TEST_GATEWAY_STATUS_EXIT_CODE:-0}}"
@@ -794,6 +838,14 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     );
     assert!(stdout(&prune_snapshot).contains("Pruned 1 snapshot(s)."));
     assert!(!recovery_root.exists());
+
+    let reuse = run_ocm(&cwd, &env, &["upgrade", "demo"]);
+    assert!(reuse.status.success(), "{}", stderr(&reuse));
+    assert!(stdout(&reuse).contains("outcome=up-to-date"));
+    let shown = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["serviceRunning"], true);
 }
 
 #[test]
@@ -870,35 +922,103 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
     let start = run_ocm(&cwd, &env, &["start", "demo", "--port", port.as_str()]);
     assert!(start.status.success(), "{}", stderr(&start));
 
+    let before_runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
+    assert!(
+        before_runtime.status.success(),
+        "{}",
+        stderr(&before_runtime)
+    );
+    let before_runtime: Value = serde_json::from_str(&stdout(&before_runtime)).unwrap();
+    let runtime_entrypoint = PathBuf::from(before_runtime["installRoot"].as_str().unwrap())
+        .join("files/node_modules/openclaw/openclaw.mjs");
+    let runtime_hash_before = Sha512::digest(fs::read(&runtime_entrypoint).unwrap()).to_vec();
+
     let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
     fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
     let ocm_home = env.get("OCM_HOME").unwrap().clone();
     write_running_supervisor_runtime(&runtime_path, &ocm_home, "stable", 4242, health_port);
 
-    let state_path = supervisor_state_path(&env, &cwd).unwrap();
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let gateway_status_started = root.child("gateway-status-started");
+    let gateway_status_release = root.child("gateway-status-release");
+    env.insert(
+        "OCM_TEST_GATEWAY_STATUS_STARTED".to_string(),
+        path_string(&gateway_status_started),
+    );
+    env.insert(
+        "OCM_TEST_GATEWAY_STATUS_RELEASE".to_string(),
+        path_string(&gateway_status_release),
+    );
     let replacement_runtime_path = runtime_path.clone();
     let replacement_ocm_home = ocm_home.clone();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let missing_while_active = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let missing_while_active_thread = Arc::clone(&missing_while_active);
+    let observed_entrypoint = runtime_entrypoint.clone();
     let restart_observer = thread::spawn(move || {
-        for _ in 0..200 {
-            let state = fs::read_to_string(&state_path).unwrap_or_default();
-            if state.contains("restartRequests") && state.contains("\"envName\": \"demo\"") {
-                write_running_supervisor_runtime(
+        let mut last_running = true;
+        let mut runtime_active = true;
+        let mut stop_count = 0;
+        let mut start_count = 0;
+        let mut next_pid = 4243;
+        let mut target_entered_backoff = false;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            if runtime_active && !observed_entrypoint.exists() {
+                missing_while_active_thread.store(true, Ordering::Relaxed);
+            }
+            let desired_running = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|registry| registry["envs"].as_array().cloned())
+                .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "demo"))
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_running);
+            if desired_running != last_running {
+                if desired_running {
+                    write_running_supervisor_runtime(
+                        &replacement_runtime_path,
+                        &replacement_ocm_home,
+                        "stable",
+                        next_pid,
+                        health_port,
+                    );
+                    next_pid += 1;
+                    start_count += 1;
+                    runtime_active = true;
+                } else {
+                    write_empty_supervisor_runtime(
+                        &replacement_runtime_path,
+                        &replacement_ocm_home,
+                    );
+                    stop_count += 1;
+                    runtime_active = false;
+                }
+                last_running = desired_running;
+            }
+            if desired_running
+                && start_count >= 1
+                && !target_entered_backoff
+                && gateway_status_started.exists()
+            {
+                write_backoff_supervisor_runtime(
                     &replacement_runtime_path,
                     &replacement_ocm_home,
                     "stable",
-                    4243,
                     health_port,
                 );
-                return;
+                fs::write(&gateway_status_release, []).unwrap();
+                target_entered_backoff = true;
             }
-            sleep(Duration::from_millis(25));
+            sleep(Duration::from_millis(1));
         }
-        panic!("upgrade did not request a supervised gateway restart");
+        (stop_count, start_count, target_entered_backoff)
     });
 
     env.insert("OCM_TEST_GATEWAY_UNREADY".to_string(), "1".to_string());
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
-    restart_observer.join().unwrap();
+    observer_done.store(true, Ordering::Relaxed);
+    let (stop_count, start_count, target_entered_backoff) = restart_observer.join().unwrap();
 
     assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
     let output = stdout(&upgrade);
@@ -909,11 +1029,23 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
         "{output}"
     );
     assert!(!health_server.requests().is_empty());
+    assert!(target_entered_backoff);
+    assert!(stop_count >= 2, "stop_count={stop_count}");
+    assert!(start_count >= 2, "start_count={start_count}");
+    assert!(
+        !missing_while_active.load(Ordering::Relaxed),
+        "the retrying in-place runtime observed its entrypoint disappear"
+    );
 
     let runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
     assert!(runtime.status.success(), "{}", stderr(&runtime));
     let runtime_json: Value = serde_json::from_str(&stdout(&runtime)).unwrap();
     assert_eq!(runtime_json["releaseVersion"], "2026.3.24");
+    assert_eq!(
+        Sha512::digest(fs::read(&runtime_entrypoint).unwrap()).to_vec(),
+        runtime_hash_before,
+        "in-place updated runtime bytes were not restored"
+    );
 
     let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
     assert!(history.status.success(), "{}", stderr(&history));
@@ -932,6 +1064,279 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
         .join("demo")
         .join(format!("{}.recovery", record["id"].as_str().unwrap()));
     assert!(!recovery_root.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn failed_named_runtime_target_in_backoff_is_not_rewritten_during_rollback() {
+    use std::os::unix::fs::MetadataExt;
+
+    let root = TestDir::new("upgrade-reused-target-backoff-rollback");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let health_server =
+        TestHttpServer::serve_bytes_times("/health", "application/json", br#"{"ok":true}"#, 8);
+    let health_port = health_server
+        .url()
+        .split(':')
+        .nth(2)
+        .and_then(|value| value.split('/').next())
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap();
+
+    let source_version = "2026.8.1";
+    let target_version = "2026.8.2";
+    let source_tarball =
+        openclaw_package_tarball(&recording_openclaw_script(source_version), source_version);
+    let source_integrity = sha512_integrity(&source_tarball);
+    let source_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.8.1.tgz",
+        "application/octet-stream",
+        &source_tarball,
+        4,
+    );
+    let target_tarball =
+        openclaw_package_tarball(&recording_openclaw_script(target_version), target_version);
+    let target_integrity = sha512_integrity(&target_tarball);
+    let target_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.8.2.tgz",
+        "application/octet-stream",
+        &target_tarball,
+        4,
+    );
+    let packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"{target_version}\"}},\"versions\":{{\"{source_version}\":{{\"version\":\"{source_version}\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{source_integrity}\"}}}},\"{target_version}\":{{\"version\":\"{target_version}\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{target_integrity}\"}}}}}},\"time\":{{\"{source_version}\":\"2026-08-01T00:00:00.000Z\",\"{target_version}\":\"2026-08-02T00:00:00.000Z\"}}}}",
+        source_server.url(),
+        target_server.url(),
+    );
+    let packument_server = TestHttpServer::serve_bytes_times(
+        "/openclaw",
+        "application/json",
+        packument.as_bytes(),
+        12,
+    );
+
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    install_fake_launchctl(&root, &mut env);
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+
+    let port = health_port.to_string();
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "start",
+            "demo",
+            "--version",
+            source_version,
+            "--port",
+            &port,
+        ],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+    let install_target = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "install", "--version", target_version],
+    );
+    assert!(
+        install_target.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&install_target),
+        stderr(&install_target)
+    );
+
+    let target = run_ocm(&cwd, &env, &["runtime", "show", target_version, "--json"]);
+    assert!(target.status.success(), "{}", stderr(&target));
+    let target: Value = serde_json::from_str(&stdout(&target)).unwrap();
+    let target_root = PathBuf::from(target["installRoot"].as_str().unwrap());
+    let target_entrypoint = target_root.join("files/node_modules/openclaw/openclaw.mjs");
+    let target_chunks = target_root.join("files/node_modules/openclaw/dist/chunks");
+    fs::create_dir_all(&target_chunks).unwrap();
+    for index in 0..2_000 {
+        fs::write(
+            target_chunks.join(format!("chunk-{index:04}.js")),
+            format!("export const chunk{index} = {index};\n"),
+        )
+        .unwrap();
+    }
+    let watched_chunk = target_chunks.join("chunk-1000.js");
+    let entrypoint_hash_before = Sha512::digest(fs::read(&target_entrypoint).unwrap()).to_vec();
+    let entrypoint_inode_before = fs::metadata(&target_entrypoint).unwrap().ino();
+    let chunk_inode_before = fs::metadata(&watched_chunk).unwrap().ino();
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, source_version, 4242, health_port);
+    let state_path = supervisor_state_path(&env, &cwd).unwrap();
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let gateway_status_started = root.child("gateway-status-started");
+    let gateway_status_release = root.child("gateway-status-release");
+    env.insert(
+        "OCM_TEST_GATEWAY_STATUS_STARTED".to_string(),
+        path_string(&gateway_status_started),
+    );
+    env.insert(
+        "OCM_TEST_GATEWAY_STATUS_RELEASE".to_string(),
+        path_string(&gateway_status_release),
+    );
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let missing_target_file = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let missing_target_file_thread = Arc::clone(&missing_target_file);
+    let observed_entrypoint = target_entrypoint.clone();
+    let observed_chunk = watched_chunk.clone();
+    let observer_runtime_path = runtime_path.clone();
+    let observer_ocm_home = ocm_home.clone();
+    let observer = thread::spawn(move || {
+        let mut last_binding = Some(source_version.to_string());
+        let mut target_was_running = false;
+        let mut target_restart_was_acknowledged = false;
+        let mut target_entered_backoff = false;
+        let mut observed_bindings = Vec::new();
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            if !observed_entrypoint.exists() || !observed_chunk.exists() {
+                missing_target_file_thread.store(true, Ordering::Relaxed);
+            }
+            let state = fs::read_to_string(&state_path).unwrap_or_default();
+            let state_json: Value = serde_json::from_str(&state).unwrap_or(Value::Null);
+            let planned_binding = state_json["children"]
+                .as_array()
+                .and_then(|children| children.iter().find(|child| child["envName"] == "demo"))
+                .and_then(|child| child["bindingName"].as_str())
+                .map(str::to_string);
+            let registry = fs::read_to_string(&registry_path).unwrap_or_default();
+            let registry_json: Value = serde_json::from_str(&registry).unwrap_or(Value::Null);
+            let registered = registry_json["envs"]
+                .as_array()
+                .and_then(|envs| envs.iter().find(|entry| entry["name"] == "demo"));
+            let next_binding = match registered {
+                Some(entry) if entry["serviceRunning"] == true => {
+                    entry["defaultRuntime"].as_str().map(str::to_string)
+                }
+                Some(_) => None,
+                None => planned_binding,
+            };
+            if next_binding != last_binding {
+                observed_bindings.push(next_binding.clone());
+                match next_binding.as_deref() {
+                    Some(value) if value == target_version => {
+                        write_running_supervisor_runtime(
+                            &observer_runtime_path,
+                            &observer_ocm_home,
+                            target_version,
+                            4243,
+                            health_port,
+                        );
+                        target_was_running = true;
+                    }
+                    Some(value) if value == source_version => write_running_supervisor_runtime(
+                        &observer_runtime_path,
+                        &observer_ocm_home,
+                        source_version,
+                        4244,
+                        health_port,
+                    ),
+                    None => {
+                        write_empty_supervisor_runtime(&observer_runtime_path, &observer_ocm_home)
+                    }
+                    _ => {}
+                }
+                last_binding = next_binding;
+            }
+            let target_restart_requested =
+                state_json["restartRequests"]
+                    .as_array()
+                    .is_some_and(|requests| {
+                        requests.iter().any(|request| request["envName"] == "demo")
+                    });
+            if target_was_running && !target_restart_was_acknowledged && target_restart_requested {
+                write_running_supervisor_runtime(
+                    &observer_runtime_path,
+                    &observer_ocm_home,
+                    target_version,
+                    4244,
+                    health_port,
+                );
+                target_restart_was_acknowledged = true;
+            }
+            if target_was_running && !target_entered_backoff && gateway_status_started.exists() {
+                write_backoff_supervisor_runtime(
+                    &observer_runtime_path,
+                    &observer_ocm_home,
+                    target_version,
+                    health_port,
+                );
+                fs::write(&gateway_status_release, []).unwrap();
+                target_entered_backoff = true;
+            }
+            sleep(Duration::from_millis(1));
+        }
+        (target_entered_backoff, observed_bindings)
+    });
+
+    env.insert("OCM_TEST_GATEWAY_UNREADY".to_string(), "1".to_string());
+    let upgrade = run_ocm(
+        &cwd,
+        &env,
+        &["upgrade", "demo", "--runtime", target_version],
+    );
+    observer_done.store(true, Ordering::Relaxed);
+    let (target_entered_backoff, observed_bindings) = observer.join().unwrap();
+
+    assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
+    let output = stdout(&upgrade);
+    assert!(output.contains("outcome=rolled-back"), "{output}");
+    assert!(output.contains("rollback=restored"), "{output}");
+    assert!(
+        target_entered_backoff,
+        "target never entered fixture backoff"
+    );
+    let target_observed = observed_bindings
+        .iter()
+        .position(|binding| binding.as_deref() == Some(target_version))
+        .expect("target binding was never observed");
+    let restored_source = observed_bindings
+        .iter()
+        .rposition(|binding| binding.as_deref() == Some(source_version))
+        .expect("restored source binding was never observed");
+    assert!(
+        target_observed < restored_source,
+        "source binding was not restored after the failed target: {observed_bindings:?}"
+    );
+    assert!(
+        !missing_target_file.load(Ordering::Relaxed),
+        "the retrying target observed its entrypoint or a chunk disappear"
+    );
+    assert_eq!(
+        fs::metadata(&target_entrypoint).unwrap().ino(),
+        entrypoint_inode_before,
+        "reused target entrypoint inode changed"
+    );
+    assert_eq!(
+        fs::metadata(&watched_chunk).unwrap().ino(),
+        chunk_inode_before,
+        "reused target chunk inode changed"
+    );
+    assert_eq!(
+        Sha512::digest(fs::read(&target_entrypoint).unwrap()).to_vec(),
+        entrypoint_hash_before,
+        "reused target entrypoint bytes changed"
+    );
+    let shown = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["defaultRuntime"], source_version);
 }
 
 #[test]
@@ -2050,20 +2455,28 @@ fn upgrade_rolls_back_runtime_when_service_restart_fails() {
     assert!(start.status.success(), "{}", stderr(&start));
 
     let launchctl_bin = env.get("OCM_INTERNAL_LAUNCHCTL_BIN").unwrap();
+    let stopped_marker = root.child("service-stopped");
     write_executable_script(
         std::path::Path::new(launchctl_bin),
-        "#!/bin/sh\ncase \"$1\" in\n  managername)\n    exit 0\n    ;;\n  print)\n    printf 'state = waiting\\n'\n    exit 0\n    ;;\n  bootout|unload)\n    exit 0\n    ;;\n  bootstrap)\n    echo 'forced bootstrap failure' >&2\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
+        &format!(
+            "#!/bin/sh\nmarker='{}'\ncase \"$1\" in\n  managername)\n    exit 0\n    ;;\n  print)\n    if [ -e \"$marker\" ]; then\n      printf 'Could not find service \\\"%s\\\" in domain for user gui\\n' \"$2\" >&2\n      exit 1\n    fi\n    printf 'state = waiting\\n'\n    exit 0\n    ;;\n  bootout|unload)\n    : > \"$marker\"\n    exit 0\n    ;;\n  bootstrap)\n    echo 'forced bootstrap failure' >&2\n    exit 1\n    ;;\n  *)\n    exit 0\n    ;;\nesac\n",
+            stopped_marker.display()
+        ),
     );
 
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--version", "2026.3.25"]);
     assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
     let output = stdout(&upgrade);
     assert!(
-        output.contains("outcome=rolled-back"),
+        output.contains("outcome=rollback-failed"),
         "stdout:\n{output}\nstderr:\n{}",
         stderr(&upgrade)
     );
-    assert!(output.contains("rollback=restored"), "{output}");
+    assert!(output.contains("rollback=failed"), "{output}");
+    assert!(
+        output.contains("failed to restart the restored service"),
+        "{output}"
+    );
     assert!(output.contains("snapshot="), "{output}");
 
     let runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
@@ -2668,8 +3081,7 @@ fn upgrade_reuses_the_bound_named_runtime_without_retaining_recovery_bytes() {
     let record = &history_json[0];
     assert_eq!(record["source"]["name"], "local");
     assert_eq!(record["target"]["name"], "local");
-    assert_eq!(record["runtimeRecovery"][0]["runtimeName"], "local");
-    assert!(record["runtimeRecovery"][0]["backupId"].is_null());
+    assert!(record["runtimeRecovery"].as_array().unwrap().is_empty());
 
     let recovery_root = Path::new(env.get("OCM_HOME").unwrap())
         .join("upgrade-history")


### PR DESCRIPTION
## Summary

- track runtime mutation ownership per transaction so reused named targets are not backed up, restored, or removed
- quiesce managed services and wait for supervisor acknowledgement before runtime-tree mutation
- restore only owned runtime bytes, restore the snapshot binding before created-runtime cleanup, and reassert the prior running policy

## Scope

This intentionally does not include snapshot excluded-state preservation. PR #60 owns that separate archive/restore invariant and its live head passes `environment_snapshot_restore_preserves_current_excluded_state`.

## Root cause

Upgrade transactions treated every pre-existing candidate runtime as mutated. During a failed switch to an already-installed named runtime, rollback recopied that unchanged target while the supervisor could still retry it from backoff. Mutation ownership was also recorded only after installer success, which could miss partial failures.

## Proof

Base: `c298f1d980b4a4f461f97dc39f9374f5badfb628`

Head: `c06901f4eaee0915e65297c96ebbd8e111463959`

- red on unmodified base: `failed_named_runtime_target_in_backoff_is_not_rewritten_during_rollback` observed the target entrypoint or a chunk disappear
- green on head: failed reused target enters backoff without missing files; target entrypoint/chunk inodes and entrypoint hash remain unchanged
- in-place update control restores original runtime bytes and observes quiescence before both update and rollback mutation
- successful local-launcher to published-runtime switch remains unchanged
- tracked-runtime no-op restores its prior running policy after the installer reports reuse
- focused suites: 44 upgrade, 35 service, and 29 store tests passed serially
- complete `cargo test -- --test-threads=1` passed
- `cargo fmt --check`, `cargo check`, and `git diff --check` passed
- Clippy passed with the base-identical `clippy::large_enum_variant` warning allowed
- source-blind validation passed the failed-target case twice, the in-place rollback case, and the successful-switch control
- autoreview reported no accepted/actionable findings
