### PR TITLE
fix(upgrade): stage runtime work before cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,14 @@ ocm upgrade simulate mira --to beta --scenario all
 ocm upgrade simulate mira --to ./openclaw
 ```
 
-`upgrade` stops a running managed gateway and creates a verified pre-upgrade
-checkpoint before changing an environment. If a running service cannot be
-restarted or started after the change, OCM keeps the restored checkpoint and
-previous runtime as the coherent rollback state. When an environment moves to a
-new runtime, OCM runs OpenClaw's update finalization path while the gateway is
-stopped, before service restart. A running managed service is considered recovered only
+`upgrade` stages the target runtime, validates the checkpoint source, and
+prepares runtime recovery while the current managed gateway remains available.
+Preparation failures leave the source environment and service unchanged. OCM
+stops a running gateway only for checkpoint capture, runtime publication,
+environment mutation, and OpenClaw update finalization. If a running service
+cannot be restarted or started after the change, OCM keeps the restored
+checkpoint and previous runtime as the coherent rollback state. A running
+managed service is considered recovered only
 after its HTTP health endpoint responds and OpenClaw's gateway status proves the
 gateway is reachable; otherwise the upgrade follows the normal rollback path.
 New snapshots preserve the complete environment root, including credentials,

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -168,7 +168,8 @@ Use `upgrade simulate` when you want to test what would happen against a publish
 - simulation envs and temporary runtimes are cleaned up automatically; use `--keep-simulations` only when you need retained debug artifacts
 - missing published targets fail before any simulation env is created
 - `--scenario all` runs built-in current, clean minimum, and Telegram-configured env shapes as separate simulation clones
-- a running managed gateway is stopped before its verified pre-upgrade checkpoint and remains stopped through mutation and finalization
+- target runtime installation, checkpoint preflight, and runtime recovery preparation run while the current managed gateway remains available; preparation failure leaves it unchanged
+- a running managed gateway is stopped only for checkpoint capture, runtime publication, environment mutation, and finalization
 - new checkpoints capture the complete environment root; APFS clone support is used when available and a metadata-preserving full copy is the fallback
 - when an env moves to a new runtime, OCM runs OpenClaw's update finalization path cold before service restart
 - if service reconciliation fails, OCM restores the snapshot and previous runtime unless `--no-rollback` is set

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -22,7 +22,7 @@ use crate::runtime::releases::{
 };
 use crate::runtime::{
     InstallRuntimeFromOfficialReleaseOptions, OfficialRuntimePrepareAction, RuntimeMeta,
-    RuntimeReleaseSelectorKind, RuntimeService,
+    RuntimeReleaseSelectorKind, RuntimeService, StagedRuntimeInstall,
 };
 use crate::service::ServiceSummary;
 use crate::store::{
@@ -1723,6 +1723,22 @@ impl Cli {
             } else {
                 vec![target_runtime_name.clone()]
             };
+            let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    return self.fail_upgrade_before_cutover(
+                        env_name,
+                        "runtime",
+                        previous_binding_name,
+                        "runtime",
+                        target_runtime_name,
+                        target_version.clone(),
+                        target.release_channel_hint(),
+                        error,
+                    );
+                }
+            };
+            let target_changed = !matches!(prepared.action, OfficialRuntimePrepareAction::Reused);
             let mut transaction = self.begin_upgrade_transaction_locked(
                 env_name,
                 UpgradeTransactionPlan {
@@ -1742,10 +1758,10 @@ impl Cli {
                 "pre-upgrade",
                 None,
             )?;
-            if !target.is_named_runtime() {
-                transaction.mark_runtime_mutated(&target_runtime_name);
+            if target_changed {
+                transaction.mark_runtime_mutated(&prepared.name);
             }
-            let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
+            let prepared = match prepared.commit() {
                 Ok(prepared) => prepared,
                 Err(error) => {
                     return self.rollback_failed_upgrade(
@@ -1761,9 +1777,6 @@ impl Cli {
                     );
                 }
             };
-            if matches!(prepared.action, OfficialRuntimePrepareAction::Reused) {
-                transaction.unmark_runtime_mutated(&prepared.name);
-            }
             let binding_changed = prepared.name != current.name;
             let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
                 Ok(note) => {
@@ -1955,6 +1968,25 @@ impl Cli {
                     ),
                 });
             }
+            let prepared = match self.prepare_isolated_upgrade_target(env_name, &target, resolved) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    return self.fail_upgrade_before_cutover(
+                        env_name,
+                        "runtime",
+                        previous_binding_name,
+                        "runtime",
+                        target_runtime_name,
+                        target_version.clone(),
+                        target.release_channel_hint(),
+                        error,
+                    );
+                }
+            };
+            let changed = matches!(
+                prepared.action,
+                OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
+            );
             let mut transaction = self.begin_upgrade_transaction_locked(
                 env_name,
                 UpgradeTransactionPlan {
@@ -1974,8 +2006,10 @@ impl Cli {
                 "pre-upgrade",
                 None,
             )?;
-            transaction.mark_runtime_mutated(&target_runtime_name);
-            let prepared = match self.prepare_isolated_upgrade_target(env_name, &target, resolved) {
+            if changed {
+                transaction.mark_runtime_mutated(&prepared.name);
+            }
+            let prepared = match prepared.commit() {
                 Ok(prepared) => prepared,
                 Err(error) => {
                     return self.rollback_failed_upgrade(
@@ -1991,13 +2025,6 @@ impl Cli {
                     );
                 }
             };
-            let changed = matches!(
-                prepared.action,
-                OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
-            );
-            if !changed {
-                transaction.unmark_runtime_mutated(&prepared.name);
-            }
             let post_update_note = if changed {
                 match self.run_post_core_update(env_name, &prepared.name) {
                     Ok(note) => {
@@ -2131,6 +2158,27 @@ impl Cli {
                 note: Some("dry run: no runtime, env, service, or snapshot changed".to_string()),
             });
         }
+        let prepared =
+            match self.with_progress(format!("Updating runtime {}", current.name), || {
+                self.with_isolated_runtime_mutation(env_name, &current.name, || {
+                    self.runtime_service()
+                        .prepare_resolved_update(resolved_update)
+                })
+            }) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    return self.fail_upgrade_before_cutover(
+                        env_name,
+                        "runtime",
+                        previous_binding_name,
+                        "runtime",
+                        current.name,
+                        current.release_version,
+                        current.release_channel,
+                        error,
+                    );
+                }
+            };
         let mut transaction = self.begin_upgrade_transaction_locked(
             env_name,
             UpgradeTransactionPlan {
@@ -2151,12 +2199,7 @@ impl Cli {
             None,
         )?;
         transaction.mark_runtime_mutated(&current.name);
-        let updated = match self.with_progress(format!("Updating runtime {}", current.name), || {
-            self.with_isolated_runtime_mutation(env_name, &current.name, || {
-                self.runtime_service()
-                    .apply_resolved_update(resolved_update, false)
-            })
-        }) {
+        let updated = match prepared.commit() {
             Ok(updated) => updated,
             Err(error) => {
                 return self.rollback_failed_upgrade(
@@ -2345,6 +2388,22 @@ impl Cli {
             });
         }
 
+        let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                return self.fail_upgrade_before_cutover(
+                    env_name,
+                    "launcher",
+                    launcher_name.to_string(),
+                    "runtime",
+                    target_runtime_name,
+                    target_version.clone(),
+                    target.release_channel_hint(),
+                    error,
+                );
+            }
+        };
+        let target_changed = !matches!(prepared.action, OfficialRuntimePrepareAction::Reused);
         let mut transaction = self.begin_upgrade_transaction_locked(
             env_name,
             UpgradeTransactionPlan {
@@ -2364,10 +2423,10 @@ impl Cli {
             "pre-upgrade",
             None,
         )?;
-        if !target.is_named_runtime() {
-            transaction.mark_runtime_mutated(&target_runtime_name);
+        if target_changed {
+            transaction.mark_runtime_mutated(&prepared.name);
         }
-        let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
+        let prepared = match prepared.commit() {
             Ok(prepared) => prepared,
             Err(error) => {
                 return self.rollback_failed_upgrade(
@@ -2383,9 +2442,6 @@ impl Cli {
                 );
             }
         };
-        if matches!(prepared.action, OfficialRuntimePrepareAction::Reused) {
-            transaction.unmark_runtime_mutated(&prepared.name);
-        }
         let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
             Ok(note) => {
                 transaction.mark_post_update_completed(note.as_deref());
@@ -2606,9 +2662,10 @@ impl Cli {
                 name: resolved.name,
                 meta,
                 action: OfficialRuntimePrepareAction::Reused,
+                staged: None,
             }),
             ResolvedUpgradeTargetKind::Official(release) => {
-                let (meta, action) = self.with_progress(
+                let staged = self.with_progress(
                     format!("Preparing OpenClaw runtime for {env_name}"),
                     || {
                         self.runtime_service()
@@ -2624,10 +2681,13 @@ impl Cli {
                             )
                     },
                 )?;
+                let meta = staged.meta().clone();
+                let action = staged.action();
                 Ok(PreparedUpgradeTarget {
                     name: resolved.name,
                     meta,
                     action,
+                    staged: Some(staged),
                 })
             }
         }
@@ -2943,9 +3003,56 @@ impl Cli {
         let prepared = self
             .environment_service()
             .prepare_snapshot_capture_locked(env_name)?;
-        let service_state = self
-            .service_service()
-            .quiesce_for_snapshot_locked(env_name)?;
+        let mut seen = BTreeSet::new();
+        let mut runtime_backups: Vec<RuntimeRollbackBackup> = Vec::new();
+        let mut created_runtime_names = Vec::new();
+
+        for runtime_name in runtime_names {
+            if !seen.insert(runtime_name.clone()) {
+                continue;
+            }
+            let meta_path = match runtime_meta_path(runtime_name, &self.env, &self.cwd) {
+                Ok(meta_path) => meta_path,
+                Err(error) => {
+                    for backup in runtime_backups {
+                        backup.cleanup();
+                    }
+                    return Err(error);
+                }
+            };
+            if meta_path.exists() {
+                let runtime = match get_runtime(runtime_name, &self.env, &self.cwd) {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        for backup in runtime_backups {
+                            backup.cleanup();
+                        }
+                        return Err(error);
+                    }
+                };
+                match self.backup_runtime_for_upgrade(&runtime) {
+                    Ok(backup) => runtime_backups.push(backup),
+                    Err(error) => {
+                        for backup in runtime_backups {
+                            backup.cleanup();
+                        }
+                        return Err(error);
+                    }
+                }
+            } else {
+                created_runtime_names.push(runtime_name.clone());
+            }
+        }
+
+        let service_state = match self.service_service().quiesce_for_snapshot_locked(env_name) {
+            Ok(service_state) => service_state,
+            Err(error) => {
+                for backup in runtime_backups {
+                    backup.cleanup();
+                }
+                return Err(error);
+            }
+        };
         let started_at = time::OffsetDateTime::now_utc();
         let id = format!(
             "{}-{:09}",
@@ -2965,6 +3072,9 @@ impl Cli {
         let snapshot = match snapshot_result {
             Ok(snapshot) => snapshot,
             Err(error) => {
+                for backup in runtime_backups {
+                    backup.cleanup();
+                }
                 let snapshot_error = format!(
                     "failed to create {snapshot_label} snapshot for env \"{env_name}\": {error}"
                 );
@@ -2979,55 +3089,6 @@ impl Cli {
                 };
             }
         };
-        let mut seen = BTreeSet::new();
-        let mut runtime_backups = Vec::new();
-        let mut created_runtime_names = Vec::new();
-
-        for runtime_name in runtime_names {
-            if !seen.insert(runtime_name.clone()) {
-                continue;
-            }
-            let meta_path = match runtime_meta_path(runtime_name, &self.env, &self.cwd) {
-                Ok(meta_path) => meta_path,
-                Err(error) => {
-                    return Err(self.cleanup_failed_transaction_setup(
-                        env_name,
-                        &snapshot.id,
-                        runtime_backups,
-                        service_state,
-                        error,
-                    ));
-                }
-            };
-            if meta_path.exists() {
-                let runtime = match get_runtime(runtime_name, &self.env, &self.cwd) {
-                    Ok(runtime) => runtime,
-                    Err(error) => {
-                        return Err(self.cleanup_failed_transaction_setup(
-                            env_name,
-                            &snapshot.id,
-                            runtime_backups,
-                            service_state,
-                            error,
-                        ));
-                    }
-                };
-                match self.backup_runtime_for_upgrade(&runtime) {
-                    Ok(backup) => runtime_backups.push(backup),
-                    Err(error) => {
-                        return Err(self.cleanup_failed_transaction_setup(
-                            env_name,
-                            &snapshot.id,
-                            runtime_backups,
-                            service_state,
-                            error,
-                        ));
-                    }
-                }
-            } else {
-                created_runtime_names.push(runtime_name.clone());
-            }
-        }
 
         let service_quiesced = service_state.is_some();
 
@@ -3056,40 +3117,6 @@ impl Cli {
             mutated_runtime_names: BTreeSet::new(),
             rollback_of,
         })
-    }
-
-    fn cleanup_failed_transaction_setup(
-        &self,
-        env_name: &str,
-        snapshot_id: &str,
-        runtime_backups: Vec<RuntimeRollbackBackup>,
-        service_state: Option<crate::service::ServiceMaintenanceState>,
-        error: String,
-    ) -> String {
-        for backup in runtime_backups {
-            backup.cleanup();
-        }
-        let cleanup_result = self.environment_service().remove_snapshot_locked(
-            crate::env::RemoveEnvSnapshotOptions {
-                env_name: env_name.to_string(),
-                snapshot_id: snapshot_id.to_string(),
-            },
-        );
-        let service_result = self
-            .service_service()
-            .restore_after_snapshot_locked(env_name, service_state);
-        let mut result = error;
-        if let Err(cleanup_error) = cleanup_result {
-            result = format!(
-                "{result}; also failed to remove the incomplete transaction snapshot: {cleanup_error}"
-            );
-        }
-        if let Err(service_error) = service_result {
-            result = format!(
-                "{result}; also failed to restore the managed service after snapshot capture: {service_error}"
-            );
-        }
-        result
     }
 
     fn finish_successful_upgrade(
@@ -3283,6 +3310,36 @@ impl Cli {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn fail_upgrade_before_cutover(
+        &self,
+        env_name: &str,
+        previous_binding_kind: &str,
+        previous_binding_name: String,
+        binding_kind: &str,
+        binding_name: String,
+        runtime_release_version: Option<String>,
+        runtime_release_channel: Option<String>,
+        error: String,
+    ) -> Result<UpgradeEnvSummary, String> {
+        Ok(UpgradeEnvSummary {
+            env_name: env_name.to_string(),
+            previous_binding_kind: previous_binding_kind.to_string(),
+            previous_binding_name,
+            binding_kind: binding_kind.to_string(),
+            binding_name,
+            outcome: "failed".to_string(),
+            runtime_release_version,
+            runtime_release_channel,
+            service_action: None,
+            snapshot_id: None,
+            rollback: None,
+            note: Some(format!(
+                "upgrade preparation failed before cutover; the source environment and service were left unchanged: {error}"
+            )),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn rollback_failed_upgrade(
         &self,
         env_name: &str,
@@ -3458,11 +3515,20 @@ impl Cli {
     }
 }
 
-#[derive(Clone, Debug)]
 struct PreparedUpgradeTarget {
     name: String,
     meta: RuntimeMeta,
     action: OfficialRuntimePrepareAction,
+    staged: Option<StagedRuntimeInstall>,
+}
+
+impl PreparedUpgradeTarget {
+    fn commit(mut self) -> Result<Self, String> {
+        if let Some(staged) = self.staged.take() {
+            self.meta = staged.commit()?;
+        }
+        Ok(self)
+    }
 }
 
 #[derive(Debug)]
@@ -3619,10 +3685,6 @@ struct UpgradeTransaction {
 impl UpgradeTransaction {
     fn mark_runtime_mutated(&mut self, runtime_name: &str) {
         self.mutated_runtime_names.insert(runtime_name.to_string());
-    }
-
-    fn unmark_runtime_mutated(&mut self, runtime_name: &str) {
-        self.mutated_runtime_names.remove(runtime_name);
     }
 
     fn mark_post_update_completed(&mut self, note: Option<&str>) {

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -7,10 +7,11 @@ use crate::runtime::releases::{
 };
 use crate::store::{
     BuildLocalRuntimeOptions as StoreBuildLocalRuntimeOptions, InstallContext,
-    RuntimeReleaseDetails, get_runtime, install_runtime, install_runtime_from_local_openclaw_build,
-    install_runtime_from_official_openclaw_release, install_runtime_from_release,
-    install_runtime_from_selected_official_openclaw_release, install_runtime_from_selected_release,
-    install_runtime_from_url, list_runtimes, runtime_integrity_issue,
+    PreparedRuntimeInstall, RuntimeReleaseDetails, get_runtime, install_runtime,
+    install_runtime_from_local_openclaw_build, install_runtime_from_official_openclaw_release,
+    install_runtime_from_release, install_runtime_from_url, list_runtimes,
+    prepare_runtime_from_selected_official_openclaw_release, prepare_runtime_from_selected_release,
+    runtime_integrity_issue,
 };
 use serde::Serialize;
 
@@ -118,6 +119,25 @@ pub enum OfficialRuntimePrepareAction {
     Updated,
 }
 
+pub(crate) struct StagedRuntimeInstall {
+    prepared: PreparedRuntimeInstall,
+    action: OfficialRuntimePrepareAction,
+}
+
+impl StagedRuntimeInstall {
+    pub(crate) fn meta(&self) -> &RuntimeMeta {
+        self.prepared.meta()
+    }
+
+    pub(crate) fn action(&self) -> OfficialRuntimePrepareAction {
+        self.action
+    }
+
+    pub(crate) fn commit(self) -> Result<RuntimeMeta, String> {
+        self.prepared.commit()
+    }
+}
+
 impl<'a> RuntimeService<'a> {
     pub fn canonical_official_openclaw_runtime_name(
         version: Option<&str>,
@@ -176,13 +196,8 @@ impl<'a> RuntimeService<'a> {
         &self,
         options: InstallRuntimeFromOfficialReleaseOptions,
         selected_release: OpenClawRelease,
-    ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
-        self.prepare_official_openclaw_runtime_with_refresh(
-            options,
-            false,
-            false,
-            Some(selected_release),
-        )
+    ) -> Result<StagedRuntimeInstall, String> {
+        self.prepare_official_openclaw_runtime_staged(options, false, Some(selected_release))
     }
 
     fn prepare_official_openclaw_runtime_with_refresh(
@@ -192,6 +207,25 @@ impl<'a> RuntimeService<'a> {
         require_unbound: bool,
         selected_release: Option<OpenClawRelease>,
     ) -> Result<(RuntimeMeta, OfficialRuntimePrepareAction), String> {
+        let prepared = self.prepare_official_openclaw_runtime_staged(
+            options,
+            require_unbound,
+            selected_release,
+        )?;
+        let action = prepared.action();
+        let meta = prepared.commit()?;
+        if refresh_supervisor {
+            self.refresh_supervisor_if_present()?;
+        }
+        Ok((meta, action))
+    }
+
+    fn prepare_official_openclaw_runtime_staged(
+        &self,
+        options: InstallRuntimeFromOfficialReleaseOptions,
+        require_unbound: bool,
+        selected_release: Option<OpenClawRelease>,
+    ) -> Result<StagedRuntimeInstall, String> {
         let version = options
             .version
             .map(|value| value.trim().to_string())
@@ -285,7 +319,10 @@ impl<'a> RuntimeService<'a> {
             };
 
             if !options.force && healthy && same_release && matches_requested_selector {
-                return Ok((existing, OfficialRuntimePrepareAction::Reused));
+                return Ok(StagedRuntimeInstall {
+                    prepared: PreparedRuntimeInstall::reuse(existing),
+                    action: OfficialRuntimePrepareAction::Reused,
+                });
             }
 
             existing_meta = Some(existing);
@@ -297,7 +334,7 @@ impl<'a> RuntimeService<'a> {
                 .and_then(|meta| meta.description.clone())
         });
         let install = || {
-            install_runtime_from_selected_official_openclaw_release(
+            prepare_runtime_from_selected_official_openclaw_release(
                 runtime_name.clone(),
                 options.force || existing_meta.is_some(),
                 releases_url,
@@ -326,17 +363,17 @@ impl<'a> RuntimeService<'a> {
         } else {
             install()?
         };
-        let action = if install.reused {
+        let action = if install.reused() {
             OfficialRuntimePrepareAction::Reused
         } else if existing_meta.is_some() {
             OfficialRuntimePrepareAction::Updated
         } else {
             OfficialRuntimePrepareAction::Installed
         };
-        if refresh_supervisor {
-            self.refresh_supervisor_if_present()?;
-        }
-        Ok((install.meta, action))
+        Ok(StagedRuntimeInstall {
+            prepared: install,
+            action,
+        })
     }
 
     pub fn install(&self, options: InstallRuntimeOptions) -> Result<RuntimeMeta, String> {
@@ -484,11 +521,23 @@ impl<'a> RuntimeService<'a> {
         resolved: ResolvedRuntimeUpdate,
         refresh_supervisor: bool,
     ) -> Result<RuntimeMeta, String> {
+        let prepared = self.prepare_resolved_update(resolved)?;
+        let meta = prepared.commit()?;
+        if refresh_supervisor {
+            self.refresh_supervisor_if_present()?;
+        }
+        Ok(meta)
+    }
+
+    pub(crate) fn prepare_resolved_update(
+        &self,
+        resolved: ResolvedRuntimeUpdate,
+    ) -> Result<StagedRuntimeInstall, String> {
         let selector_kind = Some(resolved.selector_kind);
         let selector_value = Some(resolved.selector_value);
-        let meta = match resolved.release {
+        let prepared = match resolved.release {
             ResolvedRuntimeUpdateRelease::Official(release) => {
-                install_runtime_from_selected_official_openclaw_release(
+                prepare_runtime_from_selected_official_openclaw_release(
                     resolved.existing.name,
                     true,
                     resolved.manifest_url,
@@ -500,10 +549,9 @@ impl<'a> RuntimeService<'a> {
                         cwd: self.cwd,
                     },
                 )?
-                .meta
             }
             ResolvedRuntimeUpdateRelease::Manifest(release) => {
-                install_runtime_from_selected_release(
+                prepare_runtime_from_selected_release(
                     resolved.existing.name,
                     true,
                     resolved.manifest_url,
@@ -516,10 +564,10 @@ impl<'a> RuntimeService<'a> {
                 )?
             }
         };
-        if refresh_supervisor {
-            self.refresh_supervisor_if_present()?;
-        }
-        Ok(meta)
+        Ok(StagedRuntimeInstall {
+            prepared,
+            action: OfficialRuntimePrepareAction::Updated,
+        })
     }
 
     pub fn update_all_from_release(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,6 +4,7 @@ mod registry;
 pub mod releases;
 mod verify;
 
+pub(crate) use install::StagedRuntimeInstall;
 pub use install::{
     BuildLocalRuntimeOptions, InstallRuntimeFromOfficialReleaseOptions,
     InstallRuntimeFromReleaseOptions, InstallRuntimeFromUrlOptions, InstallRuntimeOptions,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -71,8 +71,10 @@ pub(crate) use openclaw_workspaces::{
 };
 pub(crate) use runtimes::install_runtime_from_local_openclaw_build;
 pub(crate) use runtimes::install_runtime_from_selected_official_openclaw_release;
-pub(crate) use runtimes::install_runtime_from_selected_release;
-pub(crate) use runtimes::{BuildLocalRuntimeOptions, InstallContext, RuntimeReleaseDetails};
+pub(crate) use runtimes::{
+    BuildLocalRuntimeOptions, InstallContext, PreparedRuntimeInstall, RuntimeReleaseDetails,
+    prepare_runtime_from_selected_official_openclaw_release, prepare_runtime_from_selected_release,
+};
 pub use runtimes::{
     add_runtime, get_runtime, get_runtime_verified, install_runtime,
     install_runtime_from_official_openclaw_release, install_runtime_from_release,

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -289,9 +289,40 @@ struct RuntimeInstallTarget {
     _lock: ExclusiveFileLock,
 }
 
+pub(crate) struct PreparedRuntimeInstall {
+    target: Option<RuntimeInstallTarget>,
+    meta: RuntimeMeta,
+    reused: bool,
+}
+
+impl PreparedRuntimeInstall {
+    pub(crate) fn reuse(meta: RuntimeMeta) -> Self {
+        Self {
+            target: None,
+            meta,
+            reused: true,
+        }
+    }
+
+    pub(crate) fn meta(&self) -> &RuntimeMeta {
+        &self.meta
+    }
+
+    pub(crate) fn reused(&self) -> bool {
+        self.reused
+    }
+
+    pub(crate) fn commit(mut self) -> Result<RuntimeMeta, String> {
+        let meta = self.meta.clone();
+        match self.target.take() {
+            Some(target) => publish_runtime(target, meta),
+            None => Ok(meta),
+        }
+    }
+}
+
 pub(crate) struct OfficialRuntimeInstallResult {
     pub meta: RuntimeMeta,
-    pub reused: bool,
 }
 
 enum OfficialRuntimeInstallTarget {
@@ -1079,13 +1110,13 @@ fn copy_installed_runtime_binary(source_path: &Path, binary_path: &Path) -> Resu
     Ok(())
 }
 
-fn install_runtime_at_path(
+fn prepare_runtime_at_path(
     target: RuntimeInstallTarget,
     file_name: &Path,
     source: RuntimeSourceDetails,
     release: RuntimeReleaseDetails,
     description: Option<String>,
-) -> Result<RuntimeMeta, String> {
+) -> Result<PreparedRuntimeInstall, String> {
     if path_exists(&target.install_root) {
         return Err(format!(
             "runtime install root already exists: {}",
@@ -1118,7 +1149,11 @@ fn install_runtime_at_path(
 
         let meta =
             build_installed_runtime_meta(&target, &binary_path, &source, &release, description);
-        publish_runtime(target, meta)
+        Ok(PreparedRuntimeInstall {
+            target: Some(target),
+            meta,
+            reused: false,
+        })
     })()
 }
 
@@ -1208,13 +1243,13 @@ fn lock_runtime(
     )
 }
 
-fn install_runtime_from_openclaw_package(
+fn prepare_runtime_from_openclaw_package(
     target: RuntimeInstallTarget,
     source: RuntimeSourceDetails,
     release: RuntimeReleaseDetails,
     description: Option<String>,
     context: InstallContext<'_>,
-) -> Result<RuntimeMeta, String> {
+) -> Result<PreparedRuntimeInstall, String> {
     if path_exists(&target.install_root) {
         return Err(format!(
             "runtime install root already exists: {}",
@@ -1245,7 +1280,11 @@ fn install_runtime_from_openclaw_package(
             &[],
         );
         let _ = fs::remove_file(&archive_path);
-        publish_runtime(target, meta?)
+        Ok(PreparedRuntimeInstall {
+            target: Some(target),
+            meta: meta?,
+            reused: false,
+        })
     })()
 }
 
@@ -1526,7 +1565,7 @@ pub fn install_runtime(
             display_path(&source_path)
         )
     })?);
-    install_runtime_at_path(
+    prepare_runtime_at_path(
         target,
         &file_name,
         RuntimeSourceDetails {
@@ -1535,7 +1574,8 @@ pub fn install_runtime(
         },
         RuntimeReleaseDetails::default(),
         trim_description(options.description),
-    )
+    )?
+    .commit()
 }
 
 pub fn install_runtime_from_url(
@@ -1547,7 +1587,7 @@ pub fn install_runtime_from_url(
     let target = prepare_runtime_install_target(name, options.force, env, cwd)?;
 
     let file_name = artifact_file_name_from_url(&options.url)?;
-    install_runtime_at_path(
+    prepare_runtime_at_path(
         target,
         Path::new(&file_name),
         RuntimeSourceDetails {
@@ -1556,7 +1596,8 @@ pub fn install_runtime_from_url(
         },
         RuntimeReleaseDetails::default(),
         trim_description(options.description),
-    )
+    )?
+    .commit()
 }
 
 pub(crate) fn install_runtime_from_local_openclaw_build(
@@ -1689,6 +1730,32 @@ pub(crate) fn install_runtime_from_selected_release(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<RuntimeMeta, String> {
+    prepare_runtime_from_selected_release(
+        name,
+        force,
+        manifest_url,
+        release,
+        selector_kind,
+        selector_value,
+        description,
+        env,
+        cwd,
+    )?
+    .commit()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prepare_runtime_from_selected_release(
+    name: String,
+    force: bool,
+    manifest_url: String,
+    release: RuntimeRelease,
+    selector_kind: Option<RuntimeReleaseSelectorKind>,
+    selector_value: Option<String>,
+    description: Option<String>,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PreparedRuntimeInstall, String> {
     let name = validate_name(&name, "Runtime name")?;
     let source_sha256 = release
         .sha256
@@ -1711,7 +1778,7 @@ pub(crate) fn install_runtime_from_selected_release(
         trim_description(description).or_else(|| trim_description(release.description));
 
     let file_name = artifact_file_name_from_url(&release.url)?;
-    install_runtime_at_path(
+    prepare_runtime_at_path(
         target,
         Path::new(&file_name),
         RuntimeSourceDetails {
@@ -1789,6 +1856,29 @@ pub(crate) fn install_runtime_from_selected_official_openclaw_release(
     description: Option<String>,
     context: InstallContext<'_>,
 ) -> Result<OfficialRuntimeInstallResult, String> {
+    let prepared = prepare_runtime_from_selected_official_openclaw_release(
+        name,
+        force,
+        releases_url,
+        release,
+        release_details,
+        description,
+        context,
+    )?;
+    prepared
+        .commit()
+        .map(|meta| OfficialRuntimeInstallResult { meta })
+}
+
+pub(crate) fn prepare_runtime_from_selected_official_openclaw_release(
+    name: String,
+    force: bool,
+    releases_url: String,
+    release: OpenClawRelease,
+    release_details: RuntimeReleaseDetails,
+    description: Option<String>,
+    context: InstallContext<'_>,
+) -> Result<PreparedRuntimeInstall, String> {
     let source_integrity = release
         .integrity
         .as_deref()
@@ -1814,15 +1904,13 @@ pub(crate) fn install_runtime_from_selected_official_openclaw_release(
         selector_value: release_details.selector_value,
     };
     match prepare_official_runtime_install_target(name, force, &source, &release, context)? {
-        OfficialRuntimeInstallTarget::Reuse(meta) => {
-            Ok(OfficialRuntimeInstallResult { meta, reused: true })
-        }
+        OfficialRuntimeInstallTarget::Reuse(meta) => Ok(PreparedRuntimeInstall {
+            target: None,
+            meta,
+            reused: true,
+        }),
         OfficialRuntimeInstallTarget::Install(target) => {
-            install_runtime_from_openclaw_package(target, source, release, description, context)
-                .map(|meta| OfficialRuntimeInstallResult {
-                    meta,
-                    reused: false,
-                })
+            prepare_runtime_from_openclaw_package(target, source, release, description, context)
         }
     }
 }

--- a/tests/upgrade_availability_tests.rs
+++ b/tests/upgrade_availability_tests.rs
@@ -1,0 +1,539 @@
+mod support;
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle, sleep};
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use flate2::{Compression, write::GzEncoder};
+use ocm::store::{env_registry_path, now_utc, supervisor_runtime_path};
+use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
+use serde_json::Value;
+use sha2::{Digest, Sha512};
+use tar::{Builder, Header};
+
+use crate::support::{
+    TestDir, TestHttpServer, install_fake_launchctl, install_fake_node_and_npm, ocm_env,
+    path_string, run_ocm, stderr,
+};
+
+const PREPARE_DELAY: Duration = Duration::from_millis(1_500);
+const FINALIZE_DELAY: Duration = Duration::from_millis(1_500);
+
+#[derive(Clone, Default)]
+struct Timeline(Arc<Mutex<HashMap<&'static str, Instant>>>);
+
+impl Timeline {
+    fn mark(&self, phase: &'static str) {
+        self.0
+            .lock()
+            .unwrap()
+            .entry(phase)
+            .or_insert_with(Instant::now);
+    }
+
+    fn at(&self, phase: &'static str) -> Instant {
+        *self
+            .0
+            .lock()
+            .unwrap()
+            .get(phase)
+            .unwrap_or_else(|| panic!("phase {phase} was not observed"))
+    }
+
+    fn report(&self, origin: Instant) -> String {
+        let mut entries = self
+            .0
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(phase, at)| (*phase, at.duration_since(origin)))
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|(_, at)| *at);
+        entries
+            .into_iter()
+            .map(|(phase, at)| format!("{phase}={:.3}s", at.as_secs_f64()))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn append_tar_file(
+    builder: &mut Builder<&mut GzEncoder<Vec<u8>>>,
+    path: &str,
+    body: &[u8],
+    mode: u32,
+) {
+    let mut header = Header::new_gnu();
+    header.set_size(body.len() as u64);
+    header.set_mode(mode);
+    header.set_cksum();
+    builder.append_data(&mut header, path, body).unwrap();
+}
+
+fn openclaw_package_tarball(script_body: &str, version: &str) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut builder = Builder::new(&mut encoder);
+        append_tar_file(
+            &mut builder,
+            "package/openclaw.mjs",
+            script_body.as_bytes(),
+            0o755,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/package.json",
+            format!(
+                "{{\"name\":\"openclaw\",\"version\":\"{version}\",\"bin\":{{\"openclaw\":\"openclaw.mjs\"}}}}"
+            )
+            .as_bytes(),
+            0o644,
+        );
+        builder.finish().unwrap();
+    }
+    encoder.finish().unwrap()
+}
+
+fn sha512_integrity(body: &[u8]) -> String {
+    format!(
+        "sha512-{}",
+        base64::engine::general_purpose::STANDARD.encode(Sha512::digest(body))
+    )
+}
+
+fn delayed_bytes_server(
+    path: &'static str,
+    content_type: &'static str,
+    body: Vec<u8>,
+    timeline: Timeline,
+) -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).unwrap_or(0);
+        assert!(
+            request[..read].starts_with(format!("GET {path} ").as_bytes()),
+            "unexpected delayed fixture request: {}",
+            String::from_utf8_lossy(&request[..read])
+        );
+        timeline.mark("target_prepare_started");
+        sleep(PREPARE_DELAY);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: {content_type}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).unwrap();
+        stream.write_all(&body).unwrap();
+        stream.flush().unwrap();
+        timeline.mark("target_prepare_released");
+    });
+    (format!("http://{addr}{path}"), handle)
+}
+
+struct ControlledHealthServer {
+    port: u32,
+    stop: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
+}
+
+impl ControlledHealthServer {
+    fn start(available: Arc<AtomicBool>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let port = u32::from(listener.local_addr().unwrap().port());
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let handle = thread::spawn(move || {
+            while !stop_thread.load(Ordering::Relaxed) {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(accepted) => accepted,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        sleep(Duration::from_millis(2));
+                        continue;
+                    }
+                    Err(error) => panic!("health listener failed: {error}"),
+                };
+                let connection_available = Arc::clone(&available);
+                thread::spawn(move || {
+                    let _ = stream.set_read_timeout(Some(Duration::from_millis(250)));
+                    let mut request = [0_u8; 1024];
+                    let read = stream.read(&mut request).unwrap_or(0);
+                    if !request[..read].starts_with(b"GET /health ") {
+                        return;
+                    }
+                    let ok = connection_available.load(Ordering::SeqCst);
+                    let status = if ok {
+                        "200 OK"
+                    } else {
+                        "503 Service Unavailable"
+                    };
+                    let body = if ok {
+                        br#"{"ok":true}"#.as_slice()
+                    } else {
+                        br#"{"ok":false}"#.as_slice()
+                    };
+                    let response = format!(
+                        "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.write_all(body);
+                    let _ = stream.flush();
+                });
+            }
+        });
+        Self { port, stop, handle }
+    }
+
+    fn stop(self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = TcpStream::connect(("127.0.0.1", self.port as u16));
+        self.handle.join().unwrap();
+    }
+}
+
+fn health_ok(port: u32) -> bool {
+    let Ok(mut stream) = TcpStream::connect_timeout(
+        &format!("127.0.0.1:{port}").parse().unwrap(),
+        Duration::from_millis(500),
+    ) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    if stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .is_err()
+    {
+        return false;
+    }
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).is_ok() && response.starts_with(b"HTTP/1.1 200 OK")
+}
+
+fn write_running_supervisor_runtime(
+    runtime_path: &Path,
+    ocm_home: &str,
+    binding_name: &str,
+    pid: u32,
+    child_port: u32,
+) {
+    let log_root = runtime_path.parent().unwrap();
+    let stdout_path = path_string(&log_root.join("demo.stdout.log"));
+    let stderr_path = path_string(&log_root.join("demo.stderr.log"));
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: ocm_home.to_string(),
+        updated_at: now_utc(),
+        services: vec![SupervisorRuntimeService {
+            env_name: "demo".to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: binding_name.to_string(),
+            gateway_state: "running".to_string(),
+            restart_handoff: Some("none".to_string()),
+            restart_count: 0,
+            child_port,
+            pid: Some(pid),
+            stdout_path: stdout_path.clone(),
+            stderr_path: stderr_path.clone(),
+            last_exit_code: None,
+            last_error: None,
+            last_event_at: None,
+            next_retry_at: None,
+        }],
+        children: vec![SupervisorRuntimeChild {
+            env_name: "demo".to_string(),
+            binding_kind: "runtime".to_string(),
+            binding_name: binding_name.to_string(),
+            pid,
+            restart_count: 0,
+            child_port,
+            stdout_path,
+            stderr_path,
+        }],
+    };
+    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+}
+
+fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: ocm_home.to_string(),
+        updated_at: now_utc(),
+        services: Vec::new(),
+        children: Vec::new(),
+    };
+    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+}
+
+fn fixture_openclaw_script(version: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+case "$1" in
+  --version)
+    printf '{version}\n'
+    exit 0
+    ;;
+  config)
+    printf 'Config valid\n'
+    exit 0
+    ;;
+  update)
+    if [ "$2" = "finalize" ]; then
+      : > "$OCM_TEST_UPDATE_FINALIZE_STARTED"
+      while [ ! -e "$OCM_TEST_UPDATE_FINALIZE_RELEASE" ]; do
+        sleep 0.01
+      done
+      printf '{{"status":"ok","mode":"finalize"}}\n'
+      exit 0
+    fi
+    ;;
+  gateway)
+    printf '{{"rpc":{{"ok":true}}}}\n'
+    exit 0
+    ;;
+esac
+printf 'unexpected command: %s\n' "$*" >&2
+exit 1
+"#
+    )
+}
+
+fn env_desired_running(registry_path: &Path, fallback: bool) -> bool {
+    fs::read(registry_path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+        .and_then(|registry| registry["envs"].as_array().cloned())
+        .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "demo"))
+        .and_then(|entry| entry["serviceRunning"].as_bool())
+        .unwrap_or(fallback)
+}
+
+#[test]
+fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
+    let root = TestDir::new("upgrade-availability-ordering");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let timeline = Timeline::default();
+    let origin = Instant::now();
+
+    let available = Arc::new(AtomicBool::new(true));
+    let health_server = ControlledHealthServer::start(Arc::clone(&available));
+
+    let old_tarball = openclaw_package_tarball(&fixture_openclaw_script("2026.8.13"), "2026.8.13");
+    let old_integrity = sha512_integrity(&old_tarball);
+    let old_server = TestHttpServer::serve_bytes_times(
+        "/openclaw-2026.8.13.tgz",
+        "application/octet-stream",
+        &old_tarball,
+        8,
+    );
+    let new_tarball = openclaw_package_tarball(&fixture_openclaw_script("2026.8.14"), "2026.8.14");
+    let new_integrity = sha512_integrity(&new_tarball);
+    let (new_url, delayed_server) = delayed_bytes_server(
+        "/openclaw-2026.8.14.tgz",
+        "application/octet-stream",
+        new_tarball,
+        timeline.clone(),
+    );
+
+    let initial_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.8.13\"}},\"versions\":{{\"2026.8.13\":{{\"version\":\"2026.8.13\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.8.13\":\"2026-08-13T00:00:00.000Z\"}}}}",
+        old_server.url(),
+        old_integrity
+    );
+    let updated_packument = format!(
+        "{{\"dist-tags\":{{\"latest\":\"2026.8.14\"}},\"versions\":{{\"2026.8.13\":{{\"version\":\"2026.8.13\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}},\"2026.8.14\":{{\"version\":\"2026.8.14\",\"dist\":{{\"tarball\":\"{}\",\"integrity\":\"{}\"}}}}}},\"time\":{{\"2026.8.13\":\"2026-08-13T00:00:00.000Z\",\"2026.8.14\":\"2026-08-14T00:00:00.000Z\"}}}}",
+        old_server.url(),
+        old_integrity,
+        new_url,
+        new_integrity
+    );
+    let packument_server = TestHttpServer::serve_bytes_sequence(
+        "/openclaw",
+        "application/json",
+        vec![
+            initial_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+            updated_packument.as_bytes().to_vec(),
+        ],
+    );
+
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    env.insert(
+        "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
+        packument_server.url(),
+    );
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &["start", "demo", "--port", &health_server.port.to_string()],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let env_show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(env_show.status.success(), "{}", stderr(&env_show));
+    let env_json: Value = serde_json::from_slice(&env_show.stdout).unwrap();
+    let snapshot_fixture = PathBuf::from(env_json["root"].as_str().unwrap()).join("fanout");
+    fs::create_dir_all(&snapshot_fixture).unwrap();
+    for index in 0..20_000 {
+        fs::write(
+            snapshot_fixture.join(format!("entry-{index:05}")),
+            b"snapshot fixture\n",
+        )
+        .unwrap();
+    }
+
+    let finalize_started = root.child("finalize-started");
+    let finalize_release = root.child("finalize-release");
+    env.insert(
+        "OCM_TEST_UPDATE_FINALIZE_STARTED".to_string(),
+        path_string(&finalize_started),
+    );
+    env.insert(
+        "OCM_TEST_UPDATE_FINALIZE_RELEASE".to_string(),
+        path_string(&finalize_release),
+    );
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "stable", 4242, health_server.port);
+
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let observer_available = Arc::clone(&available);
+    let observer_timeline = timeline.clone();
+    let observer_runtime_path = runtime_path.clone();
+    let observer_ocm_home = ocm_home.clone();
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let health_port = health_server.port;
+    let observer = thread::spawn(move || {
+        let mut last_running = true;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let running = env_desired_running(&registry_path, last_running);
+            if running != last_running {
+                if running {
+                    write_running_supervisor_runtime(
+                        &observer_runtime_path,
+                        &observer_ocm_home,
+                        "stable",
+                        4243,
+                        health_port,
+                    );
+                    observer_available.store(true, Ordering::SeqCst);
+                    observer_timeline.mark("target_ready");
+                } else {
+                    observer_available.store(false, Ordering::SeqCst);
+                    write_empty_supervisor_runtime(&observer_runtime_path, &observer_ocm_home);
+                    observer_timeline.mark("service_stopped");
+                }
+                last_running = running;
+            }
+            sleep(Duration::from_millis(1));
+        }
+    });
+
+    let samples_done = Arc::new(AtomicBool::new(false));
+    let samples_done_thread = Arc::clone(&samples_done);
+    let samples = Arc::new(Mutex::new(Vec::<(Instant, bool)>::new()));
+    let samples_thread = Arc::clone(&samples);
+    let health_poller = thread::spawn(move || {
+        while !samples_done_thread.load(Ordering::Relaxed) {
+            let ok = health_ok(health_port);
+            samples_thread.lock().unwrap().push((Instant::now(), ok));
+            sleep(Duration::from_millis(20));
+        }
+    });
+
+    let finalize_timeline = timeline.clone();
+    let finalize_releaser = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !finalize_started.exists() {
+            assert!(Instant::now() < deadline, "finalization never started");
+            sleep(Duration::from_millis(5));
+        }
+        finalize_timeline.mark("finalization_started");
+        sleep(FINALIZE_DELAY);
+        fs::write(finalize_release, b"release\n").unwrap();
+        finalize_timeline.mark("finalization_released");
+    });
+
+    timeline.mark("command_started");
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
+    timeline.mark("command_finished");
+
+    finalize_releaser.join().unwrap();
+    delayed_server.join().unwrap();
+    observer_done.store(true, Ordering::Relaxed);
+    observer.join().unwrap();
+    samples_done.store(true, Ordering::Relaxed);
+    health_poller.join().unwrap();
+    health_server.stop();
+
+    assert!(upgrade.status.success(), "{}", stderr(&upgrade));
+    let prepare_released = timeline.at("target_prepare_released");
+    let service_stopped = timeline.at("service_stopped");
+    let finalization_started = timeline.at("finalization_started");
+    let finalization_released = timeline.at("finalization_released");
+    let target_ready = timeline.at("target_ready");
+    let report = timeline.report(origin);
+
+    let command_started = timeline.at("command_started");
+    let preparation_health = samples
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(at, _)| *at >= command_started && *at < service_stopped)
+        .copied()
+        .collect::<Vec<_>>();
+    assert!(
+        !preparation_health.is_empty(),
+        "no preparation health samples; {report}"
+    );
+    let failed_preparation_health = preparation_health
+        .iter()
+        .filter(|(_, ok)| !ok)
+        .map(|(at, _)| at.duration_since(origin).as_secs_f64())
+        .collect::<Vec<_>>();
+    assert!(
+        failed_preparation_health.is_empty(),
+        "source Gateway was unavailable during target preparation at {failed_preparation_health:?}; {report}"
+    );
+    assert!(
+        prepare_released <= service_stopped,
+        "target preparation crossed the cutover boundary; {report}"
+    );
+    assert!(
+        service_stopped <= finalization_started,
+        "finalization started before service quiescence; {report}"
+    );
+    assert!(
+        finalization_released <= target_ready,
+        "target became ready before finalization completed; {report}"
+    );
+    let downtime = target_ready.duration_since(service_stopped);
+    eprintln!(
+        "availability proof: stop-to-ready={:.3}s {report}",
+        downtime.as_secs_f64()
+    );
+}

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -208,6 +208,16 @@ fn stop_converging_health_server(port: u32, stop: &AtomicBool, handle: thread::J
     handle.join().unwrap();
 }
 
+fn health_status(port: u32) -> String {
+    let mut stream = TcpStream::connect(("127.0.0.1", port as u16)).unwrap();
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+    response.lines().next().unwrap_or_default().to_string()
+}
+
 fn recording_openclaw_script(version: &str) -> String {
     format!(
         r#"#!/bin/sh
@@ -3103,10 +3113,12 @@ fn upgrade_rolls_back_runtime_when_service_restart_fails() {
 }
 
 #[test]
-fn upgrade_restores_runtime_when_runtime_preparation_fails() {
+fn upgrade_fails_runtime_preparation_before_cutover() {
     let root = TestDir::new("upgrade-runtime-prepare-rollback");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
+    let (health_port, health_requests, health_stop, health_handle) =
+        spawn_converging_health_server();
 
     let old_tarball = openclaw_package_tarball("console.log('2026.3.24');\n", "2026.3.24");
     let old_integrity = sha512_integrity(&old_tarball);
@@ -3152,11 +3164,54 @@ fn upgrade_restores_runtime_when_runtime_preparation_fails() {
         "OCM_INTERNAL_OPENCLAW_RELEASES_URL".to_string(),
         packument_server.url(),
     );
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
 
-    let start = run_ocm(&cwd, &env, &["start", "demo", "--no-service"]);
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &["start", "demo", "--port", &health_port.to_string()],
+    );
     assert!(start.status.success(), "{}", stderr(&start));
+    assert_eq!(
+        health_status(health_port),
+        "HTTP/1.1 503 Service Unavailable"
+    );
+    assert_eq!(health_status(health_port), "HTTP/1.1 200 OK");
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "stable", 4242, health_port);
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let source_was_stopped = Arc::new(AtomicBool::new(false));
+    let source_was_stopped_thread = Arc::clone(&source_was_stopped);
+    let observer = thread::spawn(move || {
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let desired_running = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .and_then(|registry| registry["envs"].as_array().cloned())
+                .and_then(|envs| envs.into_iter().find(|entry| entry["name"] == "demo"))
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(true);
+            if !desired_running {
+                source_was_stopped_thread.store(true, Ordering::SeqCst);
+            }
+            sleep(Duration::from_millis(1));
+        }
+    });
 
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
+    observer_done.store(true, Ordering::Relaxed);
+    observer.join().unwrap();
+    assert_eq!(health_status(health_port), "HTTP/1.1 200 OK");
+    stop_converging_health_server(health_port, &health_stop, health_handle);
     assert!(
         !upgrade.status.success(),
         "stdout:\n{}\nstderr:\n{}",
@@ -3164,21 +3219,42 @@ fn upgrade_restores_runtime_when_runtime_preparation_fails() {
         stderr(&upgrade)
     );
     let output = stdout(&upgrade);
-    assert!(
-        output.contains("outcome=rolled-back"),
-        "stdout:\n{output}\nstderr:\n{}",
-        stderr(&upgrade)
-    );
-    assert!(output.contains("rollback=restored"), "{output}");
+    assert!(output.contains("outcome=failed"), "{output}");
+    assert!(!output.contains("snapshot="), "{output}");
+    assert!(!output.contains("rollback="), "{output}");
     assert!(
         output.contains("runtime artifact integrity is invalid"),
         "{output}"
     );
+    assert!(
+        !source_was_stopped.load(Ordering::SeqCst),
+        "source service policy changed during pre-cutover failure"
+    );
+    assert!(health_requests.load(Ordering::SeqCst) >= 3);
 
     let runtime = run_ocm(&cwd, &env, &["runtime", "show", "stable", "--json"]);
     assert!(runtime.status.success(), "{}", stderr(&runtime));
     let runtime_json: Value = serde_json::from_str(&stdout(&runtime)).unwrap();
     assert_eq!(runtime_json["releaseVersion"], "2026.3.24");
+    let staged_runtime_paths = fs::read_dir(Path::new(&ocm_home).join("runtimes"))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with(".stable.stage-"))
+        .collect::<Vec<_>>();
+    assert!(staged_runtime_paths.is_empty(), "{staged_runtime_paths:?}");
+    let snapshots = run_ocm(&cwd, &env, &["env", "snapshot", "list", "demo", "--json"]);
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert!(snapshots.as_array().unwrap().is_empty());
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history: Value = serde_json::from_str(&stdout(&history)).unwrap();
+    assert!(history.as_array().unwrap().is_empty());
+    let service = run_ocm(&cwd, &env, &["service", "status", "demo", "--json"]);
+    assert!(service.status.success(), "{}", stderr(&service));
+    let service: Value = serde_json::from_str(&stdout(&service)).unwrap();
+    assert_eq!(service["desiredRunning"], true);
+    assert_eq!(service["running"], true);
 }
 
 #[test]
@@ -3471,7 +3547,7 @@ fn upgrade_rollback_refuses_a_broken_source_launcher_before_mutation() {
 }
 
 #[test]
-fn upgrade_can_switch_env_to_an_installed_runtime() {
+fn upgrade_keeps_a_disabled_service_disabled_when_switching_runtime() {
     let root = TestDir::new("upgrade-installed-runtime");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
@@ -3517,6 +3593,11 @@ fn upgrade_can_switch_env_to_an_installed_runtime() {
         &["env", "create", "demo", "--runtime", "old-local"],
     );
     assert!(create.status.success(), "{}", stderr(&create));
+    let before = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(before.status.success(), "{}", stderr(&before));
+    let before: Value = serde_json::from_str(&stdout(&before)).unwrap();
+    assert_eq!(before["serviceEnabled"], false);
+    assert_eq!(before["serviceRunning"], false);
 
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
     assert!(upgrade.status.success(), "{}", stderr(&upgrade));
@@ -3524,11 +3605,14 @@ fn upgrade_can_switch_env_to_an_installed_runtime() {
     assert!(output.contains("from=runtime:old-local"), "{output}");
     assert!(output.contains("to=runtime:new-local"), "{output}");
     assert!(output.contains("outcome=switched"), "{output}");
+    assert!(!output.contains("service="), "{output}");
 
     let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
     assert!(show.status.success(), "{}", stderr(&show));
     let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     assert_eq!(env_json["defaultRuntime"], "new-local");
+    assert_eq!(env_json["serviceEnabled"], false);
+    assert_eq!(env_json["serviceRunning"], false);
     let env_root = Path::new(env_json["root"].as_str().unwrap());
     let command_log = fs::read_to_string(env_root.join("sim-commands.log")).unwrap();
     assert!(


### PR DESCRIPTION
## Summary

- stage target runtime installation privately while the current Gateway remains healthy
- run snapshot preflight and immutable runtime rollback backup before service quiescence
- keep complete snapshot capture, staged runtime publication, finalization, restart verification, and rollback inside the cold cutover
- fail preparation before cutover without changing the environment, binding, secrets, service policy, snapshot history, or published runtime

This intentionally does not change delayed stop acknowledgement, desired-versus-observed start state, health convergence, or false-rollback behavior. Those remain in the separate convergence owner lane.

## Canonical transaction boundary

Pre-cutover now contains target resolution/staging, complete snapshot preflight, and runtime rollback backup. Cutover begins immediately before source service quiescence, then captures the complete rollback snapshot, atomically publishes the staged runtime, performs config repair/finalization, restores the requested service policy, and verifies health/RPC readiness. Any failure after publication retains the existing fail-closed rollback path.

Finalization stays cold because it can mutate OpenClaw config, SQLite state, and plugins. Snapshot capture stays after quiescence for point-in-time consistency.

## Availability evidence

Same deterministic fixture: 1.5s target preparation delay, 1.5s finalization delay, continuous health polling.

Untouched canonical `main` at `614f6cb4b9c40d70342aecb1af01286feff613fb`:

- service stopped: 3.948s
- target preparation: 4.382-5.957s
- finalization: 6.218-7.777s
- target ready: 7.831s
- stop-to-ready: 3.883s
- result: red; source Gateway was unavailable during target preparation

This head at `739cac55cb1610177652093c2ce785e5d9371a17`:

- target preparation: 5.021-6.522s
- service stopped: 8.047s
- finalization: 8.966-10.541s
- target ready: 10.580s
- stop-to-ready: 2.533s
- result: green; source health remained continuous through preparation

The deterministic cutover interval drops by 1.350s (~35%). Absolute host setup time varies; the contract asserts phase ordering and continuous health rather than a flaky wall-clock threshold.

## Related work

PR #60 overlaps some upgrade/runtime files but combines broader gateway lifecycle and runtime changes. This PR keeps the transaction-ordering fix isolated and does not absorb the separate convergence workstream.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --test upgrade_availability_tests -- --nocapture`
- `cargo test --test upgrade_command_tests -- --test-threads=1` (46 passed)
- `cargo test --test runtime_command_tests -- --test-threads=1` (46 passed, including current-main source-extension coverage)
- `cargo test --lib -- --test-threads=1` (296 passed)
- `cargo clippy --all-targets -- -D warnings -A clippy::question_mark -A clippy::large_enum_variant -A clippy::too_many_arguments`
- source-blind behavior validation: 6/6 contract clauses passed, no blockers
- autoreview: clean, no accepted/actionable findings; TruffleHog clean
