### PR TITLE
fix(migrate): relocate imported plugin records

### DIFF
--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -168,6 +168,7 @@ impl Cli {
             result.cleared_sandbox_origin,
             result.sandbox_port,
         );
+        self.warn_external_migration_plugins(&result.external_plugin_ids);
         let summary = result.summary;
 
         if json_flag {
@@ -209,6 +210,7 @@ impl Cli {
             result.cleared_sandbox_origin,
             result.sandbox_port,
         );
+        self.warn_external_migration_plugins(&result.external_plugin_ids);
         let summary = result.summary;
 
         if json_flag {
@@ -231,6 +233,14 @@ impl Cli {
         sandbox_port: Option<u32>,
     ) {
         self.warn_cleared_sandbox_origin(&summary.name, cleared_sandbox_origin, sandbox_port);
+    }
+
+    fn warn_external_migration_plugins(&self, plugin_ids: &[String]) {
+        for plugin_id in plugin_ids {
+            self.stderr_line(format!(
+                "warning: imported plugin {plugin_id} could not be isolated inside the env state; OCM preserved but did not copy or modify its external location"
+            ));
+        }
     }
 
     fn handle_adopt_inspect(&self, args: Vec<String>) -> Result<i32, String> {

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -48,6 +48,7 @@ pub(crate) struct MigrateHomeResult {
     pub summary: EnvImportSummary,
     pub cleared_sandbox_origin: bool,
     pub sandbox_port: Option<u32>,
+    pub external_plugin_ids: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -181,6 +182,13 @@ fn remove_copied_external_default_workspace_link(config_path: &Path) -> Result<(
         })
 }
 
+struct CompletedMigrationImport {
+    meta: crate::env::EnvMeta,
+    cleared_sandbox_origin: bool,
+    sandbox_port: Option<u32>,
+    external_plugin_ids: Vec<String>,
+}
+
 pub fn default_migration_source_home(env: &BTreeMap<String, String>) -> PathBuf {
     resolve_user_home(env).join(".openclaw")
 }
@@ -248,13 +256,7 @@ pub(crate) fn migrate_plain_openclaw_home_with_sandbox_origin(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<MigrateHomeResult, String> {
-    let (summary, _, cleared_sandbox_origin, sandbox_port) =
-        migrate_plain_openclaw_home_inner(options, sandbox_origin, env, cwd)?;
-    Ok(MigrateHomeResult {
-        summary,
-        cleared_sandbox_origin,
-        sandbox_port,
-    })
+    migrate_plain_openclaw_home_inner(options, sandbox_origin, env, cwd)
 }
 
 fn migrate_plain_openclaw_home_inner(
@@ -262,7 +264,7 @@ fn migrate_plain_openclaw_home_inner(
     sandbox_origin: Option<&str>,
     env: &BTreeMap<String, String>,
     cwd: &Path,
-) -> Result<(EnvImportSummary, Option<String>, bool, Option<u32>), String> {
+) -> Result<MigrateHomeResult, String> {
     let sandbox_origin = normalize_new_environment_sandbox_origin(sandbox_origin)?;
     let service = EnvironmentService::new(env, cwd);
     let env_name = validate_name(&options.name, "Environment name")?;
@@ -306,7 +308,7 @@ fn migrate_plain_openclaw_home_inner(
     let created_name = created.name.clone();
     let target_paths = derive_env_paths(Path::new(&created.root));
 
-    let created = match complete_migration_import(
+    let completed = match complete_migration_import(
         created,
         &target_paths,
         &source_home,
@@ -316,12 +318,7 @@ fn migrate_plain_openclaw_home_inner(
         env,
         cwd,
     ) {
-        Ok((created, created_launcher, cleared_sandbox_origin, sandbox_port)) => (
-            created,
-            created_launcher,
-            cleared_sandbox_origin,
-            sandbox_port,
-        ),
+        Ok(result) => result,
         Err(error) => {
             let rollback = service.remove(&created_name, true).map(|_| ());
             return Err(with_rollback_error(
@@ -332,20 +329,20 @@ fn migrate_plain_openclaw_home_inner(
         }
     };
 
-    Ok((
-        EnvImportSummary {
-            name: created.0.name,
+    Ok(MigrateHomeResult {
+        summary: EnvImportSummary {
+            name: completed.meta.name,
             source_name: "plain-openclaw".to_string(),
-            root: created.0.root,
+            root: completed.meta.root,
             archive_path: display_path(&source_home),
-            default_runtime: created.0.default_runtime,
-            default_launcher: created.0.default_launcher,
-            protected: created.0.protected,
+            default_runtime: completed.meta.default_runtime,
+            default_launcher: completed.meta.default_launcher,
+            protected: completed.meta.protected,
         },
-        created.1,
-        created.2,
-        created.3,
-    ))
+        cleared_sandbox_origin: completed.cleared_sandbox_origin,
+        sandbox_port: completed.sandbox_port,
+        external_plugin_ids: completed.external_plugin_ids,
+    })
 }
 
 fn rollback_migrated_launcher(
@@ -381,7 +378,7 @@ fn complete_migration_import(
     migrated_launcher: Option<&MigratedLauncherSpec>,
     env: &BTreeMap<String, String>,
     cwd: &Path,
-) -> Result<(crate::env::EnvMeta, Option<String>, bool, Option<u32>), String> {
+) -> Result<CompletedMigrationImport, String> {
     if target_paths.state_dir.exists() {
         fs::remove_dir_all(&target_paths.state_dir).map_err(|error| error.to_string())?;
     }
@@ -395,7 +392,7 @@ fn complete_migration_import(
         created.gateway_port,
         sandbox_origin,
     )?;
-    prepare_migrated_runtime_state(
+    let runtime_state = prepare_migrated_runtime_state(
         target_paths,
         source_home,
         env,
@@ -403,12 +400,12 @@ fn complete_migration_import(
     )?;
 
     let Some(launcher) = migrated_launcher else {
-        return Ok((
-            created,
-            None,
-            config_rewrite.cleared_sandbox_origin,
-            config_rewrite.sandbox_port,
-        ));
+        return Ok(CompletedMigrationImport {
+            meta: created,
+            cleared_sandbox_origin: config_rewrite.cleared_sandbox_origin,
+            sandbox_port: config_rewrite.sandbox_port,
+            external_plugin_ids: runtime_state.external_plugin_ids,
+        });
     };
 
     let launcher_service = LauncherService::new(env, cwd);
@@ -428,12 +425,12 @@ fn complete_migration_import(
     };
 
     match EnvironmentService::new(env, cwd).set_launcher(&created.name, &launcher.name) {
-        Ok(meta) => Ok((
+        Ok(meta) => Ok(CompletedMigrationImport {
             meta,
-            created_launcher,
-            config_rewrite.cleared_sandbox_origin,
-            config_rewrite.sandbox_port,
-        )),
+            cleared_sandbox_origin: config_rewrite.cleared_sandbox_origin,
+            sandbox_port: config_rewrite.sandbox_port,
+            external_plugin_ids: runtime_state.external_plugin_ids,
+        }),
         Err(error) => {
             let rollback = rollback_migrated_launcher(created_launcher.as_deref(), env, cwd);
             Err(with_rollback_error(

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -313,14 +313,17 @@ fn relocate_installed_plugin_index_paths(
     source_state_root: &Path,
     target_state_root: &Path,
 ) -> Result<MigratedRuntimeStateResult, String> {
-    if !is_sqlite_database(database_path)? {
+    let Some(database_path) = contained_imported_database(database_path, target_state_root)? else {
+        return Ok(MigratedRuntimeStateResult::default());
+    };
+    if !is_sqlite_database(&database_path)? {
         return Ok(MigratedRuntimeStateResult::default());
     }
 
-    let connection = Connection::open(database_path).map_err(|error| {
+    let connection = Connection::open(&database_path).map_err(|error| {
         format!(
             "failed to open imported OpenClaw state database {}: {error}",
-            display_path(database_path)
+            display_path(&database_path)
         )
     })?;
     let table_exists = connection
@@ -333,7 +336,7 @@ fn relocate_installed_plugin_index_paths(
         .map_err(|error| {
             format!(
                 "failed to inspect imported OpenClaw plugin index {}: {error}",
-                display_path(database_path)
+                display_path(&database_path)
             )
         })?
         .is_some();
@@ -351,7 +354,7 @@ fn relocate_installed_plugin_index_paths(
         .map_err(|error| {
             format!(
                 "failed to read imported OpenClaw plugin install records {}: {error}",
-                display_path(database_path)
+                display_path(&database_path)
             )
         })?
     else {
@@ -361,13 +364,13 @@ fn relocate_installed_plugin_index_paths(
     let mut records: Value = serde_json::from_str(&raw_records).map_err(|error| {
         format!(
             "failed to parse imported OpenClaw plugin install records {}: {error}",
-            display_path(database_path)
+            display_path(&database_path)
         )
     })?;
     let Some(records) = records.as_object_mut() else {
         return Err(format!(
             "imported OpenClaw plugin install records are not an object: {}",
-            display_path(database_path)
+            display_path(&database_path)
         ));
     };
 
@@ -414,13 +417,40 @@ fn relocate_installed_plugin_index_paths(
         .map_err(|error| {
             format!(
                 "failed to relocate imported OpenClaw plugin install records {}: {error}",
-                display_path(database_path)
+                display_path(&database_path)
             )
         })?;
     Ok(MigratedRuntimeStateResult {
         changed: true,
         external_plugin_ids: external_plugin_ids.into_iter().collect(),
     })
+}
+
+fn contained_imported_database(
+    database_path: &Path,
+    target_state_root: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let metadata = match fs::symlink_metadata(database_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    // Resolve only regular imported files so a preserved symlink cannot redirect a writable open.
+    if !metadata.is_file() {
+        return Err(format!(
+            "imported OpenClaw state database must be a regular file inside the imported state: {}",
+            display_path(database_path)
+        ));
+    }
+    let canonical_root = fs::canonicalize(target_state_root).map_err(|error| error.to_string())?;
+    let canonical_database = fs::canonicalize(database_path).map_err(|error| error.to_string())?;
+    if !canonical_database.starts_with(&canonical_root) {
+        return Err(format!(
+            "imported OpenClaw state database must be a regular file inside the imported state: {}",
+            display_path(database_path)
+        ));
+    }
+    Ok(Some(canonical_database))
 }
 
 fn relocatable_plugin_path(

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -1,7 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::fs;
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+
+use rusqlite::{Connection, OptionalExtension};
+use serde_json::Value;
 
 use crate::env::EnvMeta;
 use crate::infra::archive::{EnvArchiveEntryKind, EnvArchiveOptions};
@@ -16,6 +20,12 @@ use super::openclaw_workspaces::{
 pub(crate) struct OpenClawStateAudit {
     pub issues: Vec<String>,
     pub repair_runtime_state: bool,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct MigratedRuntimeStateResult {
+    pub changed: bool,
+    pub external_plugin_ids: Vec<String>,
 }
 
 pub(crate) fn audit_openclaw_state(
@@ -149,9 +159,9 @@ pub(crate) fn prepare_migrated_runtime_state(
     source_state_root: &Path,
     env: &BTreeMap<String, String>,
     runtime: OpenClawWorkspaceRuntime<'_>,
-) -> Result<bool, String> {
+) -> Result<MigratedRuntimeStateResult, String> {
     if !path_exists(&paths.state_dir) {
-        return Ok(false);
+        return Ok(MigratedRuntimeStateResult::default());
     }
     let workspaces = resolve_archivable_workspaces(paths, env, runtime)?;
 
@@ -163,8 +173,17 @@ pub(crate) fn prepare_migrated_runtime_state(
         source_state_root,
         &paths.state_dir,
     )?;
+    let plugin_paths = relocate_installed_plugin_index_paths(
+        &paths.state_dir.join("state/openclaw.sqlite"),
+        source_state_root,
+        &paths.state_dir,
+    )?;
+    changed |= plugin_paths.changed;
     changed |= clear_volatile_runtime_state(&paths.state_dir, &paths.config_path, &workspaces)?;
-    Ok(changed)
+    Ok(MigratedRuntimeStateResult {
+        changed,
+        external_plugin_ids: plugin_paths.external_plugin_ids,
+    })
 }
 
 pub(crate) fn clear_nonportable_runtime_state(
@@ -287,6 +306,168 @@ fn rewrite_runtime_state_root_refs_inner(
     }
 
     Ok(())
+}
+
+fn relocate_installed_plugin_index_paths(
+    database_path: &Path,
+    source_state_root: &Path,
+    target_state_root: &Path,
+) -> Result<MigratedRuntimeStateResult, String> {
+    if !is_sqlite_database(database_path)? {
+        return Ok(MigratedRuntimeStateResult::default());
+    }
+
+    let connection = Connection::open(database_path).map_err(|error| {
+        format!(
+            "failed to open imported OpenClaw state database {}: {error}",
+            display_path(database_path)
+        )
+    })?;
+    let table_exists = connection
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'installed_plugin_index'",
+            [],
+            |_| Ok(()),
+        )
+        .optional()
+        .map_err(|error| {
+            format!(
+                "failed to inspect imported OpenClaw plugin index {}: {error}",
+                display_path(database_path)
+            )
+        })?
+        .is_some();
+    if !table_exists {
+        return Ok(MigratedRuntimeStateResult::default());
+    }
+
+    let Some(raw_records) = connection
+        .query_row(
+            "SELECT install_records_json FROM installed_plugin_index WHERE index_key = 'installed-plugin-index'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| {
+            format!(
+                "failed to read imported OpenClaw plugin install records {}: {error}",
+                display_path(database_path)
+            )
+        })?
+    else {
+        return Ok(MigratedRuntimeStateResult::default());
+    };
+
+    let mut records: Value = serde_json::from_str(&raw_records).map_err(|error| {
+        format!(
+            "failed to parse imported OpenClaw plugin install records {}: {error}",
+            display_path(database_path)
+        )
+    })?;
+    let Some(records) = records.as_object_mut() else {
+        return Err(format!(
+            "imported OpenClaw plugin install records are not an object: {}",
+            display_path(database_path)
+        ));
+    };
+
+    let mut changed = false;
+    let mut external_plugin_ids = BTreeSet::new();
+    for (plugin_id, record) in records.iter_mut() {
+        let Some(record) = record.as_object_mut() else {
+            continue;
+        };
+        let is_path_plugin = record.get("source").and_then(Value::as_str) == Some("path");
+        let mut has_external_path = false;
+        for field in ["installPath", "sourcePath"] {
+            let Some(path) = record.get(field).and_then(Value::as_str) else {
+                continue;
+            };
+            let path = Path::new(path);
+            let Some(relative) = relocatable_plugin_path(path, source_state_root, !is_path_plugin)
+            else {
+                has_external_path |= path.is_absolute() && !path.starts_with(target_state_root);
+                continue;
+            };
+            record.insert(
+                field.to_string(),
+                Value::String(display_path(&target_state_root.join(&relative))),
+            );
+            changed = true;
+        }
+        if has_external_path {
+            external_plugin_ids.insert(plugin_id.clone());
+        }
+    }
+    if !changed {
+        return Ok(MigratedRuntimeStateResult {
+            changed: false,
+            external_plugin_ids: external_plugin_ids.into_iter().collect(),
+        });
+    }
+
+    connection
+        .execute(
+            "UPDATE installed_plugin_index SET install_records_json = ?1 WHERE index_key = 'installed-plugin-index'",
+            [Value::Object(records.clone()).to_string()],
+        )
+        .map_err(|error| {
+            format!(
+                "failed to relocate imported OpenClaw plugin install records {}: {error}",
+                display_path(database_path)
+            )
+        })?;
+    Ok(MigratedRuntimeStateResult {
+        changed: true,
+        external_plugin_ids: external_plugin_ids.into_iter().collect(),
+    })
+}
+
+fn relocatable_plugin_path(
+    path: &Path,
+    source_state_root: &Path,
+    allow_copied_gateway_path: bool,
+) -> Option<PathBuf> {
+    let relative = match path.strip_prefix(source_state_root) {
+        Ok(relative) => relative,
+        Err(_) if allow_copied_gateway_path => {
+            let original_state_root = path
+                .ancestors()
+                .find(|ancestor| ancestor.file_name() == Some(OsStr::new(".openclaw")))?;
+            let relative = path.strip_prefix(original_state_root).ok()?;
+            let managed_root = relative.components().next()?.as_os_str();
+            if !matches!(
+                managed_root.to_str(),
+                Some("extensions") | Some("plugins") | Some("npm") | Some("git")
+            ) {
+                return None;
+            }
+            relative
+        }
+        Err(_) => return None,
+    };
+    if relative
+        .components()
+        .any(|component| !matches!(component, Component::CurDir | Component::Normal(_)))
+    {
+        return None;
+    }
+
+    let canonical_source = fs::canonicalize(source_state_root).ok()?;
+    let canonical_payload = fs::canonicalize(source_state_root.join(relative)).ok()?;
+    canonical_payload
+        .starts_with(canonical_source)
+        .then(|| relative.to_path_buf())
+}
+
+fn is_sqlite_database(path: &Path) -> Result<bool, String> {
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.to_string()),
+    };
+    let mut magic = [0_u8; 16];
+    Ok(file.read_exact(&mut magic).is_ok() && &magic == b"SQLite format 3\0")
 }
 
 fn clear_volatile_runtime_state(
@@ -891,7 +1072,7 @@ mod tests {
             OpenClawWorkspaceRuntime::default(),
         )
         .unwrap();
-        assert!(changed);
+        assert!(changed.changed);
         assert!(paths.workspace_dir.join("notes/todo.txt").exists());
         assert!(
             paths

--- a/tests/migrate_command_tests.rs
+++ b/tests/migrate_command_tests.rs
@@ -4,6 +4,8 @@ use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+use rusqlite::{Connection, params};
+
 use crate::support::{TestDir, ocm_env, run_ocm, stderr, stdout};
 
 fn install_fake_openclaw_on_path(
@@ -411,6 +413,41 @@ fn seed_plain_openclaw_home(source_home: &std::path::Path) {
     .unwrap();
     fs::write(source_home.join("gateway.pid"), "4242\n").unwrap();
     fs::write(source_home.join("run/live.sock"), "sock\n").unwrap();
+}
+
+fn seed_installed_plugin_index(source_home: &std::path::Path, records: serde_json::Value) {
+    let database_path = source_home.join("state/openclaw.sqlite");
+    fs::create_dir_all(database_path.parent().unwrap()).unwrap();
+    let database = Connection::open(database_path).unwrap();
+    database
+        .execute_batch(
+            "CREATE TABLE installed_plugin_index (\
+                index_key TEXT NOT NULL PRIMARY KEY, \
+                install_records_json TEXT NOT NULL\
+            );",
+        )
+        .unwrap();
+    database
+        .execute(
+            "INSERT INTO installed_plugin_index (index_key, install_records_json) VALUES (?1, ?2)",
+            params!["installed-plugin-index", records.to_string()],
+        )
+        .unwrap();
+}
+
+fn read_imported_plugin_install_records(root: &TestDir, env_name: &str) -> serde_json::Value {
+    let database = Connection::open(root.child(format!(
+        "ocm-home/envs/{env_name}/.openclaw/state/openclaw.sqlite"
+    )))
+    .unwrap();
+    let records: String = database
+        .query_row(
+            "SELECT install_records_json FROM installed_plugin_index WHERE index_key = ?1",
+            ["installed-plugin-index"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    serde_json::from_str(&records).unwrap()
 }
 
 fn assert_imported_plain_openclaw_home(
@@ -1078,6 +1115,207 @@ fn adopt_import_preserves_history_and_logs_from_plain_openclaw_home() {
 
     let imported_state = root.child("ocm-home/envs/mira/.openclaw");
     assert_imported_plain_openclaw_home(&imported_state, &source_home);
+}
+
+#[test]
+fn adopt_import_relocates_managed_plugin_install_records_into_the_imported_state() {
+    let root = TestDir::new("adopt-import-plugin-records");
+    let cwd = root.child("workspace");
+    let source_home = root.child("legacy-home/.openclaw");
+    fs::create_dir_all(&cwd).unwrap();
+    seed_plain_openclaw_home(&source_home);
+
+    let managed_hub = source_home.join("extensions/managed-hub");
+    let managed_npm = source_home.join("npm/node_modules/example-managed-npm");
+    for plugin_dir in [&managed_hub, &managed_npm] {
+        fs::create_dir_all(plugin_dir).unwrap();
+        fs::write(plugin_dir.join("openclaw.plugin.json"), "{}\n").unwrap();
+    }
+
+    seed_installed_plugin_index(
+        &source_home,
+        serde_json::json!({
+            "managed-hub": {
+                "source": "clawhub",
+                "installPath": managed_hub.display().to_string()
+            },
+            "managed-npm": {
+                "source": "npm",
+                "installPath": managed_npm.display().to_string()
+            }
+        }),
+    );
+
+    let env = ocm_env(&root);
+    let output = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "adopt",
+            "import",
+            "--name",
+            "mira",
+            source_home.to_string_lossy().as_ref(),
+            "--json",
+        ],
+    );
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let imported_records = read_imported_plugin_install_records(&root, "mira");
+
+    assert_eq!(
+        imported_records["managed-hub"]["installPath"].as_str(),
+        Some(
+            root.child("ocm-home/envs/mira/.openclaw/extensions/managed-hub")
+                .to_string_lossy()
+                .as_ref()
+        )
+    );
+    assert_eq!(
+        imported_records["managed-npm"]["installPath"].as_str(),
+        Some(
+            root.child("ocm-home/envs/mira/.openclaw/npm/node_modules/example-managed-npm")
+                .to_string_lossy()
+                .as_ref()
+        )
+    );
+    assert!(
+        !imported_records
+            .to_string()
+            .contains(&source_home.display().to_string())
+    );
+}
+
+#[test]
+fn adopt_import_preserves_external_plugin_checkouts_with_an_isolation_warning() {
+    let root = TestDir::new("adopt-import-external-plugin");
+    let cwd = root.child("workspace");
+    let source_home = root.child("legacy-home/.openclaw");
+    let external_plugin = root.child("external-checkout/example-dev-plugin");
+    fs::create_dir_all(&cwd).unwrap();
+    seed_plain_openclaw_home(&source_home);
+    fs::create_dir_all(&external_plugin).unwrap();
+    fs::write(external_plugin.join("marker.txt"), "external checkout\n").unwrap();
+
+    seed_installed_plugin_index(
+        &source_home,
+        serde_json::json!({
+            "external-dev": {
+                "source": "path",
+                "sourcePath": external_plugin.display().to_string(),
+                "installPath": external_plugin.display().to_string()
+            }
+        }),
+    );
+
+    let env = ocm_env(&root);
+    let output = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "adopt",
+            "import",
+            "--name",
+            "mira",
+            source_home.to_string_lossy().as_ref(),
+            "--json",
+        ],
+    );
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(
+        stderr(&output).contains(
+            "warning: imported plugin external-dev could not be isolated inside the env state; OCM preserved but did not copy or modify its external location"
+        ),
+        "{}",
+        stderr(&output)
+    );
+
+    let imported_records = read_imported_plugin_install_records(&root, "mira");
+    assert_eq!(
+        imported_records["external-dev"]["installPath"].as_str(),
+        Some(external_plugin.to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        fs::read_to_string(external_plugin.join("marker.txt")).unwrap(),
+        "external checkout\n"
+    );
+    assert!(
+        !root
+            .child("ocm-home/envs/mira/.openclaw/external-checkout")
+            .exists()
+    );
+}
+
+#[test]
+fn adopt_import_relocates_managed_plugin_records_from_a_copied_gateway_fixture() {
+    let root = TestDir::new("adopt-import-copied-plugin-records");
+    let cwd = root.child("workspace");
+    let original_home = root.child("personal/.openclaw");
+    let copied_home = root.child("copied-state");
+    fs::create_dir_all(&cwd).unwrap();
+    seed_plain_openclaw_home(&copied_home);
+
+    let copied_hub = copied_home.join("extensions/copied-hub");
+    let copied_npm = copied_home.join("npm/node_modules/example-copied-npm");
+    for plugin_dir in [&copied_hub, &copied_npm] {
+        fs::create_dir_all(plugin_dir).unwrap();
+        fs::write(plugin_dir.join("openclaw.plugin.json"), "{}\n").unwrap();
+    }
+
+    seed_installed_plugin_index(
+        &copied_home,
+        serde_json::json!({
+            "copied-hub": {
+                "source": "clawhub",
+                "installPath": original_home.join("extensions/copied-hub").display().to_string()
+            },
+            "copied-npm": {
+                "source": "npm",
+                "installPath": original_home
+                    .join("npm/node_modules/example-copied-npm")
+                    .display()
+                    .to_string()
+            }
+        }),
+    );
+
+    let env = ocm_env(&root);
+    let output = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "adopt",
+            "import",
+            "--name",
+            "mira",
+            copied_home.to_string_lossy().as_ref(),
+            "--json",
+        ],
+    );
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let imported_records = read_imported_plugin_install_records(&root, "mira");
+    assert_eq!(
+        imported_records["copied-hub"]["installPath"].as_str(),
+        Some(
+            root.child("ocm-home/envs/mira/.openclaw/extensions/copied-hub")
+                .to_string_lossy()
+                .as_ref()
+        )
+    );
+    assert_eq!(
+        imported_records["copied-npm"]["installPath"].as_str(),
+        Some(
+            root.child("ocm-home/envs/mira/.openclaw/npm/node_modules/example-copied-npm")
+                .to_string_lossy()
+                .as_ref()
+        )
+    );
+    assert!(
+        !imported_records
+            .to_string()
+            .contains(&original_home.display().to_string())
+    );
 }
 
 #[test]

--- a/tests/migrate_command_tests.rs
+++ b/tests/migrate_command_tests.rs
@@ -1186,6 +1186,59 @@ fn adopt_import_relocates_managed_plugin_install_records_into_the_imported_state
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn adopt_import_rejects_a_symlinked_plugin_database_without_mutating_its_target() {
+    let root = TestDir::new("adopt-import-symlinked-plugin-database");
+    let cwd = root.child("workspace");
+    let source_home = root.child("legacy-home/.openclaw");
+    let external_home = root.child("external-state");
+    fs::create_dir_all(&cwd).unwrap();
+    seed_plain_openclaw_home(&source_home);
+
+    let managed_plugin = source_home.join("extensions/managed-hub");
+    fs::create_dir_all(&managed_plugin).unwrap();
+    fs::write(managed_plugin.join("openclaw.plugin.json"), "{}\n").unwrap();
+    seed_installed_plugin_index(
+        &external_home,
+        serde_json::json!({
+            "managed-hub": {
+                "source": "clawhub",
+                "installPath": managed_plugin.display().to_string()
+            }
+        }),
+    );
+
+    let external_database = external_home.join("state/openclaw.sqlite");
+    let source_database = source_home.join("state/openclaw.sqlite");
+    fs::create_dir_all(source_database.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&external_database, &source_database).unwrap();
+    let external_before = fs::read(&external_database).unwrap();
+
+    let env = ocm_env(&root);
+    let output = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "adopt",
+            "import",
+            "--name",
+            "mira",
+            source_home.to_string_lossy().as_ref(),
+            "--json",
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        stderr(&output).contains("must be a regular file inside the imported state"),
+        "{}",
+        stderr(&output)
+    );
+    assert!(!root.child("ocm-home/envs/mira").exists());
+    assert_eq!(fs::read(&external_database).unwrap(), external_before);
+}
+
 #[test]
 fn adopt_import_preserves_external_plugin_checkouts_with_an_isolation_warning() {
     let root = TestDir::new("adopt-import-external-plugin");


### PR DESCRIPTION
## Summary

- relocate managed ClawHub and npm plugin install records into the imported environment state root during `ocm adopt import`
- handle copied fixtures whose records still reference the original gateway state root without retaining source references
- require canonically contained copied payloads, rejecting traversal and symlink escapes
- reject non-regular or escaping imported SQLite paths before opening the plugin index for write
- preserve external development checkout records and emit an explicit isolation warning instead of copying or mutating arbitrary external paths

## Validation

- `cargo test --test migrate_command_tests` (40 passed)
- `cargo test --lib` (315 passed)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features` (passed with four warnings)
- structured autoreview against `origin/main` (no actionable findings)

The symlink regression fails on the original PR head because the import succeeds and follows the copied database symlink. With the guard, the import rejects the path, removes the partial environment, and leaves the external SQLite database byte-for-byte unchanged.

## Behavior proof

The rebased binary imported a task-owned plain OpenClaw home with a managed plugin and an external workspace into an isolated `OCM_HOME`. No launcher or service was created.

```console
$ OCM_HOME=<tmp>/ocm-home PATH=/usr/bin:/bin target/debug/ocm adopt import --name proof <tmp>/source/.openclaw --json
{
  "name": "proof",
  "sourceName": "plain-openclaw",
  "root": "<tmp>/ocm-home/envs/proof",
  "archivePath": "<tmp>/source/.openclaw",
  "defaultRuntime": null,
  "defaultLauncher": null,
  "protected": false
}

$ sqlite3 <tmp>/ocm-home/envs/proof/.openclaw/state/openclaw.sqlite \
    "SELECT install_records_json FROM installed_plugin_index WHERE index_key='installed-plugin-index';"
{"demo":{"source":"clawhub","installPath":"<tmp>/ocm-home/envs/proof/.openclaw/extensions/demo"}}

$ jq -r '.agents.defaults.workspace' <tmp>/ocm-home/envs/proof/.openclaw/openclaw.json
<tmp>/ocm-home/envs/proof/.openclaw/workspaces/default
```

`cmp` confirmed that the copied workspace file matches the external source byte-for-byte. `ocm env list --json` reported `serviceEnabled: false` and `serviceRunning: false` for the proof environment.
