### PR TITLE
fix(supervisor): target registry reconciliation

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1800,7 +1800,8 @@ impl Cli {
                     .set_runtime_locked(env_name, prepared.name.as_str())
                     .map(|_| ())
             } else {
-                self.runtime_service().refresh_supervisor_if_present()
+                self.runtime_service()
+                    .refresh_supervisor_if_present(&prepared.name)
             };
             if let Err(error) = publish_result {
                 return self.rollback_failed_upgrade(
@@ -2047,7 +2048,11 @@ impl Cli {
                 transaction.mark_post_update_not_needed();
                 None
             };
-            if changed && let Err(error) = self.runtime_service().refresh_supervisor_if_present() {
+            if changed
+                && let Err(error) = self
+                    .runtime_service()
+                    .refresh_supervisor_if_present(&prepared.name)
+            {
                 return self.rollback_failed_upgrade(
                     env_name,
                     "runtime",
@@ -2232,7 +2237,10 @@ impl Cli {
                 );
             }
         };
-        if let Err(error) = self.runtime_service().refresh_supervisor_if_present() {
+        if let Err(error) = self
+            .runtime_service()
+            .refresh_supervisor_if_present(&updated.name)
+        {
             return self.rollback_failed_upgrade(
                 env_name,
                 "runtime",

--- a/src/env/binding.rs
+++ b/src/env/binding.rs
@@ -3,7 +3,7 @@ use crate::store::{
     get_environment, save_environment, save_environment_with_validated_launcher,
     save_environment_with_validated_runtime,
 };
-use crate::supervisor::sync_supervisor_if_present;
+use crate::supervisor::sync_supervisor_env_if_present;
 
 impl<'a> EnvironmentService<'a> {
     pub fn set_launcher(&self, name: &str, launcher_name: &str) -> Result<EnvMeta, String> {
@@ -16,7 +16,7 @@ impl<'a> EnvironmentService<'a> {
             meta.default_runtime = None;
         }
         let meta = save_environment_with_validated_launcher(meta, self.env, self.cwd)?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, name)?;
         Ok(meta)
     }
 
@@ -42,7 +42,7 @@ impl<'a> EnvironmentService<'a> {
         } else {
             save_environment(meta, self.env, self.cwd)?
         };
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, name)?;
         Ok(meta)
     }
 }

--- a/src/launcher/registry.rs
+++ b/src/launcher/registry.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::store::{add_launcher, get_launcher, list_launchers, remove_launcher};
-use crate::supervisor::sync_supervisor_if_present;
+use crate::supervisor::sync_supervisor_binding_if_present;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -40,8 +40,9 @@ impl<'a> LauncherService<'a> {
     }
 
     pub fn add(&self, options: AddLauncherOptions) -> Result<LauncherMeta, String> {
+        let name = options.name.clone();
         let meta = add_launcher(options, self.env, self.cwd)?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_binding_if_present(self.env, self.cwd, "launcher", &name)?;
         Ok(meta)
     }
 
@@ -55,7 +56,7 @@ impl<'a> LauncherService<'a> {
 
     pub fn remove(&self, name: &str) -> Result<LauncherMeta, String> {
         let meta = remove_launcher(name, self.env, self.cwd)?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_binding_if_present(self.env, self.cwd, "launcher", name)?;
         Ok(meta)
     }
 }

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -219,7 +219,7 @@ impl<'a> RuntimeService<'a> {
         let action = prepared.action();
         let meta = prepared.commit()?;
         if refresh_supervisor {
-            self.refresh_supervisor_if_present()?;
+            self.refresh_supervisor_if_present(&meta.name)?;
         }
         Ok((meta, action))
     }
@@ -384,7 +384,7 @@ impl<'a> RuntimeService<'a> {
         let name = options.name.clone();
         let meta =
             self.with_unbound_runtime(&name, || install_runtime(options, self.env, self.cwd))?;
-        self.refresh_supervisor_if_present()?;
+        self.refresh_supervisor_if_present(&name)?;
         Ok(meta)
     }
 
@@ -396,7 +396,7 @@ impl<'a> RuntimeService<'a> {
         let meta = self.with_unbound_runtime(&name, || {
             install_runtime_from_url(options, self.env, self.cwd)
         })?;
-        self.refresh_supervisor_if_present()?;
+        self.refresh_supervisor_if_present(&name)?;
         Ok(meta)
     }
 
@@ -408,7 +408,7 @@ impl<'a> RuntimeService<'a> {
         let meta = self.with_unbound_runtime(&name, || {
             install_runtime_from_release(options, self.env, self.cwd)
         })?;
-        self.refresh_supervisor_if_present()?;
+        self.refresh_supervisor_if_present(&name)?;
         Ok(meta)
     }
 
@@ -420,7 +420,7 @@ impl<'a> RuntimeService<'a> {
         let meta = self.with_unbound_runtime(&name, || {
             install_runtime_from_official_openclaw_release(options, self.env, self.cwd)
         })?;
-        self.refresh_supervisor_if_present()?;
+        self.refresh_supervisor_if_present(&name)?;
         Ok(meta)
     }
 
@@ -441,7 +441,7 @@ impl<'a> RuntimeService<'a> {
                 },
             )
         })?;
