### PR TITLE
fix: converge asynchronous supervisor transitions

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -938,10 +938,7 @@ impl Cli {
                                 if restored_service_state.is_none() {
                                     return Ok(());
                                 }
-                                match self.wait_for_restarted_gateway_health(name, true)? {
-                                    None => Ok(()),
-                                    Some(note) => Err(note),
-                                }
+                                self.wait_for_restarted_gateway_health(name, true)
                             });
                         match service_acceptance {
                             Ok(()) => {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -861,10 +861,7 @@ impl Cli {
             .with_progress(format!("Starting restored service for {env_name}"), || {
                 self.service_service().start_locked(env_name)
             })?;
-        let note = self.wait_for_restarted_gateway_health(env_name, started.running)?;
-        if let Some(note) = note {
-            return Err(note);
-        }
+        self.wait_for_restarted_gateway_health(env_name, started.desired_running)?;
         Ok(Some("started".to_string()))
     }
 
@@ -2684,10 +2681,8 @@ impl Cli {
                 .with_progress(format!("Restarting service for {env_name}"), || {
                     self.service_service().restart_locked(env_name)
                 })?;
-            let note = join_optional_warnings(
-                join_warnings(&restart.warnings),
-                self.wait_for_restarted_gateway_health(env_name, restart.running)?,
-            );
+            self.wait_for_restarted_gateway_health(env_name, restart.desired_running)?;
+            let note = join_warnings(&restart.warnings);
             return Ok((Some("restarted".to_string()), note));
         }
 
@@ -2695,10 +2690,8 @@ impl Cli {
             let start = self.with_progress(format!("Starting service for {env_name}"), || {
                 self.service_service().start_locked(env_name)
             })?;
-            let note = join_optional_warnings(
-                join_warnings(&start.warnings),
-                self.wait_for_restarted_gateway_health(env_name, start.running)?,
-            );
+            self.wait_for_restarted_gateway_health(env_name, start.desired_running)?;
+            let note = join_warnings(&start.warnings);
             return Ok((Some("started".to_string()), note));
         }
 
@@ -2708,10 +2701,10 @@ impl Cli {
     pub(super) fn wait_for_restarted_gateway_health(
         &self,
         env_name: &str,
-        action_reported_running: bool,
-    ) -> Result<Option<String>, String> {
-        if !action_reported_running {
-            return Ok(None);
+        action_desired_running: bool,
+    ) -> Result<(), String> {
+        if !action_desired_running {
+            return Ok(());
         }
 
         let deadline = Instant::now() + Duration::from_secs(90);
@@ -2722,7 +2715,7 @@ impl Cli {
             latest_issue = status.issue.clone();
             if status.running && gateway_health_ok(status.child_port.unwrap_or(status.gateway_port))
             {
-                return Ok(None);
+                return Ok(());
             }
             if status.gateway_state == "backoff" && status.last_exit_code != Some(0) {
                 if should_wait_for_scheduled_gateway_retry(
@@ -2743,10 +2736,10 @@ impl Cli {
             sleep(Duration::from_millis(500));
         }
 
-        Ok(Some(format!(
+        Err(format!(
             "service restart returned before the gateway health endpoint became ready; latest status: {}",
             latest_issue.unwrap_or_else(|| "starting".to_string())
-        )))
+        ))
     }
 
     fn verify_upgraded_openclaw(

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -161,25 +161,16 @@ impl<'a> ServiceService<'a> {
         name: &str,
     ) -> Result<Option<ServiceMaintenanceState>, String> {
         let status = self.status(name)?;
-        if !status.running {
-            return Ok(None);
-        }
         let meta = crate::env::EnvironmentService::new(self.env, self.cwd).get(name)?;
         let state = ServiceMaintenanceState {
             enabled: meta.service_enabled,
             running: meta.service_running,
         };
-        let stopped = self.stop_locked(name)?;
-        if stopped.running {
-            let stop_error = format!(
-                "managed service for {name} remained running after the snapshot safety stop"
-            );
-            return match self.restore_after_snapshot_locked(name, Some(state)) {
-                Ok(()) => Err(stop_error),
-                Err(restore_error) => Err(format!(
-                    "{stop_error}; also failed to restore its pre-snapshot service policy: {restore_error}"
-                )),
-            };
+        if !state.running && !status.running {
+            return Ok(None);
+        }
+        if state.running {
+            self.stop_locked(name)?;
         }
         if let Err(error) = self.wait_for_runtime_mutation_quiescence_locked(name) {
             return match self.restore_after_snapshot_locked(name, Some(state)) {

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -3,7 +3,7 @@ mod support;
 use std::process::{Command, Stdio};
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::thread;
 use std::time::Duration;
@@ -749,6 +749,335 @@ fn env_snapshot_create_and_restore_quiesce_a_running_managed_gateway() {
     assert_eq!(shown_json["serviceRunning"], true);
     observer_done.store(true, Ordering::Relaxed);
     observer.join().unwrap();
+}
+
+#[test]
+fn env_snapshot_create_waits_for_delayed_supervisor_stop_acknowledgement() {
+    let root = TestDir::new("env-snapshot-delayed-stop-ack");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let health = TestHttpServer::serve_bytes_times("/health", "text/plain", b"ok", 20);
+    let health_port = url::Url::parse(&health.url()).unwrap().port().unwrap() as u32;
+
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "create",
+            "source",
+            "--port",
+            &health_port.to_string(),
+            "--launcher",
+            "stable",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let started = run_ocm(&cwd, &env, &["service", "start", "source"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    write_running_snapshot_service(&root, &cwd, &env, health_port);
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let running_runtime = fs::read(&runtime_path).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    let observer_runtime_path = runtime_path.clone();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let observer = thread::spawn(move || {
+        let mut last_running = true;
+        let mut delayed_stop = false;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let desired_running = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|registry| registry["envs"].as_array().cloned())
+                .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "source"))
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_running);
+            if desired_running != last_running {
+                if desired_running {
+                    fs::write(&observer_runtime_path, &running_runtime).unwrap();
+                } else {
+                    delayed_stop = true;
+                    thread::sleep(Duration::from_millis(3_200));
+                    write_empty_snapshot_service(&observer_runtime_path, &ocm_home);
+                }
+                last_running = desired_running;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        delayed_stop
+    });
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "snapshot",
+            "create",
+            "source",
+            "--label",
+            "delayed-stop",
+        ],
+    );
+
+    for _ in 0..200 {
+        let running = fs::read(&runtime_path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+            .and_then(|runtime| runtime["children"].as_array().cloned())
+            .is_some_and(|children| !children.is_empty());
+        if running {
+            break;
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+    observer_done.store(true, Ordering::Relaxed);
+    assert!(
+        observer.join().unwrap(),
+        "fixture never delayed the stop acknowledgement"
+    );
+    assert!(
+        snapshot.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&snapshot),
+        stderr(&snapshot)
+    );
+
+    let shown = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["serviceEnabled"], true);
+    assert_eq!(shown["serviceRunning"], true);
+}
+
+#[test]
+fn env_snapshot_create_quiesces_desired_service_before_child_is_observable() {
+    let root = TestDir::new("env-snapshot-starting-service");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "create",
+            "source",
+            "--port",
+            "19845",
+            "--launcher",
+            "stable",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let started = run_ocm(&cwd, &env, &["service", "start", "source"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+
+    write_running_snapshot_service(&root, &cwd, &env, 19845);
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    let running_runtime = fs::read(&runtime_path).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_empty_snapshot_service(&runtime_path, &ocm_home);
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let stop_count = Arc::new(AtomicUsize::new(0));
+    let start_count = Arc::new(AtomicUsize::new(0));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let observer_stop_count = Arc::clone(&stop_count);
+    let observer_start_count = Arc::clone(&start_count);
+    let observer_runtime_path = runtime_path.clone();
+    let observer = thread::spawn(move || {
+        let mut last_running = true;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let desired_running = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|registry| registry["envs"].as_array().cloned())
+                .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "source"))
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_running);
+            if desired_running != last_running {
+                if desired_running {
+                    fs::write(&observer_runtime_path, &running_runtime).unwrap();
+                    observer_start_count.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    write_empty_snapshot_service(&observer_runtime_path, &ocm_home);
+                    observer_stop_count.fetch_add(1, Ordering::Relaxed);
+                }
+                last_running = desired_running;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+    });
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--label", "starting"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let deadline = std::time::Instant::now() + Duration::from_secs(1);
+    while start_count.load(Ordering::Relaxed) == 0 && std::time::Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+    observer_done.store(true, Ordering::Relaxed);
+    observer.join().unwrap();
+    assert_eq!(stop_count.load(Ordering::Relaxed), 1);
+    assert_eq!(start_count.load(Ordering::Relaxed), 1);
+
+    let shown = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["serviceEnabled"], true);
+    assert_eq!(shown["serviceRunning"], true);
+}
+
+#[test]
+fn env_snapshot_create_preserves_disabled_policy_while_stale_child_quiesces() {
+    let root = TestDir::new("env-snapshot-disabled-stale-child");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "create",
+            "source",
+            "--port",
+            "19846",
+            "--launcher",
+            "stable",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let started = run_ocm(&cwd, &env, &["service", "start", "source"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    write_running_snapshot_service(&root, &cwd, &env, 19846);
+
+    let disabled = run_ocm(&cwd, &env, &["service", "uninstall", "source"]);
+    assert!(disabled.status.success(), "{}", stderr(&disabled));
+    let before = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(before.status.success(), "{}", stderr(&before));
+    let before: Value = serde_json::from_str(&stdout(&before)).unwrap();
+    assert_eq!(before["serviceEnabled"], false);
+    assert_eq!(before["serviceRunning"], false);
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    let observer_runtime_path = runtime_path.clone();
+    let observer = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(200));
+        write_empty_snapshot_service(&observer_runtime_path, &ocm_home);
+    });
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--label", "disabled"],
+    );
+    observer.join().unwrap();
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+
+    let shown = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["serviceEnabled"], false);
+    assert_eq!(shown["serviceRunning"], false);
+    let list = run_ocm(&cwd, &env, &["env", "snapshot", "list", "source", "--json"]);
+    assert!(list.status.success(), "{}", stderr(&list));
+    let list: Value = serde_json::from_str(&stdout(&list)).unwrap();
+    assert_eq!(list[0]["serviceEnabled"], false);
+    assert_eq!(list[0]["serviceRunning"], false);
+}
+
+#[test]
+fn env_snapshot_create_preserves_already_stopped_enabled_policy() {
+    let root = TestDir::new("env-snapshot-already-stopped");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "create",
+            "source",
+            "--port",
+            "19847",
+            "--launcher",
+            "stable",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let installed = run_ocm(&cwd, &env, &["service", "install", "source"]);
+    assert!(installed.status.success(), "{}", stderr(&installed));
+
+    fs::write(root.child("launchctl.log"), "").unwrap();
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--label", "stopped"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let lifecycle = fs::read_to_string(root.child("launchctl.log")).unwrap();
+    assert!(!lifecycle.contains("bootout "), "{lifecycle}");
+    assert!(!lifecycle.contains("bootstrap "), "{lifecycle}");
+
+    let shown = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["serviceEnabled"], true);
+    assert_eq!(shown["serviceRunning"], false);
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -330,7 +330,10 @@ case "$1" in
         sleep 0.01
       done
     fi
-    if [ "${{OCM_TEST_GATEWAY_AUTH_HANDSHAKE:-}}" = "1" ]; then
+    if [ -n "${{OCM_TEST_GATEWAY_READY_MARKER:-}}" ] &&
+       [ ! -e "$OCM_TEST_GATEWAY_READY_MARKER" ]; then
+      printf '{{"rpc":{{"ok":false,"error":"connect ECONNREFUSED 127.0.0.1"}}}}\n'
+    elif [ "${{OCM_TEST_GATEWAY_AUTH_HANDSHAKE:-}}" = "1" ]; then
       printf '{{"rpc":{{"ok":false,"error":"device identity required"}}}}\n'
       exit "${{OCM_TEST_GATEWAY_STATUS_EXIT_CODE:-0}}"
     elif [ "${{OCM_TEST_GATEWAY_UNREADY:-}}" = "1" ]; then
@@ -722,6 +725,8 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     let root = TestDir::new("upgrade-tracked-runtime");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
+    let (health_port, health_requests, health_stop, health_handle) =
+        spawn_converging_health_server();
 
     let old_tarball =
         openclaw_package_tarball(&recording_openclaw_script("2026.3.24"), "2026.3.24");
@@ -781,7 +786,11 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     );
     install_fake_launchctl(&root, &mut env);
 
-    let start = run_ocm(&cwd, &env, &["start", "demo"]);
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &["start", "demo", "--port", &health_port.to_string()],
+    );
     assert!(start.status.success(), "{}", stderr(&start));
 
     env.insert(
@@ -792,7 +801,53 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
         "OCM_TEST_GATEWAY_STATUS_EXIT_CODE".to_string(),
         "1".to_string(),
     );
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let observer_runtime_path = runtime_path.clone();
+    let observer = thread::spawn(move || {
+        let mut last_desired_running = true;
+        let mut next_pid = 4242;
+        let mut saw_stop = false;
+        let mut saw_start = false;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let desired_running = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|registry| registry["envs"].as_array().cloned())
+                .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "demo"))
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_desired_running);
+            if desired_running != last_desired_running {
+                if desired_running {
+                    write_running_supervisor_runtime(
+                        &observer_runtime_path,
+                        &ocm_home,
+                        "stable",
+                        next_pid,
+                        health_port,
+                    );
+                    next_pid += 1;
+                    saw_start = true;
+                } else {
+                    write_empty_supervisor_runtime(&observer_runtime_path, &ocm_home);
+                    saw_stop = true;
+                }
+                last_desired_running = desired_running;
+            }
+            sleep(Duration::from_millis(5));
+        }
+        (saw_stop, saw_start)
+    });
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
+    observer_done.store(true, Ordering::Relaxed);
+    let (saw_stop, saw_start) = observer.join().unwrap();
+    assert!(saw_stop, "upgrade did not stop the source service");
+    assert!(saw_start, "upgrade did not start the updated service");
+    assert!(health_requests.load(Ordering::SeqCst) >= 2);
     assert!(upgrade.status.success(), "{}", stderr(&upgrade));
     let output = stdout(&upgrade);
     assert!(output.contains("outcome=updated"), "{output}");
