### PR TITLE
fix(supervisor): publish removed crash-loop state

### DIFF
--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1090,8 +1090,9 @@ fn reconcile_running_children(
                 }
             }
             None => {
-                pending.remove(&env_name);
-                inactive.remove(&env_name);
+                let removed_pending = pending.remove(&env_name).is_some();
+                let removed_inactive = inactive.remove(&env_name).is_some();
+                runtime_dirty |= removed_pending || removed_inactive;
             }
         }
     }
@@ -2751,6 +2752,60 @@ mod tests {
         assert_eq!(pending.get("rescue").unwrap().spec, next_rescue);
         assert_eq!(pending.get("main").unwrap().spec, main);
         assert_eq!(pending.get("main").unwrap().restart_count, 7);
+    }
+
+    #[test]
+    fn removing_crash_looping_child_marks_runtime_state_dirty() {
+        let target = child_spec("rosita", 18790);
+        let control = child_spec("control", 19123);
+        let desired = SupervisorState {
+            kind: SUPERVISOR_STATE_KIND.to_string(),
+            ocm_home: "/tmp/ocm".to_string(),
+            generated_at: OffsetDateTime::UNIX_EPOCH,
+            children: vec![control.clone()],
+            skipped_envs: Vec::new(),
+            restart_requests: Vec::new(),
+        };
+        let mut running = BTreeMap::new();
+        let mut pending = BTreeMap::from([
+            (
+                target.env_name.clone(),
+                pending_supervisor_child(
+                    target.clone(),
+                    None,
+                    4,
+                    0,
+                    30_000,
+                    Some(1),
+                    Some("schema 8 is newer than supported schema 7".to_string()),
+                ),
+            ),
+            (
+                control.env_name.clone(),
+                pending_supervisor_child(
+                    control.clone(),
+                    None,
+                    2,
+                    0,
+                    30_000,
+                    Some(1),
+                    Some("control backoff".to_string()),
+                ),
+            ),
+        ]);
+        let mut inactive = pending
+            .iter()
+            .map(|(name, child)| (name.clone(), inactive_from_pending(child, "backoff")))
+            .collect::<BTreeMap<_, _>>();
+
+        let runtime_dirty =
+            reconcile_running_children(&mut running, &mut pending, &mut inactive, &desired);
+
+        assert!(runtime_dirty, "published runtime state must drop rosita");
+        assert!(!pending.contains_key("rosita"));
+        assert!(!inactive.contains_key("rosita"));
+        assert_eq!(pending.get("control").unwrap().spec, control);
+        assert!(inactive.contains_key("control"));
     }
 
     #[test]


### PR DESCRIPTION
## What Problem This Solves

An environment can be desired-stopped while its supervised gateway has already exited and remains only in pending/inactive crash-loop state. Reconciliation removed those exact-target entries in memory but did not mark runtime state dirty, so the supervisor kept publishing a stale child. Transactional upgrade quiescence then timed out even though no live target process remained.

## Why This Change Was Made

Mark runtime state dirty when desired-state reconciliation removes an absent child's pending or inactive entry. This keeps publication owned by the supervisor state transition and preserves the existing bounded, exact-environment quiescence protocol—without sleeps, broad retries, pattern kills, or ignored errors.

## User Impact

Upgrades can converge cleanly when the old gateway is already crash-looping before cutover. Unrelated environments remain untouched, and rollback/service intent remains owned by the existing transaction.

## Evidence

- Red on `381a5ed2`: exact target entries were removed but `runtime_dirty` remained false.
- Green: `removing_crash_looping_child_marks_runtime_state_dirty` proves publication is requested and an unrelated pending/inactive control environment is preserved.
- `cargo test supervisor::tests::` — 25 passed.
- `cargo test upgrade_waits_for_one_supervisor_convergence_retry` — passed.
- `cargo test failed_named_runtime_target_in_backoff_is_not_rewritten_during_rollback` — passed.
- `cargo test upgrade_rolls_back_when_gateway_rpc_is_not_ready` — passed.
- Source-blind behavior contract — passed for exact-target removal, unrelated-service preservation, rollback material, and deterministic desired state.
- `cargo fmt -- --check` and `git diff --check` — passed.
- `cargo clippy --all-targets -- -D warnings` reports the same four pre-existing warnings on the exact base in unrelated files.
- Autoreview (Codex, high reasoning) and TruffleHog — clean.

Production LOC: +2/-2. Test LOC: +55/-0.
