### PR TITLE
feat(runtime): preserve source extensions in local builds

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -116,6 +116,26 @@ files/node_modules/openclaw/openclaw.mjs
 
 That matters for release and upgrade testing because it avoids source/Jiti execution paths and exercises the built package files that users install.
 
+When an environment should run an immutable build of a local checkout while
+retaining extensions that are available to the source launcher but intentionally
+omitted from the release-shaped core package, opt in explicitly:
+
+```bash
+ocm runtime build-local upstream-main \
+  --repo /path/to/openclaw \
+  --include-source-extensions \
+  --force
+```
+
+OCM packages only built extensions under that checkout's `dist/extensions`
+that are absent from the core tarball, installs their runtime dependencies, and
+places them in the managed runtime's bundled-extension root. Extensions from
+global, state, workspace, or other external paths are not included or promoted.
+Without the flag, `build-local` remains release-shaped.
+Because the opt-in installs every omitted extension and its dependency closure,
+the resulting runtime can take longer to build and use substantially more disk
+space than the release-shaped default.
+
 ### 6. Keep an environment running in the background
 
 ```bash
@@ -231,7 +251,9 @@ Use a launcher when you want:
 
 - published OpenClaw release: use `release` and `runtime`
 - local checkout as source command: use `launcher`
-- local checkout as built package: use `runtime build-local`
+- local checkout as built package: use `runtime build-local`; add
+  `--include-source-extensions` only when the managed artifact should retain
+  source-checkout extensions omitted from the release package
 - day-to-day work: use `env`
 
 ## Running commands inside environments

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1883,12 +1883,16 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
             "Build a local OpenClaw package runtime",
             "Run the local OpenClaw package build/pack path and install the produced tarball as an OCM-managed runtime.",
             vec![format!(
-                "{cmd} runtime build-local <name> --repo <openclaw-repo> [--description <text>] [--force] [--raw] [--json]"
+                "{cmd} runtime build-local <name> --repo <openclaw-repo> [--include-source-extensions] [--description <text>] [--force] [--raw] [--json]"
             )],
             &[
                 (
                     "--repo <openclaw-repo>",
                     "Path to a local OpenClaw checkout with package.json",
+                ),
+                (
+                    "--include-source-extensions",
+                    "Include built extensions omitted from the release-shaped core package",
                 ),
                 ("--description <text>", "Optional human description"),
                 (
@@ -1901,11 +1905,16 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 ),
                 ("--json", "Print the runtime record as JSON"),
             ],
-            vec![format!(
-                "{cmd} runtime build-local main-local --repo /path/to/openclaw --force"
-            )],
+            vec![
+                format!("{cmd} runtime build-local main-local --repo /path/to/openclaw --force"),
+                format!(
+                    "{cmd} runtime build-local upstream-main --repo /path/to/openclaw --include-source-extensions --force"
+                ),
+            ],
             &[
                 "`build-local` uses `npm pack` so OpenClaw's prepack script performs the release-style build, UI build, package inventory, and built entry smoke checks.",
+                "By default the result remains release-shaped. `--include-source-extensions` adds only built extensions from the selected checkout that the core tarball omitted, together with their installed runtime dependencies.",
+                "Source-extension runtimes can take longer to build and use substantially more disk space than the release-shaped default.",
                 "The resulting runtime is installed under OCM's package runtime layout: files/node_modules/openclaw/openclaw.mjs.",
                 "Use this when testing release and upgrade behavior from a local checkout without source/Jiti execution paths.",
                 "A runtime bound to an environment cannot be replaced directly. Clear the binding first or use `ocm upgrade <env>` for published OpenClaw releases.",

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -286,6 +286,8 @@ impl Cli {
         let (args, json_flag, profile) =
             self.consume_human_output_flags(args, "runtime build-local")?;
         let (args, force) = Self::consume_flag(args, "--force");
+        let (args, include_source_extensions) =
+            Self::consume_flag(args, "--include-source-extensions");
         let (args, repo) = Self::consume_option(args, "--repo")?;
         let repo = Self::require_option_value(repo, "--repo")?;
         let Some(repo) = repo else {
@@ -304,6 +306,7 @@ impl Cli {
                     repo: repo.clone(),
                     description,
                     force,
+                    include_source_extensions,
                 })
         })?;
 

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -55,6 +55,7 @@ pub struct BuildLocalRuntimeOptions {
     pub repo: String,
     pub description: Option<String>,
     pub force: bool,
+    pub include_source_extensions: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -391,6 +392,7 @@ impl<'a> RuntimeService<'a> {
                     repo: options.repo,
                     description: options.description,
                     force: options.force,
+                    include_source_extensions: options.include_source_extensions,
                 },
                 InstallContext {
                     env: self.env,

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::host::verify_official_openclaw_runtime_host;
@@ -317,6 +317,7 @@ pub struct BuildLocalRuntimeOptions {
     pub repo: String,
     pub description: Option<String>,
     pub force: bool,
+    pub include_source_extensions: bool,
 }
 
 fn summarize_command_output(stdout: &[u8], stderr: &[u8]) -> Option<String> {
@@ -362,6 +363,19 @@ struct LocalBuildNpmAdapter {
     command: CommandSpec,
     real_npm: String,
     workspace_dependency_dirs: Option<OsString>,
+}
+
+#[derive(Clone, Debug)]
+struct LocalSourceExtension {
+    id: String,
+    package_name: String,
+    source_dir: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct LocalSourceExtensionArchive {
+    extension: LocalSourceExtension,
+    archive_path: PathBuf,
 }
 
 impl LocalBuildNpmAdapter {
@@ -553,6 +567,7 @@ fn local_build_npm_adapter(
 
 fn install_openclaw_package_with_npm(
     archive_path: &Path,
+    additional_archives: &[PathBuf],
     install_files: &Path,
     cwd: &Path,
     env: &BTreeMap<String, String>,
@@ -580,6 +595,7 @@ fn install_openclaw_package_with_npm(
         .arg("--omit=dev")
         .arg("--no-save")
         .arg("--package-lock=false")
+        .args(additional_archives)
         .arg(archive_path)
         .env("npm_config_fund", "false")
         .env("npm_config_audit", "false")
@@ -754,6 +770,269 @@ fn pack_local_openclaw_repo(
             display_path(pack_dir)
         )),
     }
+}
+
+fn packaged_openclaw_extension_ids(archive_path: &Path) -> Result<BTreeSet<String>, String> {
+    let file = fs::File::open(archive_path).map_err(|error| {
+        format!(
+            "failed to inspect local OpenClaw package at {}: {error}",
+            display_path(archive_path)
+        )
+    })?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut ids = BTreeSet::new();
+    for entry in archive.entries().map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let path = entry.path().map_err(|error| error.to_string())?;
+        let mut components = path.components();
+        if !matches!(components.next(), Some(Component::Normal(value)) if value == "package")
+            || !matches!(components.next(), Some(Component::Normal(value)) if value == "dist")
+            || !matches!(components.next(), Some(Component::Normal(value)) if value == "extensions")
+        {
+            continue;
+        }
+        if let Some(Component::Normal(value)) = components.next()
+            && value != "node_modules"
+        {
+            ids.insert(value.to_string_lossy().to_string());
+        }
+    }
+    Ok(ids)
+}
+
+fn npm_package_relative_path(package_name: &str) -> Option<PathBuf> {
+    let valid_component = |value: &str| {
+        !value.is_empty()
+            && value != "."
+            && value != ".."
+            && !value.contains(['/', '\\'])
+            && Path::new(value).file_name() == Some(OsStr::new(value))
+    };
+    if let Some(scoped) = package_name.strip_prefix('@') {
+        let (scope, name) = scoped.split_once('/')?;
+        if !valid_component(scope) || !valid_component(name) || name.contains('/') {
+            return None;
+        }
+        return Some(PathBuf::from(format!("@{scope}")).join(name));
+    }
+    valid_component(package_name).then(|| PathBuf::from(package_name))
+}
+
+fn local_source_extensions_omitted_from_package(
+    repo_path: &Path,
+    archive_path: &Path,
+) -> Result<Vec<LocalSourceExtension>, String> {
+    let packaged_ids = packaged_openclaw_extension_ids(archive_path)?;
+    let extensions_dir = repo_path.join("dist/extensions");
+    let entries = fs::read_dir(&extensions_dir).map_err(|error| {
+        format!(
+            "failed to read built OpenClaw extensions at {}: {error}",
+            display_path(&extensions_dir)
+        )
+    })?;
+    let mut extensions = Vec::new();
+    let mut package_names = BTreeSet::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let source_dir = entry.path();
+        if !entry
+            .file_type()
+            .map_err(|error| error.to_string())?
+            .is_dir()
+        {
+            continue;
+        }
+        let id = entry.file_name().to_string_lossy().to_string();
+        if id == "node_modules" || packaged_ids.contains(&id) {
+            continue;
+        }
+        let package_json_path = source_dir.join("package.json");
+        let manifest_path = source_dir.join("openclaw.plugin.json");
+        if !package_json_path.exists() && !manifest_path.exists() {
+            continue;
+        }
+        let raw = fs::read_to_string(&package_json_path).map_err(|error| {
+            format!(
+                "source extension \"{id}\" cannot be packaged because {} is unavailable: {error}",
+                display_path(&package_json_path)
+            )
+        })?;
+        let package_json: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
+            format!(
+                "failed to parse source extension package.json at {}: {error}",
+                display_path(&package_json_path)
+            )
+        })?;
+        let package_name = package_json
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| npm_package_relative_path(value).is_some())
+            .ok_or_else(|| {
+                format!(
+                    "source extension \"{id}\" has no valid npm package name in {}",
+                    display_path(&package_json_path)
+                )
+            })?
+            .to_string();
+        if !package_names.insert(package_name.clone()) {
+            return Err(format!(
+                "multiple source extensions use npm package name \"{package_name}\""
+            ));
+        }
+        extensions.push(LocalSourceExtension {
+            id,
+            package_name,
+            source_dir,
+        });
+    }
+    extensions.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(extensions)
+}
+
+fn pack_local_source_extensions(
+    extensions: Vec<LocalSourceExtension>,
+    pack_dir: &Path,
+    env: &BTreeMap<String, String>,
+) -> Result<Vec<LocalSourceExtensionArchive>, String> {
+    if extensions.is_empty() {
+        return Ok(Vec::new());
+    }
+    let npm = CommandSpec {
+        program: npm_program(env),
+        args: Vec::new(),
+        path_prepend: None,
+    };
+    let mut command = Command::new(&npm.program);
+    command
+        .args(&npm.args)
+        .arg("pack")
+        .arg("--json")
+        .arg("--ignore-scripts")
+        .arg("--pack-destination")
+        .arg(pack_dir)
+        .args(extensions.iter().map(|extension| &extension.source_dir))
+        .env("npm_config_fund", "false")
+        .env("npm_config_audit", "false")
+        .env("npm_config_update_notifier", "false")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    npm.apply_environment(&mut command, env)?;
+    let output = command.output().map_err(|error| {
+        format!("failed to run npm pack for local OpenClaw source extensions: {error}")
+    })?;
+    if !output.status.success() {
+        let detail =
+            summarize_command_output(&output.stdout, &output.stderr).unwrap_or_else(|| {
+                format!(
+                    "npm pack exited with code {}",
+                    output.status.code().unwrap_or(1)
+                )
+            });
+        return Err(format!(
+            "failed to pack local OpenClaw source extensions: {detail}"
+        ));
+    }
+
+    let values: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("failed to parse npm pack source extension output: {error}"))?;
+    let values = values
+        .as_array()
+        .ok_or_else(|| "npm pack source extension output was not a JSON array".to_string())?;
+    let mut archives_by_name = BTreeMap::new();
+    for value in values {
+        let package_name = value
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                "npm pack source extension output is missing a package name".to_string()
+            })?;
+        let filename = value
+            .get("filename")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "npm pack source extension output is missing a filename".to_string())?;
+        if Path::new(filename).file_name() != Some(OsStr::new(filename)) {
+            return Err(format!(
+                "npm pack returned an invalid source extension filename: {filename}"
+            ));
+        }
+        let archive_path = pack_dir.join(filename);
+        if !path_exists(&archive_path) {
+            return Err(format!(
+                "npm pack did not create source extension archive {}",
+                display_path(&archive_path)
+            ));
+        }
+        if archives_by_name
+            .insert(package_name.to_string(), archive_path)
+            .is_some()
+        {
+            return Err(format!(
+                "npm pack returned duplicate source extension package \"{package_name}\""
+            ));
+        }
+    }
+
+    let archives = extensions
+        .into_iter()
+        .map(|extension| {
+            let archive_path = archives_by_name
+                .remove(&extension.package_name)
+                .ok_or_else(|| {
+                    format!(
+                        "npm pack did not return source extension package \"{}\"",
+                        extension.package_name
+                    )
+                })?;
+            Ok(LocalSourceExtensionArchive {
+                extension,
+                archive_path,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    if let Some(package_name) = archives_by_name.keys().next() {
+        return Err(format!(
+            "npm pack returned unexpected source extension package \"{package_name}\""
+        ));
+    }
+    Ok(archives)
+}
+
+fn materialize_local_source_extensions(
+    install_files: &Path,
+    extensions: &[LocalSourceExtensionArchive],
+) -> Result<(), String> {
+    let target_root = installed_openclaw_package_root(install_files).join("dist/extensions");
+    for extension in extensions {
+        let package_relative_path = npm_package_relative_path(&extension.extension.package_name)
+            .ok_or_else(|| {
+                format!(
+                    "source extension \"{}\" has an invalid npm package name",
+                    extension.extension.id
+                )
+            })?;
+        let installed_package = install_files
+            .join("node_modules")
+            .join(package_relative_path);
+        if !installed_package.join("package.json").exists() {
+            return Err(format!(
+                "installed source extension \"{}\" is missing {}",
+                extension.extension.id,
+                display_path(&installed_package.join("package.json"))
+            ));
+        }
+        let target = target_root.join(&extension.extension.id);
+        if path_exists(&target) {
+            return Err(format!(
+                "source extension target already exists after package installation: {}",
+                display_path(&target)
+            ));
+        }
+        copy_dir_recursive(&installed_package, &target)?;
+    }
+    Ok(())
 }
 
 fn build_installed_runtime_meta(
@@ -963,6 +1242,7 @@ fn install_runtime_from_openclaw_package(
             description,
             context,
             None,
+            &[],
         );
         let _ = fs::remove_file(&archive_path);
         publish_runtime(target, meta?)
@@ -977,14 +1257,21 @@ fn stage_runtime_from_openclaw_package_archive(
     description: Option<String>,
     context: InstallContext<'_>,
     local_adapter: Option<&LocalBuildNpmAdapter>,
+    source_extensions: &[LocalSourceExtensionArchive],
 ) -> Result<RuntimeMeta, String> {
+    let additional_archives = source_extensions
+        .iter()
+        .map(|extension| extension.archive_path.clone())
+        .collect::<Vec<_>>();
     install_openclaw_package_with_npm(
         archive_path,
+        &additional_archives,
         &target.install_files,
         context.cwd,
         context.env,
         local_adapter,
     )?;
+    materialize_local_source_extensions(&target.install_files, source_extensions)?;
     expose_openclaw_package_runtime_dependencies(&target.install_files)?;
 
     let binary_path = installed_openclaw_binary_path(&target.install_files);
@@ -1315,6 +1602,13 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
         let local_adapter = local_build_npm_adapter(&repo_path, context.env)?;
         let archive_path =
             pack_local_openclaw_repo(&repo_path, &pack_dir, context.env, local_adapter.as_ref())?;
+        let source_extensions = if options.include_source_extensions {
+            let extensions =
+                local_source_extensions_omitted_from_package(&repo_path, &archive_path)?;
+            pack_local_source_extensions(extensions, &pack_dir, context.env)?
+        } else {
+            Vec::new()
+        };
         let target = prepare_runtime_install_target(name, options.force, context.env, context.cwd)?;
         if path_exists(&target.install_root) {
             return Err(format!(
@@ -1339,6 +1633,7 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
             description,
             context,
             local_adapter.as_ref(),
+            &source_extensions,
         )?;
         publish_runtime(target, meta)
     })();

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -78,6 +78,75 @@ fn openclaw_package_tarball_with_dependencies(script_body: &str, version: &str) 
     encoder.finish().unwrap()
 }
 
+fn openclaw_package_tarball_with_bundled_extension(script_body: &str, version: &str) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut builder = Builder::new(&mut encoder);
+        append_tar_file(
+            &mut builder,
+            "package/openclaw.mjs",
+            script_body.as_bytes(),
+            0o755,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/package.json",
+            format!(
+                "{{\"name\":\"openclaw\",\"version\":\"{version}\",\"bin\":{{\"openclaw\":\"openclaw.mjs\"}}}}"
+            )
+            .as_bytes(),
+            0o644,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/dist/extensions/memory-core/package.json",
+            br#"{"name":"@openclaw/memory-core","version":"2026.4.25"}"#,
+            0o644,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/dist/extensions/memory-core/openclaw.plugin.json",
+            br#"{"id":"memory-core","configSchema":{"type":"object"}}"#,
+            0o644,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/dist/extensions/memory-core/index.js",
+            b"export const build = 'packaged';\n",
+            0o644,
+        );
+        builder.finish().unwrap();
+    }
+    encoder.finish().unwrap()
+}
+
+fn source_extension_package_tarball() -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut builder = Builder::new(&mut encoder);
+        append_tar_file(
+            &mut builder,
+            "package/package.json",
+            br#"{"name":"@openclaw/codex","version":"2026.4.25","dependencies":{"codex-runtime":"1.0.0"}}"#,
+            0o644,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/openclaw.plugin.json",
+            br#"{"id":"codex","configSchema":{"type":"object"}}"#,
+            0o644,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/index.js",
+            b"export const build = 'source';\n",
+            0o644,
+        );
+        builder.finish().unwrap();
+    }
+    encoder.finish().unwrap()
+}
+
 fn sha512_integrity(body: &[u8]) -> String {
     let digest = Sha512::digest(body);
     format!(
@@ -111,6 +180,36 @@ if [ "$1" = "--version" ]; then
 fi
 
 if [ "$1" = "pack" ]; then
+  case " $* " in
+    *" --json "*)
+      shift
+      destination=""
+      source_dir=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --pack-destination)
+            shift
+            destination="$1"
+            ;;
+          --json|--ignore-scripts)
+            ;;
+          *)
+            source_dir="$1"
+            ;;
+        esac
+        shift
+      done
+      if [ -z "$destination" ] || [ -z "$source_dir" ] || [ -z "$FAKE_SOURCE_EXTENSION_ARCHIVE" ]; then
+        echo "fake npm source extension pack is not configured" >&2
+        exit 1
+      fi
+      mkdir -p "$destination"
+      cp "$FAKE_SOURCE_EXTENSION_ARCHIVE" "$destination/$FAKE_SOURCE_EXTENSION_FILENAME"
+      printf '[{{"name":"%s","version":"2026.4.25","filename":"%s"}}]\n' \
+        "$FAKE_SOURCE_EXTENSION_NAME" "$FAKE_SOURCE_EXTENSION_FILENAME"
+      exit 0
+      ;;
+  esac
   printf 'verify-deps-before-run=%s\n' "$PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN" >> "{}"
   printf 'allow-unreleased-changelog=%s\n' "$OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG" >> "{}"
   printf 'ignore-scripts-lower=%s\n' "${{npm_config_ignore_scripts-unset}}" >> "{}"
@@ -138,6 +237,7 @@ fi
 
 prefix=""
 archive=""
+source_extension_archive=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --prefix)
@@ -147,6 +247,7 @@ while [ "$#" -gt 0 ]; do
     install|--omit=dev|--no-save|--package-lock=false)
       ;;
     *)
+      source_extension_archive="$archive"
       archive="$1"
       ;;
   esac
@@ -160,6 +261,13 @@ fi
 
 mkdir -p "$prefix/node_modules/openclaw"
 tar -xzf "$archive" -C "$prefix/node_modules/openclaw" --strip-components=1 package
+if [ -n "$source_extension_archive" ]; then
+  source_extension_root="$prefix/node_modules/$FAKE_SOURCE_EXTENSION_INSTALL_PATH"
+  mkdir -p "$source_extension_root"
+  tar -xzf "$source_extension_archive" -C "$source_extension_root" --strip-components=1 package
+  mkdir -p "$prefix/node_modules/codex-runtime"
+  printf '{{"name":"codex-runtime","version":"1.0.0"}}\n' > "$prefix/node_modules/codex-runtime/package.json"
+fi
 if grep -q '"chokidar"' "$prefix/node_modules/openclaw/package.json"; then
   mkdir -p "$prefix/node_modules/chokidar"
   mkdir -p "$prefix/node_modules/readdirp"
@@ -522,6 +630,171 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
 
     let verify = run_ocm(&cwd, &env, &["runtime", "verify", "main-local", "--raw"]);
     assert!(verify.status.success(), "{}", stderr(&verify));
+}
+
+#[test]
+fn runtime_build_local_can_include_source_extensions_without_widening_default_trust() {
+    let root = TestDir::new("runtime-build-local-source-extensions");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    let codex_dir = repo.join("dist/extensions/codex");
+    let memory_core_dir = repo.join("dist/extensions/memory-core");
+    let dependency_only_dir = repo.join("dist/extensions/node_modules/external-helper");
+    let external_plugin_dir = cwd.join("external-plugins/external-demo");
+    for dir in [
+        &codex_dir,
+        &memory_core_dir,
+        &dependency_only_dir,
+        &external_plugin_dir,
+    ] {
+        fs::create_dir_all(dir).unwrap();
+    }
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.4.25","bin":{"openclaw":"openclaw.mjs"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        codex_dir.join("package.json"),
+        br#"{"name":"@openclaw/codex","version":"2026.4.25","dependencies":{"codex-runtime":"1.0.0"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        codex_dir.join("openclaw.plugin.json"),
+        br#"{"id":"codex","configSchema":{"type":"object"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        codex_dir.join("index.js"),
+        "export const build = 'source';\n",
+    )
+    .unwrap();
+    fs::write(
+        memory_core_dir.join("package.json"),
+        br#"{"name":"@openclaw/memory-core","version":"2026.4.25"}"#,
+    )
+    .unwrap();
+    fs::write(
+        memory_core_dir.join("openclaw.plugin.json"),
+        br#"{"id":"memory-core","configSchema":{"type":"object"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        memory_core_dir.join("index.js"),
+        "export const build = 'source';\n",
+    )
+    .unwrap();
+    fs::write(
+        dependency_only_dir.join("package.json"),
+        br#"{"name":"external-helper","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    fs::write(
+        external_plugin_dir.join("package.json"),
+        br#"{"name":"external-demo","version":"1.0.0"}"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(
+        &external_plugin_dir,
+        repo.join("dist/extensions/linked-external-demo"),
+    )
+    .unwrap();
+
+    let archive_path = root.child("packed-openclaw.tgz");
+    fs::write(
+        &archive_path,
+        openclaw_package_tarball_with_bundled_extension(
+            "#!/usr/bin/env node\nconsole.log('source extension runtime');\n",
+            "2026.4.25",
+        ),
+    )
+    .unwrap();
+    let source_extension_archive = root.child("openclaw-codex-2026.4.25.tgz");
+    fs::write(
+        &source_extension_archive,
+        source_extension_package_tarball(),
+    )
+    .unwrap();
+
+    let mut env = ocm_env(&root);
+    env.insert(
+        "FAKE_SOURCE_EXTENSION_ARCHIVE".to_string(),
+        path_string(&source_extension_archive),
+    );
+    env.insert(
+        "FAKE_SOURCE_EXTENSION_NAME".to_string(),
+        "@openclaw/codex".to_string(),
+    );
+    env.insert(
+        "FAKE_SOURCE_EXTENSION_FILENAME".to_string(),
+        "openclaw-codex-2026.4.25.tgz".to_string(),
+    );
+    env.insert(
+        "FAKE_SOURCE_EXTENSION_INSTALL_PATH".to_string(),
+        "@openclaw/codex".to_string(),
+    );
+    install_fake_node_and_packing_npm(&root, &mut env, &archive_path);
+
+    let release_build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "release-shaped",
+            "--repo",
+            "./openclaw",
+            "--raw",
+        ],
+    );
+    assert!(release_build.status.success(), "{}", stderr(&release_build));
+    let release_root = runtime_install_root("release-shaped", &env, &cwd)
+        .unwrap()
+        .join("files/node_modules/openclaw");
+    assert!(!release_root.join("dist/extensions/codex").exists());
+    assert_eq!(
+        fs::read_to_string(release_root.join("dist/extensions/memory-core/index.js")).unwrap(),
+        "export const build = 'packaged';\n"
+    );
+
+    let source_build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "source-extensions",
+            "--repo",
+            "./openclaw",
+            "--include-source-extensions",
+            "--raw",
+        ],
+    );
+    assert!(source_build.status.success(), "{}", stderr(&source_build));
+    let source_root = runtime_install_root("source-extensions", &env, &cwd)
+        .unwrap()
+        .join("files/node_modules/openclaw");
+    assert_eq!(
+        fs::read_to_string(source_root.join("dist/extensions/codex/index.js")).unwrap(),
+        "export const build = 'source';\n"
+    );
+    assert_eq!(
+        fs::read_to_string(source_root.join("dist/extensions/memory-core/index.js")).unwrap(),
+        "export const build = 'packaged';\n"
+    );
+    assert!(
+        source_root
+            .join("node_modules/codex-runtime/package.json")
+            .exists()
+    );
+    assert!(!source_root.join("dist/extensions/external-helper").exists());
+    assert!(!source_root.join("dist/extensions/external-demo").exists());
+    assert!(
+        !source_root
+            .join("dist/extensions/linked-external-demo")
+            .exists()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add an opt-in `runtime build-local --include-source-extensions` mode
- package every built extension omitted from the release-shaped core tarball and install its runtime dependency closure
- preserve the existing release-shaped default and keep external/global plugins outside bundled trust

## Why

`runtime build-local` correctly mirrors OpenClaw's core npm package, but that package intentionally excludes separately published extensions. This makes the default useful for release validation while leaving no immutable managed-runtime option for users who build unreleased OpenClaw source and need the same extension set as the source launcher.

The new flag keeps the default contract intact. When selected, OCM inventories the core tarball, packages only omitted entries from that checkout's `dist/extensions`, installs the core and extension archives together, and materializes those exact packages under the managed runtime's bundled-extension root. Symlinked extension directories and plugins from global, state, workspace, or other external paths are excluded.

## Validation

- owner regression: default build omits Codex, opt-in build retains it, packaged `memory-core` remains unchanged, the retained dependency is exposed, and dependency/global/symlink escape controls are not promoted
- real OpenClaw `07adc745efe99ebd72abf3adf862dc8e66036dad` build:
  - source/runtime extension inventory: `87 / 87` (release-shaped red artifact: `60`)
  - Codex: `origin=bundled`, package-local `codex-cli 0.147.0`
  - memory-core: `origin=bundled`
  - unrelated npm-packed control plugin: `origin=global`
  - source-checkout links in installed runtime: `0`
  - `ocm runtime verify`: healthy
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- focused source-extension regression: pass
- runtime command suite: 45 pass; the existing concurrent-integrity timing test missed its first request in the loaded suite and passed when run alone
- source-blind behavior contract: pass
- autoreview and TruffleHog: clean

## Local baseline limitations

The full local suite is currently blocked by two unrelated host conditions outside the touched paths: Homebrew rustup no longer proxies a test-created `cargo` symlink as expected, and environment-destroy process scans encounter transient missing process CWDs. CI remains the authoritative cross-platform/full-suite gate.

## Operational note

This mode is intentionally opt-in because installing every omitted extension can substantially increase build time and disk use. In the representative macOS proof, the source-extension runtime used about 2.5 GB versus about 504 MB for the earlier release-shaped artifact.
