### PR TITLE
chore(release): bump version to 0.2.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.31"
+version = "0.2.32"
 edition = "2024"
 rust-version = "1.88"
 description = "OpenClaw Manager: the local control plane for isolated OpenClaw environments, launchers, runtimes, and services."


### PR DESCRIPTION
## What Problem This Solves

OpenClaw Performance release validation is blocked because the latest OCM release predates c34c7072bf2802beb46385ed5d9fb05b44e5ce1b, which teaches `runtime build-local` to discover the current `.mts` workspace adapter, invoke it with native Node, compute transitive workspace dependencies, and enable the required trusted npm lifecycle.

Blocked OpenClaw runs:

- https://github.com/openclaw/openclaw/actions/runs/31870866801
- https://github.com/openclaw/openclaw/actions/runs/31871544450

## Why This Change Was Made

This is the version-only release preparation required by `scripts/release.sh`. After squash merge and green exact-head `main` CI, an OCM owner can rerun `scripts/release.sh 0.2.32` to create and push the signed `v0.2.32` tag; the tag workflow then owns artifact publication.

## User Impact

Publishes the first OCM release containing the current OpenClaw build-local fix, allowing OpenClaw to remove its Bash/tsx trampoline and resume Kova performance validation.

## Evidence

- Current upstream `main` CI: https://github.com/shakkernerd/ocm/actions/runs/31878338654
- `cargo fmt --check`: passed
- `cargo build --locked --release`: passed
- `cargo test --locked`: 311 tests passed before `bin_wrapper_runs_with_an_overridden_home` stopped locally because this host has Homebrew Cargo but no `rustup`; the version-only diff does not touch runtime code, and PR CI is the authoritative full-suite proof
- Codex autoreview: clean, no accepted/actionable findings