@@ -871,6 +926,38 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
         snapshot_json[0]["id"].as_str().unwrap()
     );
 
+    let snapshot_registry_path = env_registry_path(&env, &cwd).unwrap();
+    let snapshot_ocm_home = env.get("OCM_HOME").unwrap().clone();
+    let snapshot_runtime_path = runtime_path.clone();
+    let snapshot_observer_done = Arc::new(AtomicBool::new(false));
+    let snapshot_observer_done_thread = Arc::clone(&snapshot_observer_done);
+    let snapshot_observer = thread::spawn(move || {
+        let mut last_desired_running = true;
+        while !snapshot_observer_done_thread.load(Ordering::Relaxed) {
+            let desired_running = fs::read(&snapshot_registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|registry| registry["envs"].as_array().cloned())
+                .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "demo"))
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_desired_running);
+            if desired_running != last_desired_running {
+                if desired_running {
+                    write_running_supervisor_runtime(
+                        &snapshot_runtime_path,
+                        &snapshot_ocm_home,
+                        "stable",
+                        4244,
+                        health_port,
+                    );
+                } else {
+                    write_empty_supervisor_runtime(&snapshot_runtime_path, &snapshot_ocm_home);
+                }
+                last_desired_running = desired_running;
+            }
+            sleep(Duration::from_millis(5));
+        }
+    });
     let create_newer_snapshot = run_ocm(
         &cwd,
         &env,
@@ -903,6 +990,9 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     assert!(!recovery_root.exists());
 
     let reuse = run_ocm(&cwd, &env, &["upgrade", "demo"]);
+    snapshot_observer_done.store(true, Ordering::Relaxed);
+    snapshot_observer.join().unwrap();
+    stop_converging_health_server(health_port, &health_stop, health_handle);
     assert!(reuse.status.success(), "{}", stderr(&reuse));
     assert!(stdout(&reuse).contains("outcome=up-to-date"));
     let shown = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
@@ -1311,6 +1401,147 @@ fn upgrade_waits_for_one_supervisor_convergence_retry() {
     );
     assert!(recovered_target, "fixture retry never became healthy");
     assert!(health_requests.load(Ordering::SeqCst) >= 2);
+    let shown = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["defaultRuntime"], "new");
+}
+
+#[test]
+fn upgrade_waits_for_delayed_supervisor_start_before_gateway_verification() {
+    let root = TestDir::new("upgrade-delayed-supervisor-start");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let health_server =
+        TestHttpServer::serve_bytes_times("/health", "application/json", br#"{"ok":true}"#, 20);
+    let health_port = url::Url::parse(&health_server.url())
+        .unwrap()
+        .port()
+        .unwrap() as u32;
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("2026.8.1"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("2026.8.2"));
+
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    for (name, runtime) in [("old", &old_runtime), ("new", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &["runtime", "add", name, "--path", &path_string(runtime)],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "start",
+            "demo",
+            "--runtime",
+            "old",
+            "--port",
+            &health_port.to_string(),
+        ],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "old", 4242, health_port);
+
+    let gateway_ready = root.child("gateway-ready");
+    env.insert(
+        "OCM_TEST_GATEWAY_READY_MARKER".to_string(),
+        path_string(&gateway_ready),
+    );
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let observer_runtime_path = runtime_path.clone();
+    let observer_ocm_home = ocm_home.clone();
+    let observer_gateway_ready = gateway_ready.clone();
+    let observer = thread::spawn(move || {
+        let mut last_binding = "old".to_string();
+        let mut last_desired_running = true;
+        let mut pending_start: Option<(String, Instant)> = None;
+        let mut next_pid = 4243;
+        let mut saw_delayed_target_start = false;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let registry = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .unwrap_or(Value::Null);
+            let env_meta = registry["envs"]
+                .as_array()
+                .and_then(|envs| envs.iter().find(|entry| entry["name"] == "demo"));
+            let binding = env_meta
+                .and_then(|entry| entry["defaultRuntime"].as_str())
+                .unwrap_or(&last_binding)
+                .to_string();
+            let desired_running = env_meta
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_desired_running);
+
+            if desired_running != last_desired_running {
+                if desired_running {
+                    write_empty_supervisor_runtime(&observer_runtime_path, &observer_ocm_home);
+                    pending_start = Some((binding.clone(), Instant::now()));
+                    if binding == "new" {
+                        saw_delayed_target_start = true;
+                    }
+                } else {
+                    write_empty_supervisor_runtime(&observer_runtime_path, &observer_ocm_home);
+                    let _ = fs::remove_file(&observer_gateway_ready);
+                    pending_start = None;
+                }
+                last_desired_running = desired_running;
+            }
+            last_binding = binding.clone();
+
+            if let Some((pending_binding, started_at)) = pending_start.as_ref()
+                && desired_running
+                && binding == *pending_binding
+                && started_at.elapsed() >= Duration::from_millis(250)
+            {
+                write_running_supervisor_runtime(
+                    &observer_runtime_path,
+                    &observer_ocm_home,
+                    pending_binding,
+                    next_pid,
+                    health_port,
+                );
+                next_pid += 1;
+                fs::write(&observer_gateway_ready, "ready").unwrap();
+                pending_start = None;
+            }
+            sleep(Duration::from_millis(1));
+        }
+        saw_delayed_target_start
+    });
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new"]);
+    observer_done.store(true, Ordering::Relaxed);
+    assert!(
+        observer.join().unwrap(),
+        "fixture never exposed desiredRunning=true while running=false for the target"
+    );
+    assert!(
+        upgrade.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&upgrade),
+        stderr(&upgrade)
+    );
+    assert!(!health_server.requests().is_empty());
+
     let shown = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
     assert!(shown.status.success(), "{}", stderr(&shown));
     let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
