### PR TITLE
fix(service): expose daemon version skew

### DIFF
--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1023,6 +1023,10 @@ pub fn service_help(cmd: &str) -> String {
                         "restart",
                         "Restart one env gateway under the background service",
                     ),
+                    (
+                        "refresh-daemon",
+                        "Explicitly activate the installed CLI in the background service",
+                    ),
                     ("uninstall", "Disable one env in the background service"),
                 ],
             ),
@@ -2147,6 +2151,31 @@ pub fn service_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             vec![format!("{cmd} service restart mira")],
             &[],
+        ),
+        "refresh-daemon" => render_leaf(
+            "Refresh the OCM background service",
+            "Explicitly restart the OCM background service from the installed CLI while preserving persisted gateway desired state.",
+            vec![format!(
+                "{cmd} service refresh-daemon [--acknowledge-gateway-restarts] [--raw] [--json]"
+            )],
+            &[
+                (
+                    "--acknowledge-gateway-restarts",
+                    "Acknowledge that active managed gateways will be interrupted and restarted",
+                ),
+                (
+                    "--raw",
+                    "Force plain line output instead of the TTY receipt view",
+                ),
+                ("--json", "Print the daemon refresh summary as JSON"),
+            ],
+            vec![format!(
+                "{cmd} service refresh-daemon --acknowledge-gateway-restarts"
+            )],
+            &[
+                "Run this only in a maintenance window when service status reports a CLI/daemon version mismatch.",
+                "The command never rebuilds desired state before restarting the daemon.",
+            ],
         ),
         "uninstall" => render_leaf(
             "Disable an env in the background service",

--- a/src/cli/render/self_update.rs
+++ b/src/cli/render/self_update.rs
@@ -56,6 +56,15 @@ pub fn self_update(summary: &SelfUpdateSummary, profile: RenderProfile, cmd: &st
         ));
     } else if matches!(summary.status, SelfUpdateStatus::Updated) {
         next.push(KeyValueRow::accent("Run", format!("{cmd} --version")));
+        if summary.daemon_refresh_required {
+            next.push(KeyValueRow::warning(
+                "Refresh daemon",
+                format!("{cmd} service refresh-daemon --acknowledge-gateway-restarts"),
+            ));
+        }
+    }
+    if let Some(note) = summary.daemon_refresh_note.as_deref() {
+        next.push(KeyValueRow::warning("Background service", note.to_string()));
     }
     if !next.is_empty() {
         push_card(&mut lines, "Next", next, profile.color);
@@ -75,6 +84,13 @@ fn self_update_raw(summary: &SelfUpdateSummary) -> Vec<String> {
     lines.insert("targetVersion".to_string(), summary.target_version.clone());
     lines.insert("binaryPath".to_string(), summary.binary_path.clone());
     lines.insert("assetName".to_string(), summary.asset_name.clone());
+    lines.insert(
+        "daemonRefreshRequired".to_string(),
+        summary.daemon_refresh_required.to_string(),
+    );
+    if let Some(note) = summary.daemon_refresh_note.as_ref() {
+        lines.insert("daemonRefreshNote".to_string(), note.clone());
+    }
     format_key_value_lines(lines)
 }
 

--- a/src/cli/render/service.rs
+++ b/src/cli/render/service.rs
@@ -5,6 +5,7 @@ use crate::infra::terminal::{
 use crate::service::{
     ServiceActionSummary, ServiceInstallSummary, ServiceSummary, ServiceSummaryList,
 };
+use crate::supervisor::SupervisorDaemonRefreshSummary;
 
 fn ocm_service_state(installed: bool, loaded: bool, running: bool) -> &'static str {
     if running {
@@ -78,7 +79,15 @@ fn service_overview_with_width(
     }
 
     if summary.services.is_empty() {
-        return vec!["No supervised env gateways.".to_string()];
+        return vec![
+            "No supervised env gateways.".to_string(),
+            format!(
+                "OCM versions: CLI {}, service {} ({})",
+                summary.ocm_cli_version,
+                summary.ocm_service_version.as_deref().unwrap_or("unknown"),
+                summary.ocm_service_version_status
+            ),
+        ];
     }
 
     let rows = summary
@@ -125,6 +134,26 @@ fn service_overview_with_width(
         Tone::Muted,
         profile.color,
     ));
+    lines.push(paint(
+        &format!(
+            "OCM versions: CLI {}, service {} ({})",
+            summary.ocm_cli_version,
+            summary.ocm_service_version.as_deref().unwrap_or("unknown"),
+            summary.ocm_service_version_status
+        ),
+        if matches!(
+            summary.ocm_service_version_status.as_str(),
+            "mismatch" | "unknown"
+        ) {
+            Tone::Warning
+        } else {
+            Tone::Muted
+        },
+        profile.color,
+    ));
+    if let Some(note) = summary.ocm_service_version_note.as_deref() {
+        lines.push(paint(note, Tone::Warning, profile.color));
+    }
     lines
 }
 
@@ -137,6 +166,15 @@ fn service_overview_raw(summary: &ServiceSummaryList) -> Vec<String> {
             summary.ocm_service_running
         )
     )];
