### PR TITLE
fix(snapshot): make environment restore complete and atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "base64",
  "ctrlc",
  "dialoguer",
+ "filetime",
  "flate2",
  "fs2",
  "indicatif",
@@ -605,6 +606,7 @@ dependencies = [
  "ureq",
  "url",
  "windows-sys 0.61.2",
+ "xattr",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ semver = "1.0"
 base64 = "0.22"
 flate2 = "1.1"
 fs2 = "0.4"
+filetime = "0.2"
 tar = "0.4"
 tempfile = "3.27"
 time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
@@ -37,6 +38,7 @@ rusqlite = { version = "0.37", default-features = false, features = ["backup", "
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+xattr = "1.6"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/README.md
+++ b/README.md
@@ -135,19 +135,28 @@ ocm upgrade simulate mira --to beta --scenario all
 ocm upgrade simulate mira --to ./openclaw
 ```
 
-`upgrade` creates a pre-upgrade snapshot before changing an environment. If a
-running service cannot be restarted or started after the change, OCM restores
-the snapshot and previous runtime by default. When an environment moves to a new
-runtime, OCM runs OpenClaw's update finalization path inside that environment
-before service restart. A running managed service is considered recovered only
+`upgrade` stops a running managed gateway and creates a verified pre-upgrade
+checkpoint before changing an environment. If a running service cannot be
+restarted or started after the change, OCM keeps the restored checkpoint and
+previous runtime as the coherent rollback state. When an environment moves to a
+new runtime, OCM runs OpenClaw's update finalization path while the gateway is
+stopped, before service restart. A running managed service is considered recovered only
 after its HTTP health endpoint responds and OpenClaw's gateway status proves the
 gateway is reachable; otherwise the upgrade follows the normal rollback path.
-Snapshots preserve managed path, npm, and Git plugin payloads together with
-their package metadata and symlinks, while generated plugin dependency caches
-and live runtime residue stay out of the archive.
+New snapshots preserve the complete environment root, including credentials,
+browser profiles, plugin payloads, unknown future directories, modes, symlinks,
+and SQLite sidecars. OCM verifies tree contents and SQLite integrity before
+publishing the checkpoint. APFS uses copy-on-write clones when available;
+other filesystems use a metadata-preserving full copy. Restore discards only
+explicit process residue such as locks, sockets, PIDs, and temporary runtime
+directories. Legacy tar snapshots remain readable.
+
+Checkpoints contain secrets and share the source filesystem. Keep `OCM_HOME`
+private, allow enough space for checkpoint divergence plus a restore candidate,
+and retain an off-disk backup for disaster recovery.
 Snapshot removal validates that the stored environment, snapshot ID, and
-archive path match the named snapshot before deleting anything. It takes the
-live metadata and archive out of service together, then reports warnings if
+artifact path match the named snapshot before deleting anything. It takes the
+live metadata and checkpoint out of service together, then reports warnings if
 linked upgrade recovery or staged artifact cleanup still needs attention.
 When both OpenClaw versions are known, `upgrade` rejects an older target before
 creating a snapshot, downloading the target, or changing runtime metadata.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -148,8 +148,9 @@ Use `upgrade simulate` when you want to test what would happen against a publish
 - simulation envs and temporary runtimes are cleaned up automatically; use `--keep-simulations` only when you need retained debug artifacts
 - missing published targets fail before any simulation env is created
 - `--scenario all` runs built-in current, clean minimum, and Telegram-configured env shapes as separate simulation clones
-- a pre-upgrade snapshot is created before env state changes
-- when an env moves to a new runtime, OCM runs OpenClaw's update finalization path inside that env before service restart
+- a running managed gateway is stopped before its verified pre-upgrade checkpoint and remains stopped through mutation and finalization
+- new checkpoints capture the complete environment root; APFS clone support is used when available and a metadata-preserving full copy is the fallback
+- when an env moves to a new runtime, OCM runs OpenClaw's update finalization path cold before service restart
 - if service reconciliation fails, OCM restores the snapshot and previous runtime unless `--no-rollback` is set
 - pinned runtimes stay pinned unless you pass `--version`, `--channel`, or `--runtime`
 - local-command environments are reported clearly instead of being changed behind your back
@@ -362,6 +363,19 @@ ocm start rowan
 ```
 
 ### Snapshots
+
+Snapshot create and restore stop a running OCM-managed gateway before copying or
+replacing its root, then restore the recorded service policy. New snapshots are
+verified whole-root checkpoints: they include secrets, browser state, SQLite
+sidecars, modes, symlinks, plugin data, and unknown future paths. Restore stages
+an exclusive candidate beside the live root and retains the displaced root
+until service acceptance; failed acceptance restores the displaced root.
+
+APFS checkpoints begin as space-efficient copy-on-write clones. Other
+filesystems require a full metadata-preserving copy. Plan space for checkpoint
+divergence and a temporary restore candidate. These same-disk, secret-bearing
+checkpoints are operational rollback—not off-disk disaster recovery. Legacy tar
+snapshots remain readable.
 
 Create:
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -807,11 +807,33 @@ impl Cli {
         Self::assert_no_extra_args(&args[1..])?;
 
         let snapshot = self.with_progress(format!("Creating snapshot for {name}"), || {
-            self.environment_service()
-                .create_snapshot(CreateEnvSnapshotOptions {
-                    env_name: name.clone(),
-                    label,
-                })
+            let _operation_lock = self.environment_service().lock_operation(name)?;
+            let service_state = self
+                .service_service()
+                .quiesce_for_snapshot_locked(name)?;
+            let snapshot_result = self
+                .environment_service()
+                .create_snapshot_locked_with_service_state(
+                    CreateEnvSnapshotOptions {
+                        env_name: name.clone(),
+                        label,
+                    },
+                    service_state.map(|state| (state.enabled, state.running)),
+                );
+            let service_result = self
+                .service_service()
+                .restore_after_snapshot_locked(name, service_state);
+            match (snapshot_result, service_result) {
+                (Ok(snapshot), Ok(())) => Ok(snapshot),
+                (Ok(snapshot), Err(service_error)) => Err(format!(
+                    "snapshot {} was created, but the managed service could not be restored: {service_error}",
+                    snapshot.id
+                )),
+                (Err(snapshot_error), Ok(())) => Err(snapshot_error),
+                (Err(snapshot_error), Err(service_error)) => Err(format!(
+                    "{snapshot_error}; also failed to restore the managed service after snapshot capture: {service_error}"
+                )),
+            }
         })?;
 
         if json_flag {
@@ -884,11 +906,84 @@ impl Cli {
         let restored = self.with_progress(
             format!("Restoring snapshot {snapshot_id} for {name}"),
             || {
-                self.environment_service()
-                    .restore_snapshot(RestoreEnvSnapshotOptions {
+                let _operation_lock = self.environment_service().lock_operation(name)?;
+                let selected_snapshot = self
+                    .environment_service()
+                    .get_snapshot(name, snapshot_id)?;
+                let service_state = self
+                    .service_service()
+                    .quiesce_for_snapshot_locked(name)?;
+                let restore_result = self.environment_service().prepare_snapshot_restore_locked(
+                    RestoreEnvSnapshotOptions {
                         env_name: name.clone(),
                         snapshot_id: snapshot_id.clone(),
-                    })
+                    },
+                );
+                match restore_result {
+                    Ok(transaction) => {
+                        let restored = transaction.summary.clone();
+                        let restored_service_state =
+                            if selected_snapshot.service_enabled && selected_snapshot.service_running {
+                                Some(crate::service::ServiceMaintenanceState {
+                                    enabled: true,
+                                    running: true,
+                                })
+                            } else {
+                                None
+                            };
+                        let service_acceptance = self
+                            .service_service()
+                            .restore_after_snapshot_locked(name, restored_service_state)
+                            .and_then(|()| {
+                                if restored_service_state.is_none() {
+                                    return Ok(());
+                                }
+                                match self.wait_for_restarted_gateway_health(name, true)? {
+                                    None => Ok(()),
+                                    Some(note) => Err(note),
+                                }
+                            });
+                        match service_acceptance {
+                            Ok(()) => {
+                                self.environment_service()
+                                    .commit_snapshot_restore_locked(transaction)?;
+                                Ok(restored)
+                            }
+                            Err(service_error) => {
+                                let rollback_result = self
+                                    .environment_service()
+                                    .rollback_snapshot_restore_locked(transaction);
+                                let service_restore_result = self
+                                    .service_service()
+                                    .restore_after_snapshot_locked(name, service_state);
+                                let mut error = format!(
+                                    "snapshot {} failed managed-service acceptance: {service_error}",
+                                    restored.snapshot_id
+                                );
+                                if let Err(rollback_error) = rollback_result {
+                                    error.push_str(&format!(
+                                        "; restoring the displaced environment root also failed: {rollback_error}"
+                                    ));
+                                }
+                                if let Err(restore_error) = service_restore_result {
+                                    error.push_str(&format!(
+                                        "; restoring the pre-restore managed service also failed: {restore_error}"
+                                    ));
+                                }
+                                Err(error)
+                            }
+                        }
+                    }
+                    Err(restore_error) => match self
+                        .service_service()
+                        .restore_after_snapshot_locked(name, service_state)
+                    {
+                        Ok(()) => Err(restore_error),
+                        Err(service_error) => Err(format!(
+                            "{restore_error}; also failed to restore the pre-restore managed service state: {service_error}"
+                        )),
+                    },
+                }
             },
         )?;
 

--- a/src/cli/render/env.rs
+++ b/src/cli/render/env.rs
@@ -1667,7 +1667,7 @@ mod tests {
         assert!(lines[1].contains("[scope:all]"));
         assert!(lines[1].contains("[1 candidate(s)]"));
         assert!(lines.iter().any(|line| line.starts_with('┌')));
-        assert!(lines.iter().any(|line| line.contains("Archive")));
+        assert!(lines.iter().any(|line| line.contains("Checkpoint")));
         assert_eq!(lines.last().unwrap(), "Re-run with --yes to remove them.");
     }
 
@@ -1727,6 +1727,7 @@ mod tests {
             env_name: env_name.to_string(),
             label: Some(label.to_string()),
             archive_path: "/tmp/demo-snapshot.tar".to_string(),
+            storage_kind: "tar-archive-v1".to_string(),
             source_root: "/tmp/demo".to_string(),
             gateway_port: Some(18789),
             service_enabled: true,
@@ -2230,7 +2231,8 @@ pub fn env_snapshot_created(snapshot: &EnvSnapshotSummary, profile: RenderProfil
     let mut rows = vec![
         KeyValueRow::accent("Env", snapshot.env_name.clone()),
         KeyValueRow::accent("Snapshot", snapshot.id.clone()),
-        KeyValueRow::plain("Archive", snapshot.archive_path.clone()),
+        KeyValueRow::plain("Checkpoint", snapshot.archive_path.clone()),
+        KeyValueRow::plain("Storage", snapshot.storage_kind.clone()),
     ];
     if let Some(label) = snapshot.label.as_deref() {
         rows.push(KeyValueRow::plain("Label", label));
@@ -2245,7 +2247,8 @@ fn env_snapshot_created_raw(snapshot: &EnvSnapshotSummary) -> Vec<String> {
             "Created snapshot {} for env {}",
             snapshot.id, snapshot.env_name
         ),
-        format!("  archive: {}", snapshot.archive_path),
+        format!("  checkpoint: {}", snapshot.archive_path),
+        format!("  storage: {}", snapshot.storage_kind),
         format!("  root: {}", snapshot.source_root),
     ];
     if let Some(label) = snapshot.label.as_deref() {
@@ -2284,7 +2287,8 @@ pub fn env_snapshot_show(
         &mut lines,
         "Paths",
         vec![
-            KeyValueRow::plain("Archive", snapshot.archive_path.clone()),
+            KeyValueRow::plain("Checkpoint", snapshot.archive_path.clone()),
+            KeyValueRow::plain("Storage", snapshot.storage_kind.clone()),
             KeyValueRow::plain("Source root", snapshot.source_root.clone()),
         ],
         profile.color,
@@ -2312,6 +2316,7 @@ fn env_snapshot_show_raw(snapshot: &EnvSnapshotSummary) -> Result<Vec<String>, S
         format!("snapshotId: {}", snapshot.id),
         format!("envName: {}", snapshot.env_name),
         format!("archivePath: {}", snapshot.archive_path),
+        format!("storageKind: {}", snapshot.storage_kind),
         format!("sourceRoot: {}", snapshot.source_root),
     ];
     if let Some(label) = snapshot.label.as_deref() {
@@ -2402,7 +2407,8 @@ pub fn env_snapshot_restored(
         KeyValueRow::accent("Env", restored.env_name.clone()),
         KeyValueRow::accent("Snapshot", restored.snapshot_id.clone()),
         KeyValueRow::plain("Root", restored.root.clone()),
-        KeyValueRow::plain("Archive", restored.archive_path.clone()),
+        KeyValueRow::plain("Checkpoint", restored.archive_path.clone()),
+        KeyValueRow::plain("Storage", restored.storage_kind.clone()),
         action_export_binding_row(
             restored.default_runtime.clone(),
             restored.default_launcher.clone(),
@@ -2425,7 +2431,8 @@ fn env_snapshot_restored_raw(restored: &EnvSnapshotRestoreSummary) -> Vec<String
             restored.env_name, restored.snapshot_id
         ),
         format!("  root: {}", restored.root),
-        format!("  archive: {}", restored.archive_path),
+        format!("  checkpoint: {}", restored.archive_path),
+        format!("  storage: {}", restored.storage_kind),
     ];
     if let Some(label) = restored.label.as_deref() {
         lines.push(format!("  label: {label}"));
@@ -2454,7 +2461,8 @@ pub fn env_snapshot_removed(
     let mut rows = vec![
         KeyValueRow::accent("Env", removed.env_name.clone()),
         KeyValueRow::accent("Snapshot", removed.snapshot_id.clone()),
-        KeyValueRow::plain("Archive", removed.archive_path.clone()),
+        KeyValueRow::plain("Checkpoint", removed.archive_path.clone()),
+        KeyValueRow::plain("Storage", removed.storage_kind.clone()),
     ];
     if let Some(label) = removed.label.as_deref() {
         rows.push(KeyValueRow::plain("Label", label));
@@ -2477,7 +2485,8 @@ fn env_snapshot_removed_raw(removed: &EnvSnapshotRemoveSummary) -> Vec<String> {
             "Removed snapshot {} for env {}",
             removed.snapshot_id, removed.env_name
         ),
-        format!("  archive: {}", removed.archive_path),
+        format!("  checkpoint: {}", removed.archive_path),
+        format!("  storage: {}", removed.storage_kind),
     ];
     if let Some(label) = removed.label.as_deref() {
         lines.push(format!("  label: {label}"));
@@ -2533,7 +2542,7 @@ pub fn env_snapshot_prune_preview(
         })
         .collect::<Result<Vec<_>, String>>()?;
     lines.extend(render_table(
-        &["Snapshot", "Env", "Label", "Created", "Archive"],
+        &["Snapshot", "Env", "Label", "Created", "Checkpoint"],
         &rows,
         profile.color,
     ));
@@ -2599,7 +2608,7 @@ pub fn env_snapshot_pruned(
         })
         .collect::<Vec<_>>();
     lines.extend(render_table(
-        &["Snapshot", "Env", "Label", "Archive"],
+        &["Snapshot", "Env", "Label", "Checkpoint"],
         &rows,
         profile.color,
     ));

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1600,7 +1600,7 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
     Some(match action {
         "create" => render_leaf(
             "Create an environment snapshot",
-            "Capture a point-in-time snapshot of an environment.",
+            "Capture a verified whole-root checkpoint while its managed gateway is stopped.",
             vec![format!(
                 "{cmd} env snapshot create <name> [--label <label>] [--raw] [--json]"
             )],
@@ -1615,7 +1615,7 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
             vec![format!(
                 "{cmd} env snapshot create mira --label before-upgrade"
             )],
-            &[],
+            &["Checkpoints include secret-bearing state and remain on the source filesystem."],
         ),
         "show" => render_leaf(
             "Show one environment snapshot",
@@ -1659,7 +1659,7 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
         ),
         "restore" => render_leaf(
             "Restore an environment snapshot",
-            "Replace an environment root with the contents of a snapshot.",
+            "Replace an environment root from a checkpoint while its managed gateway is stopped.",
             vec![format!(
                 "{cmd} env snapshot restore <name> <snapshot> [--raw] [--json]"
             )],
@@ -1673,11 +1673,13 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
             vec![format!(
                 "{cmd} env snapshot restore mira 1742922000-123456789"
             )],
-            &["Snapshot restore keeps existing safety rails around foreign directories."],
+            &[
+                "Restore uses an exclusive same-filesystem namespace and retains the displaced root through service acceptance.",
+            ],
         ),
         "remove" => render_leaf(
             "Remove an environment snapshot",
-            "Delete snapshot metadata and archived content for a snapshot.",
+            "Delete snapshot metadata and checkpoint content for a snapshot.",
             vec![format!(
                 "{cmd} env snapshot remove <name> <snapshot> [--raw] [--json]"
             )],
@@ -1692,8 +1694,8 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
                 "{cmd} env snapshot remove mira 1742922000-123456789"
             )],
             &[
-                "OCM validates the stored environment, snapshot ID, and archive path before removal.",
-                "Metadata and archive content leave their live paths together; later cleanup failures are reported as warnings.",
+                "OCM validates the stored environment, snapshot ID, storage kind, and artifact path before removal.",
+                "Metadata and checkpoint content leave their live paths together; later cleanup failures are reported as warnings.",
             ],
         ),
         "prune" => render_leaf(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2705,7 +2705,7 @@ impl Cli {
         Ok((None, None))
     }
 
-    fn wait_for_restarted_gateway_health(
+    pub(super) fn wait_for_restarted_gateway_health(
         &self,
         env_name: &str,
         action_reported_running: bool,
@@ -2937,23 +2937,41 @@ impl Cli {
         rollback_of: Option<String>,
     ) -> Result<UpgradeTransaction, String> {
         let env_meta = self.environment_service().get(env_name)?;
+        let service_state = self
+            .service_service()
+            .quiesce_for_snapshot_locked(env_name)?;
         let started_at = time::OffsetDateTime::now_utc();
         let id = format!(
             "{}-{:09}",
             started_at.unix_timestamp(),
             started_at.nanosecond()
         );
-        let snapshot = self
+        let snapshot_result = self
             .environment_service()
-            .create_snapshot_locked(CreateEnvSnapshotOptions {
-                env_name: env_name.to_string(),
-                label: Some(snapshot_label.to_string()),
-            })
-            .map_err(|error| {
-                format!(
+            .create_snapshot_locked_with_service_state(
+                CreateEnvSnapshotOptions {
+                    env_name: env_name.to_string(),
+                    label: Some(snapshot_label.to_string()),
+                },
+                Some((env_meta.service_enabled, env_meta.service_running)),
+            );
+        let snapshot = match snapshot_result {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let snapshot_error = format!(
                     "failed to create {snapshot_label} snapshot for env \"{env_name}\": {error}"
-                )
-            })?;
+                );
+                return match self
+                    .service_service()
+                    .restore_after_snapshot_locked(env_name, service_state)
+                {
+                    Ok(()) => Err(snapshot_error),
+                    Err(service_error) => Err(format!(
+                        "{snapshot_error}; also failed to restore the managed service after snapshot capture: {service_error}"
+                    )),
+                };
+            }
+        };
         let mut seen = BTreeSet::new();
         let mut runtime_backups = Vec::new();
         let mut created_runtime_names = Vec::new();
@@ -2969,6 +2987,7 @@ impl Cli {
                         env_name,
                         &snapshot.id,
                         runtime_backups,
+                        service_state,
                         error,
                     ));
                 }
@@ -2981,6 +3000,7 @@ impl Cli {
                             env_name,
                             &snapshot.id,
                             runtime_backups,
+                            service_state,
                             error,
                         ));
                     }
@@ -2992,6 +3012,7 @@ impl Cli {
                             env_name,
                             &snapshot.id,
                             runtime_backups,
+                            service_state,
                             error,
                         ));
                     }
@@ -3001,26 +3022,7 @@ impl Cli {
             }
         }
 
-        let service_quiesced = if runtime_names.is_empty() {
-            false
-        } else {
-            match self
-                .service_service()
-                .quiesce_for_runtime_mutation_locked(env_name)
-            {
-                Ok(quiesced) => quiesced,
-                Err(error) => {
-                    return Err(self.cleanup_failed_transaction_setup(
-                        env_name,
-                        &snapshot.id,
-                        runtime_backups,
-                        format!(
-                            "failed to quiesce managed service before runtime mutation: {error}"
-                        ),
-                    ));
-                }
-            }
-        };
+        let service_quiesced = service_state.is_some();
 
         Ok(UpgradeTransaction {
             id,
@@ -3054,24 +3056,33 @@ impl Cli {
         env_name: &str,
         snapshot_id: &str,
         runtime_backups: Vec<RuntimeRollbackBackup>,
+        service_state: Option<crate::service::ServiceMaintenanceState>,
         error: String,
     ) -> String {
         for backup in runtime_backups {
             backup.cleanup();
         }
-        match self.environment_service().remove_snapshot_locked(
+        let cleanup_result = self.environment_service().remove_snapshot_locked(
             crate::env::RemoveEnvSnapshotOptions {
                 env_name: env_name.to_string(),
                 snapshot_id: snapshot_id.to_string(),
             },
-        ) {
-            Ok(_) => error,
-            Err(cleanup_error) => {
-                format!(
-                    "{error}; also failed to remove the incomplete transaction snapshot: {cleanup_error}"
-                )
-            }
+        );
+        let service_result = self
+            .service_service()
+            .restore_after_snapshot_locked(env_name, service_state);
+        let mut result = error;
+        if let Err(cleanup_error) = cleanup_result {
+            result = format!(
+                "{result}; also failed to remove the incomplete transaction snapshot: {cleanup_error}"
+            );
         }
+        if let Err(service_error) = service_result {
+            result = format!(
+                "{result}; also failed to restore the managed service after snapshot capture: {service_error}"
+            );
+        }
+        result
     }
 
     fn finish_successful_upgrade(

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -5,8 +5,10 @@ use time::{Duration, OffsetDateTime};
 
 use super::EnvironmentService;
 use crate::store::{
-    create_env_snapshot, get_env_snapshot, list_all_env_snapshots, list_env_snapshots, now_utc,
-    remove_env_snapshot, restore_env_snapshot, summarize_snapshot,
+    EnvSnapshotRestoreTransaction, commit_env_snapshot_restore, create_env_snapshot,
+    create_env_snapshot_with_service_state, get_env_snapshot, list_all_env_snapshots,
+    list_env_snapshots, now_utc, prepare_env_snapshot_restore, remove_env_snapshot,
+    restore_env_snapshot, rollback_env_snapshot_restore, summarize_snapshot,
 };
 use crate::supervisor::sync_supervisor_if_present;
 
@@ -23,6 +25,7 @@ pub struct EnvSnapshotSummary {
     pub env_name: String,
     pub label: Option<String>,
     pub archive_path: String,
+    pub storage_kind: String,
     pub source_root: String,
     pub gateway_port: Option<u32>,
     pub service_enabled: bool,
@@ -42,6 +45,7 @@ pub struct EnvSnapshotRestoreSummary {
     pub label: Option<String>,
     pub root: String,
     pub archive_path: String,
+    pub storage_kind: String,
     pub default_runtime: Option<String>,
     pub default_launcher: Option<String>,
     pub protected: bool,
@@ -54,6 +58,7 @@ pub struct EnvSnapshotRemoveSummary {
     pub snapshot_id: String,
     pub label: Option<String>,
     pub archive_path: String,
+    pub storage_kind: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
 }
@@ -133,6 +138,16 @@ impl<'a> EnvironmentService<'a> {
         Ok(summarize_snapshot(&meta))
     }
 
+    pub(crate) fn create_snapshot_locked_with_service_state(
+        &self,
+        options: CreateEnvSnapshotOptions,
+        service_state: Option<(bool, bool)>,
+    ) -> Result<EnvSnapshotSummary, String> {
+        let meta =
+            create_env_snapshot_with_service_state(options, service_state, self.env, self.cwd)?;
+        Ok(summarize_snapshot(&meta))
+    }
+
     pub fn list_snapshots(
         &self,
         env_name: Option<&str>,
@@ -168,6 +183,38 @@ impl<'a> EnvironmentService<'a> {
         let summary = restore_env_snapshot(options, self.env, self.cwd)?;
         sync_supervisor_if_present(self.env, self.cwd)?;
         Ok(summary)
+    }
+
+    pub(crate) fn prepare_snapshot_restore_locked(
+        &self,
+        options: RestoreEnvSnapshotOptions,
+    ) -> Result<EnvSnapshotRestoreTransaction, String> {
+        let transaction = prepare_env_snapshot_restore(options, self.env, self.cwd)?;
+        sync_supervisor_if_present(self.env, self.cwd)?;
+        Ok(transaction)
+    }
+
+    pub(crate) fn commit_snapshot_restore_locked(
+        &self,
+        transaction: EnvSnapshotRestoreTransaction,
+    ) -> Result<(), String> {
+        commit_env_snapshot_restore(transaction)
+    }
+
+    pub(crate) fn rollback_snapshot_restore_locked(
+        &self,
+        transaction: EnvSnapshotRestoreTransaction,
+    ) -> Result<(), String> {
+        let cleanup_warning = rollback_env_snapshot_restore(transaction, self.env, self.cwd)?;
+        let sync_result = sync_supervisor_if_present(self.env, self.cwd).map(|_| ());
+        match (cleanup_warning, sync_result) {
+            (None, Ok(())) => Ok(()),
+            (Some(cleanup_warning), Ok(())) => Err(cleanup_warning),
+            (None, Err(sync_error)) => Err(sync_error),
+            (Some(cleanup_warning), Err(sync_error)) => Err(format!(
+                "{cleanup_warning}; supervisor resync also failed: {sync_error}"
+            )),
+        }
     }
 
     pub fn remove_snapshot(
@@ -272,6 +319,7 @@ mod tests {
             env_name: env_name.to_string(),
             label: None,
             archive_path: format!("/tmp/{id}.tar"),
+            storage_kind: "tar-archive-v1".to_string(),
             source_root: format!("/tmp/{env_name}"),
             gateway_port: None,
             service_enabled: false,

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -18,6 +18,12 @@ pub struct ServiceService<'a> {
     cwd: &'a Path,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ServiceMaintenanceState {
+    pub(crate) enabled: bool,
+    pub(crate) running: bool,
+}
+
 impl<'a> ServiceService<'a> {
     pub fn new(env: &'a BTreeMap<String, String>, cwd: &'a Path) -> Self {
         Self { env, cwd }
@@ -148,6 +154,57 @@ impl<'a> ServiceService<'a> {
             }
             sleep(Duration::from_millis(25));
         }
+    }
+
+    pub(crate) fn quiesce_for_snapshot_locked(
+        &self,
+        name: &str,
+    ) -> Result<Option<ServiceMaintenanceState>, String> {
+        let status = self.status(name)?;
+        if !status.running {
+            return Ok(None);
+        }
+        let meta = crate::env::EnvironmentService::new(self.env, self.cwd).get(name)?;
+        let state = ServiceMaintenanceState {
+            enabled: meta.service_enabled,
+            running: meta.service_running,
+        };
+        let stopped = self.stop_locked(name)?;
+        if stopped.running {
+            let stop_error = format!(
+                "managed service for {name} remained running after the snapshot safety stop"
+            );
+            return match self.restore_after_snapshot_locked(name, Some(state)) {
+                Ok(()) => Err(stop_error),
+                Err(restore_error) => Err(format!(
+                    "{stop_error}; also failed to restore its pre-snapshot service policy: {restore_error}"
+                )),
+            };
+        }
+        if let Err(error) = self.wait_for_runtime_mutation_quiescence_locked(name) {
+            return match self.restore_after_snapshot_locked(name, Some(state)) {
+                Ok(()) => Err(error),
+                Err(restore_error) => Err(format!(
+                    "{error}; also failed to restore its pre-snapshot service policy: {restore_error}"
+                )),
+            };
+        }
+        Ok(Some(state))
+    }
+
+    pub(crate) fn restore_after_snapshot_locked(
+        &self,
+        name: &str,
+        state: Option<ServiceMaintenanceState>,
+    ) -> Result<(), String> {
+        if state.is_some_and(|state| state.enabled && state.running) {
+            let meta = crate::env::EnvironmentService::new(self.env, self.cwd).get(name)?;
+            if meta.service_enabled && meta.service_running && self.status(name)?.running {
+                return Ok(());
+            }
+            self.start_locked(name)?;
+        }
+        Ok(())
     }
 
     pub fn restart(&self, name: &str) -> Result<ServiceActionSummary, String> {

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -1,0 +1,485 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+#[cfg(not(target_os = "macos"))]
+use filetime::{FileTime, set_file_times, set_symlink_file_times};
+use rusqlite::{Connection, OpenFlags};
+use sha2::{Digest, Sha256};
+#[cfg(not(target_os = "macos"))]
+use std::io::Write;
+
+use super::common::{ensure_dir, path_exists};
+use super::layout::display_path;
+
+pub(crate) const STORAGE_APFS_CLONE: &str = "apfs-clone-v1";
+pub(crate) const STORAGE_FULL_COPY: &str = "full-copy-v1";
+pub(crate) const STORAGE_TAR_ARCHIVE: &str = "tar-archive-v1";
+
+pub(crate) fn default_snapshot_storage_kind() -> String {
+    STORAGE_TAR_ARCHIVE.to_string()
+}
+
+pub(crate) fn create_tree_checkpoint(source: &Path, destination: &Path) -> Result<String, String> {
+    if path_exists(destination) {
+        return Err(format!(
+            "checkpoint destination already exists: {}",
+            display_path(destination)
+        ));
+    }
+    if let Some(parent) = destination.parent() {
+        ensure_dir(parent)?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        match copyfile_tree(source, destination, true) {
+            Ok(()) => {
+                verify_tree_checkpoint(source, destination)?;
+                verify_sqlite_databases(destination)?;
+                sync_tree_root(destination)?;
+                return Ok(STORAGE_APFS_CLONE.to_string());
+            }
+            Err(clone_error) => {
+                remove_tree_if_present(destination)?;
+                copyfile_tree(source, destination, false).map_err(|copy_error| {
+                    format!(
+                        "APFS clone was unavailable ({clone_error}); full checkpoint copy also failed: {copy_error}"
+                    )
+                })?;
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    copy_tree_preserving_metadata(source, destination)?;
+
+    if let Err(error) = (|| {
+        verify_tree_checkpoint(source, destination)?;
+        verify_sqlite_databases(destination)?;
+        sync_tree_root(destination)
+    })() {
+        let _ = remove_tree_if_present(destination);
+        return Err(error);
+    }
+    Ok(STORAGE_FULL_COPY.to_string())
+}
+
+pub(crate) fn copy_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String> {
+    let _ = create_tree_checkpoint(source, destination)?;
+    Ok(())
+}
+
+pub(crate) fn verify_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String> {
+    let source_entries = inventory_tree(source)?;
+    let destination_entries = inventory_tree(destination)?;
+    if source_entries != destination_entries {
+        return Err(format!(
+            "checkpoint verification failed: {} does not exactly match {}",
+            display_path(destination),
+            display_path(source)
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct InventoryEntry {
+    kind: &'static str,
+    len: Option<u64>,
+    mode: u32,
+    link_target: Option<PathBuf>,
+    sha256: Option<[u8; 32]>,
+}
+
+fn inventory_tree(root: &Path) -> Result<BTreeMap<PathBuf, InventoryEntry>, String> {
+    let mut out = BTreeMap::new();
+    inventory_path(root, root, &mut out)?;
+    Ok(out)
+}
+
+fn inventory_path(
+    root: &Path,
+    path: &Path,
+    out: &mut BTreeMap<PathBuf, InventoryEntry>,
+) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("failed to inspect {}: {error}", display_path(path)))?;
+    let relative = path.strip_prefix(root).unwrap_or(path).to_path_buf();
+    let file_type = metadata.file_type();
+    let (kind, link_target, sha256) = if file_type.is_symlink() {
+        (
+            "symlink",
+            Some(fs::read_link(path).map_err(|error| error.to_string())?),
+            None,
+        )
+    } else if file_type.is_dir() {
+        ("directory", None, None)
+    } else if file_type.is_file() {
+        ("file", None, Some(hash_file(path)?))
+    } else {
+        ("special", None, None)
+    };
+    out.insert(
+        relative,
+        InventoryEntry {
+            kind,
+            len: file_type.is_file().then_some(metadata.len()),
+            mode: metadata_mode(&metadata),
+            link_target,
+            sha256,
+        },
+    );
+    if file_type.is_dir() {
+        let mut entries = fs::read_dir(path)
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            inventory_path(root, &entry.path(), out)?;
+        }
+    }
+    Ok(())
+}
+
+fn hash_file(path: &Path) -> Result<[u8; 32], String> {
+    let mut file = fs::File::open(path).map_err(|error| error.to_string())?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| error.to_string())?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize().into())
+}
+
+fn verify_sqlite_databases(root: &Path) -> Result<(), String> {
+    for path in regular_files(root)? {
+        let mut file = fs::File::open(&path).map_err(|error| error.to_string())?;
+        let mut magic = [0_u8; 16];
+        if file.read_exact(&mut magic).is_err() || &magic != b"SQLite format 3\0" {
+            continue;
+        }
+        drop(file);
+        let connection = Connection::open_with_flags(
+            &path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(|error| {
+            format!(
+                "failed to open checkpoint SQLite database {}: {error}",
+                display_path(&path)
+            )
+        })?;
+        let result: String = connection
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .map_err(|error| {
+                format!(
+                    "failed to verify checkpoint SQLite database {}: {error}",
+                    display_path(&path)
+                )
+            })?;
+        if result != "ok" {
+            return Err(format!(
+                "checkpoint SQLite integrity check failed for {}: {result}",
+                display_path(&path)
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn regular_files(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut out = Vec::new();
+    collect_regular_files(root, &mut out)?;
+    Ok(out)
+}
+
+fn collect_regular_files(path: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    if metadata.is_file() {
+        out.push(path.to_path_buf());
+        return Ok(());
+    }
+    if metadata.is_dir() {
+        for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
+            collect_regular_files(&entry.map_err(|error| error.to_string())?.path(), out)?;
+        }
+    }
+    Ok(())
+}
+
+fn sync_tree_root(root: &Path) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        let _ = root;
+        return Ok(());
+    }
+    #[cfg(not(windows))]
+    fs::File::open(root)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| format!("failed to sync checkpoint {}: {error}", display_path(root)))
+}
+
+pub(crate) fn remove_tree_if_present(path: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            make_tree_removable(path)?;
+            fs::remove_dir_all(path).map_err(|error| error.to_string())
+        }
+        Ok(_) => fs::remove_file(path).map_err(|error| error.to_string()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn make_tree_removable(path: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        if metadata.is_dir() {
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(permissions.mode() | 0o700);
+            fs::set_permissions(path, permissions).map_err(|error| error.to_string())?;
+        }
+    }
+    #[cfg(windows)]
+    {
+        let mut permissions = metadata.permissions();
+        if permissions.readonly() {
+            permissions.set_readonly(false);
+            fs::set_permissions(path, permissions).map_err(|error| error.to_string())?;
+        }
+    }
+
+    if metadata.is_dir() {
+        for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
+            make_tree_removable(&entry.map_err(|error| error.to_string())?.path())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn copyfile_tree(source: &Path, destination: &Path, clone: bool) -> Result<(), String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    const COPYFILE_ALL: u32 = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
+    const COPYFILE_RECURSIVE: u32 = 1 << 15;
+    const COPYFILE_CLONE: u32 = 1 << 24;
+
+    unsafe extern "C" {
+        fn copyfile(
+            from: *const libc::c_char,
+            to: *const libc::c_char,
+            state: *mut libc::c_void,
+            flags: u32,
+        ) -> libc::c_int;
+    }
+
+    if clone {
+        verify_clone_capability(source, destination)?;
+    }
+    let source_c =
+        CString::new(source.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let destination_c =
+        CString::new(destination.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let mut flags = COPYFILE_ALL | COPYFILE_RECURSIVE;
+    if clone {
+        flags |= COPYFILE_CLONE;
+    }
+    let result = unsafe {
+        copyfile(
+            source_c.as_ptr(),
+            destination_c.as_ptr(),
+            std::ptr::null_mut(),
+            flags,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error().to_string())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn verify_clone_capability(source: &Path, destination: &Path) -> Result<(), String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
+
+    unsafe extern "C" {
+        fn clonefile(
+            source: *const libc::c_char,
+            destination: *const libc::c_char,
+            flags: libc::c_int,
+        ) -> libc::c_int;
+    }
+
+    let destination_parent = destination
+        .parent()
+        .ok_or_else(|| "checkpoint destination has no parent".to_string())?;
+    ensure_dir(destination_parent)?;
+    if fs::metadata(source)
+        .map_err(|error| error.to_string())?
+        .dev()
+        != fs::metadata(destination_parent)
+            .map_err(|error| error.to_string())?
+            .dev()
+    {
+        return Err("source and checkpoint destination are on different filesystems".to_string());
+    }
+
+    let nonce = format!(
+        ".ocm-clone-probe-{}-{}",
+        std::process::id(),
+        time::OffsetDateTime::now_utc().unix_timestamp_nanos()
+    );
+    let probe_source = destination_parent.join(format!("{nonce}.source"));
+    let probe_clone = destination_parent.join(format!("{nonce}.clone"));
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe_source)
+        .map_err(|error| error.to_string())?;
+    let source_c =
+        CString::new(probe_source.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let clone_c =
+        CString::new(probe_clone.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let result = unsafe { clonefile(source_c.as_ptr(), clone_c.as_ptr(), 0) };
+    let clone_error = (result != 0).then(std::io::Error::last_os_error);
+    let _ = fs::remove_file(&probe_clone);
+    let _ = fs::remove_file(&probe_source);
+    match clone_error {
+        Some(error) => Err(format!("filesystem clone probe failed: {error}")),
+        None => Ok(()),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn copy_tree_preserving_metadata(source: &Path, destination: &Path) -> Result<(), String> {
+    copy_path_preserving_metadata(source, destination)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn copy_path_preserving_metadata(source: &Path, destination: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        let target = fs::read_link(source).map_err(|error| error.to_string())?;
+        if let Some(parent) = destination.parent() {
+            ensure_dir(parent)?;
+        }
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target, destination).map_err(|error| error.to_string())?;
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&target, destination)
+            .or_else(|_| std::os::windows::fs::symlink_dir(target, destination))
+            .map_err(|error| error.to_string())?;
+        preserve_metadata(source, destination, &metadata, true)?;
+        return Ok(());
+    }
+    if file_type.is_dir() {
+        ensure_dir(destination)?;
+        let entries = fs::read_dir(source)
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        for entry in entries {
+            copy_path_preserving_metadata(&entry.path(), &destination.join(entry.file_name()))?;
+        }
+        preserve_metadata(source, destination, &metadata, false)?;
+        return Ok(());
+    }
+    if file_type.is_file() {
+        if let Some(parent) = destination.parent() {
+            ensure_dir(parent)?;
+        }
+        let mut input = fs::File::open(source).map_err(|error| error.to_string())?;
+        let mut output = fs::File::create(destination).map_err(|error| error.to_string())?;
+        std::io::copy(&mut input, &mut output).map_err(|error| error.to_string())?;
+        output.flush().map_err(|error| error.to_string())?;
+        output.sync_all().map_err(|error| error.to_string())?;
+        preserve_metadata(source, destination, &metadata, false)?;
+        return Ok(());
+    }
+    Err(format!(
+        "unsupported special file in checkpoint: {}",
+        display_path(source)
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn preserve_metadata(
+    source: &Path,
+    destination: &Path,
+    metadata: &fs::Metadata,
+    symlink: bool,
+) -> Result<(), String> {
+    if !symlink {
+        fs::set_permissions(destination, metadata.permissions())
+            .map_err(|error| error.to_string())?;
+    }
+    let accessed = FileTime::from_last_access_time(metadata);
+    let modified = FileTime::from_last_modification_time(metadata);
+    if symlink {
+        set_symlink_file_times(destination, accessed, modified)
+            .map_err(|error| error.to_string())?;
+    } else {
+        set_file_times(destination, accessed, modified).map_err(|error| error.to_string())?;
+    }
+    #[cfg(unix)]
+    for name in xattr::list(source).map_err(|error| error.to_string())? {
+        if let Some(value) = xattr::get(source, &name).map_err(|error| error.to_string())? {
+            xattr::set(destination, &name, &value).map_err(|error| error.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn metadata_mode(metadata: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::MetadataExt;
+    metadata.mode()
+}
+
+#[cfg(not(unix))]
+fn metadata_mode(metadata: &fs::Metadata) -> u32 {
+    u32::from(metadata.permissions().readonly())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use super::inventory_tree;
+
+    #[test]
+    fn checkpoint_inventory_ignores_directory_allocation_lengths() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("nested")).unwrap();
+        fs::write(root.path().join("nested/value.txt"), "value\n").unwrap();
+
+        let inventory = inventory_tree(root.path()).unwrap();
+        assert_eq!(inventory[Path::new("")].len, None);
+        assert_eq!(inventory[Path::new("nested")].len, None);
+        assert_eq!(inventory[Path::new("nested/value.txt")].len, Some(6));
+    }
+}

--- a/src/store/common.rs
+++ b/src/store/common.rs
@@ -70,6 +70,10 @@ pub(crate) fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<()
     Ok(())
 }
 
+pub(crate) fn copy_path_recursive(source: &Path, destination: &Path) -> Result<(), String> {
+    copy_path(source, destination)
+}
+
 pub(crate) fn copy_path(source: &Path, destination: &Path) -> Result<(), String> {
     let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
     let file_type = metadata.file_type();

--- a/src/store/layout.rs
+++ b/src/store/layout.rs
@@ -336,3 +336,12 @@ pub fn snapshot_archive_path(
 ) -> Result<PathBuf, String> {
     Ok(snapshot_env_dir(env_name, env, cwd)?.join(format!("{snapshot_id}.tar")))
 }
+
+pub fn snapshot_checkpoint_path(
+    env_name: &str,
+    snapshot_id: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PathBuf, String> {
+    Ok(snapshot_env_dir(env_name, env, cwd)?.join(format!("{snapshot_id}.checkpoint")))
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,3 +1,4 @@
+mod checkpoints;
 mod common;
 mod envs;
 mod gateway_ports;
@@ -46,8 +47,8 @@ pub use layout::{
     EnvPaths, StorePaths, clean_path, default_env_root, derive_env_paths, display_path,
     env_registry_path, launcher_meta_path, resolve_absolute_path, resolve_ocm_home,
     resolve_store_paths, resolve_user_home, runtime_install_files_dir, runtime_install_root,
-    runtime_meta_path, snapshot_archive_path, snapshot_env_dir, snapshot_meta_path,
-    source_watch_override_path, supervisor_logs_dir, supervisor_runtime_path,
+    runtime_meta_path, snapshot_archive_path, snapshot_checkpoint_path, snapshot_env_dir,
+    snapshot_meta_path, source_watch_override_path, supervisor_logs_dir, supervisor_runtime_path,
     supervisor_state_path, upgrade_history_env_dir, upgrade_history_meta_path,
     upgrade_history_recovery_dir, upgrade_history_runtime_recovery_dir, validate_name,
 };
@@ -63,8 +64,7 @@ pub(crate) use openclaw_config::{
 };
 pub(crate) use openclaw_state::{
     OpenClawStateAudit, audit_openclaw_state, clear_nonportable_runtime_state,
-    openclaw_env_archive_options, openclaw_env_snapshot_archive_options,
-    prepare_migrated_runtime_state, repair_openclaw_runtime_state,
+    openclaw_env_archive_options, prepare_migrated_runtime_state, repair_openclaw_runtime_state,
 };
 pub(crate) use openclaw_workspaces::{
     OpenClawWorkspaceRuntime, resolve_env_openclaw_workspaces, resolve_plain_openclaw_workspaces,
@@ -77,6 +77,11 @@ pub use runtimes::{
     add_runtime, get_runtime, get_runtime_verified, install_runtime,
     install_runtime_from_official_openclaw_release, install_runtime_from_release,
     install_runtime_from_url, list_runtimes, remove_runtime, runtime_integrity_issue,
+};
+pub(crate) use snapshots::{
+    EnvSnapshotRestoreTransaction, commit_env_snapshot_restore,
+    create_env_snapshot_with_service_state, prepare_env_snapshot_restore,
+    rollback_env_snapshot_restore,
 };
 pub use snapshots::{
     create_env_snapshot, get_env_snapshot, list_all_env_snapshots, list_env_snapshots,

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -119,6 +119,7 @@ pub(crate) fn openclaw_env_archive_options(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn openclaw_env_snapshot_archive_options(
     paths: &EnvPaths,
     env: &BTreeMap<String, String>,

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -8,24 +9,27 @@ use crate::env::{
     EnvSnapshotSummary, RemoveEnvSnapshotOptions, RestoreEnvSnapshotOptions,
     default_service_enabled, default_service_running,
 };
-use crate::infra::archive::{
-    ArchivedEnvMeta, EnvArchiveMetadata, extract_env_archive, write_env_archive_with_options,
-};
+use crate::infra::archive::{EnvArchiveMetadata, extract_env_archive};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-use super::common::{copy_dir_recursive, load_json_files, path_exists, read_json, write_json};
+use super::checkpoints::{
+    STORAGE_TAR_ARCHIVE, copy_tree_checkpoint, create_tree_checkpoint,
+    default_snapshot_storage_kind, remove_tree_if_present,
+};
+use super::common::{
+    copy_dir_recursive, copy_path_recursive, load_json_files, path_exists, read_json, write_json,
+};
 use super::layout::{
-    derive_env_paths, display_path, snapshot_archive_path, snapshot_env_dir, snapshot_meta_path,
-    validate_name,
+    derive_env_paths, display_path, snapshot_archive_path, snapshot_checkpoint_path,
+    snapshot_env_dir, snapshot_meta_path, validate_name,
 };
 use super::{
     OpenClawWorkspaceRuntime, audit_openclaw_state, clear_nonportable_runtime_state,
-    get_environment, list_environments, now_utc, openclaw_env_snapshot_archive_options,
-    remove_upgrade_recovery_for_snapshot, rewrite_openclaw_config_for_target, save_environment,
+    get_environment, list_environments, now_utc, remove_upgrade_recovery_for_snapshot,
+    rewrite_openclaw_config_for_target, save_environment,
 };
 
-static NEXT_RESTORE_ID: AtomicU64 = AtomicU64::new(0);
 static NEXT_REMOVAL_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -37,8 +41,12 @@ pub struct EnvSnapshotMeta {
     #[serde(default)]
     pub label: Option<String>,
     pub archive_path: String,
+    #[serde(default = "default_snapshot_storage_kind")]
+    pub storage_kind: String,
     pub source_root: String,
     pub gateway_port: Option<u32>,
+    #[serde(default)]
+    pub gateway_port_auto_assigned: bool,
     #[serde(default = "default_service_enabled")]
     pub service_enabled: bool,
     #[serde(default = "default_service_running")]
@@ -50,13 +58,43 @@ pub struct EnvSnapshotMeta {
     pub created_at: OffsetDateTime,
 }
 
+#[derive(Debug)]
+pub(crate) struct EnvSnapshotRestoreTransaction {
+    pub(crate) summary: EnvSnapshotRestoreSummary,
+    original: EnvMeta,
+    operation_root: PathBuf,
+    displaced_root: Option<PathBuf>,
+    rejected_root: PathBuf,
+    restored_root: PathBuf,
+}
+
+#[derive(Debug)]
+struct RestoreOperationNamespace {
+    root: PathBuf,
+    candidate_root: PathBuf,
+    backup_root: PathBuf,
+    legacy_staging_root: PathBuf,
+    rejected_root: PathBuf,
+}
+
 pub fn create_env_snapshot(
     options: CreateEnvSnapshotOptions,
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvSnapshotMeta, String> {
+    create_env_snapshot_with_service_state(options, None, env, cwd)
+}
+
+pub(crate) fn create_env_snapshot_with_service_state(
+    options: CreateEnvSnapshotOptions,
+    service_state: Option<(bool, bool)>,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvSnapshotMeta, String> {
     let env_name = validate_name(&options.env_name, "Environment name")?;
     let meta = get_environment(&env_name, env, cwd)?;
+    let (service_enabled, service_running) =
+        service_state.unwrap_or((meta.service_enabled, meta.service_running));
     let env_paths = derive_env_paths(Path::new(&meta.root));
     if !path_exists(&env_paths.root) {
         return Err(format!(
@@ -71,64 +109,36 @@ pub fn create_env_snapshot(
         created_at.unix_timestamp(),
         created_at.nanosecond()
     );
-    let archive_path = snapshot_archive_path(&env_name, &snapshot_id, env, cwd)?;
+    let checkpoint_path = snapshot_checkpoint_path(&env_name, &snapshot_id, env, cwd)?;
     let meta_path = snapshot_meta_path(&env_name, &snapshot_id, env, cwd)?;
 
-    let metadata = EnvArchiveMetadata {
-        kind: "ocm-env-archive".to_string(),
-        format_version: 1,
-        exported_at: created_at,
-        env: ArchivedEnvMeta {
-            name: meta.name.clone(),
-            source_root: Some(meta.root.clone()),
+    let result = (|| {
+        let storage_kind = create_tree_checkpoint(&env_paths.root, &checkpoint_path)?;
+        let snapshot = EnvSnapshotMeta {
+            kind: "ocm-env-snapshot".to_string(),
+            id: snapshot_id,
+            env_name: meta.name.clone(),
+            label: options.label,
+            archive_path: display_path(&checkpoint_path),
+            storage_kind,
+            source_root: meta.root.clone(),
             gateway_port: meta.gateway_port,
             gateway_port_auto_assigned: meta.gateway_port_auto_assigned,
-            service_enabled: meta.service_enabled,
-            service_running: meta.service_running,
+            service_enabled,
+            service_running,
             default_runtime: meta.default_runtime.clone(),
             default_launcher: meta.default_launcher.clone(),
             protected: meta.protected,
-            created_at: meta.created_at,
-            updated_at: meta.updated_at,
-            last_used_at: meta.last_used_at,
-        },
-    };
-
-    let snapshot = EnvSnapshotMeta {
-        kind: "ocm-env-snapshot".to_string(),
-        id: snapshot_id,
-        env_name: meta.name.clone(),
-        label: options.label,
-        archive_path: display_path(&archive_path),
-        source_root: meta.root.clone(),
-        gateway_port: meta.gateway_port,
-        service_enabled: meta.service_enabled,
-        service_running: meta.service_running,
-        default_runtime: meta.default_runtime.clone(),
-        default_launcher: meta.default_launcher.clone(),
-        protected: meta.protected,
-        created_at,
-    };
-
-    let result = (|| {
-        write_env_archive_with_options(
-            &metadata,
-            &env_paths.root,
-            &archive_path,
-            openclaw_env_snapshot_archive_options(
-                &env_paths,
-                env,
-                OpenClawWorkspaceRuntime::for_env(&meta.name, meta.gateway_port),
-            )?,
-        )?;
+            created_at,
+        };
         write_json(&meta_path, &snapshot)?;
         Ok(snapshot)
     })();
 
     if result.is_err() {
-        let _ = fs::remove_file(&archive_path);
+        let _ = remove_tree_if_present(&checkpoint_path);
         let _ = fs::remove_file(&meta_path);
-        if let Some(snapshot_dir) = archive_path.parent() {
+        if let Some(snapshot_dir) = checkpoint_path.parent() {
             let _ = fs::remove_dir(snapshot_dir);
         }
     }
@@ -163,6 +173,7 @@ pub fn summarize_snapshot(meta: &EnvSnapshotMeta) -> EnvSnapshotSummary {
         env_name: meta.env_name.clone(),
         label: meta.label.clone(),
         archive_path: meta.archive_path.clone(),
+        storage_kind: meta.storage_kind.clone(),
         source_root: meta.source_root.clone(),
         gateway_port: meta.gateway_port,
         service_enabled: meta.service_enabled,
@@ -179,35 +190,91 @@ pub fn restore_env_snapshot(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvSnapshotRestoreSummary, String> {
+    let transaction = prepare_env_snapshot_restore(options, env, cwd)?;
+    let summary = transaction.summary.clone();
+    commit_env_snapshot_restore(transaction)?;
+    Ok(summary)
+}
+
+pub(crate) fn prepare_env_snapshot_restore(
+    options: RestoreEnvSnapshotOptions,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvSnapshotRestoreTransaction, String> {
     let env_name = validate_name(&options.env_name, "Environment name")?;
     let snapshot = get_env_snapshot(&env_name, &options.snapshot_id, env, cwd)?;
     let current = get_environment(&env_name, env, cwd)?;
     let current_paths = derive_env_paths(Path::new(&current.root));
     let root_exists = path_exists(&current_paths.root);
 
-    let staging_dir = restore_staging_dir();
-    let backup_root = restore_backup_root(&current_paths.root);
-    if path_exists(&staging_dir) {
-        let _ = fs::remove_dir_all(&staging_dir);
-    }
+    let operation = create_restore_operation_namespace(&current_paths.root)?;
+    let staging_dir = operation.legacy_staging_root.clone();
+    let candidate_root = operation.candidate_root.clone();
+    let backup_root = operation.backup_root.clone();
 
     let result = (|| {
-        let extracted = extract_env_archive::<EnvArchiveMetadata>(
-            Path::new(&snapshot.archive_path),
-            &staging_dir,
-        )?;
-        if extracted.metadata.kind != "ocm-env-archive" {
-            return Err(format!(
-                "unsupported archive kind: {}",
-                extracted.metadata.kind
-            ));
-        }
-        if extracted.metadata.format_version != 1 {
-            return Err(format!(
-                "unsupported archive format version: {}",
-                extracted.metadata.format_version
-            ));
-        }
+        let (mut restored, legacy_archive) = if snapshot.storage_kind == STORAGE_TAR_ARCHIVE {
+            let extracted = extract_env_archive::<EnvArchiveMetadata>(
+                Path::new(&snapshot.archive_path),
+                &staging_dir,
+            )?;
+            if extracted.metadata.kind != "ocm-env-archive" {
+                return Err(format!(
+                    "unsupported archive kind: {}",
+                    extracted.metadata.kind
+                ));
+            }
+            if extracted.metadata.format_version != 1 {
+                return Err(format!(
+                    "unsupported archive format version: {}",
+                    extracted.metadata.format_version
+                ));
+            }
+            copy_dir_recursive(&extracted.root_dir, &candidate_root)?;
+            let archived = extracted.metadata.env;
+            (
+                EnvMeta {
+                    kind: "ocm-env".to_string(),
+                    name: current.name.clone(),
+                    root: current.root.clone(),
+                    gateway_port: archived.gateway_port,
+                    gateway_port_auto_assigned: archived.gateway_port_auto_assigned,
+                    service_enabled: archived.service_enabled,
+                    service_running: archived.service_running,
+                    default_runtime: archived.default_runtime,
+                    default_launcher: archived.default_launcher,
+                    dev: None,
+                    protected: archived.protected,
+                    created_at: current.created_at,
+                    updated_at: current.updated_at,
+                    last_used_at: current.last_used_at,
+                },
+                true,
+            )
+        } else {
+            copy_tree_checkpoint(Path::new(&snapshot.archive_path), &candidate_root)?;
+            clear_snapshot_runtime_residue(&candidate_root)?;
+            (
+                EnvMeta {
+                    kind: "ocm-env".to_string(),
+                    name: current.name.clone(),
+                    root: current.root.clone(),
+                    gateway_port: snapshot.gateway_port,
+                    gateway_port_auto_assigned: snapshot.gateway_port_auto_assigned,
+                    service_enabled: snapshot.service_enabled,
+                    service_running: snapshot.service_running,
+                    default_runtime: snapshot.default_runtime.clone(),
+                    default_launcher: snapshot.default_launcher.clone(),
+                    dev: None,
+                    protected: snapshot.protected,
+                    created_at: current.created_at,
+                    updated_at: current.updated_at,
+                    last_used_at: current.last_used_at,
+                },
+                false,
+            )
+        };
+
         let mut renamed = false;
         if root_exists {
             fs::rename(&current_paths.root, &backup_root).map_err(|error| error.to_string())?;
@@ -215,69 +282,277 @@ pub fn restore_env_snapshot(
         }
 
         let restore_result = (|| {
-            copy_dir_recursive(&extracted.root_dir, &current_paths.root)?;
-            rewrite_openclaw_config_for_target(
-                &current_paths,
-                Some(Path::new(&snapshot.source_root)),
-                extracted.metadata.env.gateway_port,
-            )?;
-
-            let restored = EnvMeta {
-                kind: "ocm-env".to_string(),
-                name: current.name.clone(),
-                root: current.root.clone(),
-                gateway_port: extracted.metadata.env.gateway_port,
-                gateway_port_auto_assigned: extracted.metadata.env.gateway_port_auto_assigned,
-                service_enabled: extracted.metadata.env.service_enabled,
-                service_running: extracted.metadata.env.service_running,
-                default_runtime: extracted.metadata.env.default_runtime.clone(),
-                default_launcher: extracted.metadata.env.default_launcher.clone(),
-                dev: None,
-                protected: extracted.metadata.env.protected,
-                created_at: current.created_at,
-                updated_at: current.updated_at,
-                last_used_at: current.last_used_at,
-            };
-            let known_envs = list_environments(env, cwd)?;
-            let audit = audit_openclaw_state(&restored, &known_envs, env);
-            if audit.repair_runtime_state {
-                clear_nonportable_runtime_state(
+            fs::rename(&candidate_root, &current_paths.root).map_err(|error| error.to_string())?;
+            if legacy_archive {
+                rewrite_openclaw_config_for_target(
                     &current_paths,
-                    env,
-                    OpenClawWorkspaceRuntime::for_env(&restored.name, restored.gateway_port),
+                    Some(Path::new(&snapshot.source_root)),
+                    restored.gateway_port,
                 )?;
+                let known_envs = list_environments(env, cwd)?;
+                let audit = audit_openclaw_state(&restored, &known_envs, env);
+                if audit.repair_runtime_state {
+                    clear_nonportable_runtime_state(
+                        &current_paths,
+                        env,
+                        OpenClawWorkspaceRuntime::for_env(&restored.name, restored.gateway_port),
+                    )?;
+                }
+                if renamed {
+                    preserve_current_excluded_openclaw_state(&backup_root, &current_paths.root)?;
+                }
             }
-            save_environment(restored, env, cwd)
+            restored = save_environment(restored, env, cwd)?;
+            Ok(restored.clone())
         })();
 
         match restore_result {
-            Ok(meta) => {
-                if renamed {
-                    let _ = fs::remove_dir_all(&backup_root);
-                }
-                Ok(EnvSnapshotRestoreSummary {
-                    env_name: meta.name,
+            Ok(meta) => Ok(EnvSnapshotRestoreTransaction {
+                summary: EnvSnapshotRestoreSummary {
+                    env_name: meta.name.clone(),
                     snapshot_id: snapshot.id,
                     label: snapshot.label,
-                    root: meta.root,
+                    root: meta.root.clone(),
                     archive_path: snapshot.archive_path,
-                    default_runtime: meta.default_runtime,
-                    default_launcher: meta.default_launcher,
+                    storage_kind: snapshot.storage_kind,
+                    default_runtime: meta.default_runtime.clone(),
+                    default_launcher: meta.default_launcher.clone(),
                     protected: meta.protected,
-                })
-            }
+                },
+                original: current.clone(),
+                operation_root: operation.root.clone(),
+                displaced_root: renamed.then_some(backup_root.clone()),
+                rejected_root: operation.rejected_root.clone(),
+                restored_root: current_paths.root.clone(),
+            }),
             Err(error) => {
-                let _ = fs::remove_dir_all(&current_paths.root);
-                if renamed {
-                    let _ = fs::rename(&backup_root, &current_paths.root);
+                match reinstate_displaced_environment_root(
+                    &current_paths.root,
+                    renamed.then_some(backup_root.as_path()),
+                    &operation.rejected_root,
+                    current.clone(),
+                    env,
+                    cwd,
+                ) {
+                    Ok(()) => match remove_tree_if_present(&operation.root) {
+                        Ok(()) => Err(error),
+                        Err(cleanup_error) => Err(format!(
+                            "{error}; the displaced environment root was restored, but rejected restore cleanup failed at {}: {cleanup_error}",
+                            display_path(&operation.root)
+                        )),
+                    },
+                    Err(rollback_error) => Err(format!(
+                        "{error}; restoring the displaced environment root also failed: {rollback_error}"
+                    )),
                 }
-                Err(error)
             }
         }
     })();
 
-    let _ = fs::remove_dir_all(&staging_dir);
+    if result.is_err() && !path_exists(&backup_root) {
+        let _ = remove_tree_if_present(&operation.root);
+    }
     result
+}
+
+pub(crate) fn commit_env_snapshot_restore(
+    transaction: EnvSnapshotRestoreTransaction,
+) -> Result<(), String> {
+    remove_tree_if_present(&transaction.operation_root).map_err(|error| {
+        format!(
+            "restored snapshot was accepted, but its operation namespace {} could not be removed: {error}",
+            display_path(&transaction.operation_root)
+        )
+    })
+}
+
+pub(crate) fn rollback_env_snapshot_restore(
+    transaction: EnvSnapshotRestoreTransaction,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<Option<String>, String> {
+    reinstate_displaced_environment_root(
+        &transaction.restored_root,
+        transaction.displaced_root.as_deref(),
+        &transaction.rejected_root,
+        transaction.original,
+        env,
+        cwd,
+    )?;
+    Ok(
+        remove_tree_if_present(&transaction.operation_root)
+            .err()
+            .map(|error| {
+                format!(
+                    "displaced environment root was restored, but its operation namespace {} could not be removed: {error}",
+                    display_path(&transaction.operation_root)
+                )
+            }),
+    )
+}
+
+fn reinstate_displaced_environment_root(
+    restored_root: &Path,
+    displaced_root: Option<&Path>,
+    rejected_root: &Path,
+    original: EnvMeta,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<(), String> {
+    fs::rename(restored_root, rejected_root).map_err(|error| {
+        format!(
+            "failed to retain rejected restored root {} at {}: {error}",
+            display_path(restored_root),
+            display_path(rejected_root)
+        )
+    })?;
+
+    if let Some(displaced_root) = displaced_root
+        && let Err(error) = fs::rename(displaced_root, restored_root)
+    {
+        let compensation = fs::rename(rejected_root, restored_root)
+            .err()
+            .map(|compensation_error| {
+                format!(
+                    "; restoring the rejected root after that failure also failed: {compensation_error}"
+                )
+            })
+            .unwrap_or_default();
+        return Err(format!(
+            "failed to atomically restore displaced environment root {} from {}: {error}{compensation}",
+            display_path(restored_root),
+            display_path(displaced_root)
+        ));
+    }
+
+    if let Err(error) = save_environment(original, env, cwd) {
+        let mut compensation_errors = Vec::new();
+        if let Some(displaced_root) = displaced_root
+            && let Err(compensation_error) = fs::rename(restored_root, displaced_root)
+        {
+            compensation_errors.push(format!(
+                "failed to move the displaced root back to {}: {compensation_error}",
+                display_path(displaced_root)
+            ));
+        }
+        if !path_exists(restored_root)
+            && let Err(compensation_error) = fs::rename(rejected_root, restored_root)
+        {
+            compensation_errors.push(format!(
+                "failed to restore the rejected root at {}: {compensation_error}",
+                display_path(restored_root)
+            ));
+        }
+        return Err(if compensation_errors.is_empty() {
+            format!(
+                "failed to restore the environment registry entry; the restored root was reinstated: {error}"
+            )
+        } else {
+            format!(
+                "failed to restore the environment registry entry: {error}; rollback compensation also failed: {}",
+                compensation_errors.join("; ")
+            )
+        });
+    }
+    Ok(())
+}
+
+fn preserve_current_excluded_openclaw_state(
+    backup_root: &Path,
+    restored_root: &Path,
+) -> Result<(), String> {
+    let source_root = backup_root.join(".openclaw");
+    let entries = match fs::read_dir(&source_root) {
+        Ok(entries) => entries
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    let destination_root = restored_root.join(".openclaw");
+    for entry in entries {
+        let name = entry.file_name();
+        let source = entry.path();
+        let destination = destination_root.join(&name);
+        let metadata = fs::symlink_metadata(&source).map_err(|error| error.to_string())?;
+        if should_discard_current_openclaw_restore_entry(&name, metadata.is_dir()) {
+            continue;
+        }
+
+        let current_state_wins = matches!(name.to_str(), Some("secrets") | Some("browser"));
+        if !current_state_wins && path_exists(&destination) {
+            continue;
+        }
+
+        remove_path_if_present(&destination)?;
+        copy_path_recursive(&source, &destination).map_err(|error| {
+            format!(
+                "failed to preserve current excluded OpenClaw state at {} while restoring snapshot: {error}",
+                display_path(&source)
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn should_discard_current_openclaw_restore_entry(name: &OsStr, is_dir: bool) -> bool {
+    if is_dir
+        && matches!(
+            name.to_str(),
+            Some("run") | Some("tmp") | Some("temp") | Some("locks")
+        )
+    {
+        return true;
+    }
+
+    matches!(
+        Path::new(name).extension().and_then(OsStr::to_str),
+        Some("pid") | Some("lock") | Some("sock") | Some("socket")
+    ) || matches!(
+        name.to_str(),
+        Some("pid")
+            | Some("lock")
+            | Some("sock")
+            | Some("socket")
+            | Some("gateway-supervisor-restart-handoff.json")
+    )
+}
+
+fn clear_snapshot_runtime_residue(root: &Path) -> Result<(), String> {
+    let openclaw_root = root.join(".openclaw");
+    if !path_exists(&openclaw_root) {
+        return Ok(());
+    }
+    let entries = match fs::read_dir(&openclaw_root) {
+        Ok(entries) => entries
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.to_string()),
+    };
+    for entry in entries {
+        let entry_path = entry.path();
+        let metadata = fs::symlink_metadata(&entry_path).map_err(|error| error.to_string())?;
+        if should_discard_current_openclaw_restore_entry(&entry.file_name(), metadata.is_dir()) {
+            remove_path_if_present(&entry_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_path_if_present(path: &Path) -> Result<(), String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    if metadata.is_dir() {
+        fs::remove_dir_all(path).map_err(|error| error.to_string())
+    } else {
+        fs::remove_file(path).map_err(|error| error.to_string())
+    }
 }
 
 pub fn remove_env_snapshot(
@@ -287,10 +562,10 @@ pub fn remove_env_snapshot(
 ) -> Result<EnvSnapshotRemoveSummary, String> {
     let snapshot = get_env_snapshot(&options.env_name, &options.snapshot_id, env, cwd)?;
     let meta_path = snapshot_meta_path(&snapshot.env_name, &snapshot.id, env, cwd)?;
-    let archive_path = PathBuf::from(&snapshot.archive_path);
+    let artifact_path = PathBuf::from(&snapshot.archive_path);
     let staging_dir = snapshot_removal_staging_dir(&snapshot.env_name, &snapshot.id, env, cwd)?;
     let staged_meta_path = staging_dir.join("snapshot.json");
-    let staged_archive_path = staging_dir.join("snapshot.tar");
+    let staged_artifact_path = staging_dir.join("artifact");
 
     fs::create_dir(&staging_dir).map_err(|error| {
         format!(
@@ -307,16 +582,16 @@ pub fn remove_env_snapshot(
         ));
     }
 
-    if path_exists(&archive_path)
-        && let Err(error) = fs::rename(&archive_path, &staged_archive_path)
+    if path_exists(&artifact_path)
+        && let Err(error) = fs::rename(&artifact_path, &staged_artifact_path)
     {
         let restore_error = fs::rename(&staged_meta_path, &meta_path).err();
         if restore_error.is_none() {
             let _ = fs::remove_dir(&staging_dir);
         }
         return Err(format!(
-            "failed to stage snapshot archive {} for removal: {error}{}",
-            display_path(&archive_path),
+            "failed to stage snapshot artifact {} for removal: {error}{}",
+            display_path(&artifact_path),
             restore_error
                 .map(|restore_error| {
                     format!("; restoring the staged metadata also failed: {restore_error}")
@@ -350,6 +625,7 @@ pub fn remove_env_snapshot(
         snapshot_id: snapshot.id,
         label: snapshot.label,
         archive_path: snapshot.archive_path,
+        storage_kind: snapshot.storage_kind,
         warnings,
     })
 }
@@ -438,12 +714,24 @@ fn validate_env_snapshot_identity(
             snapshot.id
         ));
     }
-    let expected_archive = snapshot_archive_path(env_name, snapshot_id, env, cwd)?;
-    if Path::new(&snapshot.archive_path) != expected_archive {
+    let expected_artifact = if snapshot.storage_kind == STORAGE_TAR_ARCHIVE {
+        snapshot_archive_path(env_name, snapshot_id, env, cwd)?
+    } else if matches!(
+        snapshot.storage_kind.as_str(),
+        super::checkpoints::STORAGE_APFS_CLONE | super::checkpoints::STORAGE_FULL_COPY
+    ) {
+        snapshot_checkpoint_path(env_name, snapshot_id, env, cwd)?
+    } else {
         return Err(format!(
-            "snapshot \"{snapshot_id}\" archive path is {}, expected {}",
+            "unsupported snapshot storage kind: {}",
+            snapshot.storage_kind
+        ));
+    };
+    if Path::new(&snapshot.archive_path) != expected_artifact {
+        return Err(format!(
+            "snapshot \"{snapshot_id}\" artifact path is {}, expected {}",
             snapshot.archive_path,
-            display_path(&expected_archive)
+            display_path(&expected_artifact)
         ));
     }
     Ok(())
@@ -458,11 +746,30 @@ fn sort_snapshots(snapshots: &mut [EnvSnapshotMeta]) {
     });
 }
 
-fn restore_staging_dir() -> PathBuf {
-    let id = NEXT_RESTORE_ID.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir()
-        .join("ocm-snapshot-restores")
-        .join(format!("{}-{id}", std::process::id()))
+fn create_restore_operation_namespace(root: &Path) -> Result<RestoreOperationNamespace, String> {
+    let parent = root.parent().unwrap_or_else(|| Path::new("."));
+    let env_name = root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("env");
+    let prefix = format!(".{env_name}-ocm-restore-");
+    let operation_root = tempfile::Builder::new()
+        .prefix(&prefix)
+        .tempdir_in(parent)
+        .map_err(|error| {
+            format!(
+                "failed to create an exclusive restore namespace beside {}: {error}",
+                display_path(root)
+            )
+        })?
+        .keep();
+    Ok(RestoreOperationNamespace {
+        candidate_root: operation_root.join("candidate"),
+        backup_root: operation_root.join("displaced"),
+        legacy_staging_root: operation_root.join("legacy"),
+        rejected_root: operation_root.join("rejected"),
+        root: operation_root,
+    })
 }
 
 fn snapshot_removal_staging_dir(
@@ -474,20 +781,6 @@ fn snapshot_removal_staging_dir(
     let id = NEXT_REMOVAL_ID.fetch_add(1, Ordering::Relaxed);
     Ok(snapshot_env_dir(env_name, env, cwd)?
         .join(format!(".remove-{snapshot_id}-{}-{id}", std::process::id())))
-}
-
-fn restore_backup_root(root: &Path) -> PathBuf {
-    let id = NEXT_RESTORE_ID.fetch_add(1, Ordering::Relaxed);
-    let backup_name = format!(
-        ".{}-ocm-restore-{}-{id}",
-        root.file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or("env"),
-        std::process::id()
-    );
-    root.parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join(backup_name)
 }
 
 fn remove_snapshot_parent_if_empty(

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -1,11 +1,78 @@
 mod support;
 
+use std::process::{Command, Stdio};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread;
+use std::time::Duration;
 use std::{fs, path::Path};
 
+use ocm::store::{env_registry_path, now_utc, supervisor_runtime_path};
+use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 
-use crate::support::{TestDir, ocm_env, run_ocm, stderr, stdout, write_text};
+use crate::support::{
+    TestDir, TestHttpServer, install_fake_launchctl, ocm_env, path_string, run_ocm, stderr, stdout,
+    write_executable_script, write_text,
+};
+
+fn write_running_snapshot_service(
+    root: &TestDir,
+    cwd: &Path,
+    env: &std::collections::BTreeMap<String, String>,
+    port: u32,
+) {
+    let runtime_path = supervisor_runtime_path(env, cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let stdout_path = path_string(&root.child("source.stdout.log"));
+    let stderr_path = path_string(&root.child("source.stderr.log"));
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: env.get("OCM_HOME").unwrap().clone(),
+        updated_at: now_utc(),
+        services: vec![SupervisorRuntimeService {
+            env_name: "source".to_string(),
+            binding_kind: "launcher".to_string(),
+            binding_name: "stable".to_string(),
+            gateway_state: "running".to_string(),
+            restart_handoff: Some("none".to_string()),
+            restart_count: 0,
+            child_port: port,
+            pid: Some(4242),
+            stdout_path: stdout_path.clone(),
+            stderr_path: stderr_path.clone(),
+            last_exit_code: None,
+            last_error: None,
+            last_event_at: None,
+            next_retry_at: None,
+        }],
+        children: vec![SupervisorRuntimeChild {
+            env_name: "source".to_string(),
+            binding_kind: "launcher".to_string(),
+            binding_name: "stable".to_string(),
+            pid: 4242,
+            restart_count: 0,
+            child_port: port,
+            stdout_path,
+            stderr_path,
+        }],
+    };
+    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+}
+
+fn write_empty_snapshot_service(runtime_path: &Path, ocm_home: &str) {
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: ocm_home.to_string(),
+        updated_at: now_utc(),
+        services: Vec::new(),
+        children: Vec::new(),
+    };
+    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+}
 
 #[test]
 fn env_snapshot_create_captures_the_current_environment_state() {
@@ -269,8 +336,423 @@ fn env_snapshot_restore_reverts_state_from_the_selected_snapshot() {
     );
 }
 
+#[cfg(unix)]
 #[test]
-fn env_snapshot_restore_preserves_device_pairing_state_while_clearing_foreign_runtime_refs() {
+fn env_snapshot_restores_the_complete_durable_root_with_metadata_and_sqlite() {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+
+    let root = TestDir::new("env-snapshot-complete-durable-root");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let env_root = root.child("ocm-home/envs/source");
+    let dotenv = env_root.join(".openclaw/.env");
+    let secret = env_root.join(".openclaw/secrets/telegram/default.token");
+    let future_state = env_root.join("durable-future/state.txt");
+    let future_non_sqlite_db = env_root.join("durable-future/cache.db");
+    let future_link = env_root.join("durable-future/state-link");
+    let database_path = env_root.join(".openclaw/state/durable.sqlite");
+    write_text(&dotenv, "OPENCLAW_SENTINEL=before\n");
+    write_text(&secret, "secret-before\n");
+    write_text(&future_state, "future-before\n");
+    write_text(&future_non_sqlite_db, "opaque future cache\n");
+    fs::set_permissions(&secret, fs::Permissions::from_mode(0o600)).unwrap();
+    symlink("state.txt", &future_link).unwrap();
+    fs::create_dir_all(database_path.parent().unwrap()).unwrap();
+    let database = Connection::open(&database_path).unwrap();
+    database
+        .execute_batch(
+            "CREATE TABLE durable_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO durable_state VALUES ('sentinel', 'before');",
+        )
+        .unwrap();
+    drop(database);
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--json"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    let snapshot_id = snapshot_json["id"].as_str().unwrap();
+
+    write_text(&dotenv, "OPENCLAW_SENTINEL=after\n");
+    write_text(&secret, "secret-after\n");
+    fs::remove_file(&future_link).unwrap();
+    fs::remove_file(&future_state).unwrap();
+    let database = Connection::open(&database_path).unwrap();
+    database
+        .execute(
+            "UPDATE durable_state SET value = 'after' WHERE key = 'sentinel'",
+            [],
+        )
+        .unwrap();
+    drop(database);
+
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+
+    assert_eq!(
+        fs::read_to_string(&dotenv).unwrap(),
+        "OPENCLAW_SENTINEL=before\n"
+    );
+    assert_eq!(fs::read_to_string(&secret).unwrap(), "secret-before\n");
+    assert_eq!(fs::metadata(&secret).unwrap().mode() & 0o777, 0o600);
+    assert_eq!(
+        fs::read_to_string(&future_state).unwrap(),
+        "future-before\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&future_non_sqlite_db).unwrap(),
+        "opaque future cache\n"
+    );
+    assert_eq!(fs::read_link(&future_link).unwrap(), Path::new("state.txt"));
+
+    let restored = Connection::open_with_flags(
+        &database_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .unwrap();
+    let value: String = restored
+        .query_row(
+            "SELECT value FROM durable_state WHERE key = 'sentinel'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(value, "before");
+    let integrity: String = restored
+        .query_row("PRAGMA quick_check", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(integrity, "ok");
+}
+
+#[test]
+fn env_snapshot_restore_does_not_collide_with_or_delete_a_foreign_restore_path() {
+    let root = TestDir::new("env-snapshot-foreign-restore-path");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let workspace = root.child("ocm-home/envs/source/.openclaw/workspace/collision-fixture");
+    for index in 0..2_048 {
+        write_text(
+            &workspace.join(format!("entry-{index:04}.txt")),
+            "snapshot payload\n",
+        );
+    }
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--json"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    let snapshot_id = snapshot_json["id"].as_str().unwrap().to_string();
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    command
+        .current_dir(&cwd)
+        .args(["env", "snapshot", "restore", "source", snapshot_id.as_str()])
+        .env_clear()
+        .envs(&env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = command.spawn().unwrap();
+    let foreign_root = root.child(format!(
+        "ocm-home/envs/.source-ocm-restore-{}-1",
+        child.id()
+    ));
+    let foreign_marker = foreign_root.join("owned-by-someone-else.txt");
+    write_text(&foreign_marker, "do not delete\n");
+
+    let restore = child.wait_with_output().unwrap();
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    assert_eq!(
+        fs::read_to_string(&foreign_marker).unwrap(),
+        "do not delete\n"
+    );
+}
+
+#[test]
+fn env_snapshot_restore_recovers_the_displaced_root_when_acceptance_fails() {
+    let root = TestDir::new("env-snapshot-acceptance-rollback");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "source", "--launcher", "stable"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
+    let notes = root.child("ocm-home/envs/source/.openclaw/workspace/notes.txt");
+    write_text(&notes, "snapshot-state\n");
+    #[cfg(unix)]
+    let rejected_read_only_dir =
+        root.child("ocm-home/envs/source/.openclaw/future-durable/read-only");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        write_text(&rejected_read_only_dir.join("state.txt"), "snapshot-only\n");
+        fs::set_permissions(&rejected_read_only_dir, fs::Permissions::from_mode(0o555)).unwrap();
+    }
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--json"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    let snapshot_id = snapshot_json["id"].as_str().unwrap();
+    let artifact = Path::new(snapshot_json["archivePath"].as_str().unwrap());
+    let metadata_path = artifact
+        .parent()
+        .unwrap()
+        .join(format!("{snapshot_id}.json"));
+    let mut metadata: Value = serde_json::from_slice(&fs::read(&metadata_path).unwrap()).unwrap();
+    metadata["serviceEnabled"] = Value::Bool(true);
+    metadata["serviceRunning"] = Value::Bool(true);
+    fs::write(
+        &metadata_path,
+        serde_json::to_vec_pretty(&metadata).unwrap(),
+    )
+    .unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(&rejected_read_only_dir, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::remove_dir_all(&rejected_read_only_dir).unwrap();
+    }
+    write_text(&notes, "pre-restore-current-state\n");
+    let launchctl_bin = env.get("OCM_INTERNAL_LAUNCHCTL_BIN").unwrap();
+    write_executable_script(
+        Path::new(launchctl_bin),
+        "#!/bin/sh\ncase \"$1\" in\n  managername) exit 0 ;;\n  print) exit 1 ;;\n  bootstrap) echo 'forced acceptance failure' >&2; exit 1 ;;\n  *) exit 0 ;;\nesac\n",
+    );
+
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", snapshot_id],
+    );
+    assert!(!restore.status.success(), "{}", stdout(&restore));
+    assert!(
+        stderr(&restore).contains("failed managed-service acceptance"),
+        "{}",
+        stderr(&restore)
+    );
+    assert_eq!(
+        fs::read_to_string(&notes).unwrap(),
+        "pre-restore-current-state\n"
+    );
+    let operation_namespaces = fs::read_dir(root.child("ocm-home/envs"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().contains("ocm-restore"))
+        .count();
+    assert_eq!(operation_namespaces, 0);
+}
+
+#[test]
+fn env_snapshot_restore_remains_compatible_with_legacy_tar_metadata() {
+    let root = TestDir::new("env-snapshot-legacy-tar");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(create.status.success(), "{}", stderr(&create));
+    let notes = root.child("ocm-home/envs/source/.openclaw/workspace/notes.txt");
+    write_text(&notes, "legacy-snapshot\n");
+
+    let snapshot_id = "1700000000-000000001";
+    let snapshot_dir = root.child("ocm-home/snapshots/source");
+    fs::create_dir_all(&snapshot_dir).unwrap();
+    let archive_path = snapshot_dir.join(format!("{snapshot_id}.tar"));
+    let export = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "export",
+            "source",
+            "--output",
+            archive_path.to_str().unwrap(),
+        ],
+    );
+    assert!(export.status.success(), "{}", stderr(&export));
+    let metadata = serde_json::json!({
+        "kind": "ocm-env-snapshot",
+        "id": snapshot_id,
+        "envName": "source",
+        "label": "legacy",
+        "archivePath": archive_path,
+        "sourceRoot": root.child("ocm-home/envs/source"),
+        "gatewayPort": 18789,
+        "serviceEnabled": false,
+        "serviceRunning": false,
+        "defaultRuntime": null,
+        "defaultLauncher": null,
+        "protected": false,
+        "createdAt": "2023-11-14T22:13:20Z"
+    });
+    fs::write(
+        snapshot_dir.join(format!("{snapshot_id}.json")),
+        serde_json::to_vec_pretty(&metadata).unwrap(),
+    )
+    .unwrap();
+
+    write_text(&notes, "current-state\n");
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    assert_eq!(fs::read_to_string(&notes).unwrap(), "legacy-snapshot\n");
+}
+
+#[test]
+fn env_snapshot_create_and_restore_quiesce_a_running_managed_gateway() {
+    let root = TestDir::new("env-snapshot-cold-lifecycle");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let health = TestHttpServer::serve_bytes_times("/health", "text/plain", b"ok", 20);
+    let health_port = url::Url::parse(&health.url()).unwrap().port().unwrap() as u32;
+
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "create",
+            "source",
+            "--port",
+            &health_port.to_string(),
+            "--launcher",
+            "stable",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let started = run_ocm(&cwd, &env, &["service", "start", "source"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    write_running_snapshot_service(&root, &cwd, &env, health_port);
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let running_runtime = fs::read(&runtime_path).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_stop = Arc::clone(&observer_done);
+    let observer = thread::spawn(move || {
+        let mut last_running = true;
+        while !observer_stop.load(Ordering::Relaxed) {
+            let desired_running = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|registry| registry["envs"].as_array().cloned())
+                .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "source"))
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_running);
+            if desired_running != last_running {
+                if desired_running {
+                    fs::write(&runtime_path, &running_runtime).unwrap();
+                } else {
+                    write_empty_snapshot_service(&runtime_path, &ocm_home);
+                }
+                last_running = desired_running;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+    });
+
+    let notes = root.child("ocm-home/envs/source/.openclaw/workspace/notes.txt");
+    write_text(&notes, "before snapshot\n");
+    fs::write(root.child("launchctl.log"), "").unwrap();
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--label", "cold"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let create_lifecycle = fs::read_to_string(root.child("launchctl.log")).unwrap();
+    let create_stop = create_lifecycle.find("bootout gui/").unwrap();
+    let create_start = create_lifecycle.rfind("bootstrap gui/").unwrap();
+    assert!(create_stop < create_start, "{create_lifecycle}");
+
+    let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source", "--json"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    let list_json: Value = serde_json::from_str(&stdout(&list)).unwrap();
+    assert_eq!(list_json[0]["serviceRunning"], true);
+    let snapshot_id = list_json[0]["id"].as_str().unwrap().to_string();
+
+    write_text(&notes, "after snapshot\n");
+    fs::write(root.child("launchctl.log"), "").unwrap();
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", &snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    let restore_lifecycle = fs::read_to_string(root.child("launchctl.log")).unwrap();
+    let restore_stop = restore_lifecycle.find("bootout gui/").unwrap();
+    let restore_start = restore_lifecycle.rfind("bootstrap gui/").unwrap();
+    assert!(restore_stop < restore_start, "{restore_lifecycle}");
+    assert_eq!(fs::read_to_string(&notes).unwrap(), "before snapshot\n");
+
+    let shown = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown_json: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown_json["serviceRunning"], true);
+    observer_done.store(true, Ordering::Relaxed);
+    observer.join().unwrap();
+}
+
+#[test]
+fn env_snapshot_restore_preserves_device_pairing_and_session_state() {
     let root = TestDir::new("env-snapshot-device-pairing-state");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -328,7 +810,7 @@ fn env_snapshot_restore_preserves_device_pairing_state_while_clearing_foreign_ru
         .unwrap();
     assert_eq!(token, "must-survive");
     assert!(
-        !source_state
+        source_state
             .join("agents/main/sessions/main.jsonl")
             .exists()
     );
@@ -484,8 +966,8 @@ fn env_snapshot_restore_preserves_configured_agent_workspaces_and_includes() {
         "custom workspace before upgrade\n"
     );
     assert!(source_state.join("config/agents.json5").exists());
-    assert!(!source_state.join("workspace-attestations").exists());
-    assert!(!source_state.join("workspace-cache").exists());
+    assert!(source_state.join("workspace-attestations").exists());
+    assert!(source_state.join("workspace-cache").exists());
 }
 
 #[test]
@@ -546,7 +1028,7 @@ fn env_snapshot_preserves_keyed_include_order_when_overriding_an_agent() {
 }
 
 #[test]
-fn env_snapshot_ignores_openclaw_blocked_keyed_agents() {
+fn env_snapshot_preserves_unknown_agent_workspace_directories() {
     let root = TestDir::new("env-snapshot-blocked-keyed-agent");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -609,11 +1091,14 @@ fn env_snapshot_ignores_openclaw_blocked_keyed_agents() {
         fs::read_to_string(source_state.join("team/real.txt")).unwrap(),
         "actual OpenClaw default workspace\n"
     );
-    assert!(!source_state.join("ignored").exists());
+    assert_eq!(
+        fs::read_to_string(source_state.join("ignored/ignored.txt")).unwrap(),
+        "ignored keyed agent workspace\n"
+    );
 }
 
 #[test]
-fn env_snapshot_uses_openclaw_config_env_precedence_for_workspace_selection() {
+fn env_snapshot_preserves_all_in_root_workspace_state() {
     let root = TestDir::new("env-snapshot-config-env-precedence");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -666,7 +1151,10 @@ fn env_snapshot_uses_openclaw_config_env_precedence_for_workspace_selection() {
         fs::read_to_string(active_workspace.join("notes.txt")).unwrap(),
         "active workspace\n"
     );
-    assert!(!vars_workspace.exists());
+    assert_eq!(
+        fs::read_to_string(vars_workspace.join("notes.txt")).unwrap(),
+        "inactive workspace\n"
+    );
 }
 
 #[test]
@@ -724,7 +1212,7 @@ fn env_snapshot_uses_the_environment_runtime_identity_for_workspace_selection() 
 }
 
 #[test]
-fn env_snapshot_rejects_external_workspaces_before_writing_an_archive() {
+fn env_snapshot_records_external_workspace_configuration_without_following_it() {
     let root = TestDir::new("env-snapshot-external-workspace");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -743,16 +1231,21 @@ fn env_snapshot_rejects_external_workspaces_before_writing_an_archive() {
     );
 
     let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
-    assert_eq!(snapshot.status.code(), Some(1));
-    assert!(
-        stderr(&snapshot).contains("outside the environment root"),
-        "{}",
-        stderr(&snapshot)
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    write_text(&external.join("notes.txt"), "external data changed\n");
+    let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source", "--json"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    let list_json: Value = serde_json::from_str(&stdout(&list)).unwrap();
+    let snapshot_id = list_json[0]["id"].as_str().unwrap();
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", snapshot_id],
     );
-    assert!(!root.child("ocm-home/snapshots/source").exists());
+    assert!(restore.status.success(), "{}", stderr(&restore));
     assert_eq!(
         fs::read_to_string(external.join("notes.txt")).unwrap(),
-        "external data\n"
+        "external data changed\n"
     );
 }
 
@@ -766,7 +1259,8 @@ fn env_snapshot_removes_partial_artifacts_when_sqlite_snapshot_fails() {
     let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
     assert!(create.status.success(), "{}", stderr(&create));
     let database = root.child("ocm-home/envs/source/.openclaw/state/openclaw.sqlite");
-    write_text(&database, "not a sqlite database\n");
+    fs::create_dir_all(database.parent().unwrap()).unwrap();
+    fs::write(&database, b"SQLite format 3\0not a valid database").unwrap();
 
     let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
     assert_eq!(snapshot.status.code(), Some(1));
@@ -777,7 +1271,7 @@ fn env_snapshot_removes_partial_artifacts_when_sqlite_snapshot_fails() {
     );
     assert_eq!(
         fs::read_to_string(&database).unwrap(),
-        "not a sqlite database\n"
+        "SQLite format 3\0not a valid database"
     );
     assert!(!root.child("ocm-home/snapshots/source").exists());
 }
@@ -884,7 +1378,7 @@ fn env_snapshot_restore_rewrites_openclaw_config_for_the_current_root() {
 
 #[cfg(unix)]
 #[test]
-fn env_snapshot_restore_materializes_a_config_symlink_even_without_textual_drift() {
+fn env_snapshot_restore_preserves_a_config_symlink_without_following_it() {
     let root = TestDir::new("env-snapshot-restore-config-symlink");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -932,24 +1426,13 @@ fn env_snapshot_restore_materializes_a_config_symlink_even_without_textual_drift
         fs::symlink_metadata(&source_config)
             .unwrap()
             .file_type()
-            .is_file()
+            .is_symlink()
     );
-    let restored: Value =
-        serde_json::from_str(&fs::read_to_string(&source_config).unwrap()).unwrap();
-    assert_eq!(
-        restored["agents"]["defaults"]["workspace"].as_str(),
-        Some(
-            source_root
-                .join(".openclaw/workspace")
-                .to_string_lossy()
-                .as_ref()
-        )
-    );
-    assert_eq!(restored["gateway"]["port"].as_u64(), Some(19789));
+    assert_eq!(fs::read_link(&source_config).unwrap(), external_config);
 }
 
 #[test]
-fn env_snapshot_restore_repairs_foreign_runtime_state_in_the_restored_snapshot() {
+fn env_snapshot_restore_preserves_captured_session_state() {
     let root = TestDir::new("env-snapshot-restore-runtime-repair");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -1013,7 +1496,7 @@ fn env_snapshot_restore_repairs_foreign_runtime_state_in_the_restored_snapshot()
             .exists()
     );
     assert!(
-        !source_root
+        source_root
             .join(".openclaw/agents/main/sessions/main.jsonl")
             .exists()
     );

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -604,7 +604,9 @@ fn nested_snapshot_help_is_available() {
     assert!(remove.status.success(), "{}", stderr(&remove));
     let output = stdout(&remove);
     assert!(output.contains("ocm env snapshot remove <name> <snapshot> [--raw] [--json]"));
-    assert!(output.contains("validates the stored environment, snapshot ID, and archive path"));
+    assert!(output.contains(
+        "validates the stored environment, snapshot ID, storage kind, and artifact path"
+    ));
     assert!(output.contains("later cleanup failures are reported as warnings"));
 
     let prune = run_ocm(&cwd, &env, &["help", "env", "snapshot", "prune"]);

--- a/tests/store_flow_tests.rs
+++ b/tests/store_flow_tests.rs
@@ -1096,20 +1096,20 @@ fn environment_snapshot_captures_a_named_point_in_time() {
 
     assert_eq!(snapshot.env_name, "source");
     assert_eq!(snapshot.label.as_deref(), Some("before-upgrade"));
-    assert!(snapshot.archive_path.ends_with(".tar"));
+    assert!(snapshot.archive_path.ends_with(".checkpoint"));
+    assert!(matches!(
+        snapshot.storage_kind.as_str(),
+        "apfs-clone-v1" | "full-copy-v1"
+    ));
 
     let fetched = get_env_snapshot("source", &snapshot.id, &env, &cwd).unwrap();
     assert_eq!(fetched.id, snapshot.id);
 
-    let extract_dir = root.child("snapshot-extracted");
-    let extracted = extract_env_archive::<EnvArchiveMetadata>(
-        std::path::Path::new(&snapshot.archive_path),
-        &extract_dir,
-    )
-    .unwrap();
-    assert_eq!(extracted.metadata.env.name, "source");
     assert_eq!(
-        fs::read_to_string(extracted.root_dir.join(".openclaw/workspace/notes.txt")).unwrap(),
+        fs::read_to_string(
+            std::path::Path::new(&snapshot.archive_path).join(".openclaw/workspace/notes.txt")
+        )
+        .unwrap(),
         "hello snapshot"
     );
 }
@@ -1197,9 +1197,6 @@ fn environment_snapshot_restores_live_global_and_agent_sqlite_state() {
 
     for database in [&global_database, &agent_database] {
         assert!(database.exists());
-        assert!(!database.with_extension("sqlite-wal").exists());
-        assert!(!database.with_extension("sqlite-shm").exists());
-        assert!(!database.with_extension("sqlite-journal").exists());
         let restored = Connection::open_with_flags(
             database,
             OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -1222,7 +1219,7 @@ fn environment_snapshot_restores_live_global_and_agent_sqlite_state() {
 
 #[cfg(unix)]
 #[test]
-fn environment_snapshot_preserves_managed_plugin_payloads_and_skips_runtime_debris() {
+fn environment_snapshot_captures_the_complete_root_and_clears_runtime_residue_on_restore() {
     let root = TestDir::new("store-env-snapshot-legacy-plugin-deps");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -1368,36 +1365,23 @@ fn environment_snapshot_preserves_managed_plugin_payloads_and_skips_runtime_debr
     )
     .unwrap();
 
-    let extract_dir = root.child("snapshot-extracted");
-    let extracted = extract_env_archive::<EnvArchiveMetadata>(
-        std::path::Path::new(&snapshot.archive_path),
-        &extract_dir,
-    )
-    .unwrap();
+    let checkpoint_root = std::path::Path::new(&snapshot.archive_path);
     assert_eq!(
-        fs::read_to_string(extracted.root_dir.join(".openclaw/workspace/notes.txt")).unwrap(),
+        fs::read_to_string(checkpoint_root.join(".openclaw/workspace/notes.txt")).unwrap(),
         "hello snapshot"
     );
     assert_eq!(
-        fs::read_to_string(extracted.root_dir.join(".openclaw/openclaw.json")).unwrap(),
+        fs::read_to_string(checkpoint_root.join(".openclaw/openclaw.json")).unwrap(),
         "{\"gateway\":{\"port\":19789}}\n"
     );
     assert_eq!(
-        fs::read_to_string(
-            extracted
-                .root_dir
-                .join(".openclaw/agents/main/agent/auth-profiles.json")
-        )
-        .unwrap(),
+        fs::read_to_string(checkpoint_root.join(".openclaw/agents/main/agent/auth-profiles.json"))
+            .unwrap(),
         "{\"default\":\"ok\"}\n"
     );
     assert_eq!(
-        fs::read_to_string(
-            extracted
-                .root_dir
-                .join(".openclaw/agents/main/sessions/main.jsonl")
-        )
-        .unwrap(),
+        fs::read_to_string(checkpoint_root.join(".openclaw/agents/main/sessions/main.jsonl"))
+            .unwrap(),
         "{\"runtime\":\"session\"}\n"
     );
     for path in [
@@ -1415,63 +1399,48 @@ fn environment_snapshot_preserves_managed_plugin_payloads_and_skips_runtime_debr
         ".openclaw/git/git-demo/repo/.git/HEAD",
         ".openclaw/git/git-demo/repo/openclaw.plugin.json",
     ] {
-        assert!(extracted.root_dir.join(path).exists(), "{path}");
+        assert!(checkpoint_root.join(path).exists(), "{path}");
     }
     assert!(
-        fs::symlink_metadata(extracted.root_dir.join(".openclaw/workspace/missing-link"))
+        fs::symlink_metadata(checkpoint_root.join(".openclaw/workspace/missing-link"))
             .unwrap()
             .file_type()
             .is_symlink()
     );
     assert!(
         fs::symlink_metadata(
-            extracted
-                .root_dir
-                .join(".openclaw/npm/projects/demo/node_modules/demo-link")
+            checkpoint_root.join(".openclaw/npm/projects/demo/node_modules/demo-link")
         )
         .unwrap()
         .file_type()
         .is_symlink()
     );
-    assert!(
-        !extracted
-            .root_dir
-            .join(".openclaw/plugin-runtime-deps")
-            .exists()
-    );
-    assert!(
-        !extracted
-            .root_dir
-            .join(".openclaw/bundled-plugin-runtime-deps")
-            .exists()
-    );
-    assert!(
-        !extracted
-            .root_dir
-            .join(".openclaw/.local/bundled-plugin-runtime-deps")
-            .exists()
-    );
-    assert!(!extracted.root_dir.join(".openclaw/run").exists());
-    assert!(!extracted.root_dir.join(".openclaw/logs").exists());
-    assert!(!extracted.root_dir.join(".openclaw/cache").exists());
-    assert!(
-        !extracted
-            .root_dir
-            .join(".openclaw/extensions/demo/.openclaw-runtime-deps.json")
-            .exists()
-    );
-    assert!(
-        !extracted
-            .root_dir
-            .join(".openclaw/extensions/demo/node_modules")
-            .exists()
-    );
-    assert!(
-        !extracted
-            .root_dir
-            .join(".openclaw/future-runtime-cache")
-            .exists()
-    );
+    for path in [
+        ".openclaw/plugin-runtime-deps",
+        ".openclaw/bundled-plugin-runtime-deps",
+        ".openclaw/.local/bundled-plugin-runtime-deps",
+        ".openclaw/run",
+        ".openclaw/logs",
+        ".openclaw/cache",
+        ".openclaw/extensions/demo/.openclaw-runtime-deps.json",
+        ".openclaw/extensions/demo/node_modules",
+        ".openclaw/future-runtime-cache",
+    ] {
+        assert!(checkpoint_root.join(path).exists(), "{path}");
+    }
+
+    restore_env_snapshot(
+        RestoreEnvSnapshotOptions {
+            env_name: "source".to_string(),
+            snapshot_id: snapshot.id,
+        },
+        &env,
+        &cwd,
+    )
+    .unwrap();
+    assert!(!source_root.join(".openclaw/run").exists());
+    assert!(source_root.join(".openclaw/logs").exists());
+    assert!(source_root.join(".openclaw/future-runtime-cache").exists());
 }
 
 #[test]
@@ -1646,7 +1615,7 @@ fn environment_snapshot_restore_replaces_env_state_from_the_snapshot() {
 }
 
 #[test]
-fn environment_snapshot_restore_clears_broken_foreign_runtime_state_but_keeps_agent_auth() {
+fn environment_snapshot_restore_preserves_captured_agent_state() {
     let root = TestDir::new("store-env-snapshot-restore-runtime-cleanup");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -1729,13 +1698,9 @@ fn environment_snapshot_restore_clears_broken_foreign_runtime_state_but_keeps_ag
             .exists()
     );
     assert!(
-        !source_root
+        source_root
             .join(".openclaw/agents/main/sessions/main.jsonl")
             .exists()
-    );
-    assert!(
-        !source_root.join(".openclaw/logs").exists(),
-        "restore should clear only broken non-portable runtime residue"
     );
 }
 
@@ -1928,7 +1893,7 @@ fn environment_snapshot_reads_reject_mismatched_identity_and_archive_paths() {
         &cwd,
     )
     .unwrap_err();
-    assert!(error.contains("archive path is"), "{error}");
+    assert!(error.contains("artifact path is"), "{error}");
     assert!(foreign_archive.exists());
 
     let error = get_env_snapshot("source", "../outside", &env, &cwd).unwrap_err();

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -23,7 +23,7 @@ use tar::{Builder, Header};
 
 use crate::support::{
     TestDir, TestHttpServer, install_fake_launchctl, install_fake_node_and_npm, ocm_env,
-    path_string, run_ocm, stderr, stdout, write_executable_script,
+    path_string, run_ocm, stderr, stdout, write_executable_script, write_text,
 };
 
 fn append_tar_file(
@@ -181,6 +181,11 @@ case "$1" in
         while [ ! -e "$OCM_TEST_UPDATE_FINALIZE_RELEASE" ]; do
           sleep 0.05
         done
+      fi
+      if [ -n "${{OCM_TEST_REQUIRE_STOP_MARKER_DURING_FINALIZE:-}}" ] &&
+         [ ! -e "$OCM_TEST_REQUIRE_STOP_MARKER_DURING_FINALIZE" ]; then
+        echo "managed service was not stopped before update finalize" >&2
+        exit 24
       fi
       if [ "${{OCM_TEST_FAIL_UPDATE_FINALIZE:-}}" = "1" ]; then
         echo "forced update finalize failure" >&2
@@ -951,6 +956,8 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
     );
     let replacement_runtime_path = runtime_path.clone();
     let replacement_ocm_home = ocm_home.clone();
+    let stop_marker = root.child("service-stopped-before-finalize");
+    let observed_stop_marker = stop_marker.clone();
     let observer_done = Arc::new(AtomicBool::new(false));
     let missing_while_active = Arc::new(AtomicBool::new(false));
     let observer_done_thread = Arc::clone(&observer_done);
@@ -991,6 +998,7 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
                         &replacement_runtime_path,
                         &replacement_ocm_home,
                     );
+                    fs::write(&observed_stop_marker, "stopped").unwrap();
                     stop_count += 1;
                     runtime_active = false;
                 }
@@ -1015,6 +1023,10 @@ fn upgrade_rolls_back_when_gateway_rpc_is_not_ready() {
         (stop_count, start_count, target_entered_backoff)
     });
 
+    env.insert(
+        "OCM_TEST_REQUIRE_STOP_MARKER_DURING_FINALIZE".to_string(),
+        path_string(&stop_marker),
+    );
     env.insert("OCM_TEST_GATEWAY_UNREADY".to_string(), "1".to_string());
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
     observer_done.store(true, Ordering::Relaxed);
@@ -2454,6 +2466,15 @@ fn upgrade_rolls_back_runtime_when_service_restart_fails() {
     let start = run_ocm(&cwd, &env, &["start", "demo"]);
     assert!(start.status.success(), "{}", stderr(&start));
 
+    let before = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(before.status.success(), "{}", stderr(&before));
+    let before_json: Value = serde_json::from_str(&stdout(&before)).unwrap();
+    let env_root = PathBuf::from(before_json["root"].as_str().unwrap());
+    let dotenv = env_root.join(".openclaw/.env");
+    let future_state = env_root.join("durable-future/rollback-marker.txt");
+    write_text(&dotenv, "OPENCLAW_ROLLBACK_SENTINEL=before\n");
+    write_text(&future_state, "safe pre-upgrade state\n");
+
     let launchctl_bin = env.get("OCM_INTERNAL_LAUNCHCTL_BIN").unwrap();
     let stopped_marker = root.child("service-stopped");
     write_executable_script(
@@ -2494,6 +2515,20 @@ fn upgrade_rolls_back_runtime_when_service_restart_fails() {
         stderr(&target_runtime).contains("runtime \"2026.3.25\" does not exist"),
         "{}",
         stderr(&target_runtime)
+    );
+
+    let restored = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(restored.status.success(), "{}", stderr(&restored));
+    let restored_json: Value = serde_json::from_str(&stdout(&restored)).unwrap();
+    assert_eq!(restored_json["defaultRuntime"], "stable");
+    assert_eq!(restored_json["root"], before_json["root"]);
+    assert_eq!(
+        fs::read_to_string(&dotenv).unwrap(),
+        "OPENCLAW_ROLLBACK_SENTINEL=before\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&future_state).unwrap(),
+        "safe pre-upgrade state\n"
     );
 }
 


### PR DESCRIPTION
## Summary

- replace selective tar snapshots with verified whole-environment-root checkpoints
- use APFS clones when available, with metadata-preserving full-copy fallback
- quiesce managed gateways for snapshot capture and restore
- restore through an exclusive same-filesystem operation namespace
- retain rejected restored roots before atomically reinstating displaced roots
- keep legacy tar snapshot metadata readable and restorable
- use the same complete snapshot transaction for coherent upgrade rollback

This builds on the whole-root checkpoint and cold-lifecycle direction explored by @hannesrudolph in #60, while keeping that PR's broader companion, build-local, and supervisor-policy work out of this change.

## Problem

Current snapshots archive selected OpenClaw paths but restore by replacing the complete environment root. On `d1c36adda05c1129af9788be35528bc1240d95da`, restoring a snapshot deleted `.openclaw/.env`, secrets, unknown future state, and symlinks that the archive omitted. A foreign directory matching the predictable restore-backup name also caused restore to fail.

## Transaction invariant

The displaced pre-restore root remains recoverable until service acceptance succeeds. If acceptance fails, OCM:

1. renames the rejected restored root into the operation-owned namespace
2. atomically renames the displaced root back into place
3. restores the original registry state
4. resynchronizes the supervisor
5. cleans operation-owned rejected/orphan paths afterward

## Scope

This PR deliberately excludes runtime build-local changes, supervisor convergence retry policy, companion management, and unrelated cleanup. It preserves the runtime mutation and rollback ordering from #66.

## Validation

- base red: complete-root data loss and predictable foreign-path collision reproduced on `d1c36adda05c1129af9788be35528bc1240d95da`
- `cargo test --locked -- --test-threads=1`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -A clippy::question_mark -A clippy::large_enum_variant -A clippy::too_many_arguments`
- `cargo fmt --check`
- `git diff --check`
- environment snapshot suite: 31/31
- store flow suite: 29/29
- upgrade suite: 44/44
- #66 regression: `failed_named_runtime_target_in_backoff_is_not_rewritten_during_rollback`
- source-blind behavior contract: complete root, modes, symlinks, SQLite, corrupt SQLite rejection, opaque `.db`, foreign collision, failed acceptance rollback, legacy tar, and failed-upgrade rollback all passed
- autoreview: clean; TruffleHog clean

Isolated synthetic Rosita-shaped benchmark, without reading or touching live Rosita:

- 6,006 files
- 168,154,957 logical bytes
- APFS clone checkpoint storage
- three cold captures
- median capture plus verification: 2.526 seconds
- median managed-gateway stopped window: 2.392 seconds
