### PR TITLE
fix(snapshot): bound APFS checkpoint cutover

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -808,17 +808,21 @@ impl Cli {
 
         let snapshot = self.with_progress(format!("Creating snapshot for {name}"), || {
             let _operation_lock = self.environment_service().lock_operation(name)?;
+            let prepared = self
+                .environment_service()
+                .prepare_snapshot_capture_locked(name)?;
             let service_state = self
                 .service_service()
                 .quiesce_for_snapshot_locked(name)?;
             let snapshot_result = self
                 .environment_service()
-                .create_snapshot_locked_with_service_state(
+                .create_snapshot_locked_from_preparation(
                     CreateEnvSnapshotOptions {
                         env_name: name.clone(),
                         label,
                     },
                     service_state.map(|state| (state.enabled, state.running)),
+                    prepared,
                 );
             let service_result = self
                 .service_service()

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2940,6 +2940,9 @@ impl Cli {
         rollback_of: Option<String>,
     ) -> Result<UpgradeTransaction, String> {
         let env_meta = self.environment_service().get(env_name)?;
+        let prepared = self
+            .environment_service()
+            .prepare_snapshot_capture_locked(env_name)?;
         let service_state = self
             .service_service()
             .quiesce_for_snapshot_locked(env_name)?;
@@ -2951,12 +2954,13 @@ impl Cli {
         );
         let snapshot_result = self
             .environment_service()
-            .create_snapshot_locked_with_service_state(
+            .create_snapshot_locked_from_preparation(
                 CreateEnvSnapshotOptions {
                     env_name: env_name.to_string(),
                     label: Some(snapshot_label.to_string()),
                 },
                 Some((env_meta.service_enabled, env_meta.service_running)),
+                prepared,
             );
         let snapshot = match snapshot_result {
             Ok(snapshot) => snapshot,

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -5,10 +5,11 @@ use time::{Duration, OffsetDateTime};
 
 use super::EnvironmentService;
 use crate::store::{
-    EnvSnapshotRestoreTransaction, commit_env_snapshot_restore, create_env_snapshot,
-    create_env_snapshot_with_service_state, get_env_snapshot, list_all_env_snapshots,
-    list_env_snapshots, now_utc, prepare_env_snapshot_restore, remove_env_snapshot,
-    restore_env_snapshot, rollback_env_snapshot_restore, summarize_snapshot,
+    EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
+    create_env_snapshot, create_env_snapshot_from_preparation, get_env_snapshot,
+    list_all_env_snapshots, list_env_snapshots, now_utc, prepare_env_snapshot_capture,
+    prepare_env_snapshot_restore, remove_env_snapshot, restore_env_snapshot,
+    rollback_env_snapshot_restore, summarize_snapshot,
 };
 use crate::supervisor::sync_supervisor_if_present;
 
@@ -138,13 +139,26 @@ impl<'a> EnvironmentService<'a> {
         Ok(summarize_snapshot(&meta))
     }
 
-    pub(crate) fn create_snapshot_locked_with_service_state(
+    pub(crate) fn prepare_snapshot_capture_locked(
+        &self,
+        env_name: &str,
+    ) -> Result<PreparedEnvSnapshotCapture, String> {
+        prepare_env_snapshot_capture(env_name, self.env, self.cwd)
+    }
+
+    pub(crate) fn create_snapshot_locked_from_preparation(
         &self,
         options: CreateEnvSnapshotOptions,
         service_state: Option<(bool, bool)>,
+        prepared: PreparedEnvSnapshotCapture,
     ) -> Result<EnvSnapshotSummary, String> {
-        let meta =
-            create_env_snapshot_with_service_state(options, service_state, self.env, self.cwd)?;
+        let meta = create_env_snapshot_from_preparation(
+            options,
+            service_state,
+            prepared,
+            self.env,
+            self.cwd,
+        )?;
         Ok(summarize_snapshot(&meta))
     }
 

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -1,11 +1,15 @@
 use std::collections::BTreeMap;
+#[cfg(target_os = "macos")]
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Read;
+#[cfg(target_os = "macos")]
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 #[cfg(not(target_os = "macos"))]
 use filetime::{FileTime, set_file_times, set_symlink_file_times};
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, ErrorCode, OpenFlags};
 use sha2::{Digest, Sha256};
 #[cfg(not(target_os = "macos"))]
 use std::io::Write;
@@ -17,11 +21,73 @@ pub(crate) const STORAGE_APFS_CLONE: &str = "apfs-clone-v1";
 pub(crate) const STORAGE_FULL_COPY: &str = "full-copy-v1";
 pub(crate) const STORAGE_TAR_ARCHIVE: &str = "tar-archive-v1";
 
+#[derive(Debug)]
+pub(crate) struct PreparedTreeCheckpoint {
+    source: PathBuf,
+    #[cfg(target_os = "macos")]
+    regular_files: HashMap<Box<[u8]>, PreparedRegularFile>,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct FileFingerprint {
+    device: u64,
+    inode: u64,
+    len: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+    mode: u32,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug)]
+struct PreparedRegularFile {
+    fingerprint: Option<FileFingerprint>,
+    sqlite: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SqliteCheck {
+    NotDatabase,
+    Verified,
+    Deferred,
+}
+
 pub(crate) fn default_snapshot_storage_kind() -> String {
     STORAGE_TAR_ARCHIVE.to_string()
 }
 
 pub(crate) fn create_tree_checkpoint(source: &Path, destination: &Path) -> Result<String, String> {
+    let prepared = prepare_tree_checkpoint(source)?;
+    create_tree_checkpoint_from_preparation(prepared, destination)
+}
+
+pub(crate) fn prepare_tree_checkpoint(source: &Path) -> Result<PreparedTreeCheckpoint, String> {
+    if !path_exists(source) {
+        return Err(format!(
+            "checkpoint source does not exist: {}",
+            display_path(source)
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    let regular_files = prepare_regular_files(source)?;
+    #[cfg(not(target_os = "macos"))]
+    preflight_sqlite_databases(source)?;
+
+    Ok(PreparedTreeCheckpoint {
+        source: source.to_path_buf(),
+        #[cfg(target_os = "macos")]
+        regular_files,
+    })
+}
+
+pub(crate) fn create_tree_checkpoint_from_preparation(
+    prepared: PreparedTreeCheckpoint,
+    destination: &Path,
+) -> Result<String, String> {
     if path_exists(destination) {
         return Err(format!(
             "checkpoint destination already exists: {}",
@@ -34,16 +100,20 @@ pub(crate) fn create_tree_checkpoint(source: &Path, destination: &Path) -> Resul
 
     #[cfg(target_os = "macos")]
     {
-        match copyfile_tree(source, destination, true) {
+        match clone_tree_checkpoint(&prepared.source, destination) {
             Ok(()) => {
-                verify_tree_checkpoint(source, destination)?;
-                verify_sqlite_databases(destination)?;
-                sync_tree_root(destination)?;
+                if let Err(error) = (|| {
+                    verify_prepared_clone(&prepared.source, destination, prepared.regular_files)?;
+                    sync_tree_root(destination)
+                })() {
+                    let _ = remove_tree_if_present(destination);
+                    return Err(error);
+                }
                 return Ok(STORAGE_APFS_CLONE.to_string());
             }
             Err(clone_error) => {
                 remove_tree_if_present(destination)?;
-                copyfile_tree(source, destination, false).map_err(|copy_error| {
+                copyfile_tree(&prepared.source, destination).map_err(|copy_error| {
                     format!(
                         "APFS clone was unavailable ({clone_error}); full checkpoint copy also failed: {copy_error}"
                     )
@@ -53,10 +123,10 @@ pub(crate) fn create_tree_checkpoint(source: &Path, destination: &Path) -> Resul
     }
 
     #[cfg(not(target_os = "macos"))]
-    copy_tree_preserving_metadata(source, destination)?;
+    copy_tree_preserving_metadata(&prepared.source, destination)?;
 
     if let Err(error) = (|| {
-        verify_tree_checkpoint(source, destination)?;
+        verify_tree_checkpoint(&prepared.source, destination)?;
         verify_sqlite_databases(destination)?;
         sync_tree_root(destination)
     })() {
@@ -160,38 +230,335 @@ fn hash_file(path: &Path) -> Result<[u8; 32], String> {
 
 fn verify_sqlite_databases(root: &Path) -> Result<(), String> {
     for path in regular_files(root)? {
-        let mut file = fs::File::open(&path).map_err(|error| error.to_string())?;
-        let mut magic = [0_u8; 16];
-        if file.read_exact(&mut magic).is_err() || &magic != b"SQLite format 3\0" {
-            continue;
-        }
-        drop(file);
-        let connection = Connection::open_with_flags(
-            &path,
-            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )
-        .map_err(|error| {
-            format!(
-                "failed to open checkpoint SQLite database {}: {error}",
-                display_path(&path)
-            )
-        })?;
-        let result: String = connection
-            .query_row("PRAGMA quick_check", [], |row| row.get(0))
-            .map_err(|error| {
-                format!(
-                    "failed to verify checkpoint SQLite database {}: {error}",
-                    display_path(&path)
-                )
-            })?;
-        if result != "ok" {
+        let _ = verify_sqlite_database(&path)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn preflight_sqlite_databases(root: &Path) -> Result<(), String> {
+    for path in regular_files(root)? {
+        let _ = check_sqlite_database(&path)?;
+    }
+    Ok(())
+}
+
+fn verify_sqlite_database(path: &Path) -> Result<bool, String> {
+    match check_sqlite_database(path)? {
+        SqliteCheck::NotDatabase => Ok(false),
+        SqliteCheck::Verified => Ok(true),
+        SqliteCheck::Deferred => Err(format!(
+            "checkpoint SQLite database remained busy after quiescence: {}",
+            display_path(path)
+        )),
+    }
+}
+
+fn check_sqlite_database(path: &Path) -> Result<SqliteCheck, String> {
+    let mut file = fs::File::open(path).map_err(|error| error.to_string())?;
+    let mut magic = [0_u8; 16];
+    if file.read_exact(&mut magic).is_err() || &magic != b"SQLite format 3\0" {
+        return Ok(SqliteCheck::NotDatabase);
+    }
+    drop(file);
+    let connection = match Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(connection) => connection,
+        Err(error) if sqlite_is_busy(&error) => return Ok(SqliteCheck::Deferred),
+        Err(error) => {
             return Err(format!(
-                "checkpoint SQLite integrity check failed for {}: {result}",
-                display_path(&path)
+                "failed to open checkpoint SQLite database {}: {error}",
+                display_path(path)
             ));
+        }
+    };
+    let result: String = match connection.query_row("PRAGMA quick_check", [], |row| row.get(0)) {
+        Ok(result) => result,
+        Err(error) if sqlite_is_busy(&error) => return Ok(SqliteCheck::Deferred),
+        Err(error) => {
+            return Err(format!(
+                "failed to verify checkpoint SQLite database {}: {error}",
+                display_path(path)
+            ));
+        }
+    };
+    if result != "ok" {
+        return Err(format!(
+            "checkpoint SQLite integrity check failed for {}: {result}",
+            display_path(path)
+        ));
+    }
+    Ok(SqliteCheck::Verified)
+}
+
+fn sqlite_is_busy(error: &rusqlite::Error) -> bool {
+    matches!(
+        error.sqlite_error_code(),
+        Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn prepare_regular_files(root: &Path) -> Result<HashMap<Box<[u8]>, PreparedRegularFile>, String> {
+    let mut out = HashMap::new();
+    prepare_regular_path(root, root, &mut out)?;
+    Ok(out)
+}
+
+#[cfg(target_os = "macos")]
+fn prepare_regular_path(
+    root: &Path,
+    path: &Path,
+    out: &mut HashMap<Box<[u8]>, PreparedRegularFile>,
+) -> Result<(), String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect checkpoint source {}: {error}",
+                display_path(path)
+            ));
+        }
+    };
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Ok(());
+    }
+    if file_type.is_file() {
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|error| error.to_string())?
+            .as_os_str()
+            .as_bytes()
+            .to_vec()
+            .into_boxed_slice();
+        let before = file_fingerprint(&metadata);
+        let sqlite_check = match check_sqlite_database(path) {
+            Ok(check) => check,
+            Err(_) if !path_exists(path) => {
+                out.insert(
+                    relative,
+                    PreparedRegularFile {
+                        fingerprint: None,
+                        sqlite: false,
+                    },
+                );
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        };
+        let after = match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.is_file() => Some(file_fingerprint(&metadata)),
+            Ok(_) => None,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.to_string()),
+        };
+        out.insert(
+            relative,
+            PreparedRegularFile {
+                fingerprint: after.filter(|fingerprint| {
+                    *fingerprint == before && sqlite_check != SqliteCheck::Deferred
+                }),
+                sqlite: sqlite_check != SqliteCheck::NotDatabase,
+            },
+        );
+        return Ok(());
+    }
+    if file_type.is_dir() {
+        let entries = match fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error.to_string()),
+        };
+        for entry in entries {
+            match entry {
+                Ok(entry) => prepare_regular_path(root, &entry.path(), out)?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.to_string()),
+            }
         }
     }
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn file_fingerprint(metadata: &fs::Metadata) -> FileFingerprint {
+    use std::os::unix::fs::MetadataExt;
+
+    FileFingerprint {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        len: metadata.len(),
+        modified_seconds: metadata.mtime(),
+        modified_nanoseconds: metadata.mtime_nsec(),
+        changed_seconds: metadata.ctime(),
+        changed_nanoseconds: metadata.ctime_nsec(),
+        mode: metadata.mode(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn verify_prepared_clone(
+    source: &Path,
+    destination: &Path,
+    mut prepared: HashMap<Box<[u8]>, PreparedRegularFile>,
+) -> Result<(), String> {
+    let mut candidates = HashSet::new();
+    verify_prepared_path(source, source, destination, &mut prepared, &mut candidates)?;
+    for (relative, prior) in prepared {
+        let relative = PathBuf::from(std::ffi::OsStr::from_bytes(&relative).to_os_string());
+        verify_changed_checkpoint_path(&source.join(&relative), &destination.join(&relative))?;
+        if prior.sqlite && path_exists(&destination.join(&relative)) {
+            candidates.insert(destination.join(&relative));
+        }
+        if let Some(primary) = sqlite_primary_for_sidecar(&relative) {
+            candidates.insert(destination.join(primary));
+        }
+    }
+
+    let mut candidates = candidates.into_iter().collect::<Vec<_>>();
+    candidates.sort();
+    for path in candidates {
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.to_string()),
+        };
+        if metadata.is_file() {
+            let _ = verify_sqlite_database(&path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn verify_prepared_path(
+    root: &Path,
+    path: &Path,
+    destination: &Path,
+    prepared: &mut HashMap<Box<[u8]>, PreparedRegularFile>,
+    sqlite_candidates: &mut HashSet<PathBuf>,
+) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    if metadata.is_file() {
+        let relative = path.strip_prefix(root).map_err(|error| error.to_string())?;
+        let relative_bytes = relative.as_os_str().as_bytes();
+        let current = file_fingerprint(&metadata);
+        let prior = prepared.remove(relative_bytes);
+        let unchanged = prior
+            .and_then(|entry| entry.fingerprint)
+            .is_some_and(|fingerprint| fingerprint == current);
+        let destination_path = destination.join(relative);
+        preserve_special_mode(&destination_path, &metadata)?;
+        if !unchanged {
+            verify_changed_checkpoint_path(path, &destination_path)?;
+            if prior.is_some_and(|entry| entry.sqlite) || has_sqlite_magic(path)? {
+                sqlite_candidates.insert(destination_path);
+            }
+            if let Some(primary) = sqlite_primary_for_sidecar(relative) {
+                sqlite_candidates.insert(destination.join(primary));
+            }
+        }
+        return Ok(());
+    }
+    if metadata.is_dir() {
+        for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
+            verify_prepared_path(
+                root,
+                &entry.map_err(|error| error.to_string())?.path(),
+                destination,
+                prepared,
+                sqlite_candidates,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn preserve_special_mode(destination: &Path, source_metadata: &fs::Metadata) -> Result<(), String> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let mode = source_metadata.mode();
+    if mode & 0o6000 == 0 {
+        return Ok(());
+    }
+    let mut permissions = fs::symlink_metadata(destination)
+        .map_err(|error| error.to_string())?
+        .permissions();
+    permissions.set_mode(mode);
+    fs::set_permissions(destination, permissions)
+        .and_then(|()| fs::File::open(destination)?.sync_all())
+        .map_err(|error| {
+            format!(
+                "failed to preserve checkpoint mode for {}: {error}",
+                display_path(destination)
+            )
+        })
+}
+
+#[cfg(target_os = "macos")]
+fn preserve_special_modes(source: &Path, destination: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    if metadata.is_file() {
+        return preserve_special_mode(destination, &metadata);
+    }
+    if metadata.is_dir() {
+        for entry in fs::read_dir(source).map_err(|error| error.to_string())? {
+            let entry = entry.map_err(|error| error.to_string())?;
+            preserve_special_modes(&entry.path(), &destination.join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn verify_changed_checkpoint_path(source: &Path, destination: &Path) -> Result<(), String> {
+    let source_exists = path_exists(source);
+    let destination_exists = path_exists(destination);
+    if !source_exists && !destination_exists {
+        return Ok(());
+    }
+    if source_exists
+        && destination_exists
+        && inventory_tree(source)? == inventory_tree(destination)?
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "checkpoint verification failed: {} does not exactly match changed source {}",
+        display_path(destination),
+        display_path(source)
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn has_sqlite_magic(path: &Path) -> Result<bool, String> {
+    let mut file = fs::File::open(path).map_err(|error| error.to_string())?;
+    let mut magic = [0_u8; 16];
+    Ok(file.read_exact(&mut magic).is_ok() && &magic == b"SQLite format 3\0")
+}
+
+#[cfg(target_os = "macos")]
+fn sqlite_primary_for_sidecar(path: &Path) -> Option<PathBuf> {
+    let file_name = path.file_name()?.to_str()?;
+    for suffix in ["-wal", "-shm", "-journal"] {
+        if let Some(primary_name) = file_name.strip_suffix(suffix)
+            && !primary_name.is_empty()
+        {
+            return Some(path.with_file_name(primary_name));
+        }
+    }
+    None
 }
 
 fn regular_files(root: &Path) -> Result<Vec<PathBuf>, String> {
@@ -275,67 +642,40 @@ fn make_tree_removable(path: &Path) -> Result<(), String> {
 }
 
 #[cfg(target_os = "macos")]
-fn copyfile_tree(source: &Path, destination: &Path, clone: bool) -> Result<(), String> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
+type CopyfileState = *mut libc::c_void;
 
-    const COPYFILE_ALL: u32 = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
-    const COPYFILE_RECURSIVE: u32 = 1 << 15;
-    const COPYFILE_CLONE: u32 = 1 << 24;
-
-    unsafe extern "C" {
-        fn copyfile(
-            from: *const libc::c_char,
-            to: *const libc::c_char,
-            state: *mut libc::c_void,
-            flags: u32,
-        ) -> libc::c_int;
-    }
-
-    if clone {
-        verify_clone_capability(source, destination)?;
-    }
-    let source_c =
-        CString::new(source.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
-    let destination_c =
-        CString::new(destination.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
-    let mut flags = COPYFILE_ALL | COPYFILE_RECURSIVE;
-    if clone {
-        flags |= COPYFILE_CLONE;
-    }
-    let result = unsafe {
-        copyfile(
-            source_c.as_ptr(),
-            destination_c.as_ptr(),
-            std::ptr::null_mut(),
-            flags,
-        )
-    };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(std::io::Error::last_os_error().to_string())
-    }
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn copyfile(
+        from: *const libc::c_char,
+        to: *const libc::c_char,
+        state: CopyfileState,
+        flags: u32,
+    ) -> libc::c_int;
+    fn copyfile_state_alloc() -> CopyfileState;
+    fn copyfile_state_free(state: CopyfileState) -> libc::c_int;
+    fn copyfile_state_set(
+        state: CopyfileState,
+        flag: u32,
+        value: *const libc::c_void,
+    ) -> libc::c_int;
+    fn clonefile(
+        source: *const libc::c_char,
+        destination: *const libc::c_char,
+        flags: u32,
+    ) -> libc::c_int;
 }
 
 #[cfg(target_os = "macos")]
-fn verify_clone_capability(source: &Path, destination: &Path) -> Result<(), String> {
+fn clone_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::MetadataExt;
 
-    unsafe extern "C" {
-        fn clonefile(
-            source: *const libc::c_char,
-            destination: *const libc::c_char,
-            flags: libc::c_int,
-        ) -> libc::c_int;
-    }
-
+    const CLONE_ACL: u32 = 1 << 2;
     let destination_parent = destination
         .parent()
         .ok_or_else(|| "checkpoint destination has no parent".to_string())?;
-    ensure_dir(destination_parent)?;
     if fs::metadata(source)
         .map_err(|error| error.to_string())?
         .dev()
@@ -345,31 +685,66 @@ fn verify_clone_capability(source: &Path, destination: &Path) -> Result<(), Stri
     {
         return Err("source and checkpoint destination are on different filesystems".to_string());
     }
-
-    let nonce = format!(
-        ".ocm-clone-probe-{}-{}",
-        std::process::id(),
-        time::OffsetDateTime::now_utc().unix_timestamp_nanos()
-    );
-    let probe_source = destination_parent.join(format!("{nonce}.source"));
-    let probe_clone = destination_parent.join(format!("{nonce}.clone"));
-    fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&probe_source)
-        .map_err(|error| error.to_string())?;
     let source_c =
-        CString::new(probe_source.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
-    let clone_c =
-        CString::new(probe_clone.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
-    let result = unsafe { clonefile(source_c.as_ptr(), clone_c.as_ptr(), 0) };
-    let clone_error = (result != 0).then(std::io::Error::last_os_error);
-    let _ = fs::remove_file(&probe_clone);
-    let _ = fs::remove_file(&probe_source);
-    match clone_error {
-        Some(error) => Err(format!("filesystem clone probe failed: {error}")),
-        None => Ok(()),
+        CString::new(source.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let destination_c =
+        CString::new(destination.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    // Directory clonefile is all-or-nothing and never falls back to byte copying.
+    let result = unsafe { clonefile(source_c.as_ptr(), destination_c.as_ptr(), CLONE_ACL) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().to_string());
     }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn copyfile_tree(source: &Path, destination: &Path) -> Result<(), String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    const COPYFILE_ALL: u32 = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
+    const COPYFILE_RECURSIVE: u32 = 1 << 15;
+    const COPYFILE_NOFOLLOW_SRC: u32 = 1 << 18;
+    const COPYFILE_STATE_PRESERVE_SUID: u32 = 16;
+
+    let source_c =
+        CString::new(source.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let destination_c =
+        CString::new(destination.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
+    let state = unsafe { copyfile_state_alloc() };
+    if state.is_null() {
+        return Err("failed to allocate copyfile state".to_string());
+    }
+    let preserve_suid = 1_u32;
+    let state_result = unsafe {
+        copyfile_state_set(
+            state,
+            COPYFILE_STATE_PRESERVE_SUID,
+            std::ptr::from_ref(&preserve_suid).cast(),
+        )
+    };
+    if state_result != 0 {
+        unsafe {
+            copyfile_state_free(state);
+        }
+        return Err("failed to configure copyfile mode preservation".to_string());
+    }
+    let result = unsafe {
+        copyfile(
+            source_c.as_ptr(),
+            destination_c.as_ptr(),
+            state,
+            COPYFILE_ALL | COPYFILE_RECURSIVE | COPYFILE_NOFOLLOW_SRC,
+        )
+    };
+    unsafe {
+        copyfile_state_free(state);
+    }
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    preserve_special_modes(source, destination)?;
+    Ok(())
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -470,6 +845,11 @@ mod tests {
     use std::path::Path;
 
     use super::inventory_tree;
+    #[cfg(target_os = "macos")]
+    use super::{
+        STORAGE_APFS_CLONE, copyfile_tree, create_tree_checkpoint_from_preparation,
+        prepare_tree_checkpoint, sqlite_primary_for_sidecar, verify_tree_checkpoint,
+    };
 
     #[test]
     fn checkpoint_inventory_ignores_directory_allocation_lengths() {
@@ -481,5 +861,158 @@ mod tests {
         assert_eq!(inventory[Path::new("")].len, None);
         assert_eq!(inventory[Path::new("nested")].len, None);
         assert_eq!(inventory[Path::new("nested/value.txt")].len, Some(6));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn apfs_checkpoint_atomically_clones_the_complete_hierarchy() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let source = tempfile::tempdir().unwrap();
+        fs::create_dir_all(source.path().join("generated/node_modules/pkg")).unwrap();
+        fs::write(source.path().join("empty"), []).unwrap();
+        fs::write(
+            source.path().join("generated/node_modules/pkg/index.js"),
+            "module.exports = 1;\n",
+        )
+        .unwrap();
+        fs::write(source.path().join("privileged-tool"), "#!/bin/sh\n").unwrap();
+        fs::set_permissions(
+            source.path().join("privileged-tool"),
+            fs::Permissions::from_mode(0o4755),
+        )
+        .unwrap();
+        let destination_parent = tempfile::tempdir().unwrap();
+        let destination = destination_parent.path().join("checkpoint");
+
+        let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+        let storage = create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+
+        assert_eq!(storage, STORAGE_APFS_CLONE);
+        verify_tree_checkpoint(source.path(), &destination).unwrap();
+        assert_eq!(
+            fs::metadata(destination.join("privileged-tool"))
+                .unwrap()
+                .mode()
+                & 0o7777,
+            0o4755
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn prepared_checkpoint_rechecks_same_size_sqlite_mutation() {
+        let source = tempfile::tempdir().unwrap();
+        let database_path = source.path().join("state.sqlite");
+        let database = rusqlite::Connection::open(&database_path).unwrap();
+        database
+            .execute_batch(
+                "CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO state VALUES ('sentinel', 'before');",
+            )
+            .unwrap();
+        drop(database);
+        let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+        let metadata = fs::metadata(&database_path).unwrap();
+        let original_len = metadata.len() as usize;
+        let modified = filetime::FileTime::from_last_modification_time(&metadata);
+        let mut corrupt = vec![0_u8; original_len];
+        corrupt[..16].copy_from_slice(b"SQLite format 3\0");
+        fs::write(&database_path, corrupt).unwrap();
+        filetime::set_file_mtime(&database_path, modified).unwrap();
+
+        let destination_parent = tempfile::tempdir().unwrap();
+        let destination = destination_parent.path().join("checkpoint");
+        let error = create_tree_checkpoint_from_preparation(prepared, &destination).unwrap_err();
+
+        assert!(error.contains("SQLite"), "{error}");
+        assert!(!destination.exists());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn prepared_checkpoint_defers_busy_sqlite_until_capture() {
+        let source = tempfile::tempdir().unwrap();
+        let database_path = source.path().join("state.sqlite");
+        let database = rusqlite::Connection::open(&database_path).unwrap();
+        database
+            .execute_batch(
+                "PRAGMA journal_mode=DELETE;
+                 CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 INSERT INTO state VALUES ('sentinel', 'before');
+                 BEGIN EXCLUSIVE;",
+            )
+            .unwrap();
+
+        let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+        database.execute_batch("ROLLBACK").unwrap();
+        drop(database);
+        let destination_parent = tempfile::tempdir().unwrap();
+        let destination = destination_parent.path().join("checkpoint");
+
+        let storage = create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+
+        assert_eq!(storage, STORAGE_APFS_CLONE);
+        verify_tree_checkpoint(source.path(), &destination).unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sqlite_sidecars_revalidate_the_primary_database() {
+        assert_eq!(
+            sqlite_primary_for_sidecar(Path::new("state/openclaw.sqlite-wal")),
+            Some(Path::new("state/openclaw.sqlite").to_path_buf())
+        );
+        assert_eq!(
+            sqlite_primary_for_sidecar(Path::new("state/openclaw.sqlite-shm")),
+            Some(Path::new("state/openclaw.sqlite").to_path_buf())
+        );
+        assert_eq!(
+            sqlite_primary_for_sidecar(Path::new("state/openclaw.sqlite-journal")),
+            Some(Path::new("state/openclaw.sqlite").to_path_buf())
+        );
+        assert_eq!(
+            sqlite_primary_for_sidecar(Path::new("state/openclaw.sqlite")),
+            None
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_full_copy_preserves_symlinks() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+
+        let source = tempfile::tempdir().unwrap();
+        fs::write(source.path().join("state.txt"), "before\n").unwrap();
+        fs::write(source.path().join("privileged-tool"), "#!/bin/sh\n").unwrap();
+        fs::set_permissions(
+            source.path().join("privileged-tool"),
+            fs::Permissions::from_mode(0o4755),
+        )
+        .unwrap();
+        symlink("state.txt", source.path().join("current")).unwrap();
+        let destination_parent = tempfile::tempdir().unwrap();
+        let destination = destination_parent.path().join("checkpoint");
+
+        copyfile_tree(source.path(), &destination).unwrap();
+
+        assert!(
+            fs::symlink_metadata(destination.join("current"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            fs::read_link(destination.join("current")).unwrap(),
+            Path::new("state.txt")
+        );
+        assert_eq!(
+            fs::metadata(destination.join("privileged-tool"))
+                .unwrap()
+                .mode()
+                & 0o7777,
+            0o4755
+        );
+        verify_tree_checkpoint(source.path(), &destination).unwrap();
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -79,9 +79,9 @@ pub use runtimes::{
     install_runtime_from_url, list_runtimes, remove_runtime, runtime_integrity_issue,
 };
 pub(crate) use snapshots::{
-    EnvSnapshotRestoreTransaction, commit_env_snapshot_restore,
-    create_env_snapshot_with_service_state, prepare_env_snapshot_restore,
-    rollback_env_snapshot_restore,
+    EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
+    create_env_snapshot_from_preparation, prepare_env_snapshot_capture,
+    prepare_env_snapshot_restore, rollback_env_snapshot_restore,
 };
 pub use snapshots::{
     create_env_snapshot, get_env_snapshot, list_all_env_snapshots, list_env_snapshots,

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -14,8 +14,9 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use super::checkpoints::{
-    STORAGE_TAR_ARCHIVE, copy_tree_checkpoint, create_tree_checkpoint,
-    default_snapshot_storage_kind, remove_tree_if_present,
+    PreparedTreeCheckpoint, STORAGE_TAR_ARCHIVE, copy_tree_checkpoint,
+    create_tree_checkpoint_from_preparation, default_snapshot_storage_kind,
+    prepare_tree_checkpoint, remove_tree_if_present,
 };
 use super::common::{
     copy_dir_recursive, copy_path_recursive, load_json_files, path_exists, read_json, write_json,
@@ -69,6 +70,13 @@ pub(crate) struct EnvSnapshotRestoreTransaction {
 }
 
 #[derive(Debug)]
+pub(crate) struct PreparedEnvSnapshotCapture {
+    env_name: String,
+    source_root: PathBuf,
+    checkpoint: PreparedTreeCheckpoint,
+}
+
+#[derive(Debug)]
 struct RestoreOperationNamespace {
     root: PathBuf,
     candidate_root: PathBuf,
@@ -91,11 +99,57 @@ pub(crate) fn create_env_snapshot_with_service_state(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvSnapshotMeta, String> {
+    let prepared = prepare_env_snapshot_capture(&options.env_name, env, cwd)?;
+    create_env_snapshot_from_preparation(options, service_state, prepared, env, cwd)
+}
+
+pub(crate) fn prepare_env_snapshot_capture(
+    env_name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PreparedEnvSnapshotCapture, String> {
+    let env_name = validate_name(env_name, "Environment name")?;
+    let meta = get_environment(&env_name, env, cwd)?;
+    let env_paths = derive_env_paths(Path::new(&meta.root));
+    if !path_exists(&env_paths.root) {
+        return Err(format!(
+            "environment root does not exist: {}",
+            display_path(&env_paths.root)
+        ));
+    }
+    let checkpoint = prepare_tree_checkpoint(&env_paths.root)?;
+    Ok(PreparedEnvSnapshotCapture {
+        env_name,
+        source_root: env_paths.root,
+        checkpoint,
+    })
+}
+
+pub(crate) fn create_env_snapshot_from_preparation(
+    options: CreateEnvSnapshotOptions,
+    service_state: Option<(bool, bool)>,
+    prepared: PreparedEnvSnapshotCapture,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvSnapshotMeta, String> {
     let env_name = validate_name(&options.env_name, "Environment name")?;
+    if prepared.env_name != env_name {
+        return Err(format!(
+            "prepared snapshot belongs to environment \"{}\", not \"{env_name}\"",
+            prepared.env_name
+        ));
+    }
     let meta = get_environment(&env_name, env, cwd)?;
     let (service_enabled, service_running) =
         service_state.unwrap_or((meta.service_enabled, meta.service_running));
     let env_paths = derive_env_paths(Path::new(&meta.root));
+    if env_paths.root != prepared.source_root {
+        return Err(format!(
+            "environment root changed after snapshot preparation: expected {}, found {}",
+            display_path(&prepared.source_root),
+            display_path(&env_paths.root)
+        ));
+    }
     if !path_exists(&env_paths.root) {
         return Err(format!(
             "environment root does not exist: {}",
@@ -113,7 +167,8 @@ pub(crate) fn create_env_snapshot_with_service_state(
     let meta_path = snapshot_meta_path(&env_name, &snapshot_id, env, cwd)?;
 
     let result = (|| {
-        let storage_kind = create_tree_checkpoint(&env_paths.root, &checkpoint_path)?;
+        let storage_kind =
+            create_tree_checkpoint_from_preparation(prepared.checkpoint, &checkpoint_path)?;
         let snapshot = EnvSnapshotMeta {
             kind: "ocm-env-snapshot".to_string(),
             id: snapshot_id,

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -7,7 +7,10 @@ use std::sync::{
 };
 use std::thread;
 use std::time::Duration;
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use ocm::store::{env_registry_path, now_utc, supervisor_runtime_path};
 use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
@@ -355,22 +358,39 @@ fn env_snapshot_restores_the_complete_durable_root_with_metadata_and_sqlite() {
     let future_state = env_root.join("durable-future/state.txt");
     let future_non_sqlite_db = env_root.join("durable-future/cache.db");
     let future_link = env_root.join("durable-future/state-link");
+    let browser_cookie = env_root.join(".openclaw/browser/profile/Default/Cookies");
+    let plugin_state = env_root.join(".openclaw/plugins/example/state.json");
+    let generated_module = env_root.join(".openclaw/workspace/node_modules/example/index.js");
+    let generated_build = env_root.join(".openclaw/workspace/build/generated.js");
     let database_path = env_root.join(".openclaw/state/durable.sqlite");
+    let database_wal = PathBuf::from(format!("{}-wal", database_path.display()));
+    let database_shm = PathBuf::from(format!("{}-shm", database_path.display()));
     write_text(&dotenv, "OPENCLAW_SENTINEL=before\n");
     write_text(&secret, "secret-before\n");
     write_text(&future_state, "future-before\n");
     write_text(&future_non_sqlite_db, "opaque future cache\n");
+    write_text(&browser_cookie, "browser-cookie-before\n");
+    write_text(&plugin_state, "{\"state\":\"before\"}\n");
+    write_text(&generated_module, "module.exports = 'before';\n");
+    write_text(&generated_build, "export const generated = 'before';\n");
     fs::set_permissions(&secret, fs::Permissions::from_mode(0o600)).unwrap();
     symlink("state.txt", &future_link).unwrap();
     fs::create_dir_all(database_path.parent().unwrap()).unwrap();
     let database = Connection::open(&database_path).unwrap();
+    let journal_mode: String = database
+        .query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(journal_mode, "wal");
     database
         .execute_batch(
-            "CREATE TABLE durable_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            "PRAGMA wal_autocheckpoint=0;
+             CREATE TABLE durable_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
              INSERT INTO durable_state VALUES ('sentinel', 'before');",
         )
         .unwrap();
-    drop(database);
+    assert!(database_wal.exists());
+    assert!(database_shm.exists());
+    let expected_wal = fs::read(&database_wal).unwrap();
 
     let snapshot = run_ocm(
         &cwd,
@@ -380,9 +400,14 @@ fn env_snapshot_restores_the_complete_durable_root_with_metadata_and_sqlite() {
     assert!(snapshot.status.success(), "{}", stderr(&snapshot));
     let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
     let snapshot_id = snapshot_json["id"].as_str().unwrap();
+    drop(database);
 
     write_text(&dotenv, "OPENCLAW_SENTINEL=after\n");
     write_text(&secret, "secret-after\n");
+    write_text(&browser_cookie, "browser-cookie-after\n");
+    write_text(&plugin_state, "{\"state\":\"after\"}\n");
+    fs::remove_file(&generated_module).unwrap();
+    fs::remove_file(&generated_build).unwrap();
     fs::remove_file(&future_link).unwrap();
     fs::remove_file(&future_state).unwrap();
     let database = Connection::open(&database_path).unwrap();
@@ -415,7 +440,25 @@ fn env_snapshot_restores_the_complete_durable_root_with_metadata_and_sqlite() {
         fs::read_to_string(&future_non_sqlite_db).unwrap(),
         "opaque future cache\n"
     );
+    assert_eq!(
+        fs::read_to_string(&browser_cookie).unwrap(),
+        "browser-cookie-before\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&plugin_state).unwrap(),
+        "{\"state\":\"before\"}\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&generated_module).unwrap(),
+        "module.exports = 'before';\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&generated_build).unwrap(),
+        "export const generated = 'before';\n"
+    );
     assert_eq!(fs::read_link(&future_link).unwrap(), Path::new("state.txt"));
+    assert_eq!(fs::read(&database_wal).unwrap(), expected_wal);
+    assert!(fs::metadata(&database_shm).unwrap().len() > 0);
 
     let restored = Connection::open_with_flags(
         &database_path,
@@ -1583,14 +1626,43 @@ fn env_snapshot_removes_partial_artifacts_when_sqlite_snapshot_fails() {
     let root = TestDir::new("env-snapshot-invalid-sqlite");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
-    let env = ocm_env(&root);
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let health = TestHttpServer::serve_bytes_times("/health", "text/plain", b"ok", 10);
+    let health_port = url::Url::parse(&health.url()).unwrap().port().unwrap() as u32;
 
-    let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "create",
+            "source",
+            "--port",
+            &health_port.to_string(),
+            "--launcher",
+            "stable",
+        ],
+    );
     assert!(create.status.success(), "{}", stderr(&create));
+    let started = run_ocm(&cwd, &env, &["service", "start", "source"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    write_running_snapshot_service(&root, &cwd, &env, health_port);
     let database = root.child("ocm-home/envs/source/.openclaw/state/openclaw.sqlite");
     fs::create_dir_all(database.parent().unwrap()).unwrap();
     fs::write(&database, b"SQLite format 3\0not a valid database").unwrap();
 
+    fs::write(root.child("launchctl.log"), "").unwrap();
     let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
     assert_eq!(snapshot.status.code(), Some(1));
     assert!(
@@ -1603,6 +1675,123 @@ fn env_snapshot_removes_partial_artifacts_when_sqlite_snapshot_fails() {
         "SQLite format 3\0not a valid database"
     );
     assert!(!root.child("ocm-home/snapshots/source").exists());
+    let lifecycle = fs::read_to_string(root.child("launchctl.log")).unwrap();
+    assert!(!lifecycle.contains("bootout "), "{lifecycle}");
+    let shown = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["serviceEnabled"], true);
+    assert_eq!(shown["serviceRunning"], true);
+}
+
+#[test]
+fn env_snapshot_rechecks_sqlite_mutated_after_preflight_and_restores_service() {
+    let root = TestDir::new("env-snapshot-sqlite-mutated-after-preflight");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let health = TestHttpServer::serve_bytes_times("/health", "text/plain", b"ok", 20);
+    let health_port = url::Url::parse(&health.url()).unwrap().port().unwrap() as u32;
+
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "create",
+            "source",
+            "--port",
+            &health_port.to_string(),
+            "--launcher",
+            "stable",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let started = run_ocm(&cwd, &env, &["service", "start", "source"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    write_running_snapshot_service(&root, &cwd, &env, health_port);
+
+    let database_path = root.child("ocm-home/envs/source/.openclaw/state/openclaw.sqlite");
+    fs::create_dir_all(database_path.parent().unwrap()).unwrap();
+    let database = Connection::open(&database_path).unwrap();
+    database
+        .execute_batch(
+            "CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO state VALUES ('sentinel', 'before');",
+        )
+        .unwrap();
+    drop(database);
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let running_runtime = fs::read(&runtime_path).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_mutated = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let observer_mutated_thread = Arc::clone(&observer_mutated);
+    let observer_database = database_path.clone();
+    let observer_runtime_path = runtime_path.clone();
+    let observer = thread::spawn(move || {
+        let mut last_running = true;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let desired_running = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|registry| registry["envs"].as_array().cloned())
+                .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "source"))
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_running);
+            if desired_running != last_running {
+                if desired_running {
+                    fs::write(&observer_runtime_path, &running_runtime).unwrap();
+                } else {
+                    fs::write(
+                        &observer_database,
+                        b"SQLite format 3\0changed after snapshot preflight",
+                    )
+                    .unwrap();
+                    observer_mutated_thread.store(true, Ordering::Relaxed);
+                    write_empty_snapshot_service(&observer_runtime_path, &ocm_home);
+                }
+                last_running = desired_running;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+    });
+
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
+    observer_done.store(true, Ordering::Relaxed);
+    observer.join().unwrap();
+
+    assert!(observer_mutated.load(Ordering::Relaxed));
+    assert_eq!(snapshot.status.code(), Some(1));
+    assert!(
+        stderr(&snapshot).contains("SQLite"),
+        "{}",
+        stderr(&snapshot)
+    );
+    assert!(!root.child("ocm-home/snapshots/source").exists());
+    assert_eq!(
+        fs::read_to_string(&database_path).unwrap(),
+        "SQLite format 3\0changed after snapshot preflight"
+    );
+    let shown = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["serviceEnabled"], true);
+    assert_eq!(shown["serviceRunning"], true);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- move whole-root SQLite discovery and race fingerprints before service quiescence
- use macOS directory `clonefile` for an all-or-nothing APFS checkpoint with no byte-copy fallback
- after quiescence, rewalk metadata and verify only new, changed, removed, or unstable files and related SQLite state
- retain the complete-root full-copy fallback, legacy snapshot readability, and existing service-policy restoration
- preserve symlinks and special mode bits in the macOS fallback instead of following or weakening them

## Verdict and overlap

The outage is still present on canonical `main` after #72 and #75. PR #60's
whole-root checkpoint work was already extracted into #72; its remaining broad
lifecycle and local-source changes do not remove the post-quiesce whole-root
hashing and SQLite discovery cost. This PR is a focused checkpoint/cutover fix
and does not absorb target-readiness preflight, runtime packaging, restart
protocol, or startup migration work.

Canonical invariant:

> A published APFS checkpoint is an all-or-nothing complete-root clone with no
> byte-copy fallback. Any file that changed or was unstable during live
> preflight must match the quiesced clone, and changed SQLite state must pass
> `PRAGMA quick_check`. Otherwise OCM removes the partial and publishes only
> after complete full-copy verification.

## Performance

Same deterministic fixture on base and head:

- 393,738 regular files
- 2,718,195,923 logical bytes
- 2,718,232,576 allocated bytes
- generated `node_modules` and build trees plus secret, browser, plugin,
  SQLite, sidecar, symlink, and unknown future-owner state

| Revision | Command | Available preflight | Stopped-to-ready | Storage |
| --- | ---: | ---: | ---: | --- |
| `5d8ef1184f34e8ae8f2fccec87f14f9b31e9184c` | 254.182930s | 0.241922s | 253.941008s | `apfs-clone-v1` |
| `7eb8e05414033e2bdc7537f83983c7f8b0fb517a` | 61.418625s | 48.473917s | 12.857870s | `apfs-clone-v1` |

The final head reduces the unavailable interval by 94.9%. An independent
recursive `copyfile` control still takes 54.083927s with zero copied bytes,
confirming the improvement comes from atomic hierarchy cloning and removing
whole-root content verification from the stopped window.

## Validation

- `cargo check --all-targets --locked`
- `cargo test --locked` (complete macOS suite)
- `cargo test --locked store::checkpoints::tests`
- `cargo test --locked --test env_snapshot_tests`
- `cargo test --locked --test upgrade_command_tests`
- Linux Docker: checkpoint owner tests and all 36 environment snapshot tests
- mounted HFS+ fallback: `full-copy-v1`, secret mode `0600`, symlink target,
  browser/plugin/generated content, and SQLite quick-check
- source-blind CLI validation: exact large fixture, generated-tree controls,
  post-capture mutation isolation, and corrupt SQLite failure before any
  quiesce command while the service remained running
- structured autoreview: clean, no actionable P0/P1 findings

Focused regressions cover:

- complete durable-root restore, including secrets, browser/plugin state,
  generated trees, unknown future state, symlinks, modes, SQLite WAL/SHM
- same-size SQLite mutation after preflight
- busy live SQLite deferred until quiescence
- corrupt SQLite cleanup and service restoration
- already-stopped and disabled service policy
- macOS symlink and special-mode preservation
- legacy tar metadata and current full-copy/APFS restore paths

## Remaining risk

APFS cutover no longer scales with generated byte volume or whole-tree hashing,
but atomic directory cloning and the metadata rewalk still depend on namespace
count and filesystem pressure. Linux, non-APFS, cross-filesystem, and clone
failure paths intentionally retain the honest size-dependent full-copy outage.

No agent transcript is included.
