### PR TITLE
fix: reject cross-checkout dependency trees

### DIFF
--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -32,7 +32,8 @@ use crate::infra::process::run_direct;
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::infra::terminal::{Cell, KeyValueRow, Tone, paint, render_key_value_card, render_table};
 use crate::openclaw_repo::{
-    detect_openclaw_checkout, discover_openclaw_checkout, ensure_openclaw_worktree,
+    detect_openclaw_checkout, discover_openclaw_checkout, ensure_checkout_owned_dependencies,
+    ensure_openclaw_worktree,
 };
 use crate::service::service_backend_support_error;
 use crate::store::{
@@ -411,6 +412,7 @@ impl Cli {
                 display_path(&repo_root)
             )
         })?;
+        ensure_checkout_owned_dependencies(&repo_root)?;
         let meta = self
             .environment_service()
             .apply_effective_gateway_port(existing)?;
@@ -704,6 +706,7 @@ impl Cli {
             .as_ref()
             .ok_or_else(|| format!("environment \"{}\" is missing its dev binding", meta.name))?;
         let worktree_root = Path::new(&dev.worktree_root);
+        ensure_checkout_owned_dependencies(worktree_root)?;
         let pnpm_store = worktree_root.join("node_modules").join(".pnpm");
         let tsx_bin = worktree_root.join("node_modules").join(".bin").join("tsx");
         if pnpm_store.exists() && tsx_bin.exists() {

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -41,6 +41,40 @@ pub(crate) fn discover_openclaw_checkout(cwd: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Rejects checkout dependencies that resolve through another checkout.
+pub(crate) fn ensure_checkout_owned_dependencies(repo_root: &Path) -> Result<(), String> {
+    let node_modules = repo_root.join("node_modules");
+    if !node_modules.exists() {
+        return Ok(());
+    }
+
+    // Compare resolved directories so relative links from linked worktrees cannot
+    // make another checkout's dependency tree appear local.
+    let resolved_repo = fs::canonicalize(repo_root).map_err(|error| {
+        format!(
+            "failed to resolve selected OpenClaw checkout at {}: {error}",
+            display_path(repo_root)
+        )
+    })?;
+    let resolved_dependencies = fs::canonicalize(&node_modules).map_err(|error| {
+        format!(
+            "failed to resolve OpenClaw dependencies at {}: {error}",
+            display_path(&node_modules)
+        )
+    })?;
+    if resolved_dependencies.starts_with(&resolved_repo) {
+        return Ok(());
+    }
+
+    // OCM leaves the selected checkout untouched. A standalone checkout gives
+    // package managers an isolated dependency tree without rewriting the worktree.
+    Err(format!(
+        "OpenClaw dependencies resolve outside the selected checkout: {} -> {}. OCM will not build or run source against dependencies from another checkout. Use a standalone checkout at the selected commit, run `pnpm install --frozen-lockfile` there, and pass that checkout with `--repo`.",
+        display_path(&node_modules),
+        display_path(&resolved_dependencies)
+    ))
+}
+
 pub(crate) fn default_worktree_root(repo_root: &Path, env_name: &str) -> PathBuf {
     clean_path(&repo_root.join(".worktrees").join(env_name))
 }

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -44,8 +44,15 @@ pub(crate) fn discover_openclaw_checkout(cwd: &Path) -> Option<PathBuf> {
 /// Rejects checkout dependencies that resolve through another checkout.
 pub(crate) fn ensure_checkout_owned_dependencies(repo_root: &Path) -> Result<(), String> {
     let node_modules = repo_root.join("node_modules");
-    if !node_modules.exists() {
-        return Ok(());
+    match fs::symlink_metadata(&node_modules) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect OpenClaw dependencies at {}: {error}",
+                display_path(&node_modules)
+            ));
+        }
     }
 
     // Compare resolved directories so relative links from linked worktrees cannot

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -12,6 +12,7 @@ use crate::infra::download::{
     normalize_sha256, verify_file_integrity, verify_file_sha256,
 };
 use crate::managed_node::{CommandSpec, managed_runtime_install_command};
+use crate::openclaw_repo::ensure_checkout_owned_dependencies;
 use crate::runtime::releases::{
     OpenClawRelease, RuntimeRelease, load_official_openclaw_release_selection,
     load_release_manifest, normalize_openclaw_channel_selector, official_openclaw_releases_url,
@@ -1636,6 +1637,7 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
     }
 
     let repo_path = fs::canonicalize(&repo_path).map_err(|error| error.to_string())?;
+    ensure_checkout_owned_dependencies(&repo_path)?;
     let version = load_openclaw_repo_version(&repo_path)?;
     let commit = git_short_commit(&repo_path);
     let stores = super::ensure_store(context.env, context.cwd)?;

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1464,6 +1464,47 @@ fn dev_watch_force_rejects_dependencies_from_another_checkout_before_takeover() 
     assert!(!root.child("node.log").exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn dev_watch_force_rejects_dangling_dependency_link_before_takeover() {
+    let root = TestDir::new("dev-command-runtime-watch-dangling-dependencies");
+    let repo = init_openclaw_repo(&root);
+    let missing_dependencies = root.child("missing-checkout/node_modules");
+    std::os::unix::fs::symlink(&missing_dependencies, repo.join("node_modules")).unwrap();
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = service_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+    create_runtime_backed_env(&cwd, &env);
+
+    let start = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let watch = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "dev",
+            "demo",
+            "--repo",
+            &path_string(&repo),
+            "--watch",
+            "--force",
+        ],
+    );
+
+    assert!(!watch.status.success());
+    assert!(
+        stderr(&watch).contains("failed to resolve OpenClaw dependencies"),
+        "{}",
+        stderr(&watch)
+    );
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(show_json["serviceRunning"], true);
+    assert!(!root.child("node.log").exists());
+}
+
 #[test]
 fn dev_watch_force_warns_for_installed_plugins_missing_from_source() {
     let root = TestDir::new("dev-command-runtime-watch-external-plugin");

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1417,6 +1417,53 @@ fn dev_watch_force_takes_over_runtime_env_without_rebinding() {
     assert!(stdout(&error_logs).contains("source watch stderr"));
 }
 
+#[cfg(unix)]
+#[test]
+fn dev_watch_force_rejects_dependencies_from_another_checkout_before_takeover() {
+    let root = TestDir::new("dev-command-runtime-watch-external-dependencies");
+    let repo = init_openclaw_repo(&root);
+    let shared_dependencies = root.child("other-checkout/node_modules");
+    fs::create_dir_all(&shared_dependencies).unwrap();
+    std::os::unix::fs::symlink(&shared_dependencies, repo.join("node_modules")).unwrap();
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = service_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+    create_runtime_backed_env(&cwd, &env);
+
+    let start = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let watch = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "dev",
+            "demo",
+            "--repo",
+            &path_string(&repo),
+            "--watch",
+            "--force",
+        ],
+    );
+
+    assert!(!watch.status.success());
+    let error = stderr(&watch);
+    assert!(
+        error.contains("dependencies resolve outside the selected checkout"),
+        "{error}"
+    );
+    assert!(
+        error.contains(&path_string(&shared_dependencies)),
+        "{error}"
+    );
+    assert!(error.contains("standalone checkout"), "{error}");
+    let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(show_json["serviceRunning"], true);
+    assert!(!root.child("node.log").exists());
+}
+
 #[test]
 fn dev_watch_force_warns_for_installed_plugins_missing_from_source() {
     let root = TestDir::new("dev-command-runtime-watch-external-plugin");

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -632,6 +632,64 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
     assert!(verify.status.success(), "{}", stderr(&verify));
 }
 