+    lines.push(format!(
+        "ocmVersion cli={} service={} status={}",
+        summary.ocm_cli_version,
+        summary.ocm_service_version.as_deref().unwrap_or("unknown"),
+        summary.ocm_service_version_status
+    ));
+    if let Some(note) = summary.ocm_service_version_note.as_deref() {
+        lines.push(format!("ocmVersionNote: {note}"));
+    }
     for service in &summary.services {
         let mut bits = vec![
             service.env_name.clone(),
@@ -179,6 +217,23 @@ pub fn service_status(
     let mut summary_rows = vec![
         KeyValueRow::new("Gateway", gateway, state_tone(gateway)),
         KeyValueRow::new("OCM service", daemon, state_tone(daemon)),
+        KeyValueRow::plain("OCM CLI version", summary.ocm_cli_version.clone()),
+        KeyValueRow::new(
+            "OCM service version",
+            format!(
+                "{} ({})",
+                summary.ocm_service_version.as_deref().unwrap_or("unknown"),
+                summary.ocm_service_version_status
+            ),
+            if matches!(
+                summary.ocm_service_version_status.as_str(),
+                "mismatch" | "unknown"
+            ) {
+                Tone::Warning
+            } else {
+                Tone::Plain
+            },
+        ),
         KeyValueRow::plain("Binding", binding_label(summary)),
         KeyValueRow::accent("Port", summary.gateway_port.to_string()),
         KeyValueRow::plain("URL", gateway_url(summary.gateway_port)),
@@ -194,6 +249,14 @@ pub fn service_status(
         &summary_rows,
         profile.color,
     ));
+
+    if let Some(note) = summary.ocm_service_version_note.as_deref() {
+        lines.extend(render_key_value_card(
+            "OCM version",
+            &[KeyValueRow::warning("Action required", note.to_string())],
+            profile.color,
+        ));
+    }
 
     if let Some(issue) = summary.issue.as_deref() {
         lines.extend(render_key_value_card(
@@ -229,6 +292,21 @@ pub fn service_status(
 }
 
 fn service_status_next_steps(summary: &ServiceSummary, command_example: &str) -> Vec<KeyValueRow> {
+    if matches!(
+        summary.ocm_service_version_status.as_str(),
+        "mismatch" | "unknown"
+    ) {
+        return vec![
+            KeyValueRow::warning(
+                "Refresh daemon",
+                format!("{command_example} service refresh-daemon --acknowledge-gateway-restarts"),
+            ),
+            KeyValueRow::plain(
+                "Inspect",
+                format!("{command_example} service status {}", summary.env_name),
+            ),
+        ];
+    }
     if !summary.installed {
         return vec![
             KeyValueRow::accent(
@@ -294,6 +372,25 @@ fn service_status_raw(summary: &ServiceSummary) -> Vec<String> {
                 .unwrap_or_else(|| "unknown".to_string())
         ),
         format!("ocmService: {daemon}"),
+        format!("ocmCliVersion: {}", summary.ocm_cli_version),
+        format!(
+            "ocmServiceVersion: {}",
+            summary
+                .ocm_service_version
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string())
+        ),
+        format!(
+            "ocmServiceVersionStatus: {}",
+            summary.ocm_service_version_status
+        ),
+        format!(
+            "ocmServiceVersionNote: {}",
+            summary
+                .ocm_service_version_note
+                .clone()
+                .unwrap_or_else(|| "none".to_string())
+        ),
         format!(
             "childPid: {}",
             summary
@@ -382,6 +479,54 @@ pub fn service_action(
     if !next.is_empty() {
         lines.extend(render_key_value_card("Next", &next, profile.color));
     }
+    lines
+}
+
+pub fn service_daemon_refreshed(
+    summary: &SupervisorDaemonRefreshSummary,
+    profile: RenderProfile,
+) -> Vec<String> {
+    if !profile.pretty {
+        return vec![
+            format!("action: {}", summary.daemon.action),
+            format!(
+                "gatewayInterruptionExpected: {}",
+                summary.gateway_interruption_expected
+            ),
+            format!(
+                "gatewayInterruptionAcknowledged: {}",
+                summary.gateway_interruption_acknowledged
+            ),
+            format!("note: {}", summary.note),
+        ];
+    }
+
+    let mut lines = vec![paint(
+        "Refreshed OCM background service",
+        Tone::Strong,
+        profile.color,
+    )];
+    lines.extend(render_key_value_card(
+        "Result",
+        &[
+            KeyValueRow::plain("Action", summary.daemon.action.clone()),
+            KeyValueRow::new(
+                "OCM service",
+                if summary.daemon.running {
+                    "running"
+                } else {
+                    "not running"
+                },
+                if summary.daemon.running {
+                    Tone::Success
+                } else {
+                    Tone::Warning
+                },
+            ),
+            KeyValueRow::warning("Gateway impact", summary.note.clone()),
+        ],
+        profile.color,
+    ));
     lines
 }
 
@@ -580,6 +725,10 @@ mod tests {
             ocm_service_running: true,
             ocm_service_pid: Some(42),
             ocm_service_state: Some("running".to_string()),
+            ocm_cli_version: env!("CARGO_PKG_VERSION").to_string(),
+            ocm_service_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            ocm_service_version_status: "current".to_string(),
+            ocm_service_version_note: None,
             child_pid: Some(99),
             child_restart_count: Some(0),
             child_port: Some(18789),
@@ -603,6 +752,10 @@ mod tests {
                 ocm_service_running: true,
                 ocm_service_pid: Some(42),
                 ocm_service_state: Some("running".to_string()),
+                ocm_cli_version: env!("CARGO_PKG_VERSION").to_string(),
+                ocm_service_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                ocm_service_version_status: "current".to_string(),
+                ocm_service_version_note: None,
                 services: vec![sample_service()],
             },
             RenderProfile::pretty(false),

--- a/src/cli/self_cmd.rs
+++ b/src/cli/self_cmd.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 
 use crate::infra::archive::extract_tar_gz;
 use crate::infra::download::{download_to_file, verify_file_sha256};
+use crate::store::resolve_ocm_home;
 
 use super::{Cli, render};
 
@@ -57,6 +58,8 @@ pub(crate) struct SelfUpdateSummary {
     pub target_version: String,
     pub binary_path: String,
     pub asset_name: String,
+    pub daemon_refresh_required: bool,
+    pub daemon_refresh_note: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -264,6 +267,8 @@ impl Cli {
             target_version,
             binary_path: binary_path.to_string_lossy().into_owned(),
             asset_name,
+            daemon_refresh_required: false,
+            daemon_refresh_note: None,
         })
     }
 
@@ -282,6 +287,8 @@ impl Cli {
                 target_version,
                 binary_path: binary_path.to_string_lossy().into_owned(),
                 asset_name,
+                daemon_refresh_required: false,
+                daemon_refresh_note: None,
             });
         }
 
@@ -324,6 +331,9 @@ impl Cli {
             )
         })?;
 
+        let (daemon_refresh_required, daemon_refresh_note) =
+            self.daemon_refresh_notice_after_update(&target_version);
+
         Ok(SelfUpdateSummary {
             mode: SelfUpdateMode::Update,
             status: SelfUpdateStatus::Updated,
@@ -331,7 +341,40 @@ impl Cli {
             target_version,
             binary_path: binary_path.to_string_lossy().into_owned(),
             asset_name,
+            daemon_refresh_required,
+            daemon_refresh_note,
         })
+    }
+
+    fn daemon_refresh_notice_after_update(&self, target_version: &str) -> (bool, Option<String>) {
+        let Ok(ocm_home) = resolve_ocm_home(&self.env, &self.cwd) else {
+            return (
+                false,
+                Some(
+                    "CLI updated, but OCM could not resolve the active store; run `ocm service status` to check the background service"
+                        .to_string(),
+                ),
+            );
+        };
+        if !ocm_home.exists() {
+            return (false, None);
+        }
+
+        match self.supervisor_service().daemon_status() {
+            Ok(daemon) if daemon.running => (
+                true,
+                Some(format!(
+                    "CLI {target_version} is installed, but the running OCM background service still uses its previously mapped executable; during a maintenance window run `ocm service refresh-daemon --acknowledge-gateway-restarts`"
+                )),
+            ),
+            Ok(_) => (false, None),
+            Err(error) => (
+                false,
+                Some(format!(
+                    "CLI updated, but OCM could not inspect the background service ({error}); run `ocm service status`"
+                )),
+            ),
+        }
     }
 
     fn current_binary_path(&self) -> Result<PathBuf, String> {

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -156,6 +156,25 @@ impl Cli {
         Ok(0)
     }
 
+    pub(super) fn handle_service_refresh_daemon(&self, args: Vec<String>) -> Result<i32, String> {
+        let (args, json_flag, profile) =
+            self.consume_human_output_flags(args, "service refresh-daemon")?;
+        let (args, acknowledge_gateway_restarts) =
+            Self::consume_flag(args, "--acknowledge-gateway-restarts");
+        Self::assert_no_extra_args(&args)?;
+
+        let summary = self
+            .supervisor_service()
+            .refresh_daemon_explicit(acknowledge_gateway_restarts)?;
+        if json_flag {
+            self.print_json(&summary)?;
+            return Ok(0);
+        }
+
+        self.stdout_lines(render::service::service_daemon_refreshed(&summary, profile));
+        Ok(0)
+    }
+
     pub(super) fn dispatch_service_command(
         &self,
         action: &str,
@@ -167,6 +186,7 @@ impl Cli {
             "start" => self.handle_service_start(rest),
             "stop" => self.handle_service_stop(rest),
             "restart" => self.handle_service_restart(rest),
+            "refresh-daemon" => self.handle_service_refresh_daemon(rest),
             "uninstall" => self.handle_service_uninstall(rest),
             _ => Err(format!("unknown service command: {action}")),
         }

--- a/src/service/inspect.rs
+++ b/src/service/inspect.rs
@@ -65,6 +65,10 @@ pub struct ServiceSummary {
     pub ocm_service_running: bool,
     pub ocm_service_pid: Option<u32>,
     pub ocm_service_state: Option<String>,
+    pub ocm_cli_version: String,
+    pub ocm_service_version: Option<String>,
+    pub ocm_service_version_status: String,
+    pub ocm_service_version_note: Option<String>,
     pub child_pid: Option<u32>,
     pub child_restart_count: Option<usize>,
     pub child_port: Option<u32>,
@@ -86,11 +90,16 @@ pub struct ServiceSummaryList {
     pub ocm_service_running: bool,
     pub ocm_service_pid: Option<u32>,
     pub ocm_service_state: Option<String>,
+    pub ocm_cli_version: String,
+    pub ocm_service_version: Option<String>,
+    pub ocm_service_version_status: String,
+    pub ocm_service_version_note: Option<String>,
     pub services: Vec<ServiceSummary>,
 }
 
 struct ServiceSnapshot {
     daemon: SupervisorDaemonSummary,
+    daemon_version: Option<String>,
     planned_children: BTreeMap<String, SupervisorChildSpec>,
     skipped_envs: BTreeMap<String, String>,
     runtime_children: BTreeMap<String, SupervisorRuntimeChild>,
@@ -106,6 +115,8 @@ pub fn list_services(
     envs.sort_by(|left, right| left.name.cmp(&right.name));
 
     let snapshot = load_service_snapshot(env, cwd)?;
+    let version =
+        ocm_service_version_contract(&snapshot.daemon, snapshot.daemon_version.as_deref());
 
     let mut services = Vec::with_capacity(envs.len());
     for meta in envs {
@@ -125,6 +136,10 @@ pub fn list_services(
         ocm_service_running: snapshot.daemon.running,
         ocm_service_pid: snapshot.daemon.pid,
         ocm_service_state: snapshot.daemon.state,
+        ocm_cli_version: version.cli_version,
+        ocm_service_version: version.service_version,
+        ocm_service_version_status: version.status,
+        ocm_service_version_note: version.note,
         services,
     })
 }
@@ -148,6 +163,7 @@ fn load_service_snapshot(
     let supervisor = SupervisorService::new(env, cwd);
     let SupervisorInspection {
         daemon,
+        daemon_version,
         planned_children,
         skipped_envs,
         runtime_children,
@@ -156,6 +172,7 @@ fn load_service_snapshot(
 
     Ok(ServiceSnapshot {
         daemon,
+        daemon_version,
         planned_children: planned_children
             .into_iter()
             .map(|child| (child.env_name.clone(), child))
@@ -187,6 +204,7 @@ fn build_service_summary(
     let runtime_child = snapshot.runtime_children.get(&meta.name);
     let runtime_service = snapshot.runtime_services.get(&meta.name);
     let daemon = &snapshot.daemon;
+    let version = ocm_service_version_contract(daemon, snapshot.daemon_version.as_deref());
     let (gateway_port, _) = env_service.resolve_effective_gateway_port(meta)?;
     let resolved_process = resolve_summary_process(env_service, &meta.name, planned_child);
     let resolved_issue = resolved_process
@@ -299,6 +317,10 @@ fn build_service_summary(
         ocm_service_running: daemon.running,
         ocm_service_pid: daemon.pid,
         ocm_service_state: daemon.state.clone(),
+        ocm_cli_version: version.cli_version,
+        ocm_service_version: version.service_version,
+        ocm_service_version_status: version.status,
+        ocm_service_version_note: version.note,
         child_pid: runtime_child.map(|child| child.pid),
         child_restart_count: runtime_service.map(|child| child.restart_count),
         child_port: runtime_child.map(|child| child.child_port),
@@ -322,6 +344,49 @@ fn build_service_summary(
             .or(Some(fallback_stderr)),
         issue,
     })
+}
+
+struct OcmServiceVersionContract {
+    cli_version: String,
+    service_version: Option<String>,
+    status: String,
+    note: Option<String>,
+}
+
+fn ocm_service_version_contract(
+    daemon: &SupervisorDaemonSummary,
+    daemon_version: Option<&str>,
+) -> OcmServiceVersionContract {
+    let cli_version = env!("CARGO_PKG_VERSION").to_string();
+    let service_version = daemon_version.map(str::to_string);
+    let (status, note) = if !daemon.running {
+        ("stopped".to_string(), None)
+    } else if let Some(service_version) = daemon_version {
+        if service_version == cli_version {
+            ("current".to_string(), None)
+        } else {
+            (
+                "mismatch".to_string(),
+                Some(format!(
+                    "OCM CLI {cli_version} differs from running background service {service_version}; during a maintenance window run `ocm service refresh-daemon --acknowledge-gateway-restarts`"
+                )),
+            )
+        }
+    } else {
+        (
+            "unknown".to_string(),
+            Some(format!(
+                "running OCM background service does not report its version; during a maintenance window run `ocm service refresh-daemon --acknowledge-gateway-restarts` to activate CLI {cli_version}"
+            )),
+        )
+    };
+
+    OcmServiceVersionContract {
+        cli_version,
+        service_version,
+        status,
+        note,
+    }
 }
 
 fn resolve_summary_process(

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -148,6 +148,16 @@ pub struct SupervisorDaemonSummary {
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SupervisorDaemonRefreshSummary {
+    #[serde(flatten)]
+    pub daemon: SupervisorDaemonSummary,
+    pub gateway_interruption_acknowledged: bool,
+    pub gateway_interruption_expected: bool,
+    pub note: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SupervisorChildRunResult {
     pub env_name: String,
     pub binding_kind: String,
@@ -185,6 +195,8 @@ pub struct SupervisorRuntimeChild {
 pub struct SupervisorRuntimeState {
     pub kind: String,
     pub ocm_home: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
     #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub services: Vec<SupervisorRuntimeService>,
@@ -220,6 +232,7 @@ pub struct SupervisorRuntimeView {
     pub present: bool,
     pub kind: String,
     pub ocm_home: String,
+    pub daemon_version: Option<String>,
     #[serde(with = "time::serde::rfc3339")]
     pub updated_at: OffsetDateTime,
     pub children: Vec<SupervisorRuntimeChild>,
@@ -228,6 +241,7 @@ pub struct SupervisorRuntimeView {
 #[derive(Clone, Debug)]
 pub struct SupervisorInspection {
     pub daemon: SupervisorDaemonSummary,
+    pub daemon_version: Option<String>,
     pub planned_children: Vec<SupervisorChildSpec>,
     pub skipped_envs: Vec<SkippedSupervisorEnv>,
     pub runtime_children: Vec<SupervisorRuntimeChild>,
@@ -285,6 +299,7 @@ impl<'a> SupervisorService<'a> {
                 present: false,
                 kind: SUPERVISOR_RUNTIME_KIND.to_string(),
                 ocm_home: display_path(&ocm_home),
+                daemon_version: None,
                 updated_at: now_utc(),
                 children: Vec::new(),
             });
@@ -296,6 +311,7 @@ impl<'a> SupervisorService<'a> {
             present: true,
             kind: runtime.kind,
             ocm_home: runtime.ocm_home,
+            daemon_version: runtime.daemon_version,
             updated_at: runtime.updated_at,
             children: runtime.children,
         })
@@ -312,6 +328,9 @@ impl<'a> SupervisorService<'a> {
 
         Ok(SupervisorInspection {
             daemon,
+            daemon_version: runtime
+                .as_ref()
+                .and_then(|runtime| runtime.daemon_version.clone()),
             planned_children: state.children,
             skipped_envs: state.skipped_envs,
             runtime_children: runtime
@@ -333,6 +352,45 @@ impl<'a> SupervisorService<'a> {
     pub fn install_daemon(&self) -> Result<SupervisorDaemonSummary, String> {
         let _lifecycle_lock = self.lock_daemon_lifecycle()?;
         self.refresh_daemon("install")
+    }
+
+    pub fn refresh_daemon_explicit(
+        &self,
+        acknowledge_gateway_restarts: bool,
+    ) -> Result<SupervisorDaemonRefreshSummary, String> {
+        let _lifecycle_lock = self.lock_daemon_lifecycle()?;
+        let before = self.daemon_status()?;
+        if !before.installed {
+            return Err(
+                "OCM background service is not installed; install an environment service first"
+                    .to_string(),
+            );
+        }
+
+        let gateway_interruption_expected =
+            before.running && self.has_desired_running_services()?;
+        if gateway_interruption_expected && !acknowledge_gateway_restarts {
+            return Err(
+                "refreshing the OCM background service interrupts managed gateways; rerun during a maintenance window with --acknowledge-gateway-restarts"
+                    .to_string(),
+            );
+        }
+
+        // Preserve the persisted desired state exactly. Rebuilding it here could
+        // apply unrelated latent drift before the daemon handoff.
+        let daemon = self.activate_daemon("refresh")?;
+        Ok(SupervisorDaemonRefreshSummary {
+            daemon,
+            gateway_interruption_acknowledged: acknowledge_gateway_restarts,
+            gateway_interruption_expected,
+            note: if gateway_interruption_expected {
+                "OCM background service refreshed; managed gateways were interrupted and will converge from the preserved desired state"
+                    .to_string()
+            } else {
+                "OCM background service refreshed without active managed gateway interruption"
+                    .to_string()
+            },
+        })
     }
 
     pub fn ensure_daemon_running(&self) -> Result<SupervisorDaemonSummary, String> {
@@ -2152,6 +2210,7 @@ fn write_supervisor_runtime_state(
         &SupervisorRuntimeState {
             kind: SUPERVISOR_RUNTIME_KIND.to_string(),
             ocm_home: ocm_home.to_string(),
+            daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
             updated_at: now_utc(),
             services,
             children,

--- a/tests/behavior_flow_tests.rs
+++ b/tests/behavior_flow_tests.rs
@@ -212,6 +212,7 @@ fn supervised_gateway_restart_requires_negotiated_external_handoff() {
     let runtime_state = |restart_handoff: &str| SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: path_string(&root.child("ocm-home")),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: vec![SupervisorRuntimeService {
             env_name: "demo".to_string(),

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -526,9 +526,11 @@ fn daemon_run_persists_live_runtime_children() {
     let runtime = wait_for_runtime_children(&runtime_path, 2, Some("demo"), Duration::from_secs(5))
         .expect("daemon runtime state did not report running children");
     assert_eq!(runtime["kind"], "ocm-supervisor-runtime");
+    assert_eq!(runtime["daemonVersion"], env!("CARGO_PKG_VERSION"));
 
     let runtime_body = to_value(service.runtime().unwrap()).unwrap();
     assert_eq!(runtime_body["present"], true);
+    assert_eq!(runtime_body["daemonVersion"], env!("CARGO_PKG_VERSION"));
     assert_eq!(runtime_body["runtimePath"], path_string(&runtime_path));
     assert_eq!(runtime_body["children"].as_array().unwrap().len(), 2);
 

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1924,6 +1924,7 @@ fn dev_watch_aborts_and_restores_policy_when_service_stop_times_out() {
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: path_string(&root.child("ocm-home")),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: vec![SupervisorRuntimeService {
             env_name: "demo".to_string(),

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -35,6 +35,7 @@ fn write_running_snapshot_service(
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: env.get("OCM_HOME").unwrap().clone(),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: vec![SupervisorRuntimeService {
             env_name: "source".to_string(),
@@ -70,6 +71,7 @@ fn write_empty_snapshot_service(runtime_path: &Path, ocm_home: &str) {
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: ocm_home.to_string(),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: Vec::new(),
         children: Vec::new(),

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -567,6 +567,20 @@ fn env_and_service_status_style_help_mentions_raw_mode() {
     assert!(output.contains("ocm service install <env> [--raw] [--json]"));
     assert!(output.contains("Use `service start` to start the env after it is enabled."));
     assert!(output.contains("shared OCM background service"));
+
+    let refresh_daemon = run_ocm(&cwd, &env, &["help", "service", "refresh-daemon"]);
+    assert!(
+        refresh_daemon.status.success(),
+        "{}",
+        stderr(&refresh_daemon)
+    );
+    let output = stdout(&refresh_daemon);
+    assert!(
+        output.contains(
+            "ocm service refresh-daemon [--acknowledge-gateway-restarts] [--raw] [--json]"
+        )
+    );
+    assert!(output.contains("never rebuilds desired state"));
 }
 
 #[test]

--- a/tests/self_command_tests.rs
+++ b/tests/self_command_tests.rs
@@ -11,7 +11,8 @@ use ocm::infra::download::file_sha256;
 use tar::{Builder, EntryType};
 
 use crate::support::{
-    TestDir, TestHttpServer, ocm_env, path_string, run_ocm, run_ocm_binary, stderr, stdout,
+    TestDir, TestHttpServer, install_fake_launchctl, ocm_env, path_string, run_ocm, run_ocm_binary,
+    stderr, stdout,
 };
 
 fn current_release_asset_name() -> String {
@@ -212,6 +213,73 @@ fn self_update_replaces_a_copied_binary_in_place() {
         .unwrap();
     assert!(updated.status.success());
     assert_eq!(String::from_utf8(updated.stdout).unwrap(), "9.9.9\n");
+}
+
+#[test]
+fn self_update_reports_running_daemon_skew_without_restarting_it() {
+    let root = TestDir::new("self-update-running-daemon-skew");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let copied_binary = copied_ocm(&root);
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+
+    for args in [
+        vec!["launcher", "add", "stable", "--command", "openclaw"],
+        vec!["env", "create", "demo", "--launcher", "stable"],
+        vec!["service", "start", "demo"],
+    ] {
+        let output = run_ocm_binary(&copied_binary, &cwd, &env, &args);
+        assert!(output.status.success(), "{}", stderr(&output));
+    }
+
+    let target_version = "9.9.9";
+    let asset_name = current_release_asset_name();
+    let archive_path = root.child(&asset_name);
+    write_release_archive(
+        &archive_path,
+        &format!(
+            "#!/usr/bin/env bash\nif [[ \"$1\" == \"--version\" ]]; then\n  printf '{target_version}\\n'\nelse\n  printf 'updated ocm\\n'\nfi\n"
+        ),
+    );
+    let asset = TestHttpServer::serve_bytes(
+        "/download.tar.gz",
+        "application/gzip",
+        &fs::read(&archive_path).unwrap(),
+    );
+    let digest = file_sha256(&archive_path).unwrap();
+    let metadata = format!(
+        "{{\"tag_name\":\"v{target_version}\",\"assets\":[{{\"name\":\"{asset_name}\",\"browser_download_url\":\"{}\",\"digest\":\"sha256:{digest}\"}}]}}",
+        asset.url()
+    );
+    let release =
+        TestHttpServer::serve_bytes("/release.json", "application/json", metadata.as_bytes());
+    env.insert(
+        "OCM_INTERNAL_SELF_UPDATE_RELEASE_URL".to_string(),
+        release.url(),
+    );
+    let launchctl_log = root.child("launchctl.log");
+    fs::write(&launchctl_log, "").unwrap();
+
+    let output = run_ocm_binary(
+        &copied_binary,
+        &cwd,
+        &env,
+        &["self", "update", "--version", target_version, "--raw"],
+    );
+    assert!(output.status.success(), "{}", stderr(&output));
+    let text = stdout(&output);
+    assert!(text.contains("daemonRefreshRequired: true"));
+    assert!(text.contains("service refresh-daemon --acknowledge-gateway-restarts"));
+
+    let calls = fs::read_to_string(&launchctl_log).unwrap();
+    assert!(calls.contains("print"));
+    assert!(!calls.contains("bootout"));
+    assert!(!calls.contains("bootstrap"));
 }
 
 #[test]

--- a/tests/service_command_tests.rs
+++ b/tests/service_command_tests.rs
@@ -11,9 +11,9 @@ use std::thread::{self, sleep};
 use std::time::Duration;
 
 use ocm::env::EnvironmentService;
-use ocm::store::{now_utc, supervisor_runtime_path};
+use ocm::store::{now_utc, supervisor_runtime_path, supervisor_state_path};
 use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::support::{
     TestDir, install_fake_launchctl, install_fake_systemd_tools, managed_service_definition_path,
@@ -782,6 +782,154 @@ fn service_status_all_reports_env_and_ocm_service_state_in_json() {
 }
 
 #[test]
+fn service_status_version_contract_is_read_only_for_mismatch_unknown_and_current() {
+    let root = TestDir::new("service-status-version-mismatch");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = launchd_env(&root);
+    setup_launcher_env(&cwd, &env);
+
+    let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let runtime = json!({
+        "kind": "ocm-supervisor-runtime",
+        "ocmHome": path_string(&root.child("ocm-home")),
+        "daemonVersion": "0.1.0",
+        "updatedAt": "2026-08-17T00:00:00Z",
+        "services": [{
+            "envName": "demo",
+            "bindingKind": "launcher",
+            "bindingName": "stable",
+            "gatewayState": "running",
+            "restartHandoff": "protocol-v1",
+            "restartCount": 0,
+            "childPort": 18789,
+            "pid": 4242,
+            "stdoutPath": path_string(&root.child("demo.stdout.log")),
+            "stderrPath": path_string(&root.child("demo.stderr.log")),
+            "lastExitCode": null,
+            "lastError": null,
+            "lastEventAt": null,
+            "nextRetryAt": null
+        }],
+        "children": [{
+            "envName": "demo",
+            "bindingKind": "launcher",
+            "bindingName": "stable",
+            "pid": 4242,
+            "restartCount": 0,
+            "childPort": 18789,
+            "stdoutPath": path_string(&root.child("demo.stdout.log")),
+            "stderrPath": path_string(&root.child("demo.stderr.log"))
+        }]
+    });
+    let runtime_before = serde_json::to_vec(&runtime).unwrap();
+    fs::write(&runtime_path, &runtime_before).unwrap();
+
+    let output = run_ocm(&cwd, &env, &["service", "status", "demo", "--json"]);
+    assert!(output.status.success(), "{}", stderr(&output));
+    let body = json_output(&output);
+
+    assert_eq!(body["ocmCliVersion"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(body["ocmServiceVersion"], "0.1.0");
+    assert_eq!(body["ocmServiceVersionStatus"], "mismatch");
+    assert!(
+        body["ocmServiceVersionNote"]
+            .as_str()
+            .unwrap()
+            .contains("service refresh-daemon --acknowledge-gateway-restarts")
+    );
+    assert_eq!(body["childPid"], 4242);
+    assert_eq!(fs::read(&runtime_path).unwrap(), runtime_before);
+
+    let mut unknown_runtime = runtime.clone();
+    unknown_runtime
+        .as_object_mut()
+        .unwrap()
+        .remove("daemonVersion");
+    let unknown_before = serde_json::to_vec(&unknown_runtime).unwrap();
+    fs::write(&runtime_path, &unknown_before).unwrap();
+    let unknown = run_ocm(&cwd, &env, &["service", "status", "demo", "--json"]);
+    assert!(unknown.status.success(), "{}", stderr(&unknown));
+    let unknown_body = json_output(&unknown);
+    assert_eq!(unknown_body["ocmServiceVersion"], Value::Null);
+    assert_eq!(unknown_body["ocmServiceVersionStatus"], "unknown");
+    assert!(
+        unknown_body["ocmServiceVersionNote"]
+            .as_str()
+            .unwrap()
+            .contains("does not report its version")
+    );
+    assert_eq!(unknown_body["childPid"], 4242);
+    assert_eq!(fs::read(&runtime_path).unwrap(), unknown_before);
+
+    let mut current_runtime = runtime;
+    current_runtime["daemonVersion"] = Value::String(env!("CARGO_PKG_VERSION").to_string());
+    let current_before = serde_json::to_vec(&current_runtime).unwrap();
+    fs::write(&runtime_path, &current_before).unwrap();
+    let current = run_ocm(&cwd, &env, &["service", "status", "demo", "--json"]);
+    assert!(current.status.success(), "{}", stderr(&current));
+    let current_body = json_output(&current);
+    assert_eq!(current_body["ocmServiceVersionStatus"], "current");
+    assert_eq!(current_body["ocmServiceVersionNote"], Value::Null);
+    assert_eq!(current_body["childPid"], 4242);
+    assert_eq!(fs::read(&runtime_path).unwrap(), current_before);
+}
+
+#[test]
+fn service_refresh_daemon_requires_interruption_ack_and_preserves_desired_state() {
+    let root = TestDir::new("service-refresh-daemon-ack");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = launchd_env(&root);
+    setup_launcher_env(&cwd, &env);
+
+    let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    let state_path = supervisor_state_path(&env, &cwd).unwrap();
+    let state_before = fs::read(&state_path).unwrap();
+    let launchctl_log = root.child("launchctl.log");
+    fs::write(&launchctl_log, "").unwrap();
+
+    let refused = run_ocm(&cwd, &env, &["service", "refresh-daemon", "--json"]);
+    assert!(!refused.status.success());
+    assert!(
+        stderr(&refused).contains("--acknowledge-gateway-restarts"),
+        "{}",
+        stderr(&refused)
+    );
+    let refused_calls = fs::read_to_string(&launchctl_log).unwrap();
+    assert!(!refused_calls.contains("bootout"));
+    assert!(!refused_calls.contains("bootstrap"));
+    assert_eq!(fs::read(&state_path).unwrap(), state_before);
+
+    fs::write(&launchctl_log, "").unwrap();
+    let refreshed = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "service",
+            "refresh-daemon",
+            "--acknowledge-gateway-restarts",
+            "--json",
+        ],
+    );
+    assert!(refreshed.status.success(), "{}", stderr(&refreshed));
+    let body = json_output(&refreshed);
+    assert_eq!(body["action"], "refresh");
+    assert_eq!(body["gatewayInterruptionExpected"], true);
+    assert_eq!(body["gatewayInterruptionAcknowledged"], true);
+    assert!(body["note"].as_str().unwrap().contains("interrupted"));
+    let refreshed_calls = fs::read_to_string(&launchctl_log).unwrap();
+    assert!(refreshed_calls.contains("bootout"));
+    assert!(refreshed_calls.contains("bootstrap"));
+    assert_eq!(fs::read(&state_path).unwrap(), state_before);
+}
+
+#[test]
 fn systemd_service_install_writes_the_ocm_unit() {
     let root = TestDir::new("service-systemd-install");
     let cwd = root.child("workspace");
@@ -933,6 +1081,7 @@ fn service_status_ignores_stale_runtime_children_when_the_daemon_is_down() {
     let stale_runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: path_string(&root.child("ocm-home")),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: Vec::new(),
         children: vec![SupervisorRuntimeChild {
@@ -979,6 +1128,7 @@ fn service_status_reports_clean_backoff_as_restarting_without_issue() {
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: path_string(&root.child("ocm-home")),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: vec![SupervisorRuntimeService {
             env_name: "demo".to_string(),
@@ -1026,6 +1176,7 @@ fn service_status_keeps_failed_backoff_as_issue() {
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: path_string(&root.child("ocm-home")),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: vec![SupervisorRuntimeService {
             env_name: "demo".to_string(),

--- a/tests/upgrade_availability_tests.rs
+++ b/tests/upgrade_availability_tests.rs
@@ -232,6 +232,7 @@ fn write_running_supervisor_runtime(
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: ocm_home.to_string(),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: vec![SupervisorRuntimeService {
             env_name: "demo".to_string(),
@@ -267,6 +268,7 @@ fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: ocm_home.to_string(),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: Vec::new(),
         children: Vec::new(),

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -78,6 +78,7 @@ fn write_running_supervisor_runtime(
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: ocm_home.to_string(),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: vec![SupervisorRuntimeService {
             env_name: "demo".to_string(),
@@ -113,6 +114,7 @@ fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: ocm_home.to_string(),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: Vec::new(),
         children: Vec::new(),
@@ -130,6 +132,7 @@ fn write_backoff_supervisor_runtime(
     let runtime = SupervisorRuntimeState {
         kind: "ocm-supervisor-runtime".to_string(),
         ocm_home: ocm_home.to_string(),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         updated_at: now_utc(),
         services: vec![SupervisorRuntimeService {
             env_name: "demo".to_string(),


### PR DESCRIPTION
## Summary

- publish the running supervisor daemon's OCM version in runtime state
- report CLI/service version status as `current`, `mismatch`, `unknown`, or `stopped`
- warn after `ocm self update` when a running daemon still maps its previous executable
- add an explicit `ocm service refresh-daemon --acknowledge-gateway-restarts` path that preserves desired state and refuses unacknowledged active-gateway interruption

## Root cause

Atomic CLI replacement changes the binary at its filesystem path, but a long-running daemon continues executing its already mapped image. OCM exposed no daemon version, so an installed daemon-side fix could appear active while the old process was still running.

The contract intentionally reports pre-contract daemons as `unknown`; it never assumes absence means current and never restarts the daemon as a self-update side effect.

## Observable proof

Final head `44f3e4a` on current main `3e82970`:

- equal CLI/daemon versions reported `current` and preserved child PID `7815`
- atomic replacement changed the CLI inode from `342179652` to `342179846` while the old daemon remained running
- a pre-contract daemon reported `unknown`
- explicit `9.9.9` skew reported `mismatch`
- status queries and refused refresh preserved child PID `8085` and listener health
- refresh without acknowledgement performed no service-manager bootout/bootstrap
- self-update reports the maintenance action without restarting the daemon

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- service command tests: 37/37 pass
- self-update tests: 9/9 pass
- help tests: 32/32 pass
- exact read-only version-status regression: pass
- exact refresh acknowledgement/state-preservation regression: pass
- exact self-update no-restart regression: pass
- `cargo test --locked --all-targets --no-run`: pass
- source-blind equal/skew disposable launchd-shim fixtures: pass
- autoreview: clean, no actionable findings

The full local daemon-runtime suite also contains three readiness failures introduced on current main by #82; all three reproduce unchanged in a pristine `e594446` worktree. Local Rust 1.97 clippy likewise reports four untouched current-main warnings in `src/service/manage.rs` and `src/store/runtimes.rs`.

## Safety boundary

This does not implement or claim zero-downtime daemon handoff. A refresh that can interrupt active managed gateways requires an explicit acknowledgement and reports that limitation. Real systemd, Windows service-manager, and acknowledged real-launchd acceptance remain outside the disposable shim proof.

No live OCM environment or gateway was used.