-        self.refresh_supervisor_if_present()?;
+        self.refresh_supervisor_if_present(&name)?;
         Ok(meta)
     }
 
@@ -528,7 +528,7 @@ impl<'a> RuntimeService<'a> {
         let prepared = self.prepare_resolved_update(resolved)?;
         let meta = prepared.commit()?;
         if refresh_supervisor {
-            self.refresh_supervisor_if_present()?;
+            self.refresh_supervisor_if_present(&meta.name)?;
         }
         Ok(meta)
     }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -7,7 +7,7 @@ use time::OffsetDateTime;
 use crate::store::{
     add_runtime, get_runtime_verified, list_runtimes, remove_runtime, with_locked_environments,
 };
-use crate::supervisor::sync_supervisor_if_present;
+use crate::supervisor::sync_supervisor_binding_if_present;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -114,8 +114,8 @@ impl<'a> RuntimeService<'a> {
         })
     }
 
-    pub(crate) fn refresh_supervisor_if_present(&self) -> Result<(), String> {
-        sync_supervisor_if_present(self.env, self.cwd)?;
+    pub(crate) fn refresh_supervisor_if_present(&self, name: &str) -> Result<(), String> {
+        sync_supervisor_binding_if_present(self.env, self.cwd, "runtime", name)?;
         Ok(())
     }
 
@@ -126,7 +126,7 @@ impl<'a> RuntimeService<'a> {
     pub fn add(&self, options: AddRuntimeOptions) -> Result<RuntimeMeta, String> {
         let name = options.name.clone();
         let meta = self.with_unbound_runtime(&name, || add_runtime(options, self.env, self.cwd))?;
-        self.refresh_supervisor_if_present()?;
+        self.refresh_supervisor_if_present(&name)?;
         Ok(meta)
     }
 
@@ -140,7 +140,7 @@ impl<'a> RuntimeService<'a> {
 
     pub fn remove(&self, name: &str) -> Result<RuntimeMeta, String> {
         let meta = self.with_unbound_runtime(name, || remove_runtime(name, self.env, self.cwd))?;
-        self.refresh_supervisor_if_present()?;
+        self.refresh_supervisor_if_present(name)?;
         Ok(meta)
     }
 }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, OpenOptions};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
@@ -252,6 +252,35 @@ pub fn sync_supervisor_if_present(
     Ok(true)
 }
 
+pub fn sync_supervisor_env_if_present(
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+    env_name: &str,
+) -> Result<bool, String> {
+    let state_path = supervisor_state_path(env, cwd)?;
+    let runtime_path = supervisor_runtime_path(env, cwd)?;
+    if !state_path.exists() && !runtime_path.exists() {
+        return Ok(false);
+    }
+    SupervisorService::new(env, cwd).sync_env(env_name)?;
+    Ok(true)
+}
+
+pub fn sync_supervisor_binding_if_present(
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+    binding_kind: &str,
+    binding_name: &str,
+) -> Result<bool, String> {
+    let state_path = supervisor_state_path(env, cwd)?;
+    let runtime_path = supervisor_runtime_path(env, cwd)?;
+    if !state_path.exists() && !runtime_path.exists() {
+        return Ok(false);
+    }
+    SupervisorService::new(env, cwd).sync_binding(binding_kind, binding_name)?;
+    Ok(true)
+}
+
 impl<'a> SupervisorService<'a> {
     pub fn new(env: &'a BTreeMap<String, String>, cwd: &'a Path) -> Self {
         Self { env, cwd }
@@ -268,6 +297,57 @@ impl<'a> SupervisorService<'a> {
         let _lock = lock_supervisor_state(&state_path)?;
         let mut state = self.build_state()?;
         preserve_persisted_restart_requests(&state_path, &mut state);
+        if let Some(parent) = state_path.parent() {
+            ensure_dir(parent)?;
+        }
+        ensure_dir(&supervisor_logs_dir(self.env, self.cwd)?)?;
+        write_json(&state_path, &state)?;
+        Ok(view_from_state(&state_path, true, state))
+    }
+
+    fn sync_env(&self, env_name: &str) -> Result<SupervisorView, String> {
+        self.sync_targeted(|_, _| BTreeSet::from([env_name.to_string()]))
+    }
+
+    fn sync_binding(
+        &self,
+        binding_kind: &str,
+        binding_name: &str,
+    ) -> Result<SupervisorView, String> {
+        self.sync_targeted(|fresh_state, persisted_state| {
+            fresh_state
+                .children
+                .iter()
+                .chain(
+                    persisted_state
+                        .into_iter()
+                        .flat_map(|state| state.children.iter()),
+                )
+                .filter(|child| {
+                    child.binding_kind == binding_kind && child.binding_name == binding_name
+                })
+                .map(|child| child.env_name.clone())
+                .collect()
+        })
+    }
+
+    fn sync_targeted(
+        &self,
+        select_envs: impl FnOnce(&SupervisorState, Option<&SupervisorState>) -> BTreeSet<String>,
+    ) -> Result<SupervisorView, String> {
+        let state_path = supervisor_state_path(self.env, self.cwd)?;
+        let _lock = lock_supervisor_state(&state_path)?;
+        let mut state = self.build_state()?;
+        let persisted_state = read_json::<SupervisorState>(&state_path).ok();
+
+        if let Some(persisted_state) = persisted_state {
+            let refreshed_envs = select_envs(&state, Some(&persisted_state));
+            if refreshed_envs.is_empty() {
+                return Ok(view_from_state(&state_path, true, persisted_state));
+            }
+            merge_targeted_supervisor_state(&mut state, persisted_state, &refreshed_envs);
+        }
+
         if let Some(parent) = state_path.parent() {
             ensure_dir(parent)?;
         }
@@ -1005,6 +1085,42 @@ fn preserve_persisted_child_specs_except(
             *child = persisted_child.clone();
         }
     }
+}
+
+fn merge_targeted_supervisor_state(
+    fresh_state: &mut SupervisorState,
+    persisted_state: SupervisorState,
+    refreshed_envs: &BTreeSet<String>,
+) {
+    let mut children = persisted_state
+        .children
+        .into_iter()
+        .filter(|child| !refreshed_envs.contains(&child.env_name))
+        .collect::<Vec<_>>();
+    children.extend(
+        fresh_state
+            .children
+            .drain(..)
+            .filter(|child| refreshed_envs.contains(&child.env_name)),
+    );
+    children.sort_by(|left, right| left.env_name.cmp(&right.env_name));
+    fresh_state.children = children;
+
+    let mut skipped_envs = persisted_state
+        .skipped_envs
+        .into_iter()
+        .filter(|entry| !refreshed_envs.contains(&entry.env_name))
+        .collect::<Vec<_>>();
+    skipped_envs.extend(
+        fresh_state
+            .skipped_envs
+            .drain(..)
+            .filter(|entry| refreshed_envs.contains(&entry.env_name)),
+    );
+    skipped_envs.sort_by(|left, right| left.env_name.cmp(&right.env_name));
+    fresh_state.skipped_envs = skipped_envs;
+
+    preserve_restart_requests(fresh_state, persisted_state.restart_requests);
 }
 
 fn preserve_restart_requests(
@@ -2255,6 +2371,111 @@ mod tests {
             skipped_envs: Vec::new(),
             restart_requests,
         }
+    }
+
+    #[test]
+    fn targeted_state_merge_preserves_unrelated_children_skips_and_requests() {
+        let mut persisted = supervisor_state(vec![SupervisorRestartRequest {
+            env_name: "sibling".to_string(),
+            request_id: "restart-sibling".to_string(),
+        }]);
+        persisted.children.push(child_spec("sibling", 20_001));
+        persisted.skipped_envs.push(SkippedSupervisorEnv {
+            env_name: "persisted-skipped".to_string(),
+            reason: "persisted reason".to_string(),
+        });
+
+        let mut fresh = supervisor_state(Vec::new());
+        fresh.children[0].runtime_release_version = Some("2.0.0".to_string());
+        let mut drifted_sibling = child_spec("sibling", 30_001);
+        drifted_sibling.runtime_release_version = Some("latent-drift".to_string());
+        fresh.children.push(drifted_sibling);
+        fresh.children.push(child_spec("new-unrelated", 30_002));
+        fresh.skipped_envs.push(SkippedSupervisorEnv {
+            env_name: "new-skipped".to_string(),
+            reason: "fresh reason".to_string(),
+        });
+
+        merge_targeted_supervisor_state(
+            &mut fresh,
+            persisted,
+            &BTreeSet::from(["demo".to_string()]),
+        );
+
+        assert_eq!(fresh.children.len(), 2);
+        assert_eq!(
+            active_child_spec(&fresh, "demo")
+                .unwrap()
+                .runtime_release_version,
+            Some("2.0.0".to_string())
+        );
+        let sibling = active_child_spec(&fresh, "sibling").unwrap();
+        assert_eq!(sibling.child_port, 20_001);
+        assert_eq!(sibling.runtime_release_version, Some("1.0.0".to_string()));
+        assert!(active_child_spec(&fresh, "new-unrelated").is_none());
+        assert_eq!(
+            fresh.skipped_envs,
+            vec![SkippedSupervisorEnv {
+                env_name: "persisted-skipped".to_string(),
+                reason: "persisted reason".to_string(),
+            }]
+        );
+        assert_eq!(
+            fresh.restart_requests,
+            vec![SupervisorRestartRequest {
+                env_name: "sibling".to_string(),
+                request_id: "restart-sibling".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn targeted_state_merge_can_replace_a_child_with_a_skipped_target() {
+        let mut persisted = supervisor_state(vec![
+            SupervisorRestartRequest {
+                env_name: "demo".to_string(),
+                request_id: "restart-demo".to_string(),
+            },
+            SupervisorRestartRequest {
+                env_name: "sibling".to_string(),
+                request_id: "restart-sibling".to_string(),
+            },
+        ]);
+        persisted.children.push(child_spec("sibling", 20_001));
+
+        let mut fresh = supervisor_state(Vec::new());
+        fresh.children.retain(|child| child.env_name != "demo");
+        fresh.children.push(child_spec("sibling", 30_001));
+        fresh.skipped_envs.push(SkippedSupervisorEnv {
+            env_name: "demo".to_string(),
+            reason: "service is stopped".to_string(),
+        });
+
+        merge_targeted_supervisor_state(
+            &mut fresh,
+            persisted,
+            &BTreeSet::from(["demo".to_string()]),
+        );
+
+        assert!(active_child_spec(&fresh, "demo").is_none());
+        assert_eq!(
+            active_child_spec(&fresh, "sibling").unwrap().child_port,
+            20_001
+        );
+        assert_eq!(
+            fresh.skipped_envs,
+            vec![SkippedSupervisorEnv {
+                env_name: "demo".to_string(),
+                reason: "service is stopped".to_string(),
+            }]
+        );
+        assert_eq!(
+            fresh.restart_requests,
+            vec![SupervisorRestartRequest {
+                env_name: "sibling".to_string(),
+                request_id: "restart-sibling".to_string(),
+            }]
+        );
     }
 
     fn exited_child(

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -9,7 +9,7 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use ocm::env::EnvironmentService;
-use ocm::supervisor::SupervisorService;
+use ocm::supervisor::{SupervisorService, sync_supervisor_binding_if_present};
 use serde_json::{Value, to_value};
 
 use crate::support::{
@@ -818,6 +818,245 @@ fn daemon_run_reloads_children_after_binding_changes() {
     assert!(wait_for_file(&new_started, Duration::from_secs(5)));
 
     stop_process(&mut daemon);
+}
+
+#[test]
+fn publishing_an_unbound_runtime_preserves_unrelated_active_child_spec_and_pid() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-unbound-runtime-publish");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+    let runtime_meta_path = root.child("ocm-home/runtimes/runtime-a.json");
+    let started = root.child("runtime-a-started.txt");
+    let stopped = root.child("runtime-a-stopped.txt");
+
+    let runtime_a = root.child("bin/runtime-a");
+    write_legacy_openclaw_script(
+        &runtime_a,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&started),
+            path_string(&stopped),
+        ),
+    );
+    let add_a = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "add",
+            "runtime-a",
+            "--path",
+            &path_string(&runtime_a),
+        ],
+    );
+    assert!(add_a.status.success(), "{}", stderr(&add_a));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "env-a", "--runtime", "runtime-a"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    set_service_enabled(&cwd, &env, "env-a", true);
+    service.sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let initial_runtime =
+        wait_for_runtime_children(&runtime_path, 1, Some("env-a"), Duration::from_secs(5))
+            .expect("daemon runtime state did not report env-a");
+    let initial_pid = runtime_child_pid(&initial_runtime, "env-a").unwrap();
+
+    let mut latent_runtime_meta = read_persisted_service_state(&runtime_meta_path);
+    latent_runtime_meta["releaseVersion"] = Value::String("latent-v2".to_string());
+    write_persisted_service_state(&runtime_meta_path, &latent_runtime_meta);
+
+    let runtime_b = root.child("bin/runtime-b");
+    write_legacy_openclaw_script(&runtime_b, "#!/bin/sh\nexit 0\n");
+    let add_b = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "add",
+            "runtime-b",
+            "--path",
+            &path_string(&runtime_b),
+        ],
+    );
+    let add_b_error = stderr(&add_b);
+
+    sleep(Duration::from_millis(800));
+    let final_runtime =
+        wait_for_runtime_children(&runtime_path, 1, Some("env-a"), Duration::from_secs(2))
+            .expect("daemon runtime state stopped reporting env-a");
+    let final_pid = runtime_child_pid(&final_runtime, "env-a").unwrap();
+    let state = read_persisted_service_state(&state_path);
+    let persisted_env_a = state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "env-a")
+        .unwrap()
+        .clone();
+    let started_count = fs::read_to_string(&started).unwrap().lines().count();
+    let stopped_exists = stopped.exists();
+
+    stop_process(&mut daemon);
+
+    assert!(add_b.status.success(), "{add_b_error}");
+    assert_eq!(final_pid, initial_pid, "unrelated child PID changed");
+    assert_eq!(started_count, 1, "unrelated child started more than once");
+    assert!(!stopped_exists, "unrelated child received a stop signal");
+    assert!(
+        persisted_env_a["runtimeReleaseVersion"].is_null(),
+        "unrelated latent runtime metadata was applied"
+    );
+}
+
+#[test]
+fn targeted_runtime_refresh_ignores_unrelated_drift_and_restarts_effective_change_once() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-targeted-runtime-refresh");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+    let runtime_a_meta_path = root.child("ocm-home/runtimes/runtime-a.json");
+    let runtime_b_meta_path = root.child("ocm-home/runtimes/runtime-b.json");
+    let runtime_a_started = root.child("runtime-a-started.txt");
+    let runtime_a_stopped = root.child("runtime-a-stopped.txt");
+    let runtime_b_started = root.child("runtime-b-started.txt");
+    let runtime_b_stopped = root.child("runtime-b-stopped.txt");
+
+    let runtime_a = root.child("bin/runtime-a");
+    write_legacy_openclaw_script(
+        &runtime_a,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&runtime_a_started),
+            path_string(&runtime_a_stopped),
+        ),
+    );
+    let runtime_b = root.child("bin/runtime-b");
+    write_legacy_openclaw_script(
+        &runtime_b,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&runtime_b_started),
+            path_string(&runtime_b_stopped),
+        ),
+    );
+    let runtime_b_next = root.child("bin/runtime-b-next");
+    write_legacy_openclaw_script(
+        &runtime_b_next,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&runtime_b_started),
+            path_string(&runtime_b_stopped),
+        ),
+    );
+
+    for (name, path) in [("runtime-a", &runtime_a), ("runtime-b", &runtime_b)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &["runtime", "add", name, "--path", &path_string(path)],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+        let env_name = name.replace("runtime", "env");
+        let create = run_ocm(&cwd, &env, &["env", "create", &env_name, "--runtime", name]);
+        assert!(create.status.success(), "{}", stderr(&create));
+        set_service_enabled(&cwd, &env, &env_name, true);
+    }
+    service.sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let initial_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(5))
+        .expect("daemon runtime state did not report both children");
+    let env_a_pid = runtime_child_pid(&initial_runtime, "env-a").unwrap();
+    let env_b_pid = runtime_child_pid(&initial_runtime, "env-b").unwrap();
+
+    let mut runtime_a_meta = read_persisted_service_state(&runtime_a_meta_path);
+    runtime_a_meta["releaseVersion"] = Value::String("latent-a-v2".to_string());
+    write_persisted_service_state(&runtime_a_meta_path, &runtime_a_meta);
+
+    let mut runtime_b_meta = read_persisted_service_state(&runtime_b_meta_path);
+    runtime_b_meta["description"] = Value::String("metadata only".to_string());
+    write_persisted_service_state(&runtime_b_meta_path, &runtime_b_meta);
+    sync_supervisor_binding_if_present(&env, &cwd, "runtime", "runtime-b").unwrap();
+
+    sleep(Duration::from_millis(800));
+    let metadata_runtime =
+        wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(2))
+            .expect("daemon runtime state stopped reporting both children");
+    let metadata_a_pid = runtime_child_pid(&metadata_runtime, "env-a").unwrap();
+    let metadata_b_pid = runtime_child_pid(&metadata_runtime, "env-b").unwrap();
+    let metadata_state = read_persisted_service_state(&state_path);
+    let metadata_env_a = metadata_state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "env-a")
+        .unwrap();
+    let metadata_preserved = metadata_a_pid == env_a_pid
+        && metadata_b_pid == env_b_pid
+        && metadata_env_a["runtimeReleaseVersion"].is_null()
+        && !runtime_a_stopped.exists()
+        && !runtime_b_stopped.exists();
+
+    runtime_b_meta["binaryPath"] = Value::String(path_string(&runtime_b_next));
+    runtime_b_meta["releaseVersion"] = Value::String("effective-b-v2".to_string());
+    write_persisted_service_state(&runtime_b_meta_path, &runtime_b_meta);
+    sync_supervisor_binding_if_present(&env, &cwd, "runtime", "runtime-b").unwrap();
+
+    let changed_runtime = wait_for_runtime_child_pid_change(
+        &runtime_path,
+        "env-b",
+        env_b_pid,
+        "env-a",
+        env_a_pid,
+        Duration::from_secs(10),
+    )
+    .expect("effective runtime change did not replace only env-b");
+    sleep(Duration::from_millis(500));
+    let final_a_pid = runtime_child_pid(&changed_runtime, "env-a").unwrap();
+    let final_b_pid = runtime_child_pid(&changed_runtime, "env-b").unwrap();
+    let runtime_a_start_count = fs::read_to_string(&runtime_a_started)
+        .unwrap()
+        .lines()
+        .count();
+    let runtime_b_start_count = fs::read_to_string(&runtime_b_started)
+        .unwrap()
+        .lines()
+        .count();
+    let runtime_b_stop_count = fs::read_to_string(&runtime_b_stopped)
+        .unwrap()
+        .lines()
+        .count();
+
+    stop_process(&mut daemon);
+
+    assert!(
+        metadata_preserved,
+        "metadata-only refresh changed active state"
+    );
+    assert_eq!(final_a_pid, env_a_pid, "unrelated child PID changed");
+    assert_ne!(final_b_pid, env_b_pid, "effective child PID did not change");
+    assert_eq!(runtime_a_start_count, 1, "unrelated child restarted");
+    assert_eq!(
+        runtime_b_start_count, 2,
+        "effective child did not restart once"
+    );
+    assert_eq!(
+        runtime_b_stop_count, 1,
+        "effective child stop count was not one"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reconcile supervisor desired state only for environments that depend on the runtime, launcher, or environment binding that changed
- preserve unrelated persisted child specs, skipped environments, and restart requests
- keep real effective target changes converging through the existing supervisor path

## Root cause

Runtime and launcher registry mutations called a registry-wide supervisor sync. That rebuilt every managed child spec, so unrelated latent metadata drift could make a running child's full `SupervisorChildSpec` compare unequal and trigger a restart even though its binding had not changed.

The durable invariant is dependency-aware synchronization at the supervisor owner, rather than a `build-local` special case.

## Observable proof

Base fixture on `2a283cc`:

- publishing unrelated runtime B changed A's persisted `runtimeReleaseVersion` from `null` to `latent-v2`
- A restarted from PID `1485` to `1986`
- continuous listener sampling recorded 12 failed health checks

Rebased head `390fb0b` on current main `e594446`:

- A remained PID `90669` through clean B publication, unrelated latent drift, and metadata-only publication
- each unrelated/no-op trace had zero failed health samples
- an effective A executable change converged once to PID `90834`
- total observed starts: 2

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- 2 targeted supervisor merge unit tests
- exact unbound-publication PID/listener regression: pass
- exact latent-drift/no-op/effective-change regression: pass
- `cargo test --locked --all-targets --no-run`: pass
- source-blind disposable launchd-shim fixture: pass
- autoreview: clean, no actionable findings

The full local daemon-runtime suite also contains three readiness failures introduced on current main by #82; all three reproduce unchanged in a pristine `e594446` worktree. Local Rust 1.97 clippy likewise reports four untouched current-main warnings in `src/service/manage.rs` and `src/store/runtimes.rs`.

## Alternatives rejected

- skipping refresh only in `build-local`: leaves sibling runtime/install/update paths with the same broken invariant
- ignoring runtime metadata in child equality: can conceal meaningful target changes
- broad registry sync: opportunistically applies unrelated drift

No live OCM environment or gateway was used.