+#[cfg(unix)]
+#[test]
+fn runtime_build_local_rejects_dependencies_from_another_checkout_before_pack() {
+    let root = TestDir::new("runtime-build-local-external-dependencies");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    let shared_dependencies = root.child("other-checkout/node_modules");
+    fs::create_dir_all(&repo).unwrap();
+    fs::create_dir_all(&shared_dependencies).unwrap();
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.4.25","bin":{"openclaw":"openclaw.mjs"}}"#,
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&shared_dependencies, repo.join("node_modules")).unwrap();
+
+    let archive_path = root.child("packed-openclaw.tgz");
+    fs::write(
+        &archive_path,
+        openclaw_package_tarball_with_version(
+            "#!/usr/bin/env node\nconsole.log('wrong dependency tree');\n",
+            "2026.4.25",
+        ),
+    )
+    .unwrap();
+    let mut env = ocm_env(&root);
+    let npm_log = install_fake_node_and_packing_npm(&root, &mut env, &archive_path);
+
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "main-local",
+            "--repo",
+            &path_string(&repo),
+            "--raw",
+        ],
+    );
+
+    assert!(!build.status.success());
+    let error = stderr(&build);
+    assert!(
+        error.contains("dependencies resolve outside the selected checkout"),
+        "{error}"
+    );
+    assert!(
+        error.contains(&path_string(&shared_dependencies)),
+        "{error}"
+    );
+    assert!(error.contains("standalone checkout"), "{error}");
+    assert!(
+        !npm_log.exists(),
+        "npm pack ran before dependency validation"
+    );
+}
+
 #[test]
 fn runtime_build_local_can_include_source_extensions_without_widening_default_trust() {
     let root = TestDir::new("runtime-build-local-source-extensions");

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -690,6 +690,58 @@ fn runtime_build_local_rejects_dependencies_from_another_checkout_before_pack() 
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn runtime_build_local_rejects_dangling_dependency_link_before_pack() {
+    let root = TestDir::new("runtime-build-local-dangling-dependencies");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    let missing_dependencies = root.child("missing-checkout/node_modules");
+    fs::create_dir_all(&repo).unwrap();
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.4.25","bin":{"openclaw":"openclaw.mjs"}}"#,
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&missing_dependencies, repo.join("node_modules")).unwrap();
+
+    let archive_path = root.child("packed-openclaw.tgz");
+    fs::write(
+        &archive_path,
+        openclaw_package_tarball_with_version(
+            "#!/usr/bin/env node\nconsole.log('wrong dependency tree');\n",
+            "2026.4.25",
+        ),
+    )
+    .unwrap();
+    let mut env = ocm_env(&root);
+    let npm_log = install_fake_node_and_packing_npm(&root, &mut env, &archive_path);
+
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "main-local",
+            "--repo",
+            &path_string(&repo),
+            "--raw",
+        ],
+    );
+
+    assert!(!build.status.success());
+    assert!(
+        stderr(&build).contains("failed to resolve OpenClaw dependencies"),
+        "{}",
+        stderr(&build)
+    );
+    assert!(
+        !npm_log.exists(),
+        "npm pack ran before dependency validation"
+    );
+}
+
 #[test]
 fn runtime_build_local_can_include_source_extensions_without_widening_default_trust() {
     let root = TestDir::new("runtime-build-local-source-extensions");


### PR DESCRIPTION
## What

Reject OpenClaw source workflows when the selected checkout’s top-level `node_modules` resolves through another checkout. The validation runs before local package construction and before source watch stops a managed service.

## Why

A linked worktree can point `node_modules` at a different checkout. OCM then combines source from the selected commit with workspace packages from another commit, which can fail during plugin loading or run incompatible code.

## Changes

- Validate checkout-owned dependency resolution
- Reject dangling dependency symlinks
- Block takeover before service stop
- Report isolated-checkout remediation
- Cover build and takeover regressions

## Maintainer decision

OCM should reject cross-checkout dependency trees. Combining source from one checkout with workspace packages from another does not represent either revision and caused the primary Gateway test failure that motivated this change. The error preserves the checkout and gives an isolated-checkout remediation.

## Real behavior proof

Ran the PR-head OCM binary against the real `.worktrees/plugins-hub-stable-shell` linked worktree, whose `node_modules` resolves to the root OpenClaw checkout. An isolated temporary `OCM_HOME` kept the primary environment out of scope.

```text
$ OCM_HOME=<temporary-home> cargo run --quiet -- runtime build-local pr87-real-worktree-proof --repo <openclaw>/.worktrees/plugins-hub-stable-shell --raw
ocm: OpenClaw dependencies resolve outside the selected checkout: <openclaw>/.worktrees/plugins-hub-stable-shell/node_modules -> <openclaw>/node_modules. OCM will not build or run source against dependencies from another checkout. Use a standalone checkout at the selected commit, run `pnpm install --frozen-lockfile` there, and pass that checkout with `--repo`.
Run "ocm help" for usage.
proof_exit=1

$ find <temporary-home>/runtimes -mindepth 1 -maxdepth 1 -print
<no output>
```

The rejection occurred before `npm pack`, runtime creation, or service takeover.

## Review follow-up

The first review found that `Path::exists()` treated a dangling `node_modules` symlink as absent. Both affected entry-point tests failed on the previous PR head because package construction and forced takeover proceeded:

```text
runtime_build_local_rejects_dangling_dependency_link_before_pack ... FAILED
dev_watch_force_rejects_dangling_dependency_link_before_takeover ... FAILED
```

The shared dependency-owner check now uses symlink metadata to distinguish an absent path from a dangling link, then canonicalizes every present path. Both tests pass and verify that `npm pack` does not run and the managed service remains running.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo test --locked --test runtime_command_tests -- --test-threads=1` (48 passed)
- `cargo test --locked --test dev_command_tests -- --test-threads=1` (41 passed)
- Structured autoreview: no actionable findings
- Real linked-worktree build: rejected before pack

The runtime suite’s existing concurrent-install test flaked during earlier full-suite runs and passed on its exact rerun. `bin_wrapper_runs_with_an_overridden_home` also fails on this host because its isolated `HOME` cannot initialize Rustup; the focused changed-surface suites pass.
