### PR TITLE
fix: target local builds to environment plugins

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -136,6 +136,23 @@ Because the opt-in installs every omitted extension and its dependency closure,
 the resulting runtime can take longer to build and use substantially more disk
 space than the release-shaped default.
 
+To build for an existing environment without including unrelated source
+plugins, name the target explicitly:
+
+```bash
+ocm runtime build-local primary-test \
+  --repo /path/to/openclaw \
+  --for-env primary \
+  --force
+```
+
+OCM reads the target environment's effective config before `npm pack`, validates
+explicit plugin references against the checkout and installed-plugin records,
+and follows transitive local plugin package dependencies. The resulting runtime
+adds only required source plugins omitted from the core package. `--for-env` and
+`--include-source-extensions` are mutually exclusive. A build without either
+option remains release-shaped.
+
 ### 6. Keep an environment running in the background
 
 ```bash

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1883,7 +1883,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
             "Build a local OpenClaw package runtime",
             "Run the local OpenClaw package build/pack path and install the produced tarball as an OCM-managed runtime.",
             vec![format!(
-                "{cmd} runtime build-local <name> --repo <openclaw-repo> [--include-source-extensions] [--description <text>] [--force] [--raw] [--json]"
+                "{cmd} runtime build-local <name> --repo <openclaw-repo> [--include-source-extensions | --for-env <env>] [--description <text>] [--force] [--raw] [--json]"
             )],
             &[
                 (
@@ -1893,6 +1893,10 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 (
                     "--include-source-extensions",
                     "Include built extensions omitted from the release-shaped core package",
+                ),
+                (
+                    "--for-env <env>",
+                    "Include the source-plugin closure required by one target environment",
                 ),
                 ("--description <text>", "Optional human description"),
                 (
@@ -1910,10 +1914,15 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 format!(
                     "{cmd} runtime build-local upstream-main --repo /path/to/openclaw --include-source-extensions --force"
                 ),
+                format!(
+                    "{cmd} runtime build-local primary-test --repo /path/to/openclaw --for-env primary --force"
+                ),
             ],
             &[
                 "`build-local` uses `npm pack` so OpenClaw's prepack script performs the release-style build, UI build, package inventory, and built entry smoke checks.",
                 "By default the result remains release-shaped. `--include-source-extensions` adds only built extensions from the selected checkout that the core tarball omitted, together with their installed runtime dependencies.",
+                "`--for-env` resolves the target config before the build, validates its plugin references against the selected checkout and installed-plugin records, and adds only required omitted source plugins plus transitive local plugin dependencies.",
+                "`--for-env` and `--include-source-extensions` are mutually exclusive.",
                 "Source-extension runtimes can take longer to build and use substantially more disk space than the release-shaped default.",
                 "The resulting runtime is installed under OCM's package runtime layout: files/node_modules/openclaw/openclaw.mjs.",
                 "Use this when testing release and upgrade behavior from a local checkout without source/Jiti execution paths.",

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -288,6 +288,14 @@ impl Cli {
         let (args, force) = Self::consume_flag(args, "--force");
         let (args, include_source_extensions) =
             Self::consume_flag(args, "--include-source-extensions");
+        let (args, target_env) = Self::consume_option(args, "--for-env")?;
+        let target_env = Self::require_option_value(target_env, "--for-env")?;
+        if include_source_extensions && target_env.is_some() {
+            return Err(
+                "runtime build-local accepts only one of --include-source-extensions or --for-env"
+                    .to_string(),
+            );
+        }
         let (args, repo) = Self::consume_option(args, "--repo")?;
         let repo = Self::require_option_value(repo, "--repo")?;
         let Some(repo) = repo else {
@@ -307,6 +315,7 @@ impl Cli {
                     description,
                     force,
                     include_source_extensions,
+                    target_env,
                 })
         })?;
 

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -57,6 +57,8 @@ pub struct BuildLocalRuntimeOptions {
     pub description: Option<String>,
     pub force: bool,
     pub include_source_extensions: bool,
+    /// Existing environment whose configured source-plugin closure must be packaged.
+    pub target_env: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -434,6 +436,7 @@ impl<'a> RuntimeService<'a> {
                     description: options.description,
                     force: options.force,
                     include_source_extensions: options.include_source_extensions,
+                    target_env: options.target_env,
                 },
                 InstallContext {
                     env: self.env,

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -28,11 +28,13 @@ use super::common::{
     ExclusiveFileLock, copy_dir_recursive, ensure_dir, load_json_files, lock_file, path_exists,
     read_json, write_json,
 };
+use super::envs::get_environment;
 use super::layout::{
-    clean_path, display_path, resolve_absolute_path, runtime_install_root, runtime_meta_path,
-    validate_name,
+    clean_path, derive_env_paths, display_path, resolve_absolute_path, runtime_install_root,
+    runtime_meta_path, validate_name,
 };
 use super::now_utc;
+use super::openclaw_workspaces::load_effective_openclaw_config;
 
 fn trim_description(description: Option<String>) -> Option<String> {
     description
@@ -356,6 +358,8 @@ pub struct BuildLocalRuntimeOptions {
     pub description: Option<String>,
     pub force: bool,
     pub include_source_extensions: bool,
+    /// Existing environment whose configured source-plugin closure must be packaged.
+    pub target_env: Option<String>,
 }
 
 fn summarize_command_output(stdout: &[u8], stderr: &[u8]) -> Option<String> {
@@ -406,14 +410,29 @@ struct LocalBuildNpmAdapter {
 #[derive(Clone, Debug)]
 struct LocalSourceExtension {
     id: String,
+    directory_name: String,
     package_name: String,
     source_dir: PathBuf,
+    materialize: bool,
 }
 
 #[derive(Clone, Debug)]
 struct LocalSourceExtensionArchive {
     extension: LocalSourceExtension,
     archive_path: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct SourcePluginDefinition {
+    directory_name: String,
+    package_name: Option<String>,
+    dependency_names: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SourcePluginInventory {
+    by_id: BTreeMap<String, SourcePluginDefinition>,
+    id_by_package_name: BTreeMap<String, String>,
 }
 
 impl LocalBuildNpmAdapter {
@@ -487,14 +506,18 @@ fn local_workspace_package_dirs(repo_path: &Path) -> Result<Vec<PathBuf>, String
     Ok(dirs)
 }
 
-fn workspace_dependency_names(value: &serde_json::Value) -> BTreeSet<String> {
+fn workspace_dependency_names(
+    value: &serde_json::Value,
+    include_dev_dependencies: bool,
+) -> BTreeSet<String> {
     let mut names = BTreeSet::new();
-    for section in [
-        "dependencies",
-        "optionalDependencies",
-        "peerDependencies",
-        "devDependencies",
-    ] {
+    let sections = [
+        Some("dependencies"),
+        Some("optionalDependencies"),
+        Some("peerDependencies"),
+        include_dev_dependencies.then_some("devDependencies"),
+    ];
+    for section in sections.into_iter().flatten() {
         let Some(dependencies) = value.get(section).and_then(serde_json::Value::as_object) else {
             continue;
         };
@@ -508,6 +531,245 @@ fn workspace_dependency_names(value: &serde_json::Value) -> BTreeSet<String> {
         }
     }
     names
+}
+
+fn source_plugin_inventory(repo_path: &Path) -> Result<SourcePluginInventory, String> {
+    let extensions_dir = repo_path.join("extensions");
+    let entries = fs::read_dir(&extensions_dir).map_err(|error| error.to_string())?;
+    let mut inventory = SourcePluginInventory::default();
+
+    // The manifest id is the runtime identity. Directory names are retained separately because
+    // OpenClaw permits a source directory such as kimi-coding to expose plugin id "kimi".
+    for entry in entries {
+        let entry = entry.map_err(|error| error.to_string())?;
+        if !entry
+            .file_type()
+            .map_err(|error| error.to_string())?
+            .is_dir()
+        {
+            continue;
+        }
+        let source_dir = entry.path();
+        let manifest_path = source_dir.join("openclaw.plugin.json");
+        if !manifest_path.exists() {
+            continue;
+        }
+        let manifest: serde_json::Value = read_json(&manifest_path)
+            .map_err(|error| format!("invalid source plugin manifest: {error}"))?;
+        let id = manifest
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                format!(
+                    "source plugin manifest has no id: {}",
+                    display_path(&manifest_path)
+                )
+            })?
+            .to_string();
+        let directory_name = entry.file_name().to_string_lossy().to_string();
+        if let Some(previous) = inventory.by_id.get(&id) {
+            return Err(format!(
+                "source plugin id \"{id}\" is ambiguous between extensions/{} and extensions/{directory_name}",
+                previous.directory_name
+            ));
+        }
+
+        let package_path = source_dir.join("package.json");
+        let (package_name, dependency_names) = if package_path.exists() {
+            let package: serde_json::Value = read_json(&package_path)
+                .map_err(|error| format!("invalid source plugin package: {error}"))?;
+            let package_name = package
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| npm_package_relative_path(value).is_some())
+                .ok_or_else(|| format!("source plugin \"{id}\" has no valid npm package name"))?
+                .to_string();
+            (
+                Some(package_name),
+                workspace_dependency_names(&package, false),
+            )
+        } else {
+            // Source-only plugin directories without package.json are built into the core archive
+            // and cannot be selected as separately packed source plugins.
+            (None, BTreeSet::new())
+        };
+
+        if let Some(package_name) = package_name.as_deref()
+            && let Some(previous_id) = inventory
+                .id_by_package_name
+                .insert(package_name.to_string(), id.clone())
+        {
+            return Err(format!(
+                "source plugin npm package \"{package_name}\" is ambiguous between plugin ids \"{previous_id}\" and \"{id}\""
+            ));
+        }
+        inventory.by_id.insert(
+            id,
+            SourcePluginDefinition {
+                directory_name,
+                package_name,
+                dependency_names,
+            },
+        );
+    }
+    Ok(inventory)
+}
+
+fn source_plugin_dependency_closure(
+    direct: BTreeSet<String>,
+    inventory: &SourcePluginInventory,
+) -> Result<BTreeSet<String>, String> {
+    let mut ids = BTreeSet::new();
+    let mut pending = direct.into_iter().collect::<Vec<_>>();
+    while let Some(id) = pending.pop() {
+        if !ids.insert(id.clone()) {
+            continue;
+        }
+        let plugin = inventory.by_id.get(&id).ok_or_else(|| {
+            format!("source plugin \"{id}\" disappeared during closure resolution")
+        })?;
+        for dependency_name in &plugin.dependency_names {
+            if let Some(dependency_id) = inventory.id_by_package_name.get(dependency_name)
+                && !ids.contains(dependency_id)
+            {
+                pending.push(dependency_id.clone());
+            }
+        }
+    }
+    Ok(ids)
+}
+
+fn collect_plugin_ids_from_records(value: &serde_json::Value, ids: &mut BTreeSet<String>) {
+    for pointer in ["/plugins/installs", "/installRecords"] {
+        if let Some(records) = value
+            .pointer(pointer)
+            .and_then(serde_json::Value::as_object)
+        {
+            ids.extend(records.keys().filter_map(|id| normalized_plugin_id(id)));
+        }
+    }
+    if let Some(records) = value.get("plugins").and_then(serde_json::Value::as_array) {
+        ids.extend(
+            records
+                .iter()
+                .filter_map(|record| record.get("pluginId")?.as_str())
+                .filter_map(normalized_plugin_id),
+        );
+    }
+}
+
+fn normalized_plugin_id(id: &str) -> Option<String> {
+    let id = id.trim();
+    (!id.is_empty()).then(|| id.to_string())
+}
+
+fn collect_explicit_plugin_references(config: &serde_json::Value) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    let Some(plugins) = config.get("plugins").and_then(serde_json::Value::as_object) else {
+        return ids;
+    };
+    if let Some(entries) = plugins
+        .get("entries")
+        .and_then(serde_json::Value::as_object)
+    {
+        ids.extend(
+            entries
+                .iter()
+                .filter(|(_, entry)| {
+                    entry.get("enabled").and_then(serde_json::Value::as_bool) != Some(false)
+                })
+                .filter_map(|(id, _)| normalized_plugin_id(id)),
+        );
+    }
+    if let Some(values) = plugins.get("allow").and_then(serde_json::Value::as_array) {
+        ids.extend(
+            values
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .filter_map(normalized_plugin_id),
+        );
+    }
+    if let Some(slots) = plugins.get("slots").and_then(serde_json::Value::as_object) {
+        ids.extend(
+            slots
+                .values()
+                .filter_map(serde_json::Value::as_str)
+                .filter(|id| id.trim() != "none")
+                .filter_map(normalized_plugin_id),
+        );
+    }
+    if let Some(deny) = plugins.get("deny").and_then(serde_json::Value::as_array) {
+        for id in deny.iter().filter_map(serde_json::Value::as_str) {
+            ids.remove(id.trim());
+        }
+    }
+    ids
+}
+
+fn installed_target_plugin_ids(
+    paths: &super::layout::EnvPaths,
+    config: &serde_json::Value,
+) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    collect_plugin_ids_from_records(config, &mut ids);
+    let installs_path = paths.state_dir.join("plugins/installs.json");
+    if let Ok(value) = read_json::<serde_json::Value>(&installs_path) {
+        collect_plugin_ids_from_records(&value, &mut ids);
+    }
+    ids
+}
+
+fn resolve_target_source_plugin_closure(
+    target_env: &str,
+    repo_path: &Path,
+    context: InstallContext<'_>,
+) -> Result<BTreeSet<String>, String> {
+    let target_env = validate_name(target_env, "Environment name")?;
+    let target = get_environment(&target_env, context.env, context.cwd)?;
+    let paths = derive_env_paths(Path::new(&target.root));
+    let config = load_effective_openclaw_config(&paths.config_path)?
+        .map(|resolved| resolved.value)
+        .unwrap_or_else(|| serde_json::json!({}));
+    if config
+        .pointer("/plugins/enabled")
+        .and_then(serde_json::Value::as_bool)
+        == Some(false)
+    {
+        return Ok(BTreeSet::new());
+    }
+
+    // Only OpenClaw's explicit plugin policy fields are part of this contract. Inferring plugin
+    // ids from arbitrary provider, agent, or plugin-owned config would create false dependencies.
+    let inventory = source_plugin_inventory(repo_path)?;
+    let source_ids = inventory.by_id.keys().cloned().collect::<BTreeSet<_>>();
+    let explicit = collect_explicit_plugin_references(&config);
+    let installed = installed_target_plugin_ids(&paths, &config);
+    let missing = explicit
+        .iter()
+        .filter(|id| !source_ids.contains(*id) && !installed.contains(*id))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(format!(
+            "target environment \"{target_env}\" references plugins unavailable from the selected checkout or its installed plugin records: {}. Repair the target plugin config or install the missing plugins before building",
+            missing.join(", ")
+        ));
+    }
+
+    let mut direct = explicit;
+    direct.retain(|id| {
+        inventory
+            .by_id
+            .get(id)
+            .is_some_and(|plugin| plugin.package_name.is_some())
+    });
+
+    // Follow local workspace dependencies by npm package name so a selected plugin is installed
+    // with every separately packed source plugin it imports at runtime.
+    source_plugin_dependency_closure(direct, &inventory)
 }
 
 fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>, String> {
@@ -525,7 +787,7 @@ fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>,
         )
     })?;
 
-    let mut pending = workspace_dependency_names(&root_package);
+    let mut pending = workspace_dependency_names(&root_package, true);
     if pending.is_empty() {
         return Ok(None);
     }
@@ -568,7 +830,7 @@ fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>,
             )
         })?;
         selected.insert(name, package_dir.clone());
-        pending.extend(workspace_dependency_names(package_value));
+        pending.extend(workspace_dependency_names(package_value, true));
     }
 
     std::env::join_paths(selected.into_values())
@@ -857,11 +1119,12 @@ fn npm_package_relative_path(package_name: &str) -> Option<PathBuf> {
     valid_component(package_name).then(|| PathBuf::from(package_name))
 }
 
-fn local_source_extensions_omitted_from_package(
+fn local_source_extensions_from_build(
     repo_path: &Path,
-    archive_path: &Path,
+    packaged_ids: &BTreeSet<String>,
+    include_packaged: bool,
+    target_ids: Option<&BTreeSet<String>>,
 ) -> Result<Vec<LocalSourceExtension>, String> {
-    let packaged_ids = packaged_openclaw_extension_ids(archive_path)?;
     let extensions_dir = repo_path.join("dist/extensions");
     let entries = fs::read_dir(&extensions_dir).map_err(|error| {
         format!(
@@ -881,8 +1144,10 @@ fn local_source_extensions_omitted_from_package(
         {
             continue;
         }
-        let id = entry.file_name().to_string_lossy().to_string();
-        if id == "node_modules" || packaged_ids.contains(&id) {
+        let directory_name = entry.file_name().to_string_lossy().to_string();
+        if directory_name == "node_modules"
+            || (!include_packaged && packaged_ids.contains(&directory_name))
+        {
             continue;
         }
         let package_json_path = source_dir.join("package.json");
@@ -890,9 +1155,24 @@ fn local_source_extensions_omitted_from_package(
         if !package_json_path.exists() && !manifest_path.exists() {
             continue;
         }
+        let id = fs::read_to_string(&manifest_path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+            .and_then(|manifest| {
+                manifest
+                    .get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| directory_name.clone());
+        if target_ids.is_some_and(|target_ids| !target_ids.contains(&id)) {
+            continue;
+        }
         let raw = fs::read_to_string(&package_json_path).map_err(|error| {
             format!(
-                "source extension \"{id}\" cannot be packaged because {} is unavailable: {error}",
+                "source extension \"{directory_name}\" cannot be packaged because {} is unavailable: {error}",
                 display_path(&package_json_path)
             )
         })?;
@@ -919,10 +1199,13 @@ fn local_source_extensions_omitted_from_package(
                 "multiple source extensions use npm package name \"{package_name}\""
             ));
         }
+        let materialize = !packaged_ids.contains(&directory_name);
         extensions.push(LocalSourceExtension {
             id,
+            directory_name,
             package_name,
             source_dir,
+            materialize,
         });
     }
     extensions.sort_by(|left, right| left.id.cmp(&right.id));
@@ -1044,6 +1327,9 @@ fn materialize_local_source_extensions(
 ) -> Result<(), String> {
     let target_root = installed_openclaw_package_root(install_files).join("dist/extensions");
     for extension in extensions {
+        if !extension.extension.materialize {
+            continue;
+        }
         let package_relative_path = npm_package_relative_path(&extension.extension.package_name)
             .ok_or_else(|| {
                 format!(
@@ -1061,7 +1347,7 @@ fn materialize_local_source_extensions(
                 display_path(&installed_package.join("package.json"))
             ));
         }
-        let target = target_root.join(&extension.extension.id);
+        let target = target_root.join(&extension.extension.directory_name);
         if path_exists(&target) {
             return Err(format!(
                 "source extension target already exists after package installation: {}",
@@ -1638,6 +1924,11 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
     let repo_path = fs::canonicalize(&repo_path).map_err(|error| error.to_string())?;
     let version = load_openclaw_repo_version(&repo_path)?;
     let commit = git_short_commit(&repo_path);
+    let target_source_plugins = options
+        .target_env
+        .as_deref()
+        .map(|target_env| resolve_target_source_plugin_closure(target_env, &repo_path, context))
+        .transpose()?;
     let stores = super::ensure_store(context.env, context.cwd)?;
     let pack_dir = stores.runtimes_dir.join(format!(
         ".{name}.pack-{}-{}",
@@ -1650,9 +1941,43 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
         let local_adapter = local_build_npm_adapter(&repo_path, context.env)?;
         let archive_path =
             pack_local_openclaw_repo(&repo_path, &pack_dir, context.env, local_adapter.as_ref())?;
+        let needs_source_extensions = options.include_source_extensions
+            || target_source_plugins
+                .as_ref()
+                .is_some_and(|plugins| !plugins.is_empty());
+        let packaged_ids = needs_source_extensions
+            .then(|| packaged_openclaw_extension_ids(&archive_path))
+            .transpose()?
+            .unwrap_or_default();
         let source_extensions = if options.include_source_extensions {
             let extensions =
-                local_source_extensions_omitted_from_package(&repo_path, &archive_path)?;
+                local_source_extensions_from_build(&repo_path, &packaged_ids, false, None)?;
+            pack_local_source_extensions(extensions, &pack_dir, context.env)?
+        } else if let Some(target_source_plugins) = target_source_plugins
+            .as_ref()
+            .filter(|plugins| !plugins.is_empty())
+        {
+            let extensions = local_source_extensions_from_build(
+                &repo_path,
+                &packaged_ids,
+                true,
+                Some(target_source_plugins),
+            )?;
+            let available_ids = extensions
+                .iter()
+                .map(|extension| extension.id.clone())
+                .collect::<BTreeSet<_>>();
+            let missing = target_source_plugins
+                .difference(&available_ids)
+                .cloned()
+                .collect::<Vec<_>>();
+            if !missing.is_empty() {
+                return Err(format!(
+                    "the local OpenClaw build did not produce required source plugins for target environment {}: {}",
+                    options.target_env.as_deref().unwrap_or_default(),
+                    missing.join(", ")
+                ));
+            }
             pack_local_source_extensions(extensions, &pack_dir, context.env)?
         } else {
             Vec::new()
@@ -1982,7 +2307,93 @@ pub fn verify_runtime_binary(
 
 #[cfg(test)]
 mod tests {
-    use super::summarize_command_output;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use super::{
+        SourcePluginDefinition, SourcePluginInventory, collect_explicit_plugin_references,
+        source_plugin_dependency_closure, source_plugin_inventory, summarize_command_output,
+    };
+
+    #[test]
+    fn target_plugin_references_ignore_arbitrary_matching_config_values() {
+        let config = serde_json::json!({
+            "agents": { "list": [{ "id": "codex" }] },
+            "plugins": {
+                "entries": {
+                    "workboard": { "enabled": true },
+                    "disabled": { "enabled": false }
+                },
+                "deny": ["blocked"],
+                "allow": ["blocked", "allowed"],
+                "slots": { "memory": "memory-core" }
+            }
+        });
+
+        assert_eq!(
+            collect_explicit_plugin_references(&config),
+            BTreeSet::from([
+                "allowed".to_string(),
+                "memory-core".to_string(),
+                "workboard".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn source_plugin_inventory_rejects_ambiguous_manifest_ids() {
+        let repo = tempfile::tempdir().unwrap();
+        for directory in ["first", "second"] {
+            let plugin = repo.path().join("extensions").join(directory);
+            std::fs::create_dir_all(&plugin).unwrap();
+            std::fs::write(plugin.join("openclaw.plugin.json"), r#"{"id":"duplicate"}"#).unwrap();
+            std::fs::write(
+                plugin.join("package.json"),
+                format!(r#"{{"name":"@openclaw/{directory}"}}"#),
+            )
+            .unwrap();
+        }
+
+        let error = source_plugin_inventory(repo.path()).unwrap_err();
+
+        assert!(error.contains("source plugin id \"duplicate\" is ambiguous"));
+    }
+
+    #[test]
+    fn target_source_plugin_closure_includes_transitive_workspace_plugins() {
+        let inventory = SourcePluginInventory {
+            by_id: BTreeMap::from([
+                (
+                    "codex".to_string(),
+                    SourcePluginDefinition {
+                        directory_name: "codex".to_string(),
+                        package_name: Some("@openclaw/codex".to_string()),
+                        dependency_names: BTreeSet::from(["@openclaw/shared-ui".to_string()]),
+                    },
+                ),
+                (
+                    "shared-ui".to_string(),
+                    SourcePluginDefinition {
+                        directory_name: "shared-ui".to_string(),
+                        package_name: Some("@openclaw/shared-ui".to_string()),
+                        dependency_names: BTreeSet::new(),
+                    },
+                ),
+            ]),
+            id_by_package_name: BTreeMap::from([
+                ("@openclaw/codex".to_string(), "codex".to_string()),
+                ("@openclaw/shared-ui".to_string(), "shared-ui".to_string()),
+            ]),
+        };
+
+        let closure =
+            source_plugin_dependency_closure(BTreeSet::from(["codex".to_string()]), &inventory)
+                .unwrap();
+
+        assert_eq!(
+            closure,
+            BTreeSet::from(["codex".to_string(), "shared-ui".to_string()])
+        );
+    }
 
     #[test]
     fn command_summary_prefers_errors_over_npm_warnings() {

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -674,6 +674,11 @@ fn runtime_mutation_help_directs_bound_environments_to_upgrade() {
         assert!(stdout(&help).contains("ocm upgrade <env>"));
     }
 
+    let build_local = run_ocm(&cwd, &env, &["help", "runtime", "build-local"]);
+    let output = stdout(&build_local);
+    assert!(output.contains("--for-env <env>"));
+    assert!(output.contains("mutually exclusive"));
+
     let remove = run_ocm(&cwd, &env, &["help", "runtime", "remove"]);
     assert!(remove.status.success(), "{}", stderr(&remove));
     assert!(stdout(&remove).contains("Clear every environment binding"));

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -798,6 +798,243 @@ fn runtime_build_local_can_include_source_extensions_without_widening_default_tr
 }
 
 #[test]
+fn runtime_build_local_derives_source_plugins_from_target_env_before_pack() {
+    let root = TestDir::new("runtime-build-local-target-source-plugins");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    let source_codex_dir = repo.join("extensions/codex");
+    let built_codex_dir = repo.join("dist/extensions/codex");
+    for dir in [&source_codex_dir, &built_codex_dir] {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(
+            dir.join("package.json"),
+            br#"{"name":"@openclaw/codex","version":"2026.4.25","dependencies":{"codex-runtime":"1.0.0"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("openclaw.plugin.json"),
+            br#"{"id":"codex","configSchema":{"type":"object"}}"#,
+        )
+        .unwrap();
+    }
+    fs::write(
+        built_codex_dir.join("index.js"),
+        "export const build = 'source';\n",
+    )
+    .unwrap();
+    let unrelated_dir = repo.join("dist/extensions/unrelated");
+    fs::create_dir_all(&unrelated_dir).unwrap();
+    fs::write(
+        unrelated_dir.join("openclaw.plugin.json"),
+        br#"{"id":"unrelated"}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.4.25","bin":{"openclaw":"openclaw.mjs"}}"#,
+    )
+    .unwrap();
+
+    let archive_path = root.child("packed-openclaw.tgz");
+    fs::write(
+        &archive_path,
+        openclaw_package_tarball_with_bundled_extension(
+            "#!/usr/bin/env node\nconsole.log('target runtime');\n",
+            "2026.4.25",
+        ),
+    )
+    .unwrap();
+    let source_extension_archive = root.child("openclaw-codex-2026.4.25.tgz");
+    fs::write(
+        &source_extension_archive,
+        source_extension_package_tarball(),
+    )
+    .unwrap();
+
+    let mut env = ocm_env(&root);
+    env.insert(
+        "FAKE_SOURCE_EXTENSION_ARCHIVE".to_string(),
+        path_string(&source_extension_archive),
+    );
+    env.insert(
+        "FAKE_SOURCE_EXTENSION_NAME".to_string(),
+        "@openclaw/codex".to_string(),
+    );
+    env.insert(
+        "FAKE_SOURCE_EXTENSION_FILENAME".to_string(),
+        "openclaw-codex-2026.4.25.tgz".to_string(),
+    );
+    env.insert(
+        "FAKE_SOURCE_EXTENSION_INSTALL_PATH".to_string(),
+        "@openclaw/codex".to_string(),
+    );
+    install_fake_node_and_packing_npm(&root, &mut env, &archive_path);
+
+    let old_runtime = cwd.join("old-openclaw");
+    write_executable_script(&old_runtime, "#!/bin/sh\nexit 0\n");
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "add",
+            "old-local",
+            "--path",
+            old_runtime.to_str().unwrap(),
+        ],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "primary", "--runtime", "old-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    fs::write(
+        root.child("ocm-home/envs/primary/.openclaw/openclaw.json"),
+        br#"{"plugins":{"entries":{"codex":{"enabled":true}}}}"#,
+    )
+    .unwrap();
+
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "primary-test",
+            "--repo",
+            "./openclaw",
+            "--for-env",
+            "primary",
+            "--raw",
+        ],
+    );
+    assert!(build.status.success(), "{}", stderr(&build));
+    let runtime_root = runtime_install_root("primary-test", &env, &cwd)
+        .unwrap()
+        .join("files/node_modules/openclaw");
+    assert_eq!(
+        fs::read_to_string(runtime_root.join("dist/extensions/codex/index.js")).unwrap(),
+        "export const build = 'source';\n"
+    );
+}
+
+#[test]
+fn runtime_build_local_rejects_missing_target_plugin_before_pack() {
+    let root = TestDir::new("runtime-build-local-missing-target-plugin");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    fs::create_dir_all(repo.join("extensions/codex")).unwrap();
+    fs::write(
+        repo.join("extensions/codex/openclaw.plugin.json"),
+        br#"{"id":"codex"}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("extensions/codex/package.json"),
+        br#"{"name":"@openclaw/codex","version":"2026.4.25"}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.4.25","bin":{"openclaw":"openclaw.mjs"}}"#,
+    )
+    .unwrap();
+
+    let archive_path = root.child("packed-openclaw.tgz");
+    fs::write(
+        &archive_path,
+        openclaw_package_tarball("#!/usr/bin/env node\n"),
+    )
+    .unwrap();
+    let mut env = ocm_env(&root);
+    let npm_log = install_fake_node_and_packing_npm(&root, &mut env, &archive_path);
+    let old_runtime = cwd.join("old-openclaw");
+    write_executable_script(&old_runtime, "#!/bin/sh\nexit 0\n");
+    let add = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "add",
+            "old-local",
+            "--path",
+            old_runtime.to_str().unwrap(),
+        ],
+    );
+    assert!(add.status.success(), "{}", stderr(&add));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "primary", "--runtime", "old-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    fs::write(
+        root.child("ocm-home/envs/primary/.openclaw/openclaw.json"),
+        br#"{"plugins":{"entries":{"missing-plugin":{"enabled":true}}}}"#,
+    )
+    .unwrap();
+
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "primary-test",
+            "--repo",
+            "./openclaw",
+            "--for-env",
+            "primary",
+            "--raw",
+        ],
+    );
+    assert!(!build.status.success(), "{}", stdout(&build));
+    assert!(
+        stderr(&build).contains("missing-plugin"),
+        "{}",
+        stderr(&build)
+    );
+    assert!(
+        !npm_log.exists(),
+        "npm pack must not run after preflight failure"
+    );
+}
+
+#[test]
+fn runtime_build_local_rejects_conflicting_source_plugin_modes() {
+    let root = TestDir::new("runtime-build-local-conflicting-source-plugin-modes");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "primary-test",
+            "--repo",
+            "./openclaw",
+            "--for-env",
+            "primary",
+            "--include-source-extensions",
+        ],
+    );
+
+    assert!(!build.status.success(), "{}", stdout(&build));
+    assert!(
+        stderr(&build).contains(
+            "runtime build-local accepts only one of --include-source-extensions or --for-env"
+        ),
+        "{}",
+        stderr(&build)
+    );
+}
+
+#[test]
 fn runtime_build_local_rejects_a_bound_runtime_before_repo_validation() {
     let root = TestDir::new("runtime-build-local-bound");
     let cwd = root.child("workspace");


### PR DESCRIPTION
## What

Add target-aware source-plugin packaging to `ocm runtime build-local` through `--for-env <env>`.

## Why

Release-shaped local builds omit source-only plugins. An environment that references one of those plugins can fail after the build because its runtime lacks the required plugin entrypoint. OCM now resolves the target environment's explicit plugin policy before packing and includes the required local workspace plugin closure.

Maintainer decision: sponsor `--for-env` as the supported selective source-plugin build mode. The existing `--include-source-extensions` mode remains available when an operator intentionally wants every source extension.

## Changes

- Add the `--for-env` build option
- Load effective target config and install records
- Resolve transitive source-plugin dependencies
- Reject missing and ambiguous plugin references
- Preserve release-shaped default build behavior
- Document mutually exclusive source modes

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo test --locked --lib`
- `cargo test --locked --test runtime_command_tests runtime_build_local_`
- `cargo test --locked --test launcher_help_tests`
- `cargo clippy --workspace --all-targets --locked`

