### PR TITLE
test: replace supervisor runtime fixtures atomically

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -16,9 +16,11 @@ use std::time::Duration;
 
 use base64::Engine;
 use flate2::{Compression, write::GzEncoder};
+use serde::Serialize;
 use sha2::Digest;
 use sha2::Sha512;
 use tar::{Builder, Header};
+use tempfile::NamedTempFile;
 use zip::ZipWriter;
 use zip::write::SimpleFileOptions;
 
@@ -271,6 +273,16 @@ pub fn write_text(path: &Path, contents: &str) {
         fs::create_dir_all(parent).unwrap();
     }
     fs::write(path, contents).unwrap();
+}
+
+/// Writes a complete JSON document by atomically replacing the destination path.
+pub fn write_json_replacing_path<T: Serialize>(path: &Path, value: &T) {
+    let parent = path.parent().unwrap();
+    fs::create_dir_all(parent).unwrap();
+    let mut temp = NamedTempFile::new_in(parent).unwrap();
+    serde_json::to_writer(&mut temp, value).unwrap();
+    temp.write_all(b"\n").unwrap();
+    temp.persist(path).unwrap();
 }
 
 pub fn write_executable_script(path: &Path, contents: &str) {

--- a/tests/upgrade_availability_tests.rs
+++ b/tests/upgrade_availability_tests.rs
@@ -20,7 +20,7 @@ use tar::{Builder, Header};
 
 use crate::support::{
     TestDir, TestHttpServer, install_fake_launchctl, install_fake_node_and_npm, ocm_env,
-    path_string, run_ocm, stderr,
+    path_string, run_ocm, stderr, write_json_replacing_path,
 };
 
 const PREPARE_DELAY: Duration = Duration::from_millis(1_500);
@@ -261,7 +261,7 @@ fn write_running_supervisor_runtime(
             stderr_path,
         }],
     };
-    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+    write_json_replacing_path(runtime_path, &runtime);
 }
 
 fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
@@ -273,7 +273,7 @@ fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
         services: Vec::new(),
         children: Vec::new(),
     };
-    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+    write_json_replacing_path(runtime_path, &runtime);
 }
 
 fn fixture_openclaw_script(version: &str) -> String {

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -25,7 +25,8 @@ use tar::{Builder, Header};
 
 use crate::support::{
     TestDir, TestHttpServer, install_fake_launchctl, install_fake_node_and_npm, ocm_env,
-    path_string, run_ocm, stderr, stdout, write_executable_script, write_text,
+    path_string, run_ocm, stderr, stdout, write_executable_script, write_json_replacing_path,
+    write_text,
 };
 
 fn append_tar_file(
@@ -107,7 +108,7 @@ fn write_running_supervisor_runtime(
             stderr_path,
         }],
     };
-    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+    write_json_replacing_path(runtime_path, &runtime);
 }
 
 fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
@@ -119,7 +120,7 @@ fn write_empty_supervisor_runtime(runtime_path: &Path, ocm_home: &str) {
         services: Vec::new(),
         children: Vec::new(),
     };
-    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+    write_json_replacing_path(runtime_path, &runtime);
 }
 
 fn write_backoff_supervisor_runtime(
@@ -152,7 +153,26 @@ fn write_backoff_supervisor_runtime(
         }],
         children: Vec::new(),
     };
-    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+    write_json_replacing_path(runtime_path, &runtime);
+}
+
+#[test]
+fn supervisor_runtime_fixture_writes_replace_complete_documents() {
+    let root = TestDir::new("supervisor-runtime-fixture-replacement");
+    let runtime_path = root.child("runtime.json");
+    let ocm_home = path_string(&root.child("ocm-home"));
+
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "stable", 4242, 18789);
+    // A reader that opened the previous snapshot must retain that complete document
+    // while the runtime path moves to the next snapshot.
+    let prior_runtime = fs::File::open(&runtime_path).unwrap();
+    write_empty_supervisor_runtime(&runtime_path, &ocm_home);
+
+    let prior_json: Value = serde_json::from_reader(prior_runtime).unwrap();
+    assert_eq!(prior_json["services"].as_array().unwrap().len(), 1);
+
+    let current_json: Value = serde_json::from_slice(&fs::read(&runtime_path).unwrap()).unwrap();
+    assert!(current_json["services"].as_array().unwrap().is_empty());
 }
 
 fn spawn_converging_health_server() -> (


### PR DESCRIPTION
## What

Use atomic path replacement when upgrade tests publish simulated supervisor runtime state.

## Why

The fixture helpers used `fs::write`, which truncates `runtime.json` before writing the next document. Concurrent OCM commands could read the file during that interval and fail with `EOF while parsing a value`.

## Changes

- Add a shared atomic JSON fixture writer
- Update all upgrade supervisor-state writers
- Cover replacement semantics with an open reader

## Testing

- `cargo test --test upgrade_command_tests` (49 passed)
- `cargo test --test upgrade_availability_tests` (1 passed)
- `cargo check --all-targets` (passed)
- `cargo fmt --all -- --check` (passed)
- `cargo clippy --all-targets -- -D warnings` (blocked by four warnings in unchanged production code)
- Autoreview (no actionable findings)
