### PR TITLE
fix: preserve actionable command failure diagnostics

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -3599,7 +3599,7 @@ impl SimulationCommandOutput {
     }
 
     fn failure_summary(&self) -> String {
-        let detail = summarize_command_text(&self.stderr, &self.stdout)
+        let detail = summarize_command_failure_text(&self.stderr, &self.stdout)
             .unwrap_or_else(|| "no output".to_string());
         format!(
             "exited with code {}: {detail}",
@@ -4020,10 +4020,14 @@ fn summarize_command_text(primary: &str, secondary: &str) -> Option<String> {
     None
 }
 
+fn summarize_command_failure_text(primary: &str, secondary: &str) -> Option<String> {
+    crate::infra::command_output::summarize_command_failure(primary, secondary)
+}
+
 fn summarize_command_output(stdout: &[u8], stderr: &[u8]) -> String {
     let stdout = String::from_utf8_lossy(stdout);
     let stderr = String::from_utf8_lossy(stderr);
-    summarize_command_text(&stderr, &stdout).unwrap_or_else(|| "no output".to_string())
+    summarize_command_failure_text(&stderr, &stdout).unwrap_or_else(|| "no output".to_string())
 }
 
 fn command_output_reports_unsupported_command(stdout: &str, stderr: &str) -> bool {
@@ -4259,9 +4263,22 @@ fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
 mod tests {
     use super::{
         candidate_codex_preflight_is_unsupported, command_output_reports_unsupported_command,
-        release_version_from_output, verify_gateway_status_readiness,
-        version_output_matches_expected,
+        release_version_from_output, summarize_command_failure_text,
+        verify_gateway_status_readiness, version_output_matches_expected,
     };
+
+    #[test]
+    fn command_summary_prefers_structured_cli_error_message() {
+        let stderr = "[openclaw] Could not start the CLI.\n[openclaw] Try: openclaw doctor\n";
+        let stdout = r#"{"ok":false,"error":{"type":"cli_error","message":"Cannot find package '@openclaw/plugin-api'; token=fixture-secret Authorization: Bearer bearer-secret"}}"#;
+
+        let summary = summarize_command_failure_text(stderr, stdout).unwrap();
+
+        assert!(summary.contains("Cannot find package '@openclaw/plugin-api'"));
+        assert!(!summary.contains("Could not start the CLI"));
+        assert!(!summary.contains("fixture-secret"));
+        assert!(!summary.contains("bearer-secret"));
+    }
 
     #[test]
     fn version_output_accepts_exact_version() {

--- a/src/infra/command_output.rs
+++ b/src/infra/command_output.rs
@@ -92,16 +92,31 @@ fn bounded_summary<'a>(lines: impl Iterator<Item = &'a str>) -> Option<String> {
     if summary.chars().count() <= MAX_SUMMARY_CHARS {
         return Some(summary);
     }
+
+    // Split the character budget so an oversized first line cannot discard
+    // the command's final error context.
+    let content_budget = MAX_SUMMARY_CHARS - 3;
+    let head_budget = content_budget / 2;
+    let tail_budget = content_budget - head_budget;
+    let tail = summary
+        .chars()
+        .rev()
+        .take(tail_budget)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev();
     Some(
         summary
             .chars()
-            .take(MAX_SUMMARY_CHARS - 3)
+            .take(head_budget)
             .chain("...".chars())
+            .chain(tail)
             .collect(),
     )
 }
 
 fn redact_obvious_secrets(line: &str) -> String {
+    let line = redact_url_userinfo(line);
     let lower_line = line.to_ascii_lowercase();
     if let Some((marker, start)) = ["authorization:", "authorization="]
         .into_iter()
@@ -114,7 +129,35 @@ fn redact_obvious_secrets(line: &str) -> String {
         return format!("{prefix}{separator}{marker}<redacted>");
     }
 
-    redact_assignments(line)
+    redact_assignments(&line)
+}
+
+// Replace URL userinfo as a unit so usernames, passwords, and percent-encoded
+// credentials cannot reach operator-facing diagnostics.
+fn redact_url_userinfo(line: &str) -> String {
+    let mut output = String::with_capacity(line.len());
+    let mut cursor = 0;
+    while let Some(separator) = line[cursor..].find("://") {
+        let authority_start = cursor + separator + 3;
+        let authority_end = line[authority_start..]
+            .find(|character: char| {
+                character.is_whitespace() || matches!(character, '/' | '?' | '#')
+            })
+            .map(|offset| authority_start + offset)
+            .unwrap_or(line.len());
+        let authority = &line[authority_start..authority_end];
+        let Some(userinfo_end) = authority.rfind('@') else {
+            output.push_str(&line[cursor..authority_start]);
+            cursor = authority_start;
+            continue;
+        };
+        output.push_str(&line[cursor..authority_start]);
+        output.push_str("<redacted>@");
+        output.push_str(&authority[userinfo_end + 1..]);
+        cursor = authority_end;
+    }
+    output.push_str(&line[cursor..]);
+    output
 }
 
 fn redact_assignments(line: &str) -> String {
@@ -148,4 +191,36 @@ fn redact_assignments(line: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_SUMMARY_CHARS, bounded_summary};
+
+    #[test]
+    fn summary_redacts_url_userinfo() {
+        let summary = bounded_summary(
+            ["download failed: https://user:password@example.test/package.tgz"].into_iter(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            summary,
+            "download failed: https://<redacted>@example.test/package.tgz"
+        );
+        assert!(!summary.contains("user"));
+        assert!(!summary.contains("password"));
+    }
+
+    #[test]
+    fn character_limit_preserves_head_and_tail() {
+        let oversized_head = format!("root cause: {}", "x".repeat(MAX_SUMMARY_CHARS));
+        let summary =
+            bounded_summary([oversized_head.as_str(), "final actionable error"].into_iter())
+                .unwrap();
+
+        assert!(summary.starts_with("root cause:"));
+        assert!(summary.ends_with("final actionable error"));
+        assert_eq!(summary.chars().count(), MAX_SUMMARY_CHARS);
+    }
 }

--- a/src/infra/command_output.rs
+++ b/src/infra/command_output.rs
@@ -213,6 +213,21 @@ mod tests {
     }
 
     #[test]
+    fn summary_redacts_url_userinfo_with_uppercase_scheme() {
+        let summary = bounded_summary(
+            ["download failed: HTTPS://user:password@example.test/package.tgz"].into_iter(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            summary,
+            "download failed: HTTPS://<redacted>@example.test/package.tgz"
+        );
+        assert!(!summary.contains("user"));
+        assert!(!summary.contains("password"));
+    }
+
+    #[test]
     fn character_limit_preserves_head_and_tail() {
         let oversized_head = format!("root cause: {}", "x".repeat(MAX_SUMMARY_CHARS));
         let summary =

--- a/src/infra/command_output.rs
+++ b/src/infra/command_output.rs
@@ -1,0 +1,151 @@
+use serde_json::Value;
+
+const MAX_SUMMARY_LINES: usize = 12;
+const MAX_SUMMARY_CHARS: usize = 4_096;
+const SENSITIVE_ASSIGNMENTS: [&str; 14] = [
+    "access_token=",
+    "access_token:",
+    "refresh_token=",
+    "refresh_token:",
+    "api_key=",
+    "api_key:",
+    "api-key=",
+    "api-key:",
+    "password=",
+    "password:",
+    "secret=",
+    "secret:",
+    "token=",
+    "token:",
+];
+
+/// Returns a bounded, redacted diagnostic from failed command output.
+pub(crate) fn summarize_command_failure(primary: &str, secondary: &str) -> Option<String> {
+    // Machine output owns the precise failure when a command emits both a
+    // generic human preamble and a structured error envelope.
+    if let Some(message) = [primary, secondary]
+        .into_iter()
+        .find_map(structured_error_message)
+    {
+        return bounded_summary(message.lines());
+    }
+
+    let mut fallback = Vec::new();
+    for text in [primary, secondary] {
+        let lines = command_lines(text, false);
+        if !lines.is_empty() {
+            return bounded_summary(lines.iter().map(String::as_str));
+        }
+        fallback.extend(command_lines(text, true));
+    }
+    bounded_summary(fallback.iter().map(String::as_str))
+}
+
+fn structured_error_message(text: &str) -> Option<String> {
+    let extract = |value: Value| match value.get("error")? {
+        Value::String(message) => Some(message.clone()),
+        Value::Object(error) => ["message", "detail", "cause"]
+            .into_iter()
+            .find_map(|key| error.get(key).and_then(Value::as_str).map(str::to_string)),
+        _ => None,
+    };
+    serde_json::from_str::<Value>(text.trim())
+        .ok()
+        .and_then(&extract)
+        .or_else(|| {
+            text.lines()
+                .rev()
+                .filter_map(|line| serde_json::from_str::<Value>(line.trim()).ok())
+                .find_map(extract)
+        })
+}
+
+fn command_lines(text: &str, include_npm_chatter: bool) -> Vec<String> {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter(|line| {
+            include_npm_chatter
+                || (!line.starts_with("npm notice") && !line.starts_with("npm warn"))
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+fn bounded_summary<'a>(lines: impl Iterator<Item = &'a str>) -> Option<String> {
+    let lines = lines.map(redact_obvious_secrets).collect::<Vec<_>>();
+    if lines.is_empty() {
+        return None;
+    }
+
+    // Keep both the producer's first cause and the command's final context.
+    let selected = if lines.len() > MAX_SUMMARY_LINES {
+        let omitted = lines.len() - (MAX_SUMMARY_LINES - 1);
+        let mut selected = lines[..4].to_vec();
+        selected.push(format!("... {omitted} lines omitted ..."));
+        selected.extend_from_slice(&lines[lines.len() - 7..]);
+        selected
+    } else {
+        lines
+    };
+    let summary = selected.join("\n");
+    if summary.chars().count() <= MAX_SUMMARY_CHARS {
+        return Some(summary);
+    }
+    Some(
+        summary
+            .chars()
+            .take(MAX_SUMMARY_CHARS - 3)
+            .chain("...".chars())
+            .collect(),
+    )
+}
+
+fn redact_obvious_secrets(line: &str) -> String {
+    let lower_line = line.to_ascii_lowercase();
+    if let Some((marker, start)) = ["authorization:", "authorization="]
+        .into_iter()
+        .find_map(|marker| lower_line.find(marker).map(|start| (marker, start)))
+    {
+        // Authorization schemes vary, so retaining any following word can
+        // expose the credential for Basic, Digest, or another scheme.
+        let prefix = redact_assignments(line[..start].trim_end());
+        let separator = if prefix.is_empty() { "" } else { " " };
+        return format!("{prefix}{separator}{marker}<redacted>");
+    }
+
+    redact_assignments(line)
+}
+
+fn redact_assignments(line: &str) -> String {
+    let mut redact_next = false;
+    line.split_whitespace()
+        .map(|word| {
+            // Bearer values are separate words; assignments keep their key so
+            // the resulting diagnostic still explains which input was used.
+            if redact_next && word.eq_ignore_ascii_case("bearer") {
+                return word.to_string();
+            }
+            if std::mem::take(&mut redact_next) {
+                return "<redacted>".to_string();
+            }
+            let lower = word.to_ascii_lowercase();
+            if lower == "bearer" || lower.ends_with("bearer") {
+                redact_next = true;
+                return word.to_string();
+            }
+            let assignment = SENSITIVE_ASSIGNMENTS
+                .into_iter()
+                .find_map(|marker| lower.find(marker).map(|start| (marker, start)));
+            let Some((marker, start)) = assignment else {
+                return word.to_string();
+            };
+            let value_start = start + marker.len();
+            if marker.ends_with(':') && value_start == word.len() {
+                redact_next = true;
+            }
+            format!("{}<redacted>", &word[..value_start])
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,4 +1,5 @@
 pub mod archive;
+pub(crate) mod command_output;
 pub mod download;
 pub mod process;
 pub mod shell;

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -359,30 +359,9 @@ pub struct BuildLocalRuntimeOptions {
 }
 
 fn summarize_command_output(stdout: &[u8], stderr: &[u8]) -> Option<String> {
-    let mut fallback = Vec::new();
-    for bytes in [stderr, stdout] {
-        let text = String::from_utf8_lossy(bytes);
-        let meaningful = text
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty())
-            .filter(|line| !line.starts_with("npm notice"))
-            .filter(|line| !line.starts_with("npm warn"))
-            .map(ToOwned::to_owned)
-            .collect::<Vec<_>>();
-        if !meaningful.is_empty() {
-            let start = meaningful.len().saturating_sub(12);
-            return Some(meaningful[start..].join("\n"));
-        }
-        fallback.extend(
-            text.lines()
-                .map(str::trim)
-                .filter(|line| !line.is_empty())
-                .take(3)
-                .map(ToOwned::to_owned),
-        );
-    }
-    (!fallback.is_empty()).then(|| fallback.join("\n"))
+    let stderr = String::from_utf8_lossy(stderr);
+    let stdout = String::from_utf8_lossy(stdout);
+    crate::infra::command_output::summarize_command_failure(&stderr, &stdout)
 }
 
 fn npm_program(env: &BTreeMap<String, String>) -> String {
@@ -2012,7 +1991,7 @@ npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMExcep
     }
 
     #[test]
-    fn command_summary_keeps_the_failure_tail() {
+    fn command_summary_keeps_the_failure_head_and_tail() {
         let stderr = br#"
 phase 01
 phase 02
@@ -2032,8 +2011,43 @@ Error: CHANGELOG.md does not contain a release section
 
         let summary = summarize_command_output(b"", stderr).unwrap();
 
-        assert!(!summary.contains("phase 01"));
-        assert!(summary.contains("phase 03"));
+        assert!(summary.contains("phase 01"));
+        assert!(summary.contains("lines omitted"));
         assert!(summary.contains("Error: CHANGELOG.md does not contain a release section"));
+        assert!(summary.lines().count() <= 12);
+    }
+
+    #[test]
+    fn command_summary_keeps_the_root_cause_and_redacts_secrets() {
+        let stderr = br#"
+npm error Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@openclaw/ai'
+phase 01
+phase 02
+phase 03
+phase 04
+phase 05
+phase 06
+phase 07
+phase 08
+phase 09
+phase 10
+phase 11
+phase 12
+phase 13
+phase 14
+npm error token=fixture-secret
+npm error password: colon-secret
+npm error Authorization: Basic basic-secret
+npm error command failed
+"#;
+
+        let summary = summarize_command_output(b"", stderr).unwrap();
+
+        assert!(summary.contains("ERR_MODULE_NOT_FOUND"), "{summary}");
+        assert!(summary.contains("command failed"), "{summary}");
+        assert!(!summary.contains("fixture-secret"), "{summary}");
+        assert!(!summary.contains("colon-secret"), "{summary}");
+        assert!(!summary.contains("basic-secret"), "{summary}");
+        assert!(summary.lines().count() <= 12, "{summary}");
     }
 }


### PR DESCRIPTION
## What

Preserve the cause of failed runtime and upgrade commands while keeping diagnostics bounded and safe to display.

## Why

Runtime build summaries retained only the last 12 lines, which could remove the original error. Upgrade checks preferred the first stderr line, so OpenClaw's generic startup heading hid the structured `error.message` written to stdout.

## Changes

- Prefer structured CLI error messages
- Preserve diagnostic head and tail
- Bound summaries by lines and characters
- Redact credential assignments and headers
- Redact URL userinfo before display
- Preserve tail context under character truncation
- Cover runtime and upgrade regressions

## Real command proof

Ran the PR-head OCM binary through `runtime build-local` with an isolated temporary `OCM_HOME`. A real `npm pack` prepack failure emitted a 5,000-character first line, 14 phase lines, a credential-bearing URL, and a final actionable error.

```text
$ OCM_HOME=<temporary-home> cargo run --quiet -- runtime build-local pr88-diagnostic-proof --repo <temporary-openclaw-package> --raw
ocm: failed to pack local OpenClaw build: root cause: xxxxx...xxxxx
phase 00
phase 01
phase 02
... 11 lines omitted ...
download https://<redacted>@example.test/package.tgz
final actionable error: inspect the missing package
npm error code 1
npm error command failed
npm error command sh -c node fail.mjs
Run "ocm help" for usage.
proof_exit=1
```

The emitted diagnostic was 4,096 characters, retained both ends, and did not contain the username or password.

## Review follow-up

ClawSweeper reported that uppercase schemes bypassed redaction. The implementation searches for the punctuation delimiter `://`, so scheme casing does not affect matching. An explicit regression on the unchanged production implementation confirms the behavior:

```text
$ cargo test --locked summary_redacts_url_userinfo_with_uppercase_scheme -- --nocapture
test infra::command_output::tests::summary_redacts_url_userinfo_with_uppercase_scheme ... ok
```

The assertion verifies that `HTTPS://user:password@example.test/package.tgz` becomes `HTTPS://<redacted>@example.test/package.tgz` and that neither credential remains.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked`
- `cargo test --locked --lib` (305 passed)
- `cargo test --locked --test runtime_command_tests -- --test-threads=1` (46 passed)
- `cargo test --locked --test upgrade_command_tests -- --test-threads=1` (48 passed)
- Exact rerun of `upgrade_holds_the_environment_operation_lock_until_completion` passed after one unrelated parallel-suite timing failure
- Structured autoreview: no actionable findings