The full runtime command suite passed 48 of 49 tests. Its existing concurrent-install timing test failed waiting for the first tarball request, then passed when rerun alone.

## Real behavior proof

The proof used a standalone OpenClaw checkout at `1d36dac99d136a551b03fc8db773c0ec6dbd95b6`. Dependencies were installed inside that checkout, so the build did not reuse the primary checkout's linked `node_modules`.

The target environment enables `codex`, `diffs`, `openai`, `reef`, and `workboard`. The target-aware build completed:

```text
$ cargo run --quiet -- runtime build-local pr89-primary-1d36 \
    --repo /Users/jalehman/Projects/ocm-pr89-openclaw-proof \
    --for-env primary --raw
Built runtime pr89-primary-1d36
binary: /Users/jalehman/.ocm/runtimes/pr89-primary-1d36/files/node_modules/openclaw/openclaw.mjs
```

I cloned the primary environment with its service disabled, bound the clone to the new runtime, and listed plugins through that runtime:

```text
$ cargo run --quiet -- env set-runtime pr89-primary-proof pr89-primary-1d36 --raw
Updated env pr89-primary-proof: defaultRuntime=pr89-primary-1d36

$ cargo run --quiet -- @pr89-primary-proof -- plugins list --json
codex        loaded  .../pr89-primary-1d36/files/node_modules/openclaw/dist/extensions/codex/index.js
diffs        loaded  .../pr89-primary-1d36/files/node_modules/openclaw/dist/extensions/diffs/index.js
memory-core  loaded  .../pr89-primary-1d36/files/node_modules/openclaw/dist/extensions/memory-core/index.js
openai       loaded  .../pr89-primary-1d36/files/node_modules/openclaw/dist/extensions/openai/index.js
reef         loaded  .../pr89-primary-1d36/files/node_modules/openclaw/dist/extensions/reef/index.js
workboard    loaded  .../pr89-primary-1d36/files/node_modules/openclaw/dist/extensions/workboard/index.js
```

The clone remained stopped on port `19011`. The primary environment remained running on port `18789` with zero child restarts.
