### PR TITLE
fix(upgrade): honor one scheduled convergence retry

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2716,6 +2716,7 @@ impl Cli {
 
         let deadline = Instant::now() + Duration::from_secs(90);
         let mut latest_issue = None;
+        let mut permitted_retry_count = None;
         while Instant::now() < deadline {
             let status = self.service_service().status(env_name)?;
             latest_issue = status.issue.clone();
@@ -2724,6 +2725,15 @@ impl Cli {
                 return Ok(None);
             }
             if status.gateway_state == "backoff" && status.last_exit_code != Some(0) {
+                if should_wait_for_scheduled_gateway_retry(
+                    &mut permitted_retry_count,
+                    status.child_restart_count,
+                    status.next_retry_at.as_deref(),
+                    time::OffsetDateTime::now_utc(),
+                ) {
+                    sleep(Duration::from_millis(500));
+                    continue;
+                }
                 let issue = status
                     .issue
                     .or(status.last_error)
@@ -4010,6 +4020,33 @@ fn gateway_health_ok(port: u32) -> bool {
     text.starts_with("HTTP/1.1 200") || text.starts_with("HTTP/1.0 200")
 }
 
+fn should_wait_for_scheduled_gateway_retry(
+    permitted_retry_count: &mut Option<usize>,
+    restart_count: Option<usize>,
+    next_retry_at: Option<&str>,
+    now: time::OffsetDateTime,
+) -> bool {
+    let (Some(restart_count), Some(next_retry_at)) = (restart_count, next_retry_at) else {
+        return false;
+    };
+    let Ok(next_retry_at) = time::OffsetDateTime::parse(
+        next_retry_at,
+        &time::format_description::well_known::Rfc3339,
+    ) else {
+        return false;
+    };
+    if now > next_retry_at + time::Duration::seconds(3) {
+        return false;
+    }
+    match permitted_retry_count {
+        Some(permitted) => restart_count == *permitted,
+        None => {
+            *permitted_retry_count = Some(restart_count);
+            true
+        }
+    }
+}
+
 fn verify_gateway_status_readiness(stdout: &str) -> Result<(), String> {
     let status: Value = serde_json::from_str(stdout.trim()).map_err(|error| {
         format!("post-upgrade gateway readiness failed: invalid status JSON ({error})")
@@ -4116,7 +4153,8 @@ fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
 mod tests {
     use super::{
         command_output_reports_unsupported_command, release_version_from_output,
-        verify_gateway_status_readiness, version_output_matches_expected,
+        should_wait_for_scheduled_gateway_retry, verify_gateway_status_readiness,
+        version_output_matches_expected,
     };
 
     #[test]
@@ -4258,6 +4296,61 @@ mod tests {
             unknown.contains("did not report RPC reachability"),
             "{unknown}"
         );
+    }
+
+    #[test]
+    fn scheduled_gateway_retry_allows_only_the_observed_next_attempt() {
+        let now = time::OffsetDateTime::now_utc();
+        let next_retry_at = (now + time::Duration::seconds(1))
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+        let mut permitted_retry_count = None;
+
+        assert!(should_wait_for_scheduled_gateway_retry(
+            &mut permitted_retry_count,
+            Some(2),
+            Some(&next_retry_at),
+            now,
+        ));
+        assert!(should_wait_for_scheduled_gateway_retry(
+            &mut permitted_retry_count,
+            Some(2),
+            Some(&next_retry_at),
+            now,
+        ));
+        assert!(!should_wait_for_scheduled_gateway_retry(
+            &mut permitted_retry_count,
+            Some(3),
+            Some(&next_retry_at),
+            now,
+        ));
+    }
+
+    #[test]
+    fn scheduled_gateway_retry_rejects_missing_or_stale_retry_state() {
+        let now = time::OffsetDateTime::now_utc();
+        let stale_retry_at = (now - time::Duration::seconds(4))
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+
+        assert!(!should_wait_for_scheduled_gateway_retry(
+            &mut None,
+            Some(1),
+            None,
+            now,
+        ));
+        assert!(!should_wait_for_scheduled_gateway_retry(
+            &mut None,
+            Some(1),
+            Some(&stale_retry_at),
+            now,
+        ));
+        assert!(!should_wait_for_scheduled_gateway_retry(
+            &mut None,
+            Some(1),
+            Some("not-a-timestamp"),
+            now,
+        ));
     }
 
     #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -2,16 +2,18 @@ mod support;
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::thread::{self, sleep};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use base64::Engine;
 use flate2::{Compression, write::GzEncoder};
@@ -148,6 +150,62 @@ fn write_backoff_supervisor_runtime(
         children: Vec::new(),
     };
     fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+}
+
+fn spawn_converging_health_server() -> (
+    u32,
+    Arc<AtomicUsize>,
+    Arc<AtomicBool>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let port = u32::from(listener.local_addr().unwrap().port());
+    let requests = Arc::new(AtomicUsize::new(0));
+    let requests_thread = Arc::clone(&requests);
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_thread = Arc::clone(&stop);
+    let handle = thread::spawn(move || {
+        while !stop_thread.load(Ordering::Relaxed) {
+            let (mut stream, _) = match listener.accept() {
+                Ok(accepted) => accepted,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    sleep(Duration::from_millis(5));
+                    continue;
+                }
+                Err(error) => panic!("health listener failed: {error}"),
+            };
+            let mut request = [0_u8; 1024];
+            let read = stream.read(&mut request).unwrap_or(0);
+            if !request[..read].starts_with(b"GET /health ") {
+                continue;
+            }
+            let request_number = requests_thread.fetch_add(1, Ordering::SeqCst);
+            let status = if request_number == 0 {
+                "503 Service Unavailable"
+            } else {
+                "200 OK"
+            };
+            let body = if request_number == 0 {
+                br#"{"ok":false}"#.as_slice()
+            } else {
+                br#"{"ok":true}"#.as_slice()
+            };
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(body);
+        }
+    });
+    (port, requests, stop, handle)
+}
+
+fn stop_converging_health_server(port: u32, stop: &AtomicBool, handle: thread::JoinHandle<()>) {
+    stop.store(true, Ordering::Relaxed);
+    let _ = TcpStream::connect(("127.0.0.1", port as u16));
+    handle.join().unwrap();
 }
 
 fn recording_openclaw_script(version: &str) -> String {
@@ -1064,6 +1122,171 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
         .join("demo")
         .join(format!("{}.recovery", record["id"].as_str().unwrap()));
     assert!(!recovery_root.exists());
+}
+
+#[test]
+fn upgrade_waits_for_one_supervisor_convergence_retry() {
+    let root = TestDir::new("upgrade-supervisor-convergence-retry");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let (health_port, health_requests, health_stop, health_handle) =
+        spawn_converging_health_server();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("2026.8.1"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("2026.8.2"));
+
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    for (name, runtime) in [("old", &old_runtime), ("new", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &["runtime", "add", name, "--path", &path_string(runtime)],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "start",
+            "demo",
+            "--runtime",
+            "old",
+            "--port",
+            &health_port.to_string(),
+        ],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "old", 4242, health_port);
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let state_path = supervisor_state_path(&env, &cwd).unwrap();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let observer_health_requests = Arc::clone(&health_requests);
+    let observer_runtime_path = runtime_path.clone();
+    let observer_ocm_home = ocm_home.clone();
+    let observer = thread::spawn(move || {
+        let mut last_binding = "old".to_string();
+        let mut next_pid = 4243;
+        let mut restart_acknowledged = false;
+        let mut backoff_started = None;
+        let mut saw_backoff = false;
+        let mut recovered_target = false;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let registry = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .unwrap_or(Value::Null);
+            let env_meta = registry["envs"]
+                .as_array()
+                .and_then(|envs| envs.iter().find(|entry| entry["name"] == "demo"));
+            let binding = env_meta
+                .and_then(|entry| entry["defaultRuntime"].as_str())
+                .unwrap_or(&last_binding)
+                .to_string();
+            let desired_running = env_meta
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(true);
+
+            if binding != last_binding && desired_running {
+                write_running_supervisor_runtime(
+                    &observer_runtime_path,
+                    &observer_ocm_home,
+                    &binding,
+                    next_pid,
+                    health_port,
+                );
+                next_pid += 1;
+                last_binding = binding.clone();
+            }
+
+            let restart_requested = fs::read(&state_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|state| state["restartRequests"].as_array().cloned())
+                .is_some_and(|requests| {
+                    requests.iter().any(|request| request["envName"] == "demo")
+                });
+            if binding == "new" && desired_running && restart_requested && !restart_acknowledged {
+                write_running_supervisor_runtime(
+                    &observer_runtime_path,
+                    &observer_ocm_home,
+                    "new",
+                    next_pid,
+                    health_port,
+                );
+                next_pid += 1;
+                restart_acknowledged = true;
+            }
+
+            if binding == "new"
+                && desired_running
+                && !saw_backoff
+                && observer_health_requests.load(Ordering::SeqCst) >= 1
+            {
+                write_backoff_supervisor_runtime(
+                    &observer_runtime_path,
+                    &observer_ocm_home,
+                    "new",
+                    health_port,
+                );
+                backoff_started = Some(Instant::now());
+                saw_backoff = true;
+            }
+
+            if binding == "new"
+                && desired_running
+                && !recovered_target
+                && backoff_started
+                    .is_some_and(|started| started.elapsed() >= Duration::from_secs(2))
+            {
+                write_running_supervisor_runtime(
+                    &observer_runtime_path,
+                    &observer_ocm_home,
+                    "new",
+                    next_pid,
+                    health_port,
+                );
+                recovered_target = true;
+            }
+            sleep(Duration::from_millis(1));
+        }
+        (saw_backoff, recovered_target)
+    });
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new"]);
+    observer_done.store(true, Ordering::Relaxed);
+    let (saw_backoff, recovered_target) = observer.join().unwrap();
+    stop_converging_health_server(health_port, &health_stop, health_handle);
+
+    assert!(
+        saw_backoff,
+        "fixture never exposed the scheduled retry state"
+    );
+    assert!(
+        upgrade.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&upgrade),
+        stderr(&upgrade)
+    );
+    assert!(recovered_target, "fixture retry never became healthy");
+    assert!(health_requests.load(Ordering::SeqCst) >= 2);
+    let shown = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["defaultRuntime"], "new");
 }
 
 #[cfg(unix)]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -1179,6 +1179,7 @@ fn upgrade_waits_for_one_supervisor_convergence_retry() {
     let observer_ocm_home = ocm_home.clone();
     let observer = thread::spawn(move || {
         let mut last_binding = "old".to_string();
+        let mut last_desired_running = true;
         let mut next_pid = 4243;
         let mut restart_acknowledged = false;
         let mut backoff_started = None;
@@ -1200,7 +1201,22 @@ fn upgrade_waits_for_one_supervisor_convergence_retry() {
                 .and_then(|entry| entry["serviceRunning"].as_bool())
                 .unwrap_or(true);
 
-            if binding != last_binding && desired_running {
+            if desired_running != last_desired_running {
+                if desired_running {
+                    write_running_supervisor_runtime(
+                        &observer_runtime_path,
+                        &observer_ocm_home,
+                        &binding,
+                        next_pid,
+                        health_port,
+                    );
+                    next_pid += 1;
+                } else {
+                    write_empty_supervisor_runtime(&observer_runtime_path, &observer_ocm_home);
+                }
+                last_desired_running = desired_running;
+                last_binding = binding.clone();
+            } else if binding != last_binding && desired_running {
                 write_running_supervisor_runtime(
                     &observer_runtime_path,
                     &observer_ocm_home,


### PR DESCRIPTION
## Summary

- allow upgrade health acceptance to wait for exactly one supervisor-scheduled
  gateway retry after a nonzero backoff
- require an observed restart count and valid, non-stale `nextRetryAt`
- remain fail-closed for missing, malformed, stale, or changed-count retry state
- add a lifecycle integration fixture for transient convergence

The supervisor remains the sole owner of scheduling and starting the retry.
OCM only observes the published retry state and continues polling health.

## Behavior

On canonical base `d1c36adda05c1129af9788be35528bc1240d95da`,
`upgrade_waits_for_one_supervisor_convergence_retry` failed because OCM rolled
back immediately on the first failed backoff:

```text
outcome=rolled-back
service restart did not recover: fixture target failed
```

With this change, the same fixture waits for the published attempt, observes
the gateway become healthy, and keeps the target runtime. A changed restart
count is terminal, so a second failed attempt still rolls back.

## Validation

- transient integration fixture: 1/1 passed
- scheduled-retry decision controls: 2/2 passed
- upgrade unit module: 12/12 passed
- persistent-unready rollback guard: 1/1 passed
- complete `upgrade_command_tests`: 45/45 passed
- `cargo fmt --all -- --check`
- `git diff --check`
- source-blind behavior validation: clauses 1-6 passed; untouched-surface
  clause remained black-box-unprovable and was confirmed by source-aware scope
- autoreview: clean, no accepted/actionable findings

## Coordination

PR #60 also changes `src/cli/upgrade.rs` and
`tests/upgrade_command_tests.rs`, but this PR intentionally contains no
snapshot, restore, OpenClaw convergence-exit, global retry-policy, or
`runtime build-local` changes.

If #60 lands first, rebase this branch onto the resulting `main` and rerun the
upgrade proofs. If this PR lands first, #60 should preserve the one-retry gate
when rebasing its upgrade-health helper.
