### PR TITLE
fix(runtime): support current OpenClaw build-local

### DIFF
--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
@@ -435,22 +435,8 @@ fn local_workspace_package_dirs(repo_path: &Path) -> Result<Vec<PathBuf>, String
     Ok(dirs)
 }
 
-fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>, String> {
-    let package_json_path = repo_path.join("package.json");
-    let raw = fs::read_to_string(&package_json_path).map_err(|error| {
-        format!(
-            "failed to read OpenClaw package.json at {}: {error}",
-            display_path(&package_json_path)
-        )
-    })?;
-    let value: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
-        format!(
-            "failed to parse OpenClaw package.json at {}: {error}",
-            display_path(&package_json_path)
-        )
-    })?;
-
-    let mut names = Vec::new();
+fn workspace_dependency_names(value: &serde_json::Value) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
     for section in [
         "dependencies",
         "optionalDependencies",
@@ -465,15 +451,38 @@ fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>,
                 .as_str()
                 .is_some_and(|value| value.starts_with("workspace:"))
             {
-                names.push(name.clone());
+                names.insert(name.clone());
             }
         }
     }
-    names.sort();
-    names.dedup();
-    if names.is_empty() {
+    names
+}
+
+fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>, String> {
+    let package_json_path = repo_path.join("package.json");
+    let raw = fs::read_to_string(&package_json_path).map_err(|error| {
+        format!(
+            "failed to read OpenClaw package.json at {}: {error}",
+            display_path(&package_json_path)
+        )
+    })?;
+    let root_package: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
+        format!(
+            "failed to parse OpenClaw package.json at {}: {error}",
+            display_path(&package_json_path)
+        )
+    })?;
+
+    let mut pending = workspace_dependency_names(&root_package);
+    if pending.is_empty() {
         return Ok(None);
     }
+    let mut visited = root_package
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
 
     let mut packages = BTreeMap::new();
     for package_dir in local_workspace_package_dirs(repo_path)? {
@@ -492,21 +501,25 @@ fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>,
             .get("name")
             .and_then(serde_json::Value::as_str)
         {
-            packages.insert(name.to_string(), package_dir);
+            packages.insert(name.to_string(), (package_dir, package_value));
         }
     }
 
