### PR TITLE
fix: preserve durable OpenClaw state during cleanup

### DIFF
--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -187,7 +187,7 @@ pub(crate) fn clear_nonportable_runtime_state(
         let path = entry.path();
         let name = entry.file_name();
         if name == OsStr::new("openclaw.json")
-            || is_managed_plugin_state_root(&name)
+            || is_durable_openclaw_state_root(&name)
             || workspaces.contains(&path)
         {
             continue;
@@ -210,10 +210,10 @@ pub(crate) fn clear_nonportable_runtime_state(
     Ok(changed)
 }
 
-fn is_managed_plugin_state_root(name: &OsStr) -> bool {
+fn is_durable_openclaw_state_root(name: &OsStr) -> bool {
     matches!(
         name.to_str(),
-        Some("plugins") | Some("extensions") | Some("npm") | Some("git")
+        Some("state") | Some("plugins") | Some("extensions") | Some("npm") | Some("git")
     )
 }
 
@@ -780,6 +780,12 @@ mod tests {
             "keep secondary workspace\n",
         )
         .unwrap();
+        fs::create_dir_all(paths.state_dir.join("state")).unwrap();
+        fs::write(
+            paths.state_dir.join("state/openclaw.sqlite"),
+            "paired device state must survive\n",
+        )
+        .unwrap();
 
         let changed = clear_nonportable_runtime_state(
             &paths,
@@ -796,6 +802,7 @@ mod tests {
                 .join("workspace-clawforce/skills/social.md")
                 .exists()
         );
+        assert!(paths.state_dir.join("state/openclaw.sqlite").exists());
         assert!(
             paths
                 .state_dir

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -2,6 +2,7 @@ mod support;
 
 use std::{fs, path::Path};
 
+use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 
 use crate::support::{TestDir, ocm_env, run_ocm, stderr, stdout, write_text};
@@ -265,6 +266,71 @@ fn env_snapshot_restore_reverts_state_from_the_selected_snapshot() {
         fs::read_to_string(root.child("ocm-home/envs/source/.openclaw/workspace/notes.txt"))
             .unwrap(),
         "before restore"
+    );
+}
+
+#[test]
+fn env_snapshot_restore_preserves_device_pairing_state_while_clearing_foreign_runtime_refs() {
+    let root = TestDir::new("env-snapshot-device-pairing-state");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    for (name, port) in [("foreign", "19780"), ("source", "19781")] {
+        let create = run_ocm(&cwd, &env, &["env", "create", name, "--port", port]);
+        assert!(create.status.success(), "{}", stderr(&create));
+    }
+
+    let source_state = root.child("ocm-home/envs/source/.openclaw");
+    let foreign_workspace = root.child("ocm-home/envs/foreign/.openclaw/workspace");
+    write_text(
+        &source_state.join("agents/main/sessions/main.jsonl"),
+        &format!("{{\"cwd\":\"{}\"}}\n", foreign_workspace.display()),
+    );
+    let database_path = source_state.join("state/openclaw.sqlite");
+    fs::create_dir_all(database_path.parent().unwrap()).unwrap();
+    let database = Connection::open(&database_path).unwrap();
+    database
+        .execute_batch(
+            "CREATE TABLE device_pairing_paired (
+               device_id TEXT PRIMARY KEY,
+               token TEXT NOT NULL
+             );
+             INSERT INTO device_pairing_paired VALUES ('paired-browser', 'must-survive');",
+        )
+        .unwrap();
+    drop(database);
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--json"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    let snapshot_id = snapshot_json["id"].as_str().unwrap();
+
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+
+    let restored = Connection::open_with_flags(&database_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("snapshot restore must retain OpenClaw's shared state database");
+    let token: String = restored
+        .query_row(
+            "SELECT token FROM device_pairing_paired WHERE device_id = 'paired-browser'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(token, "must-survive");
+    assert!(
+        !source_state
+            .join("agents/main/sessions/main.jsonl")
+            .exists()
     );
 }
 


### PR DESCRIPTION
## Summary

- preserve OpenClaw's durable `.openclaw/state` directory during nonportable runtime-state cleanup
- continue removing foreign environment session references during snapshot restore and repair
- add unit and integration coverage for the device-pairing SQLite state

## Root cause

OpenClaw now stores paired-device records in `.openclaw/state/openclaw.sqlite`. OCM included that database in environment snapshots, but the post-restore repair path treated the root-level `state` directory as disposable whenever it detected stale or foreign environment references. The archive therefore contained the pairing database, then cleanup deleted it after restore.

## Reproduction and validation

On the unmodified base, restoring the same snapshot with a foreign session reference removed `state/openclaw.sqlite`; a control environment without that reference retained its pairing row.

With this change, the same restore contract preserves the paired-device token while still removing the foreign session reference. A repeated source-blind restore also retained the pairing row, and the locally deployed binary kept Rosita healthy and ready.

## Tests

- `cargo fmt --check`
- `cargo test --test env_snapshot_tests env_snapshot_restore_preserves_device_pairing_state_while_clearing_foreign_runtime_refs -- --exact --nocapture`
- `cargo test --lib -- --test-threads=1` (288 passed)
- autoreview: clean, no accepted/actionable findings