@@ -4082,15 +4313,8 @@ fn upgrade_rollback_restarts_and_verifies_a_managed_service() {
     let root = TestDir::new("upgrade-explicit-rollback-service");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
-    let health_server =
-        TestHttpServer::serve_bytes_times("/health", "application/json", br#"{"ok":true}"#, 20);
-    let health_port = health_server
-        .url()
-        .split(':')
-        .nth(2)
-        .and_then(|value| value.split('/').next())
-        .and_then(|value| value.parse::<u32>().ok())
-        .unwrap();
+    let (health_port, health_requests, health_stop, health_handle) =
+        spawn_converging_health_server();
 
     let old_runtime = root.child("old-openclaw");
     let new_runtime = root.child("new-openclaw");
@@ -4143,8 +4367,64 @@ fn upgrade_rollback_restarts_and_verifies_a_managed_service() {
     assert!(snapshot.status.success(), "{}", stderr(&snapshot));
     let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
     let snapshot_id = snapshot_json["id"].as_str().unwrap();
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "old", 4242, health_port);
+    let state_path = supervisor_state_path(&env, &cwd).unwrap();
+    let bind_observer_done = Arc::new(AtomicBool::new(false));
+    let bind_observer_done_thread = Arc::clone(&bind_observer_done);
+    let bind_runtime_path = runtime_path.clone();
+    let bind_ocm_home = ocm_home.clone();
+    let bind_state_path = state_path.clone();
+    let bind_observer = thread::spawn(move || {
+        let mut observed_binding = Some("old".to_string());
+        let mut next_pid = 4243;
+        let mut saw_stop = false;
+        let mut saw_target_start = false;
+        while !bind_observer_done_thread.load(Ordering::Relaxed) {
+            let state = fs::read_to_string(&bind_state_path).unwrap_or_default();
+            let parsed: Value = serde_json::from_str(&state).unwrap_or(Value::Null);
+            let desired_binding = parsed["children"]
+                .as_array()
+                .and_then(|children| children.iter().find(|child| child["envName"] == "demo"))
+                .and_then(|child| child["bindingName"].as_str())
+                .map(str::to_string);
+            if desired_binding != observed_binding {
+                if let Some(binding) = desired_binding.as_deref() {
+                    write_running_supervisor_runtime(
+                        &bind_runtime_path,
+                        &bind_ocm_home,
+                        binding,
+                        next_pid,
+                        health_port,
+                    );
+                    next_pid += 1;
+                    if binding == "new" {
+                        saw_target_start = true;
+                    }
+                } else {
+                    write_empty_supervisor_runtime(&bind_runtime_path, &bind_ocm_home);
+                    saw_stop = true;
+                }
+                observed_binding = desired_binding;
+            }
+            sleep(Duration::from_millis(25));
+        }
+        (saw_stop, saw_target_start)
+    });
     let bind = run_ocm(&cwd, &env, &["env", "set-runtime", "demo", "new"]);
+    bind_observer_done.store(true, Ordering::Relaxed);
+    let (bind_saw_stop, bind_saw_target_start) = bind_observer.join().unwrap();
     assert!(bind.status.success(), "{}", stderr(&bind));
+    assert!(
+        bind_saw_stop,
+        "runtime switch did not stop the source service"
+    );
+    assert!(
+        bind_saw_target_start,
+        "runtime switch did not start the target service"
+    );
     fs::write(&marker, "after-upgrade").unwrap();
 
     let transaction_id = "1782864000-000000001";
@@ -4181,11 +4461,6 @@ fn upgrade_rollback_restarts_and_verifies_a_managed_service() {
     )
     .unwrap();
 
-    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
-    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
-    let ocm_home = env.get("OCM_HOME").unwrap().clone();
-    write_running_supervisor_runtime(&runtime_path, &ocm_home, "new", 4242, health_port);
-    let state_path = supervisor_state_path(&env, &cwd).unwrap();
     let observed_runtime_path = runtime_path.clone();
     let observed_ocm_home = ocm_home.clone();
     let service_observer = thread::spawn(move || {
@@ -4218,13 +4493,19 @@ fn upgrade_rollback_restarts_and_verifies_a_managed_service() {
 
     let rollback = run_ocm(&cwd, &env, &["upgrade", "rollback", "demo", "--raw"]);
     service_observer.join().unwrap();
-    assert!(rollback.status.success(), "{}", stderr(&rollback));
+    stop_converging_health_server(health_port, &health_stop, health_handle);
+    assert!(
+        rollback.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&rollback),
+        stderr(&rollback)
+    );
     let output = stdout(&rollback);
     assert!(output.contains("outcome=rolled-back"), "{output}");
     assert!(output.contains("service=started"), "{output}");
     assert!(output.contains("to=runtime:old"), "{output}");
     assert_eq!(fs::read_to_string(&marker).unwrap(), "before-upgrade");
-    assert!(!health_server.requests().is_empty());
+    assert!(health_requests.load(Ordering::SeqCst) >= 2);
 
     let service = run_ocm(&cwd, &env, &["service", "status", "demo", "--json"]);
     assert!(service.status.success(), "{}", stderr(&service));


### PR DESCRIPTION
## Summary

- treat desired service policy and observed child state as separate inputs at the snapshot safety boundary
- wait for a requested start/restart to converge on an observed child and HTTP health before deep gateway verification
- preserve existing bounded stop/start timeouts, restore prior policy on snapshot failure, and fail closed when convergence or gateway readiness does not arrive

## Root cause

Supervisor actions publish desired policy before the child transition is necessarily observable. Snapshot creation treated a still-running advisory stop result as final before its existing quiescence wait. Upgrade did the inverse: it skipped health convergence when start/restart returned desiredRunning=true with running=false, then probed the gateway early and rolled back on ECONNREFUSED.

The owner-level invariant is now: policy decides what state OCM must converge toward; observed child and gateway state decide when maintenance is safe or successful.

## Compatibility and failure boundary

- synchronous supervisors retain their existing fast path
- already-stopped enabled services and disabled services retain their requested policy
- a stale observed child under desired-running=false is quiesced without re-enabling the service
- snapshot/runtime mutation remains blocked until the supervisor reports no planned, runtime-child, or runtime-service state
- upgrade success still requires observed child state, HTTP health, and the existing deep gateway RPC
- no retry was added; the existing 3s advisory stop wait, 5s snapshot quiescence wait, and 90s gateway convergence deadline are unchanged
- rollback restoration remains unchanged apart from using the requested policy to decide whether convergence is required

This PR intentionally excludes the separate cold-finalization/long-outage transaction-ordering work in #60.

## Proof

Canonical base: f6dea9f7e90215964d8a5dfc25c841c71f298629

On that exact unmodified base, the delayed-stop fixture aborted before bounded quiescence with managed service remained running after the snapshot safety stop; the delayed-start fixture rolled back after an early ECONNREFUSED probe. Canonical main remains that same SHA, and #60 current head retains both broken gates.

On this head:

- exact delayed-stop and delayed-start regression commands passed
- cargo test --test env_snapshot_tests -- --test-threads=1 - 35 passed
- cargo test --test upgrade_command_tests -- --test-threads=1 - 46 passed
- cargo check --workspace --all-targets --locked
- cargo fmt --all -- --check
- git diff --check
- source-blind CLI validation: delayed stop converged in 3.52s with running/stopped/disabled policies preserved; delayed start converged on new, made a real health request, and did not roll back
- structured autoreview: clean, no accepted/actionable P0 findings

No Crabbox was used; the local fake launchd/supervisor contract exercises the same JSON policy/runtime boundary without platform-specific behavior.