-    let dirs = names
-        .into_iter()
-        .map(|name| {
-            packages.remove(&name).ok_or_else(|| {
-                format!(
-                    "OpenClaw workspace dependency \"{name}\" is not declared by pnpm-workspace.yaml"
-                )
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    std::env::join_paths(dirs)
+    let mut selected = BTreeMap::new();
+    while let Some(name) = pending.pop_first() {
+        if !visited.insert(name.clone()) {
+            continue;
+        }
+        let (package_dir, package_value) = packages.get(&name).ok_or_else(|| {
+            format!(
+                "OpenClaw workspace dependency \"{name}\" is not declared by pnpm-workspace.yaml"
+            )
+        })?;
+        selected.insert(name, package_dir.clone());
+        pending.extend(workspace_dependency_names(package_value));
+    }
+
+    std::env::join_paths(selected.into_values())
         .map(Some)
         .map_err(|error| format!("failed to encode OpenClaw workspace dependency paths: {error}"))
 }
@@ -519,10 +532,13 @@ fn local_build_npm_adapter(
         return Ok(None);
     }
 
-    let adapter_path = repo_path.join("scripts/ocm-npm-workspace-deps.mjs");
-    if !adapter_path.is_file() {
+    let adapter_path = ["mts", "mjs"]
+        .into_iter()
+        .map(|extension| repo_path.join(format!("scripts/ocm-npm-workspace-deps.{extension}")))
+        .find(|path| path.is_file());
+    let Some(adapter_path) = adapter_path else {
         return Ok(None);
-    }
+    };
 
     Ok(Some(LocalBuildNpmAdapter {
         command: CommandSpec {
@@ -683,6 +699,8 @@ fn pack_local_openclaw_repo(
         .env("npm_config_fund", "false")
         .env("npm_config_audit", "false")
         .env("npm_config_update_notifier", "false")
+        .env_remove("NPM_CONFIG_IGNORE_SCRIPTS")
+        .env("npm_config_ignore_scripts", "false")
         .env("PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN", "false")
         .env("OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG", "1")
         .current_dir(repo_path)

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -100,7 +100,7 @@ fn install_fake_node_and_packing_npm(
     let log_path = root.child("fake-pack-npm.log");
     write_executable_script(
         &bin_dir.join("node"),
-        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'v22.22.3\\n'\n  exit 0\nfi\nif [ \"$(basename \"$1\")\" = \"ocm-npm-workspace-deps.mjs\" ]; then\n  script=\"$1\"\n  shift\n  exec \"$script\" \"$@\"\nfi\nprintf 'fake node\\n'\n",
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'v22.22.3\\n'\n  exit 0\nfi\ncase \"$(basename \"$1\")\" in\n  ocm-npm-workspace-deps.mjs|ocm-npm-workspace-deps.mts)\n    script=\"$1\"\n    shift\n    exec \"$script\" \"$@\"\n    ;;\nesac\nprintf 'fake node\\n'\n",
     );
     let npm_script = format!(
         r#"#!/bin/sh
@@ -113,6 +113,8 @@ fi
 if [ "$1" = "pack" ]; then
   printf 'verify-deps-before-run=%s\n' "$PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN" >> "{}"
   printf 'allow-unreleased-changelog=%s\n' "$OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG" >> "{}"
+  printf 'ignore-scripts-lower=%s\n' "${{npm_config_ignore_scripts-unset}}" >> "{}"
+  printf 'ignore-scripts-upper=%s\n' "${{NPM_CONFIG_IGNORE_SCRIPTS-unset}}" >> "{}"
   shift
   destination=""
   while [ "$#" -gt 0 ]; do
@@ -167,6 +169,8 @@ if grep -q '"chokidar"' "$prefix/node_modules/openclaw/package.json"; then
   printf '{{"name":"@scope/tool","version":"1.0.0"}}\n' > "$prefix/node_modules/@scope/tool/package.json"
 fi
 "#,
+        path_string(&log_path),
+        path_string(&log_path),
         path_string(&log_path),
         path_string(&log_path),
         path_string(&log_path),
@@ -468,6 +472,8 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
     .unwrap();
 
     let mut env = ocm_env(&root);
+    env.insert("npm_config_ignore_scripts".to_string(), "true".to_string());
+    env.insert("NPM_CONFIG_IGNORE_SCRIPTS".to_string(), "true".to_string());
     let npm_log = install_fake_node_and_packing_npm(&root, &mut env, &archive_path);
 
     let build = run_ocm(
@@ -489,6 +495,8 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
     assert!(npm_log.contains("pack --pack-destination"));
     assert!(npm_log.contains("verify-deps-before-run=false"));
     assert!(npm_log.contains("allow-unreleased-changelog=1"));
+    assert!(npm_log.contains("ignore-scripts-lower=false"));
+    assert!(npm_log.contains("ignore-scripts-upper=unset"));
     assert!(npm_log.contains("install --prefix"));
 
     let install_root = runtime_install_root("main-local", &env, &cwd).unwrap();
@@ -559,14 +567,25 @@ fn runtime_build_local_rejects_a_bound_runtime_before_repo_validation() {
     assert!(!error.contains("repo path does not exist"), "{error}");
 }
 
-#[test]
-fn runtime_build_local_uses_repo_workspace_dependency_adapter() {
-    let root = TestDir::new("runtime-build-local-workspace-adapter");
+fn assert_runtime_build_local_uses_repo_workspace_dependency_adapter(
+    adapter_extension: &str,
+    include_legacy_adapter: bool,
+) {
+    let root = TestDir::new(&format!(
+        "runtime-build-local-workspace-adapter-{adapter_extension}"
+    ));
     let cwd = root.child("workspace");
     let repo = cwd.join("openclaw");
-    let workspace_dependency = repo.join("packages/ai");
+    let workspace_dependencies = [
+        repo.join("packages/ai"),
+        repo.join("packages/normalization-core"),
+        repo.join("packages/session-url-contract"),
+        repo.join("packages/gateway-protocol"),
+    ];
     fs::create_dir_all(repo.join("scripts")).unwrap();
-    fs::create_dir_all(&workspace_dependency).unwrap();
+    for package_dir in &workspace_dependencies {
+        fs::create_dir_all(package_dir).unwrap();
+    }
     fs::write(
         repo.join("pnpm-workspace.yaml"),
         "packages:\n  - .\n  - packages/*\n",
@@ -578,16 +597,34 @@ fn runtime_build_local_uses_repo_workspace_dependency_adapter() {
     )
     .unwrap();
     fs::write(
-        workspace_dependency.join("package.json"),
-        br#"{"name":"@openclaw/ai","version":"2026.4.25"}"#,
+        workspace_dependencies[0].join("package.json"),
+        br#"{"name":"@openclaw/ai","version":"2026.4.25","optionalDependencies":{"@openclaw/normalization-core":"workspace:*"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        workspace_dependencies[1].join("package.json"),
+        br#"{"name":"@openclaw/normalization-core","version":"0.0.0-private","peerDependencies":{"@openclaw/session-url-contract":"workspace:^"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        workspace_dependencies[2].join("package.json"),
+        br#"{"name":"@openclaw/session-url-contract","version":"0.0.0-private","devDependencies":{"@openclaw/gateway-protocol":"workspace:~"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        workspace_dependencies[3].join("package.json"),
+        br#"{"name":"@openclaw/gateway-protocol","version":"0.0.0-private","dependencies":{"@openclaw/ai":"workspace:*","openclaw":"workspace:*"}}"#,
     )
     .unwrap();
 
     let adapter_log = root.child("workspace-adapter.log");
     write_executable_script(
-        &repo.join("scripts/ocm-npm-workspace-deps.mjs"),
+        &repo.join(format!(
+            "scripts/ocm-npm-workspace-deps.{adapter_extension}"
+        )),
         &format!(
             r#"#!/bin/sh
+printf 'adapter={adapter_extension}\n' >> "{}"
 printf 'args=%s\n' "$*" >> "{}"
 printf 'real-npm=%s\n' "$OPENCLAW_OCM_REAL_NPM_BIN" >> "{}"
 printf 'workspace-dirs=%s\n' "$OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS" >> "{}"
@@ -596,8 +633,18 @@ exec "$OPENCLAW_OCM_REAL_NPM_BIN" "$@"
             path_string(&adapter_log),
             path_string(&adapter_log),
             path_string(&adapter_log),
+            path_string(&adapter_log),
         ),
     );
+    if include_legacy_adapter {
+        write_executable_script(
+            &repo.join("scripts/ocm-npm-workspace-deps.mjs"),
+            &format!(
+                "#!/bin/sh\nprintf 'adapter=mjs\\n' >> \"{}\"\nexit 1\n",
+                path_string(&adapter_log)
+            ),
+        );
+    }
 
     let archive_path = root.child("packed-openclaw.tgz");
     fs::write(
@@ -629,10 +676,88 @@ exec "$OPENCLAW_OCM_REAL_NPM_BIN" "$@"
     assert!(adapter_log.contains("args=pack --pack-destination"));
     assert!(adapter_log.contains("args=install --prefix"));
     assert!(adapter_log.contains("real-npm=npm"));
-    assert!(adapter_log.contains(&format!(
-        "workspace-dirs={}",
-        path_string(&fs::canonicalize(workspace_dependency).unwrap())
-    )));
+    assert!(adapter_log.contains(&format!("adapter={adapter_extension}")));
+    if include_legacy_adapter {
+        assert!(!adapter_log.contains("adapter=mjs"));
+    }
+    let expected_dirs = workspace_dependencies
+        .into_iter()
+        .map(|package_dir| fs::canonicalize(package_dir).unwrap())
+        .collect::<BTreeSet<_>>();
+    let workspace_dir_values = adapter_log
+        .lines()
+        .filter_map(|line| line.strip_prefix("workspace-dirs="))
+        .collect::<Vec<_>>();
+    assert_eq!(workspace_dir_values.len(), 2, "{adapter_log}");
+    for value in workspace_dir_values {
+        assert_eq!(
+            std::env::split_paths(value).collect::<BTreeSet<_>>(),
+            expected_dirs,
+            "{adapter_log}"
+        );
+    }
+}
+
+#[test]
+fn runtime_build_local_prefers_current_mts_workspace_dependency_adapter() {
+    assert_runtime_build_local_uses_repo_workspace_dependency_adapter("mts", true);
+}
+
+#[test]
+fn runtime_build_local_keeps_legacy_mjs_workspace_dependency_adapter() {
+    assert_runtime_build_local_uses_repo_workspace_dependency_adapter("mjs", false);
+}
+
+#[test]
+fn runtime_build_local_rejects_a_missing_transitive_workspace_dependency() {
+    let root = TestDir::new("runtime-build-local-missing-transitive-workspace");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    let workspace_dependency = repo.join("packages/ai");
+    fs::create_dir_all(repo.join("scripts")).unwrap();
+    fs::create_dir_all(&workspace_dependency).unwrap();
+    fs::write(
+        repo.join("pnpm-workspace.yaml"),
+        "packages:\n  - .\n  - packages/*\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.4.25","bin":{"openclaw":"openclaw.mjs"},"dependencies":{"@openclaw/ai":"workspace:*"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        workspace_dependency.join("package.json"),
+        br#"{"name":"@openclaw/ai","version":"2026.4.25","dependencies":{"@openclaw/missing":"workspace:*"}}"#,
+    )
+    .unwrap();
+    write_executable_script(
+        &repo.join("scripts/ocm-npm-workspace-deps.mts"),
+        "#!/bin/sh\nexit 0\n",
+    );
+
+    let env = ocm_env(&root);
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "main-workspace",
+            "--repo",
+            "./openclaw",
+            "--raw",
+        ],
+    );
+
+    assert_eq!(build.status.code(), Some(1));
+    assert!(
+        stderr(&build).contains(
+            "OpenClaw workspace dependency \"@openclaw/missing\" is not declared by pnpm-workspace.yaml"
+        ),
+        "{}",
+        stderr(&build)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- prefer OpenClaw's current `scripts/ocm-npm-workspace-deps.mts` adapter while retaining `.mjs` fallback compatibility
- compute the complete transitive workspace dependency closure across dependencies, optional dependencies, peer dependencies, and dev dependencies
- handle cycles without repacking the root package, and fail closed when a referenced workspace package is missing
- force the trusted local `npm pack` lifecycle even when ambient npm configuration has `ignore-scripts=true`

Archive rewriting remains owned by OpenClaw. This PR does not add managed-Node support, snapshot/rollback behavior, or convergence retries.

## Review decisions

- omitted the supplied install-command context change because it was unrelated diagnostic polish rather than part of the broken build-local invariant
- corrected the supplied closure implementation by seeding the root package as visited, preventing a dependency cycle back to the root from packing it as a workspace dependency
- kept the implementation at the existing runtime build-local owner in `src/store/runtimes.rs`

This is the focused runtime subset overlapping #60; it intentionally excludes that PR's lifecycle, snapshot, and retry changes.

## Proof

Red reproduction on unmodified `d1c36adda05c1129af9788be35528bc1240d95da` confirmed three independent failures:

1. the `.mts` workspace adapter was not invoked
2. nested workspace dependencies were omitted
3. ambient `ignore-scripts=true` silently skipped trusted prepack

Validation on `c22dc5b41c1b0d12603e1cd80a5285748c02e3c3`:

- focused build-local tests: 6/6 passed (18.88s)
- runtime unit tests: 3/3 passed
- full `cargo test --locked` with `ulimit -n 4096`: passed (122.41s)
- `cargo check --workspace --all-targets --locked`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- `cargo build --release --locked`: passed (59.52s)
- source-blind behavior validation: passed (2.31s)
- autoreview: no actionable findings, confidence 0.94; TruffleHog clean

Exact real OpenClaw `build-local` E2E used:

- OCM: `c22dc5b41c1b0d12603e1cd80a5285748c02e3c3`
- OpenClaw base: `5179e1235293bbd80c623cf3b6359414b1cb1e74`
- transitive tarball head: `22ad7d29af7c0da2d50259ab3f0365a7b9820e8f` (openclaw/openclaw#122214)
- standalone prepack smoke head: `57b93482e640db32bb10467f72aad50a19eceeea` (openclaw/openclaw#122212)
- combined OpenClaw test SHA: `7f77ff34273cd93d9bb7ee7ccda32a603ee5d418`
- host Node/npm: Node 24.18.1, npm 11.16.0, scripts enabled
- command: `ocm runtime build-local current-openclaw --repo . --raw`
- duration: 206.54s

The installed runtime verified healthy as OpenClaw 2026.8.1 (`7f77ff3`). Installed `openclaw` and `@openclaw/ai` were both 2026.8.1; `@openclaw/normalization-core` and `@openclaw/session-url-contract` were present at `0.0.0-private`, with the rewritten root-to-AI and AI-to-normalization versions matching exactly.
