### PR TITLE
fix(upgrade): validate managed Codex candidate before cutover

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -13,6 +13,7 @@ use serde_json::{Value, json};
 use super::{Cli, render};
 use crate::env::{
     CloneEnvironmentOptions, CreateEnvSnapshotOptions, EnvDevMeta, RestoreEnvSnapshotOptions,
+    resolve_runtime_run_dir,
 };
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::openclaw_repo::{detect_openclaw_checkout, ensure_openclaw_worktree};
@@ -22,7 +23,7 @@ use crate::runtime::releases::{
 };
 use crate::runtime::{
     InstallRuntimeFromOfficialReleaseOptions, OfficialRuntimePrepareAction, RuntimeMeta,
-    RuntimeReleaseSelectorKind, RuntimeService, StagedRuntimeInstall,
+    RuntimeReleaseSelectorKind, RuntimeService, StagedRuntimeInstall, resolve_runtime_launch,
 };
 use crate::service::ServiceSummary;
 use crate::store::{
@@ -2660,6 +2661,7 @@ impl Cli {
         match resolved.kind {
             ResolvedUpgradeTargetKind::Named(meta) => Ok(PreparedUpgradeTarget {
                 name: resolved.name,
+                prepared_binary_path: PathBuf::from(&meta.binary_path),
                 meta,
                 action: OfficialRuntimePrepareAction::Reused,
                 staged: None,
@@ -2681,10 +2683,12 @@ impl Cli {
                             )
                     },
                 )?;
+                let prepared_binary_path = staged.prepared_binary_path();
                 let meta = staged.meta().clone();
                 let action = staged.action();
                 Ok(PreparedUpgradeTarget {
                     name: resolved.name,
+                    prepared_binary_path,
                     meta,
                     action,
                     staged: Some(staged),
@@ -2699,13 +2703,73 @@ impl Cli {
         target: &UpgradeTarget,
         resolved: ResolvedUpgradeTarget,
     ) -> Result<PreparedUpgradeTarget, String> {
-        if target.is_named_runtime() {
-            return self.prepare_resolved_upgrade_target(env_name, target, resolved);
+        let prepared = if target.is_named_runtime() {
+            self.prepare_resolved_upgrade_target(env_name, target, resolved)?
+        } else {
+            let runtime_name = resolved.name.clone();
+            self.with_isolated_runtime_mutation(env_name, &runtime_name, || {
+                self.prepare_resolved_upgrade_target(env_name, target, resolved)
+            })?
+        };
+        self.validate_prepared_upgrade_target(env_name, &prepared)?;
+        Ok(prepared)
+    }
+
+    fn validate_prepared_upgrade_target(
+        &self,
+        env_name: &str,
+        prepared: &PreparedUpgradeTarget,
+    ) -> Result<(), String> {
+        const CHECK_ID: &str = "codex/managed-app-server";
+        let args = [
+            "doctor".to_string(),
+            "--lint".to_string(),
+            "--only".to_string(),
+            CHECK_ID.to_string(),
+            "--json".to_string(),
+        ];
+        let mut meta = prepared.meta.clone();
+        meta.binary_path = display_path(&prepared.prepared_binary_path);
+        let launch = resolve_runtime_launch(&meta, &args, &self.env, &self.cwd, true)
+            .map_err(|error| format!("candidate managed Codex preflight failed: {error}"))?;
+        let env_meta = self
+            .environment_service()
+            .get(env_name)
+            .map_err(|error| format!("candidate managed Codex preflight failed: {error}"))?;
+        let mut process_env = build_openclaw_env(&env_meta, &self.env);
+        crate::managed_node::apply_path_prepend_to_environment(
+            &mut process_env,
+            launch.path_prepend.as_deref(),
+        )
+        .map_err(|error| format!("candidate managed Codex preflight failed: {error}"))?;
+        process_env.insert("OPENCLAW_UPDATE_IN_PROGRESS".to_string(), "1".to_string());
+
+        let output = Command::new(&launch.program)
+            .args(&launch.args)
+            .current_dir(resolve_runtime_run_dir(&self.cwd))
+            .env_clear()
+            .envs(process_env)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|error| {
+                format!(
+                    "candidate managed Codex preflight failed to start {}: {error}",
+                    display_path(Path::new(&launch.program))
+                )
+            })?;
+        let output = SimulationCommandOutput::from_output(output);
+        if output.status.success() {
+            return Ok(());
         }
-        let runtime_name = resolved.name.clone();
-        self.with_isolated_runtime_mutation(env_name, &runtime_name, || {
-            self.prepare_resolved_upgrade_target(env_name, target, resolved)
-        })
+        if candidate_codex_preflight_is_unsupported(&output.stdout, &output.stderr) {
+            return Ok(());
+        }
+        Err(format!(
+            "candidate managed Codex preflight failed: {}. Repair or reinstall the staged OpenClaw runtime, then rerun the upgrade; the source environment was not changed",
+            output.failure_summary()
+        ))
     }
 
     fn with_isolated_runtime_mutation<T>(
@@ -3517,6 +3581,7 @@ impl Cli {
 
 struct PreparedUpgradeTarget {
     name: String,
+    prepared_binary_path: PathBuf,
     meta: RuntimeMeta,
     action: OfficialRuntimePrepareAction,
     staged: Option<StagedRuntimeInstall>,
@@ -3993,6 +4058,44 @@ fn command_output_reports_unsupported_command(stdout: &str, stderr: &str) -> boo
     })
 }
 
+fn candidate_codex_preflight_is_unsupported(stdout: &str, stderr: &str) -> bool {
+    const CHECK_ID: &str = "codex/managed-app-server";
+    if let Ok(value) = serde_json::from_str::<Value>(stdout)
+        && value
+            .get("findings")
+            .and_then(Value::as_array)
+            .is_some_and(|findings| {
+                findings.iter().any(|finding| {
+                    finding.get("checkId").and_then(Value::as_str)
+                        == Some("core/doctor/lint-selection")
+                        && finding.get("path").and_then(Value::as_str) == Some(CHECK_ID)
+                        && finding
+                            .get("message")
+                            .and_then(Value::as_str)
+                            .is_some_and(|message| {
+                                message.contains("Unknown health check id selected by --only")
+                            })
+                })
+            })
+    {
+        return true;
+    }
+
+    let normalized = format!("{stdout}\n{stderr}").to_ascii_lowercase();
+    [
+        "unknown command 'doctor'",
+        "unknown command \"doctor\"",
+        "unrecognized command 'doctor'",
+        "unrecognized command \"doctor\"",
+        "unknown option '--lint'",
+        "unknown option \"--lint\"",
+        "unrecognized option '--lint'",
+        "unrecognized option \"--lint\"",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
 fn shell_command(command: &str) -> Command {
     if cfg!(windows) {
         let mut process = Command::new("cmd");
@@ -4224,9 +4327,9 @@ fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        command_output_reports_unsupported_command, release_version_from_output,
-        should_wait_for_scheduled_gateway_retry, verify_gateway_status_readiness,
-        version_output_matches_expected,
+        candidate_codex_preflight_is_unsupported, command_output_reports_unsupported_command,
+        release_version_from_output, should_wait_for_scheduled_gateway_retry,
+        verify_gateway_status_readiness, version_output_matches_expected,
     };
 
     #[test]
@@ -4442,6 +4545,26 @@ mod tests {
         assert!(!command_output_reports_unsupported_command(
             "",
             "OpenClaw config is invalid\nProblem: meta: Unrecognized key: lastTouchedAt"
+        ));
+    }
+
+    #[test]
+    fn codex_candidate_probe_only_skips_explicit_unsupported_results() {
+        assert!(candidate_codex_preflight_is_unsupported(
+            r#"{"findings":[{"checkId":"core/doctor/lint-selection","path":"codex/managed-app-server","message":"Unknown health check id selected by --only: codex/managed-app-server."}]}"#,
+            ""
+        ));
+        assert!(candidate_codex_preflight_is_unsupported(
+            "",
+            "error: unknown option '--lint'"
+        ));
+        assert!(!candidate_codex_preflight_is_unsupported(
+            r#"{"findings":[{"checkId":"codex/managed-app-server","path":"/candidate/codex","message":"version mismatch"}]}"#,
+            ""
+        ));
+        assert!(!candidate_codex_preflight_is_unsupported(
+            "",
+            "managed Codex binary command not found"
         ));
     }
 }

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -133,6 +133,10 @@ impl StagedRuntimeInstall {
         self.action
     }
 
+    pub(crate) fn prepared_binary_path(&self) -> std::path::PathBuf {
+        self.prepared.prepared_binary_path()
+    }
+
     pub(crate) fn commit(self) -> Result<RuntimeMeta, String> {
         self.prepared.commit()
     }

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -312,6 +312,13 @@ impl PreparedRuntimeInstall {
         self.reused
     }
 
+    pub(crate) fn prepared_binary_path(&self) -> PathBuf {
+        self.target
+            .as_ref()
+            .map(|target| installed_openclaw_binary_path(&target.install_files))
+            .unwrap_or_else(|| PathBuf::from(&self.meta.binary_path))
+    }
+
     pub(crate) fn commit(mut self) -> Result<RuntimeMeta, String> {
         let meta = self.meta.clone();
         match self.target.take() {

--- a/tests/upgrade_availability_tests.rs
+++ b/tests/upgrade_availability_tests.rs
@@ -286,6 +286,10 @@ case "$1" in
     printf 'Config valid\n'
     exit 0
     ;;
+  doctor)
+    printf '%s\n' '{{"ok":false,"checksRun":0,"checksSkipped":1,"findings":[{{"checkId":"core/doctor/lint-selection","severity":"error","message":"Unknown health check id selected by --only: codex/managed-app-server.","path":"codex/managed-app-server"}}]}}'
+    exit 1
+    ;;
   update)
     if [ "$2" = "finalize" ]; then
       : > "$OCM_TEST_UPDATE_FINALIZE_STARTED"

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -291,6 +291,26 @@ case "$1" in
     exit 0
     ;;
   doctor)
+    if [ "$2" = "--lint" ]; then
+      has_arg "--only" "$@" && has_arg "codex/managed-app-server" "$@" && has_arg "--json" "$@" || {{
+        echo "missing managed Codex candidate flags" >&2
+        exit 1
+      }}
+      case "${{OCM_TEST_CODEX_PREFLIGHT:-unsupported}}" in
+        pass)
+          printf '{{"ok":true,"checksRun":1,"checksSkipped":0,"findings":[]}}\n'
+          exit 0
+          ;;
+        fail)
+          printf '{{"ok":false,"checksRun":1,"checksSkipped":0,"findings":[{{"checkId":"codex/managed-app-server","severity":"error","message":"Managed Codex app-server version mismatch: expected 0.147.0, detected 0.146.0.","path":"/candidate/codex"}}]}}\n'
+          exit 1
+          ;;
+        unsupported)
+          printf '{{"ok":false,"checksRun":0,"checksSkipped":1,"findings":[{{"checkId":"core/doctor/lint-selection","severity":"error","message":"Unknown health check id selected by --only: codex/managed-app-server.","path":"codex/managed-app-server"}}]}}\n'
+          exit 1
+          ;;
+      esac
+    fi
     has_arg "--non-interactive" "$@" && has_arg "--fix" "$@" || {{
       echo "missing doctor update flags" >&2
       exit 1
@@ -519,6 +539,12 @@ case "$1" in
       exit 0
     fi
     ;;
+  doctor)
+    if [ "$2" = "--lint" ]; then
+      printf '{{"ok":false,"findings":[{{"checkId":"core/doctor/lint-selection","message":"Unknown health check id selected by --only: codex/managed-app-server.","path":"codex/managed-app-server"}}]}}\n'
+      exit 1
+    fi
+    ;;
 esac
 echo "unexpected args: $*" >&2
 exit 1
@@ -545,6 +571,12 @@ case "$1" in
       fi
       printf '{{"status":"ok"}}\n'
       exit 0
+    fi
+    ;;
+  doctor)
+    if [ "$2" = "--lint" ]; then
+      printf '{{"ok":false,"findings":[{{"checkId":"core/doctor/lint-selection","message":"Unknown health check id selected by --only: codex/managed-app-server.","path":"codex/managed-app-server"}}]}}\n'
+      exit 1
     fi
     ;;
 esac
@@ -875,6 +907,13 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
     let env_json: Value = serde_json::from_str(&stdout(&env_show)).unwrap();
     let env_root = Path::new(env_json["root"].as_str().unwrap());
     let command_log = fs::read_to_string(env_root.join("sim-commands.log")).unwrap();
+    let candidate_preflight = command_log
+        .find("doctor --lint --only codex/managed-app-server --json")
+        .expect("staged official runtime must run the candidate preflight");
+    let finalization = command_log
+        .find("update finalize --json --yes --no-restart")
+        .expect("updated runtime must finalize");
+    assert!(candidate_preflight < finalization, "{command_log}");
     assert!(
         command_log.contains("update finalize --json --yes --no-restart"),
         "{command_log}"
@@ -5212,4 +5251,101 @@ fn upgrade_all_json_exits_failed_when_any_env_fails() {
             .unwrap()
             .contains("runtime \"missing-soon\" does not exist")
     );
+}
+
+fn setup_named_runtime_candidate_fixture(
+    root: &TestDir,
+) -> (PathBuf, BTreeMap<String, String>, PathBuf) {
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("old-openclaw"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("new-openclaw"));
+
+    let env = ocm_env(root);
+    for (name, runtime) in [("old-local", &old_runtime), ("new-local", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                name,
+                "--path",
+                &runtime.display().to_string(),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "old-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let env_root = root.child("ocm-home/envs/demo");
+    fs::write(env_root.join(".openclaw/openclaw.json"), "{}\n").unwrap();
+    (cwd, env, env_root)
+}
+
+#[test]
+fn upgrade_validates_managed_codex_candidate_before_transactional_cutover() {
+    let root = TestDir::new("upgrade-codex-candidate-preflight");
+    let (cwd, mut env, env_root) = setup_named_runtime_candidate_fixture(&root);
+    env.insert("OCM_TEST_CODEX_PREFLIGHT".to_string(), "pass".to_string());
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
+    assert!(upgrade.status.success(), "{}", stderr(&upgrade));
+
+    let command_log = fs::read_to_string(env_root.join("sim-commands.log")).unwrap();
+    let candidate = command_log
+        .find("doctor --lint --only codex/managed-app-server --json")
+        .expect("candidate managed Codex check must run");
+    let finalize = command_log
+        .find("update finalize --json --yes --no-restart")
+        .expect("target finalization must run");
+    assert!(candidate < finalize, "{command_log}");
+}
+
+#[test]
+fn managed_codex_candidate_failure_stops_before_upgrade_mutation() {
+    let root = TestDir::new("upgrade-codex-candidate-preflight-failure");
+    let (cwd, mut env, env_root) = setup_named_runtime_candidate_fixture(&root);
+    env.insert("OCM_TEST_CODEX_PREFLIGHT".to_string(), "fail".to_string());
+    let config_path = env_root.join(".openclaw/openclaw.json");
+    let config_before = fs::read(&config_path).unwrap();
+
+    let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
+    assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
+    let output = stdout(&upgrade);
+    assert!(output.contains("outcome=failed"), "{output}");
+    assert!(
+        output.contains("source environment and service were left unchanged"),
+        "{output}"
+    );
+    assert!(
+        output.contains("expected 0.147.0, detected 0.146.0"),
+        "{output}"
+    );
+
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(show.status.success(), "{}", stderr(&show));
+    let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(env_json["defaultRuntime"], "old-local");
+    assert_eq!(fs::read(&config_path).unwrap(), config_before);
+
+    let snapshots = run_ocm(&cwd, &env, &["env", "snapshot", "list", "demo", "--json"]);
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    let snapshots_json: Value = serde_json::from_str(&stdout(&snapshots)).unwrap();
+    assert!(snapshots_json.as_array().unwrap().is_empty());
+    assert!(!root.child("ocm-home/upgrade-history/demo").exists());
+
+    let command_log = fs::read_to_string(env_root.join("sim-commands.log")).unwrap();
+    assert!(
+        command_log.contains("doctor --lint --only codex/managed-app-server --json"),
+        "{command_log}"
+    );
+    assert!(!command_log.contains("config validate"), "{command_log}");
+    assert!(!command_log.contains("update finalize"), "{command_log}");
 }


### PR DESCRIPTION
## What problem this solves

An OCM upgrade could pass gateway readiness and enter the transaction even when the staged OpenClaw runtime's managed Codex app-server was missing or the wrong version. Gateway readiness does not start Codex, so the first post-cutover Codex turn could fail after source quiescence and runtime mutation had already begun.

## Canonical fix

OCM now runs the staged candidate binary's named read-only health check before creating the upgrade transaction:

`doctor --lint --only codex/managed-app-server --json`

The check runs through the candidate's normal launch policy and environment using the exact prepared binary path. A real check failure exits through the existing pre-cutover failure path, leaving source binding, service desired/running state, configuration, snapshots, and history unchanged. Older OpenClaw candidates that do not expose the named check retain backward-compatible upgrade behavior through narrowly matched unknown-check/unsupported-doctor responses.

OpenClaw PR https://github.com/openclaw/openclaw/pull/124137 owns the named managed-binary/version check. OpenClaw PR #124124 already owns exact plugin-root binary selection. OCM owns only candidate invocation and transaction ordering; neither OpenClaw concern is duplicated here.

## Evidence

- Red on detached canonical OCM main `0686a2b7003403d092be0b7f3ddcf3f02a6413b6`: the staged target proceeded to config validation/finalization without any managed-Codex candidate check.
- Green: all 48 `upgrade_command_tests` pass, including exact prepared-binary invocation, pass/fail/unsupported compatibility, pre-transaction ordering, staged official installs, and negative controls for lookalike errors.
- Full unit suite reached 298/298 passing unit tests; the later `bin_wrapper_tests` failure reproduces unchanged on the exact unmodified base and is unrelated environment baseline noise.
- `cargo clippy --all-targets --all-features` passes with the same four pre-existing warnings as main. `cargo fmt --all -- --check` and `git diff --check` pass.
- Source-blind failure proof: a candidate reporting Codex 0.146.0 instead of required 0.147.0 exits 1 before cutover. Source runtime binding remains `old-local`, service remains disabled/stopped, snapshots remain `[]`, no upgrade history is created, and config SHA-256 remains unchanged.
- Source-blind success proof: exact candidate order is `--version`, managed-Codex doctor check, `config validate`, `update finalize`, `--version`; outcome switches to `new-local` and retains one `pre-upgrade` snapshot recording `old-local`.
- An unrelated environment remains untouched, with no command log or service-state change.
- Autoreview used the trusted TruffleHog binary and returned clean with no accepted/actionable findings.

This PR is separate from the already-landed crash-loop convergence repair in #79 and the OpenClaw doctor schema-safety repair in openclaw/openclaw#124110.
