### PR TITLE
improve(upgrade): attribute and reduce stopped-window work

### DIFF
--- a/src/cli/render/upgrade.rs
+++ b/src/cli/render/upgrade.rs
@@ -587,6 +587,25 @@ fn upgrade_history_raw_line(record: &UpgradeHistoryRecord) -> Result<String, Str
     if let Some(rollback_of) = record.rollback_of.as_deref() {
         bits.push(format!("rollbackOf={rollback_of}"));
     }
+    if !record.phases.is_empty() {
+        bits.push(format!(
+            "phases={}",
+            record
+                .phases
+                .iter()
+                .map(|phase| format!(
+                    "{}:{}:{}:{}+{}:{}",
+                    phase.owner,
+                    phase.phase,
+                    phase.window,
+                    phase.started_offset_ms,
+                    phase.duration_ms,
+                    phase.outcome
+                ))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
     Ok(bits.join("  "))
 }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::{Cli, render};
@@ -23,14 +24,15 @@ use crate::runtime::{
 };
 use crate::service::{ServiceSummary, wait_for_gateway_readiness};
 use crate::store::{
-    InstallContext, RuntimeReleaseDetails, UpgradeHistoryBinding, UpgradeHistoryRecord,
-    UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage,
-    UpgradeRuntimeRecovery, clean_path, copy_dir_recursive, derive_env_paths, display_path,
-    ensure_minimum_local_openclaw_config, ensure_store, get_runtime, get_upgrade_history_record,
-    get_upgrade_runtime_recovery, install_runtime_from_selected_official_openclaw_release,
-    list_upgrade_history, lock_env_registry, lock_upgrade_transaction, remove_runtime,
-    remove_upgrade_recovery, resolve_absolute_path, runtime_install_root, runtime_integrity_issue,
-    runtime_meta_path, save_environment, save_upgrade_history_record, upgrade_history_recovery_dir,
+    InstallContext, RuntimeReleaseDetails, UpgradeHistoryBinding, UpgradeHistoryPhaseTiming,
+    UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState,
+    UpgradeHistoryStage, UpgradeRuntimeRecovery, clean_path, copy_dir_recursive, derive_env_paths,
+    display_path, ensure_minimum_local_openclaw_config, ensure_store, get_runtime,
+    get_upgrade_history_record, get_upgrade_runtime_recovery,
+    install_runtime_from_selected_official_openclaw_release, list_upgrade_history,
+    lock_env_registry, lock_upgrade_transaction, remove_runtime, remove_upgrade_recovery,
+    resolve_absolute_path, runtime_install_root, runtime_integrity_issue, runtime_meta_path,
+    save_environment, save_upgrade_history_record, upgrade_history_recovery_dir,
     upgrade_history_runtime_recovery_dir, write_json,
 };
 
@@ -173,6 +175,97 @@ struct UpgradeSimulationOptions {
 struct UpgradeTransactionPlan {
     source: UpgradeHistoryBinding,
     target: UpgradeHistoryBinding,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct UpgradePhaseStart {
+    at: Instant,
+    started_offset_ms: u64,
+}
+
+#[derive(Debug)]
+struct UpgradeTimingRecorder {
+    started_at: time::OffsetDateTime,
+    origin: Instant,
+    phases: Vec<UpgradeHistoryPhaseTiming>,
+}
+
+impl UpgradeTimingRecorder {
+    fn new() -> Self {
+        Self {
+            started_at: time::OffsetDateTime::now_utc(),
+            origin: Instant::now(),
+            phases: Vec::new(),
+        }
+    }
+
+    fn start(&self) -> UpgradePhaseStart {
+        let at = Instant::now();
+        UpgradePhaseStart {
+            at,
+            started_offset_ms: duration_ms(at.duration_since(self.origin)),
+        }
+    }
+
+    fn finish(
+        &mut self,
+        owner: &str,
+        phase: &str,
+        window: &str,
+        started: UpgradePhaseStart,
+        outcome: &str,
+    ) {
+        self.phases.push(UpgradeHistoryPhaseTiming {
+            owner: owner.to_string(),
+            phase: phase.to_string(),
+            window: window.to_string(),
+            started_offset_ms: started.started_offset_ms,
+            duration_ms: duration_ms(started.at.elapsed()),
+            outcome: outcome.to_string(),
+        });
+    }
+
+    fn record(
+        &mut self,
+        owner: &str,
+        phase: &str,
+        window: &str,
+        started_offset_ms: u64,
+        duration_ms: u64,
+        outcome: &str,
+    ) {
+        self.phases.push(UpgradeHistoryPhaseTiming {
+            owner: owner.to_string(),
+            phase: phase.to_string(),
+            window: window.to_string(),
+            started_offset_ms,
+            duration_ms,
+            outcome: outcome.to_string(),
+        });
+    }
+
+    fn append_openclaw_phases(
+        &mut self,
+        command_started: UpgradePhaseStart,
+        phases: &[OpenClawFinalizePhaseTiming],
+    ) {
+        for phase in phases {
+            self.phases.push(UpgradeHistoryPhaseTiming {
+                owner: "openclaw".to_string(),
+                phase: phase.phase.clone(),
+                window: "stopped".to_string(),
+                started_offset_ms: command_started
+                    .started_offset_ms
+                    .saturating_add(phase.started_offset_ms),
+                duration_ms: phase.duration_ms,
+                outcome: phase.outcome.clone(),
+            });
+        }
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 #[derive(Clone, Debug)]
@@ -714,6 +807,7 @@ impl Cli {
             true,
             "pre-rollback",
             Some(plan.record.id.clone()),
+            UpgradeTimingRecorder::new(),
         )?;
         let rollback_transaction_id = transaction.id.clone();
         let safety_snapshot_id = transaction.snapshot_id.clone();
@@ -1720,6 +1814,8 @@ impl Cli {
             } else {
                 vec![target_runtime_name.clone()]
             };
+            let mut timings = UpgradeTimingRecorder::new();
+            let preparation_started = timings.start();
             let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
                 Ok(prepared) => prepared,
                 Err(error) => {
@@ -1735,6 +1831,13 @@ impl Cli {
                     );
                 }
             };
+            timings.finish(
+                "ocm",
+                "preparation",
+                "preparation",
+                preparation_started,
+                "completed",
+            );
             let target_changed = !matches!(prepared.action, OfficialRuntimePrepareAction::Reused);
             let mut transaction = self.begin_upgrade_transaction_locked(
                 env_name,
@@ -1754,6 +1857,7 @@ impl Cli {
                 options.rollback_enabled,
                 "pre-upgrade",
                 None,
+                timings,
             )?;
             if target_changed {
                 transaction.mark_runtime_mutated(&prepared.name);
@@ -1775,26 +1879,31 @@ impl Cli {
                 }
             };
             let binding_changed = prepared.name != current.name;
-            let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
-                Ok(note) => {
-                    transaction.mark_post_update_completed(note.as_deref());
-                    note
-                }
-                Err(error) => {
-                    transaction.mark_post_update_failed(&error);
-                    return self.rollback_failed_upgrade(
-                        env_name,
-                        "runtime",
-                        previous_binding_name,
-                        "runtime",
-                        prepared.name,
-                        prepared.meta.release_version,
-                        prepared.meta.release_channel,
-                        transaction,
-                        error,
-                    );
-                }
-            };
+            let post_update =
+                match self.run_post_core_update(env_name, &prepared.name, &mut transaction.timings)
+                {
+                    Ok(result) => {
+                        transaction.mark_post_update_completed(result.note.as_deref());
+                        result
+                    }
+                    Err(error) => {
+                        transaction.mark_post_update_failed(&error);
+                        return self.rollback_failed_upgrade(
+                            env_name,
+                            "runtime",
+                            previous_binding_name,
+                            "runtime",
+                            prepared.name,
+                            prepared.meta.release_version,
+                            prepared.meta.release_channel,
+                            transaction,
+                            error,
+                        );
+                    }
+                };
+            let post_update_note = post_update.note;
+            let completion_deferred = post_update.completion_deferred;
+            let publish_started = transaction.timings.start();
             let publish_result = if binding_changed {
                 self.environment_service()
                     .set_runtime_locked(env_name, prepared.name.as_str())
@@ -1803,6 +1912,17 @@ impl Cli {
                 self.runtime_service()
                     .refresh_supervisor_if_present(&prepared.name)
             };
+            transaction.timings.finish(
+                "ocm",
+                "bindingPublish",
+                "stopped",
+                publish_started,
+                if publish_result.is_ok() {
+                    "completed"
+                } else {
+                    "failed"
+                },
+            );
             if let Err(error) = publish_result {
                 return self.rollback_failed_upgrade(
                     env_name,
@@ -1821,6 +1941,7 @@ impl Cli {
                 service.as_ref(),
                 binding_changed,
                 true,
+                &mut transaction.timings,
             );
             let (service_action, service_note) = match service_result {
                 Ok(result) => result,
@@ -1845,13 +1966,36 @@ impl Cli {
                     note_for_official_prepare_action(&prepared.action)
                 }
             });
+            let completion_note = self.refresh_deferred_completion_cache(
+                env_name,
+                &prepared.name,
+                completion_deferred,
+                &mut transaction.timings,
+            );
+            let verification_started = transaction.timings.start();
             let verification_note = match self.verify_upgraded_openclaw(
                 env_name,
                 prepared.meta.release_version.as_deref(),
                 service_action.is_some(),
             ) {
-                Ok(note) => note,
+                Ok(note) => {
+                    transaction.timings.finish(
+                        "ocm",
+                        "deepVerification",
+                        "post-ready",
+                        verification_started,
+                        "completed",
+                    );
+                    note
+                }
                 Err(error) => {
+                    transaction.timings.finish(
+                        "ocm",
+                        "deepVerification",
+                        "post-ready",
+                        verification_started,
+                        "failed",
+                    );
                     return self.rollback_failed_upgrade(
                         env_name,
                         "runtime",
@@ -1866,7 +2010,10 @@ impl Cli {
                 }
             };
             let note = join_optional_warnings(
-                join_optional_warnings(post_update_note, runtime_note),
+                join_optional_warnings(
+                    join_optional_warnings(post_update_note, runtime_note),
+                    completion_note,
+                ),
                 verification_note,
             );
 
@@ -1966,6 +2113,8 @@ impl Cli {
                     ),
                 });
             }
+            let mut timings = UpgradeTimingRecorder::new();
+            let preparation_started = timings.start();
             let prepared = match self.prepare_isolated_upgrade_target(env_name, &target, resolved) {
                 Ok(prepared) => prepared,
                 Err(error) => {
@@ -1981,6 +2130,13 @@ impl Cli {
                     );
                 }
             };
+            timings.finish(
+                "ocm",
+                "preparation",
+                "preparation",
+                preparation_started,
+                "completed",
+            );
             let changed = matches!(
                 prepared.action,
                 OfficialRuntimePrepareAction::Installed | OfficialRuntimePrepareAction::Updated
@@ -2003,6 +2159,7 @@ impl Cli {
                 options.rollback_enabled,
                 "pre-upgrade",
                 None,
+                timings,
             )?;
             if changed {
                 transaction.mark_runtime_mutated(&prepared.name);
@@ -2023,11 +2180,12 @@ impl Cli {
                     );
                 }
             };
-            let post_update_note = if changed {
-                match self.run_post_core_update(env_name, &prepared.name) {
-                    Ok(note) => {
-                        transaction.mark_post_update_completed(note.as_deref());
-                        note
+            let (post_update_note, completion_deferred) = if changed {
+                match self.run_post_core_update(env_name, &prepared.name, &mut transaction.timings)
+                {
+                    Ok(result) => {
+                        transaction.mark_post_update_completed(result.note.as_deref());
+                        (result.note, result.completion_deferred)
                     }
                     Err(error) => {
                         transaction.mark_post_update_failed(&error);
@@ -2046,13 +2204,27 @@ impl Cli {
                 }
             } else {
                 transaction.mark_post_update_not_needed();
-                None
+                (None, false)
             };
-            if changed
-                && let Err(error) = self
-                    .runtime_service()
+            let publish_started = transaction.timings.start();
+            let publish_result = if changed {
+                self.runtime_service()
                     .refresh_supervisor_if_present(&prepared.name)
-            {
+            } else {
+                Ok(())
+            };
+            transaction.timings.finish(
+                "ocm",
+                "bindingPublish",
+                "stopped",
+                publish_started,
+                if publish_result.is_ok() {
+                    if changed { "completed" } else { "skipped" }
+                } else {
+                    "failed"
+                },
+            );
+            if let Err(error) = publish_result {
                 return self.rollback_failed_upgrade(
                     env_name,
                     "runtime",
@@ -2070,6 +2242,7 @@ impl Cli {
                 service.as_ref(),
                 false,
                 changed || transaction.service_quiesced,
+                &mut transaction.timings,
             );
             let (service_action, service_note) = match service_result {
                 Ok(result) => result,
@@ -2087,13 +2260,36 @@ impl Cli {
                     );
                 }
             };
+            let completion_note = self.refresh_deferred_completion_cache(
+                env_name,
+                &prepared.name,
+                completion_deferred,
+                &mut transaction.timings,
+            );
+            let verification_started = transaction.timings.start();
             let verification_note = match self.verify_upgraded_openclaw(
                 env_name,
                 prepared.meta.release_version.as_deref(),
                 service_action.is_some(),
             ) {
-                Ok(note) => note,
+                Ok(note) => {
+                    transaction.timings.finish(
+                        "ocm",
+                        "deepVerification",
+                        "post-ready",
+                        verification_started,
+                        "completed",
+                    );
+                    note
+                }
                 Err(error) => {
+                    transaction.timings.finish(
+                        "ocm",
+                        "deepVerification",
+                        "post-ready",
+                        verification_started,
+                        "failed",
+                    );
                     return self.rollback_failed_upgrade(
                         env_name,
                         "runtime",
@@ -2121,7 +2317,7 @@ impl Cli {
                 rollback: None,
                 note: join_optional_warnings(
                     join_optional_warnings(
-                        post_update_note,
+                        join_optional_warnings(post_update_note, completion_note),
                         service_note.or_else(|| note_for_official_prepare_action(&prepared.action)),
                     ),
                     verification_note,
@@ -2160,6 +2356,8 @@ impl Cli {
                 note: Some("dry run: no runtime, env, service, or snapshot changed".to_string()),
             });
         }
+        let mut timings = UpgradeTimingRecorder::new();
+        let preparation_started = timings.start();
         let prepared =
             match self.with_progress(format!("Updating runtime {}", current.name), || {
                 self.with_isolated_runtime_mutation(env_name, &current.name, || {
@@ -2181,6 +2379,13 @@ impl Cli {
                     );
                 }
             };
+        timings.finish(
+            "ocm",
+            "preparation",
+            "preparation",
+            preparation_started,
+            "completed",
+        );
         let mut transaction = self.begin_upgrade_transaction_locked(
             env_name,
             UpgradeTransactionPlan {
@@ -2199,6 +2404,7 @@ impl Cli {
             options.rollback_enabled,
             "pre-upgrade",
             None,
+            timings,
         )?;
         transaction.mark_runtime_mutated(&current.name);
         let updated = match prepared.commit() {
@@ -2217,30 +2423,45 @@ impl Cli {
                 );
             }
         };
-        let post_update_note = match self.run_post_core_update(env_name, &updated.name) {
-            Ok(note) => {
-                transaction.mark_post_update_completed(note.as_deref());
-                note
-            }
-            Err(error) => {
-                transaction.mark_post_update_failed(&error);
-                return self.rollback_failed_upgrade(
-                    env_name,
-                    "runtime",
-                    previous_binding_name,
-                    "runtime",
-                    updated.name,
-                    updated.release_version,
-                    updated.release_channel,
-                    transaction,
-                    error,
-                );
-            }
-        };
-        if let Err(error) = self
+        let post_update =
+            match self.run_post_core_update(env_name, &updated.name, &mut transaction.timings) {
+                Ok(result) => {
+                    transaction.mark_post_update_completed(result.note.as_deref());
+                    result
+                }
+                Err(error) => {
+                    transaction.mark_post_update_failed(&error);
+                    return self.rollback_failed_upgrade(
+                        env_name,
+                        "runtime",
+                        previous_binding_name,
+                        "runtime",
+                        updated.name,
+                        updated.release_version,
+                        updated.release_channel,
+                        transaction,
+                        error,
+                    );
+                }
+            };
+        let post_update_note = post_update.note;
+        let completion_deferred = post_update.completion_deferred;
+        let publish_started = transaction.timings.start();
+        let publish_result = self
             .runtime_service()
-            .refresh_supervisor_if_present(&updated.name)
-        {
+            .refresh_supervisor_if_present(&updated.name);
+        transaction.timings.finish(
+            "ocm",
+            "bindingPublish",
+            "stopped",
+            publish_started,
+            if publish_result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        if let Err(error) = publish_result {
             return self.rollback_failed_upgrade(
                 env_name,
                 "runtime",
@@ -2253,8 +2474,13 @@ impl Cli {
                 format!("failed to publish upgraded runtime: {error}"),
             );
         }
-        let service_result =
-            self.reconcile_upgraded_service_locked(env_name, service.as_ref(), false, true);
+        let service_result = self.reconcile_upgraded_service_locked(
+            env_name,
+            service.as_ref(),
+            false,
+            true,
+            &mut transaction.timings,
+        );
         let (service_action, service_note) = match service_result {
             Ok(result) => result,
             Err(error) => {
@@ -2271,13 +2497,36 @@ impl Cli {
                 );
             }
         };
+        let completion_note = self.refresh_deferred_completion_cache(
+            env_name,
+            &updated.name,
+            completion_deferred,
+            &mut transaction.timings,
+        );
+        let verification_started = transaction.timings.start();
         let verification_note = match self.verify_upgraded_openclaw(
             env_name,
             updated.release_version.as_deref(),
             service_action.is_some(),
         ) {
-            Ok(note) => note,
+            Ok(note) => {
+                transaction.timings.finish(
+                    "ocm",
+                    "deepVerification",
+                    "post-ready",
+                    verification_started,
+                    "completed",
+                );
+                note
+            }
             Err(error) => {
+                transaction.timings.finish(
+                    "ocm",
+                    "deepVerification",
+                    "post-ready",
+                    verification_started,
+                    "failed",
+                );
                 return self.rollback_failed_upgrade(
                     env_name,
                     "runtime",
@@ -2304,7 +2553,10 @@ impl Cli {
             snapshot_id: Some(transaction.snapshot_id.clone()),
             rollback: None,
             note: join_optional_warnings(
-                join_optional_warnings(post_update_note, service_note),
+                join_optional_warnings(
+                    join_optional_warnings(post_update_note, completion_note),
+                    service_note,
+                ),
                 verification_note,
             ),
         };
@@ -2393,6 +2645,8 @@ impl Cli {
             });
         }
 
+        let mut timings = UpgradeTimingRecorder::new();
+        let preparation_started = timings.start();
         let prepared = match self.prepare_isolated_upgrade_target(env_name, target, resolved) {
             Ok(prepared) => prepared,
             Err(error) => {
@@ -2408,6 +2662,13 @@ impl Cli {
                 );
             }
         };
+        timings.finish(
+            "ocm",
+            "preparation",
+            "preparation",
+            preparation_started,
+            "completed",
+        );
         let target_changed = !matches!(prepared.action, OfficialRuntimePrepareAction::Reused);
         let mut transaction = self.begin_upgrade_transaction_locked(
             env_name,
@@ -2427,6 +2688,7 @@ impl Cli {
             options.rollback_enabled,
             "pre-upgrade",
             None,
+            timings,
         )?;
         if target_changed {
             transaction.mark_runtime_mutated(&prepared.name);
@@ -2447,30 +2709,45 @@ impl Cli {
                 );
             }
         };
-        let post_update_note = match self.run_post_core_update(env_name, &prepared.name) {
-            Ok(note) => {
-                transaction.mark_post_update_completed(note.as_deref());
-                note
-            }
-            Err(error) => {
-                transaction.mark_post_update_failed(&error);
-                return self.rollback_failed_upgrade(
-                    env_name,
-                    "launcher",
-                    launcher_name.to_string(),
-                    "runtime",
-                    prepared.name,
-                    prepared.meta.release_version,
-                    prepared.meta.release_channel,
-                    transaction,
-                    error,
-                );
-            }
-        };
-        if let Err(error) = self
+        let post_update =
+            match self.run_post_core_update(env_name, &prepared.name, &mut transaction.timings) {
+                Ok(result) => {
+                    transaction.mark_post_update_completed(result.note.as_deref());
+                    result
+                }
+                Err(error) => {
+                    transaction.mark_post_update_failed(&error);
+                    return self.rollback_failed_upgrade(
+                        env_name,
+                        "launcher",
+                        launcher_name.to_string(),
+                        "runtime",
+                        prepared.name,
+                        prepared.meta.release_version,
+                        prepared.meta.release_channel,
+                        transaction,
+                        error,
+                    );
+                }
+            };
+        let post_update_note = post_update.note;
+        let completion_deferred = post_update.completion_deferred;
+        let publish_started = transaction.timings.start();
+        let publish_result = self
             .environment_service()
-            .set_runtime_locked(env_name, prepared.name.as_str())
-        {
+            .set_runtime_locked(env_name, prepared.name.as_str());
+        transaction.timings.finish(
+            "ocm",
+            "bindingPublish",
+            "stopped",
+            publish_started,
+            if publish_result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        if let Err(error) = publish_result {
             return self.rollback_failed_upgrade(
                 env_name,
                 "launcher",
@@ -2483,8 +2760,13 @@ impl Cli {
                 format!("failed to publish upgraded runtime: {error}"),
             );
         }
-        let service_result =
-            self.reconcile_upgraded_service_locked(env_name, service.as_ref(), true, true);
+        let service_result = self.reconcile_upgraded_service_locked(
+            env_name,
+            service.as_ref(),
+            true,
+            true,
+            &mut transaction.timings,
+        );
         let (service_action, service_note) = match service_result {
             Ok(result) => result,
             Err(error) => {
@@ -2501,13 +2783,36 @@ impl Cli {
                 );
             }
         };
+        let completion_note = self.refresh_deferred_completion_cache(
+            env_name,
+            &prepared.name,
+            completion_deferred,
+            &mut transaction.timings,
+        );
+        let verification_started = transaction.timings.start();
         let verification_note = match self.verify_upgraded_openclaw(
             env_name,
             prepared.meta.release_version.as_deref(),
             service_action.is_some(),
         ) {
-            Ok(note) => note,
+            Ok(note) => {
+                transaction.timings.finish(
+                    "ocm",
+                    "deepVerification",
+                    "post-ready",
+                    verification_started,
+                    "completed",
+                );
+                note
+            }
             Err(error) => {
+                transaction.timings.finish(
+                    "ocm",
+                    "deepVerification",
+                    "post-ready",
+                    verification_started,
+                    "failed",
+                );
                 return self.rollback_failed_upgrade(
                     env_name,
                     "launcher",
@@ -2535,7 +2840,7 @@ impl Cli {
             rollback: None,
             note: join_optional_warnings(
                 join_optional_warnings(
-                    post_update_note,
+                    join_optional_warnings(post_update_note, completion_note),
                     service_note
                         .or_else(|| Some(format!("env now uses runtime {}", prepared.name))),
                 ),
@@ -2793,6 +3098,7 @@ impl Cli {
         service: Option<&ServiceSummary>,
         binding_changed: bool,
         runtime_changed: bool,
+        timings: &mut UpgradeTimingRecorder,
     ) -> Result<(Option<String>, Option<String>), String> {
         let Some(service) = service else {
             return Ok((None, None));
@@ -2805,20 +3111,51 @@ impl Cli {
         }
 
         if service.running {
-            let restart = self
+            let convergence_started = timings.start();
+            let restart_result = self
                 .with_progress(format!("Restarting service for {env_name}"), || {
                     self.service_service().restart_locked(env_name)
-                })?;
-            self.wait_for_restarted_gateway_health(env_name, restart.desired_running)?;
+                });
+            timings.finish(
+                "ocm",
+                "supervisorConvergence",
+                "stopped",
+                convergence_started,
+                if restart_result.is_ok() {
+                    "completed"
+                } else {
+                    "failed"
+                },
+            );
+            let restart = restart_result?;
+            self.wait_for_restarted_gateway_health_timed(
+                env_name,
+                restart.desired_running,
+                timings,
+            )?;
             let note = join_warnings(&restart.warnings);
             return Ok((Some("restarted".to_string()), note));
         }
 
         if binding_changed || runtime_changed {
-            let start = self.with_progress(format!("Starting service for {env_name}"), || {
-                self.service_service().start_locked(env_name)
-            })?;
-            self.wait_for_restarted_gateway_health(env_name, start.desired_running)?;
+            let convergence_started = timings.start();
+            let start_result = self
+                .with_progress(format!("Starting service for {env_name}"), || {
+                    self.service_service().start_locked(env_name)
+                });
+            timings.finish(
+                "ocm",
+                "supervisorConvergence",
+                "stopped",
+                convergence_started,
+                if start_result.is_ok() {
+                    "completed"
+                } else {
+                    "failed"
+                },
+            );
+            let start = start_result?;
+            self.wait_for_restarted_gateway_health_timed(env_name, start.desired_running, timings)?;
             let note = join_warnings(&start.warnings);
             return Ok((Some("started".to_string()), note));
         }
@@ -2836,6 +3173,71 @@ impl Cli {
         }
 
         let readiness = wait_for_gateway_readiness(env_name, &self.env, &self.cwd)?;
+        if readiness.ready {
+            Ok(())
+        } else {
+            Err(format!(
+                "service restart did not recover: {}",
+                readiness
+                    .issue
+                    .unwrap_or_else(|| "gateway did not become ready".to_string())
+            ))
+        }
+    }
+
+    fn wait_for_restarted_gateway_health_timed(
+        &self,
+        env_name: &str,
+        action_desired_running: bool,
+        timings: &mut UpgradeTimingRecorder,
+    ) -> Result<(), String> {
+        if !action_desired_running {
+            return Ok(());
+        }
+
+        let started = timings.start();
+        let readiness = wait_for_gateway_readiness(env_name, &self.env, &self.cwd)?;
+        let elapsed_ms = duration_ms(started.at.elapsed());
+        let process_ms = readiness.process_observed_after_ms;
+        if let Some(process_ms) = process_ms {
+            timings.record(
+                "ocm",
+                "processSpawn",
+                "stopped",
+                started.started_offset_ms,
+                process_ms,
+                if process_ms == 0 {
+                    "already-observed"
+                } else {
+                    "completed"
+                },
+            );
+            timings.record(
+                "ocm",
+                "httpReady",
+                "stopped",
+                started.started_offset_ms.saturating_add(process_ms),
+                readiness
+                    .ready_after_ms
+                    .unwrap_or(elapsed_ms)
+                    .saturating_sub(process_ms),
+                if readiness.ready {
+                    "completed"
+                } else {
+                    "failed"
+                },
+            );
+        } else {
+            timings.record(
+                "ocm",
+                "processSpawn",
+                "stopped",
+                started.started_offset_ms,
+                elapsed_ms,
+                "failed",
+            );
+        }
+
         if readiness.ready {
             Ok(())
         } else {
@@ -2919,62 +3321,210 @@ impl Cli {
         &self,
         env_name: &str,
         runtime_name: &str,
-    ) -> Result<Option<String>, String> {
+        timings: &mut UpgradeTimingRecorder,
+    ) -> Result<PostCoreUpdateResult, String> {
         // Resolve the replacement explicitly while the previous binding remains published.
         // A failed finalizer can then roll back without ever activating the replacement.
-        let config_repaired = self.repair_target_openclaw_config(env_name, runtime_name)?;
-        self.run_update_mode_openclaw_command(
+        let config_repaired =
+            self.repair_target_openclaw_config(env_name, runtime_name, timings)?;
+        let finalize_started = timings.start();
+        let output = match self.run_update_mode_openclaw_command_output_with_env(
             env_name,
             runtime_name,
             "openclaw update finalize",
             &["update", "finalize", "--json", "--yes", "--no-restart"],
-        )?;
-        Ok(Some(if config_repaired {
-            "OpenClaw config repair and update finalization completed".to_string()
+            &[("OPENCLAW_UPDATE_POST_CORE", "1")],
+        ) {
+            Ok(output) => output,
+            Err(error) => {
+                timings.finish(
+                    "ocm",
+                    "openclawFinalize",
+                    "stopped",
+                    finalize_started,
+                    "failed",
+                );
+                return Err(error);
+            }
+        };
+        let child_phases = parse_openclaw_finalize_phases(&output.stdout);
+        if !output.status.success() {
+            if child_phases.is_empty() {
+                timings.finish(
+                    "ocm",
+                    "openclawFinalize",
+                    "stopped",
+                    finalize_started,
+                    "failed",
+                );
+            } else {
+                timings.append_openclaw_phases(finalize_started, &child_phases);
+            }
+            return Err(format!(
+                "openclaw update finalize failed: {}",
+                output.failure_summary()
+            ));
+        }
+        let completion_deferred = child_phases
+            .iter()
+            .any(|phase| phase.phase == "completionCache" && phase.outcome == "deferred");
+        if child_phases.is_empty() {
+            timings.finish(
+                "ocm",
+                "openclawFinalize",
+                "stopped",
+                finalize_started,
+                "completed",
+            );
         } else {
-            "OpenClaw update finalization completed".to_string()
-        }))
+            timings.append_openclaw_phases(finalize_started, &child_phases);
+        }
+        Ok(PostCoreUpdateResult {
+            note: Some(if config_repaired {
+                "OpenClaw config repair and update finalization completed".to_string()
+            } else {
+                "OpenClaw update finalization completed".to_string()
+            }),
+            completion_deferred,
+        })
+    }
+
+    fn refresh_deferred_completion_cache(
+        &self,
+        env_name: &str,
+        runtime_name: &str,
+        deferred: bool,
+        timings: &mut UpgradeTimingRecorder,
+    ) -> Option<String> {
+        if !deferred {
+            return None;
+        }
+        let started = timings.start();
+        let result = self.run_update_mode_openclaw_command(
+            env_name,
+            runtime_name,
+            "openclaw completion cache refresh",
+            &["completion", "--write-state"],
+        );
+        timings.finish(
+            "ocm",
+            "completionCache",
+            "post-ready",
+            started,
+            if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        result.err().map(|error| {
+            format!(
+                "OpenClaw completion cache refresh failed after readiness and can be retried manually: {error}"
+            )
+        })
     }
 
     fn repair_target_openclaw_config(
         &self,
         env_name: &str,
         runtime_name: &str,
+        timings: &mut UpgradeTimingRecorder,
     ) -> Result<bool, String> {
+        let validation_started = timings.start();
         let env = self
             .environment_service()
             .get(env_name)
             .map_err(|error| format!("failed to inspect OpenClaw config: {error}"))?;
         let config_path = derive_env_paths(Path::new(&env.root)).config_path;
         if !config_path.exists() {
+            timings.finish(
+                "ocm",
+                "targetConfigValidation",
+                "stopped",
+                validation_started,
+                "skipped",
+            );
             return Ok(false);
         }
 
-        let validation = self.run_update_mode_openclaw_command_output(
+        let validation = match self.run_update_mode_openclaw_command_output(
             env_name,
             runtime_name,
             "openclaw config validate",
             &["config", "validate"],
-        )?;
+        ) {
+            Ok(validation) => validation,
+            Err(error) => {
+                timings.finish(
+                    "ocm",
+                    "targetConfigValidation",
+                    "stopped",
+                    validation_started,
+                    "failed",
+                );
+                return Err(error);
+            }
+        };
+        let validation_unsupported = !validation.status.success()
+            && command_output_reports_unsupported_command(&validation.stdout, &validation.stderr);
+        timings.finish(
+            "ocm",
+            "targetConfigValidation",
+            "stopped",
+            validation_started,
+            if validation.status.success() {
+                "completed"
+            } else if validation_unsupported {
+                "skipped"
+            } else {
+                "failed"
+            },
+        );
         if validation.status.success() {
             return Ok(false);
         }
-        if command_output_reports_unsupported_command(&validation.stdout, &validation.stderr) {
+        if validation_unsupported {
             return Ok(false);
         }
 
-        self.run_update_mode_openclaw_command(
+        let doctor_started = timings.start();
+        let doctor_result = self.run_update_mode_openclaw_command(
             env_name,
             runtime_name,
             "openclaw doctor",
             &["doctor", "--non-interactive", "--fix"],
-        )?;
-        self.run_update_mode_openclaw_command(
+        );
+        timings.finish(
+            "ocm",
+            "doctor",
+            "stopped",
+            doctor_started,
+            if doctor_result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        doctor_result?;
+        let revalidation_started = timings.start();
+        let revalidation_result = self.run_update_mode_openclaw_command(
             env_name,
             runtime_name,
             "openclaw config validate after doctor",
             &["config", "validate"],
-        )?;
+        );
+        timings.finish(
+            "ocm",
+            "targetConfigRevalidation",
+            "stopped",
+            revalidation_started,
+            if revalidation_result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        revalidation_result?;
         Ok(true)
     }
 
@@ -3001,22 +3551,38 @@ impl Cli {
         name: &str,
         args: &[&str],
     ) -> Result<SimulationCommandOutput, String> {
+        self.run_update_mode_openclaw_command_output_with_env(
+            env_name,
+            runtime_name,
+            name,
+            args,
+            &[],
+        )
+    }
+
+    fn run_update_mode_openclaw_command_output_with_env(
+        &self,
+        env_name: &str,
+        runtime_name: &str,
+        name: &str,
+        args: &[&str],
+        extra_env: &[(&str, &str)],
+    ) -> Result<SimulationCommandOutput, String> {
         let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
         let resolved = self
             .environment_service()
             .resolve(env_name, Some(runtime_name.to_string()), None, &args)
             .map_err(|error| format!("{name} failed: {error}"))?;
-        self.run_resolved_for_simulation(
-            resolved,
-            &[
-                ("OPENCLAW_UPDATE_IN_PROGRESS", "1"),
-                ("OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE", "1"),
-                ("OPENCLAW_UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART", "1"),
-                ("OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR", "0"),
-                ("OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION", "0"),
-            ],
-        )
-        .map_err(|error| format!("{name} failed: {error}"))
+        let mut command_env = vec![
+            ("OPENCLAW_UPDATE_IN_PROGRESS", "1"),
+            ("OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE", "1"),
+            ("OPENCLAW_UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART", "1"),
+            ("OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR", "0"),
+            ("OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION", "0"),
+        ];
+        command_env.extend_from_slice(extra_env);
+        self.run_resolved_for_simulation(resolved, &command_env)
+            .map_err(|error| format!("{name} failed: {error}"))
     }
 
     fn run_launcher_mode_openclaw_command_output(
@@ -3044,7 +3610,9 @@ impl Cli {
         rollback_enabled: bool,
         snapshot_label: &str,
         rollback_of: Option<String>,
+        mut timings: UpgradeTimingRecorder,
     ) -> Result<UpgradeTransaction, String> {
+        let snapshot_preparation_started = timings.start();
         let env_meta = self.environment_service().get(env_name)?;
         let prepared = self
             .environment_service()
@@ -3090,6 +3658,14 @@ impl Cli {
             }
         }
 
+        timings.finish(
+            "ocm",
+            "snapshotPreparation",
+            "preparation",
+            snapshot_preparation_started,
+            "completed",
+        );
+        let quiescence_started = timings.start();
         let service_state = match self.service_service().quiesce_for_snapshot_locked(env_name) {
             Ok(service_state) => service_state,
             Err(error) => {
@@ -3099,7 +3675,7 @@ impl Cli {
                 return Err(error);
             }
         };
-        let started_at = time::OffsetDateTime::now_utc();
+        let started_at = timings.started_at;
         let id = format!(
             "{}-{:09}",
             started_at.unix_timestamp(),
@@ -3137,6 +3713,13 @@ impl Cli {
         };
 
         let service_quiesced = service_state.is_some();
+        timings.finish(
+            "ocm",
+            "quiescenceSnapshot",
+            "stopped",
+            quiescence_started,
+            "completed",
+        );
 
         Ok(UpgradeTransaction {
             id,
@@ -3145,6 +3728,7 @@ impl Cli {
             created_runtime_names,
             rollback_enabled,
             started_at,
+            timings,
             source: plan.source,
             target: plan.target,
             service_before: UpgradeHistoryServiceState {
@@ -3306,6 +3890,7 @@ impl Cli {
             started_at: transaction.started_at,
             completed_at: time::OffsetDateTime::now_utc(),
             outcome: summary.outcome.clone(),
+            phases: transaction.timings.phases.clone(),
             migration: transaction.migration.clone(),
             finalization: transaction.finalization.clone(),
             service_before: transaction.service_before.clone(),
@@ -3569,6 +4154,52 @@ struct PreparedUpgradeTarget {
     staged: Option<StagedRuntimeInstall>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenClawFinalizeReceipt {
+    #[serde(default)]
+    phase_timings: Vec<OpenClawFinalizePhaseTiming>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenClawFinalizePhaseTiming {
+    phase: String,
+    started_offset_ms: u64,
+    duration_ms: u64,
+    outcome: String,
+}
+
+#[derive(Debug)]
+struct PostCoreUpdateResult {
+    note: Option<String>,
+    completion_deferred: bool,
+}
+
+fn parse_openclaw_finalize_phases(stdout: &str) -> Vec<OpenClawFinalizePhaseTiming> {
+    let Ok(receipt) = serde_json::from_str::<OpenClawFinalizeReceipt>(stdout.trim()) else {
+        return Vec::new();
+    };
+    receipt
+        .phase_timings
+        .into_iter()
+        .filter(|phase| {
+            matches!(
+                phase.phase.as_str(),
+                "configSnapshot"
+                    | "doctor"
+                    | "plugins"
+                    | "targetConfigValidation"
+                    | "targetConfigConvergence"
+                    | "completionCache"
+            ) && matches!(
+                phase.outcome.as_str(),
+                "completed" | "failed" | "warning" | "skipped" | "deferred"
+            )
+        })
+        .collect()
+}
+
 impl PreparedUpgradeTarget {
     fn commit(mut self) -> Result<Self, String> {
         if let Some(staged) = self.staged.take() {
@@ -3719,6 +4350,7 @@ struct UpgradeTransaction {
     created_runtime_names: Vec<String>,
     rollback_enabled: bool,
     started_at: time::OffsetDateTime,
+    timings: UpgradeTimingRecorder,
     source: UpgradeHistoryBinding,
     target: UpgradeHistoryBinding,
     service_before: UpgradeHistoryServiceState,
@@ -4259,8 +4891,8 @@ fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
 mod tests {
     use super::{
         candidate_codex_preflight_is_unsupported, command_output_reports_unsupported_command,
-        release_version_from_output, verify_gateway_status_readiness,
-        version_output_matches_expected,
+        parse_openclaw_finalize_phases, release_version_from_output,
+        verify_gateway_status_readiness, version_output_matches_expected,
     };
 
     #[test]
@@ -4422,6 +5054,18 @@ mod tests {
             "",
             "OpenClaw config is invalid\nProblem: meta: Unrecognized key: lastTouchedAt"
         ));
+    }
+
+    #[test]
+    fn finalize_timing_parser_accepts_only_structured_safe_fields() {
+        let phases = parse_openclaw_finalize_phases(
+            r#"{"phaseTimings":[{"phase":"doctor","startedOffsetMs":7,"durationMs":11,"outcome":"warning","config":"secret"},{"phase":"config=/private/token","startedOffsetMs":0,"durationMs":1,"outcome":"completed"},{"phase":"plugins","startedOffsetMs":19,"durationMs":23,"outcome":"invented"}]}"#,
+        );
+        assert_eq!(phases.len(), 1);
+        assert_eq!(phases[0].phase, "doctor");
+        assert_eq!(phases[0].started_offset_ms, 7);
+        assert_eq!(phases[0].duration_ms, 11);
+        assert_eq!(phases[0].outcome, "warning");
     }
 
     #[test]

--- a/src/service/readiness.rs
+++ b/src/service/readiness.rs
@@ -14,6 +14,8 @@ pub(crate) struct GatewayReadiness {
     pub(crate) ready: bool,
     pub(crate) status: ServiceSummary,
     pub(crate) issue: Option<String>,
+    pub(crate) process_observed_after_ms: Option<u64>,
+    pub(crate) ready_after_ms: Option<u64>,
 }
 
 pub(crate) fn wait_for_gateway_readiness(
@@ -35,15 +37,22 @@ fn wait_for_gateway_readiness_with_timeout(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<GatewayReadiness, String> {
+    let started = Instant::now();
     let deadline = Instant::now() + timeout;
     let mut permitted_retry_count = None;
+    let mut process_observed_after_ms = None;
     loop {
         let status = service_status_fast(name, env, cwd)?;
+        if process_observed_after_ms.is_none() && status.child_pid.is_some() {
+            process_observed_after_ms = Some(duration_ms(started.elapsed()));
+        }
         if status.running && gateway_health_ok(status.child_port.unwrap_or(status.gateway_port)) {
             return Ok(GatewayReadiness {
                 ready: true,
                 status,
                 issue: None,
+                process_observed_after_ms,
+                ready_after_ms: Some(duration_ms(started.elapsed())),
             });
         }
 
@@ -73,6 +82,8 @@ fn wait_for_gateway_readiness_with_timeout(
                 ready: false,
                 status,
                 issue: Some(issue),
+                process_observed_after_ms,
+                ready_after_ms: None,
             });
         }
 
@@ -88,12 +99,18 @@ fn wait_for_gateway_readiness_with_timeout(
                     "gateway did not become ready within {} seconds; latest status: {latest}",
                     timeout.as_secs_f64()
                 )),
+                process_observed_after_ms,
+                ready_after_ms: None,
             });
         }
         sleep(
             GATEWAY_READINESS_POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now())),
         );
     }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 fn gateway_health_ok(port: u32) -> bool {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -90,9 +90,9 @@ pub use snapshots::{
     remove_env_snapshot, restore_env_snapshot, summarize_snapshot,
 };
 pub use upgrade_history::{
-    UpgradeHistoryBinding, UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery,
-    UpgradeHistoryServiceState, UpgradeHistoryStage, get_upgrade_history_record,
-    list_upgrade_history, save_upgrade_history_record,
+    UpgradeHistoryBinding, UpgradeHistoryPhaseTiming, UpgradeHistoryRecord,
+    UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage,
+    get_upgrade_history_record, list_upgrade_history, save_upgrade_history_record,
 };
 pub(crate) use upgrade_history::{
     UpgradeRuntimeRecovery, get_upgrade_runtime_recovery, lock_upgrade_transaction,

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -48,6 +48,17 @@ pub struct UpgradeHistoryRuntimeRecovery {
     pub backup_id: Option<String>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeHistoryPhaseTiming {
+    pub owner: String,
+    pub phase: String,
+    pub window: String,
+    pub started_offset_ms: u64,
+    pub duration_ms: u64,
+    pub outcome: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpgradeHistoryRecord {
@@ -67,6 +78,8 @@ pub struct UpgradeHistoryRecord {
     pub outcome: String,
     pub migration: UpgradeHistoryStage,
     pub finalization: UpgradeHistoryStage,
+    #[serde(default)]
+    pub phases: Vec<UpgradeHistoryPhaseTiming>,
     pub service_before: UpgradeHistoryServiceState,
     pub service_after: UpgradeHistoryServiceState,
     #[serde(default)]
@@ -302,6 +315,37 @@ fn validate_upgrade_history_record(record: &UpgradeHistoryRecord) -> Result<(), 
             record.format_version
         ));
     }
+    for phase in &record.phases {
+        if !matches!(phase.owner.as_str(), "ocm" | "openclaw") {
+            return Err(format!("unsupported upgrade timing owner: {}", phase.owner));
+        }
+        if !matches!(
+            phase.window.as_str(),
+            "preparation" | "stopped" | "post-ready"
+        ) {
+            return Err(format!(
+                "unsupported upgrade timing window: {}",
+                phase.window
+            ));
+        }
+        if !matches!(
+            phase.outcome.as_str(),
+            "completed" | "failed" | "warning" | "skipped" | "deferred" | "already-observed"
+        ) {
+            return Err(format!(
+                "unsupported upgrade timing outcome: {}",
+                phase.outcome
+            ));
+        }
+        if phase.phase.is_empty()
+            || !phase
+                .phase
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err("upgrade timing phase must be a non-empty identifier".to_string());
+        }
+    }
     Ok(())
 }
 
@@ -336,10 +380,11 @@ mod tests {
     use time::OffsetDateTime;
 
     use super::{
-        RuntimeMeta, RuntimeSourceKind, UpgradeHistoryBinding, UpgradeHistoryRecord,
-        UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState, UpgradeHistoryStage,
-        get_upgrade_history_record, get_upgrade_runtime_recovery, list_upgrade_history,
-        lock_upgrade_transaction, runtime_install_root, save_upgrade_history_record, write_json,
+        RuntimeMeta, RuntimeSourceKind, UpgradeHistoryBinding, UpgradeHistoryPhaseTiming,
+        UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState,
+        UpgradeHistoryStage, get_upgrade_history_record, get_upgrade_runtime_recovery,
+        list_upgrade_history, lock_upgrade_transaction, runtime_install_root,
+        save_upgrade_history_record, write_json,
     };
     use crate::store::layout::upgrade_history_runtime_recovery_dir;
 
@@ -389,6 +434,14 @@ mod tests {
                 status: "completed".to_string(),
                 note: None,
             },
+            phases: vec![UpgradeHistoryPhaseTiming {
+                owner: "ocm".to_string(),
+                phase: "preparation".to_string(),
+                window: "preparation".to_string(),
+                started_offset_ms: 0,
+                duration_ms: 10,
+                outcome: "completed".to_string(),
+            }],
             service_before: UpgradeHistoryServiceState {
                 enabled: true,
                 running: true,
@@ -424,6 +477,7 @@ mod tests {
         let loaded = get_upgrade_history_record("demo", "1700000000-000000001", &env, cwd).unwrap();
         assert_eq!(loaded.source.openclaw_version.as_deref(), Some("2026.6.11"));
         assert_eq!(loaded.target.openclaw_version.as_deref(), Some("2026.6.33"));
+        assert_eq!(loaded.phases, record("ignored", older).phases);
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -464,6 +518,20 @@ mod tests {
 
         let loaded = get_upgrade_history_record("demo", "1700000000-000000001", &env, cwd).unwrap();
         assert!(loaded.rollback_of.is_none());
+        assert!(loaded.phases.is_empty());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn upgrade_history_rejects_unstructured_phase_labels() {
+        let (root, env) = test_env("phase-label");
+        let started_at = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+        let mut record = record("1700000000-000000001", started_at);
+        record.phases[0].phase = "config=/private/token".to_string();
+
+        let error = save_upgrade_history_record(&record, &env, root.as_path()).unwrap_err();
+        assert_eq!(error, "upgrade timing phase must be a non-empty identifier");
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/tests/upgrade_availability_tests.rs
+++ b/tests/upgrade_availability_tests.rs
@@ -1,7 +1,7 @@
 mod support;
 
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
@@ -12,7 +12,8 @@ use std::time::{Duration, Instant};
 
 use base64::Engine;
 use flate2::{Compression, write::GzEncoder};
-use ocm::store::{env_registry_path, now_utc, supervisor_runtime_path};
+use fs2::FileExt;
+use ocm::store::{env_registry_path, now_utc, supervisor_runtime_path, supervisor_state_path};
 use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
 use serde_json::Value;
 use sha2::{Digest, Sha512};
@@ -24,7 +25,14 @@ use crate::support::{
 };
 
 const PREPARE_DELAY: Duration = Duration::from_millis(1_500);
-const FINALIZE_DELAY: Duration = Duration::from_millis(1_500);
+const TARGET_CONFIG_DELAY_SECONDS: &str = "0.11";
+const CONFIG_SNAPSHOT_DELAY_SECONDS: &str = "0.13";
+const DOCTOR_DELAY_SECONDS: &str = "0.17";
+const PLUGIN_DELAY_SECONDS: &str = "0.19";
+const TARGET_CONVERGENCE_DELAY_SECONDS: &str = "0.23";
+const COMPLETION_DELAY_SECONDS: &str = "0.29";
+const FINALIZER_AND_PUBLICATION_DELAY: Duration = Duration::from_millis(1_830);
+const GATEWAY_STARTUP_DELAY: Duration = Duration::from_millis(370);
 
 #[derive(Clone, Default)]
 struct Timeline(Arc<Mutex<HashMap<&'static str, Instant>>>);
@@ -285,6 +293,7 @@ case "$1" in
     exit 0
     ;;
   config)
+    sleep "${{OCM_TEST_TARGET_CONFIG_VALIDATE_DELAY:-0}}"
     printf 'Config valid\n'
     exit 0
     ;;
@@ -294,13 +303,33 @@ case "$1" in
     ;;
   update)
     if [ "$2" = "finalize" ]; then
+      if [ "$OPENCLAW_UPDATE_POST_CORE" != "1" ]; then
+        printf 'missing post-core capability handshake\n' >&2
+        exit 32
+      fi
       : > "$OCM_TEST_UPDATE_FINALIZE_STARTED"
       while [ ! -e "$OCM_TEST_UPDATE_FINALIZE_RELEASE" ]; do
         sleep 0.01
       done
-      printf '{{"status":"ok","mode":"finalize"}}\n'
+      sleep "${{OCM_TEST_TARGET_CONFIG_VALIDATE_DELAY:-0}}"
+      sleep "${{OCM_TEST_CONFIG_SNAPSHOT_DELAY:-0}}"
+      sleep "${{OCM_TEST_DOCTOR_DELAY:-0}}"
+      sleep "${{OCM_TEST_PLUGIN_DELAY:-0}}"
+      sleep "${{OCM_TEST_TARGET_CONFIG_CONVERGENCE_DELAY:-0}}"
+      printf 'prepared\n' > "$OCM_TEST_COMPLETION_INPUT"
+      printf '{{"status":"ok","mode":"finalize","phaseTimings":[{{"phase":"targetConfigValidation","startedOffsetMs":0,"durationMs":110,"outcome":"completed"}},{{"phase":"configSnapshot","startedOffsetMs":110,"durationMs":130,"outcome":"completed"}},{{"phase":"doctor","startedOffsetMs":240,"durationMs":170,"outcome":"completed"}},{{"phase":"plugins","startedOffsetMs":410,"durationMs":190,"outcome":"completed"}},{{"phase":"targetConfigConvergence","startedOffsetMs":600,"durationMs":230,"outcome":"completed"}},{{"phase":"completionCache","startedOffsetMs":830,"durationMs":0,"outcome":"deferred"}}]}}\n'
       exit 0
     fi
+    ;;
+  completion)
+    : > "$OCM_TEST_COMPLETION_STARTED"
+    if [ "$(cat "$OCM_TEST_COMPLETION_INPUT")" != "committed" ]; then
+      printf 'completion used stale prepared input\n' >&2
+      exit 31
+    fi
+    sleep "${{OCM_TEST_COMPLETION_DELAY:-0}}"
+    printf 'Completion cache written\n'
+    exit 0
     ;;
   gateway)
     printf '{{"rpc":{{"ok":true}}}}\n'
@@ -401,7 +430,7 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
     let env_json: Value = serde_json::from_slice(&env_show.stdout).unwrap();
     let snapshot_fixture = PathBuf::from(env_json["root"].as_str().unwrap()).join("fanout");
     fs::create_dir_all(&snapshot_fixture).unwrap();
-    for index in 0..20_000 {
+    for index in 0..2_000 {
         fs::write(
             snapshot_fixture.join(format!("entry-{index:05}")),
             b"snapshot fixture\n",
@@ -419,8 +448,41 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
         "OCM_TEST_UPDATE_FINALIZE_RELEASE".to_string(),
         path_string(&finalize_release),
     );
+    let completion_started = root.child("completion-started");
+    let completion_input = root.child("completion-input");
+    env.insert(
+        "OCM_TEST_COMPLETION_STARTED".to_string(),
+        path_string(&completion_started),
+    );
+    env.insert(
+        "OCM_TEST_COMPLETION_INPUT".to_string(),
+        path_string(&completion_input),
+    );
+    for (key, value) in [
+        (
+            "OCM_TEST_TARGET_CONFIG_VALIDATE_DELAY",
+            TARGET_CONFIG_DELAY_SECONDS,
+        ),
+        (
+            "OCM_TEST_CONFIG_SNAPSHOT_DELAY",
+            CONFIG_SNAPSHOT_DELAY_SECONDS,
+        ),
+        ("OCM_TEST_DOCTOR_DELAY", DOCTOR_DELAY_SECONDS),
+        ("OCM_TEST_PLUGIN_DELAY", PLUGIN_DELAY_SECONDS),
+        (
+            "OCM_TEST_TARGET_CONFIG_CONVERGENCE_DELAY",
+            TARGET_CONVERGENCE_DELAY_SECONDS,
+        ),
+        ("OCM_TEST_COMPLETION_DELAY", COMPLETION_DELAY_SECONDS),
+    ] {
+        env.insert(key.to_string(), value.to_string());
+    }
 
     let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    let supervisor_lock_path = supervisor_state_path(&env, &cwd)
+        .unwrap()
+        .with_extension("lock");
+    fs::create_dir_all(supervisor_lock_path.parent().unwrap()).unwrap();
     fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
     let ocm_home = env.get("OCM_HOME").unwrap().clone();
     write_running_supervisor_runtime(&runtime_path, &ocm_home, "stable", 4242, health_server.port);
@@ -431,6 +493,8 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
     let observer_timeline = timeline.clone();
     let observer_runtime_path = runtime_path.clone();
     let observer_ocm_home = ocm_home.clone();
+    let observer_completion_started = completion_started.clone();
+    let observer_completion_input = completion_input.clone();
     let registry_path = env_registry_path(&env, &cwd).unwrap();
     let health_port = health_server.port;
     let observer = thread::spawn(move || {
@@ -439,6 +503,8 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
             let running = env_desired_running(&registry_path, last_running);
             if running != last_running {
                 if running {
+                    sleep(GATEWAY_STARTUP_DELAY);
+                    fs::write(&observer_completion_input, b"committed\n").unwrap();
                     write_running_supervisor_runtime(
                         &observer_runtime_path,
                         &observer_ocm_home,
@@ -454,6 +520,9 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
                     observer_timeline.mark("service_stopped");
                 }
                 last_running = running;
+            }
+            if observer_completion_started.exists() {
+                observer_timeline.mark("completion_started");
             }
             sleep(Duration::from_millis(1));
         }
@@ -473,15 +542,25 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
 
     let finalize_timeline = timeline.clone();
     let finalize_releaser = thread::spawn(move || {
-        let deadline = Instant::now() + Duration::from_secs(30);
+        let deadline = Instant::now() + Duration::from_secs(180);
         while !finalize_started.exists() {
             assert!(Instant::now() < deadline, "finalization never started");
             sleep(Duration::from_millis(5));
         }
         finalize_timeline.mark("finalization_started");
-        sleep(FINALIZE_DELAY);
+        let supervisor_lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(supervisor_lock_path)
+            .unwrap();
+        supervisor_lock.lock_exclusive().unwrap();
         fs::write(finalize_release, b"release\n").unwrap();
         finalize_timeline.mark("finalization_released");
+        sleep(FINALIZER_AND_PUBLICATION_DELAY);
+        FileExt::unlock(&supervisor_lock).unwrap();
+        finalize_timeline.mark("publication_released");
     });
 
     timeline.mark("command_started");
@@ -501,7 +580,9 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
     let service_stopped = timeline.at("service_stopped");
     let finalization_started = timeline.at("finalization_started");
     let finalization_released = timeline.at("finalization_released");
+    let publication_released = timeline.at("publication_released");
     let target_ready = timeline.at("target_ready");
+    let completion_started = timeline.at("completion_started");
     let report = timeline.report(origin);
 
     let command_started = timeline.at("command_started");
@@ -537,9 +618,103 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
         finalization_released <= target_ready,
         "target became ready before finalization completed; {report}"
     );
+    assert!(
+        publication_released <= target_ready,
+        "target became ready before supervisor publication was released; {report}"
+    );
+    assert!(
+        target_ready <= completion_started,
+        "completion cache refresh started before the target was ready; {report}"
+    );
     let downtime = target_ready.duration_since(service_stopped);
     eprintln!(
         "availability proof: stop-to-ready={:.3}s {report}",
         downtime.as_secs_f64()
+    );
+
+    let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+    assert!(history.status.success(), "{}", stderr(&history));
+    let history_json: Value = serde_json::from_slice(&history.stdout).unwrap();
+    let phases = history_json[0]["phases"]
+        .as_array()
+        .expect("upgrade receipt must include structured phase timings");
+    eprintln!("phase receipt: {}", serde_json::to_string(phases).unwrap());
+    let phase = |owner: &str, name: &str, window: &str| {
+        phases
+            .iter()
+            .find(|phase| {
+                phase["owner"] == owner && phase["phase"] == name && phase["window"] == window
+            })
+            .unwrap_or_else(|| panic!("missing {owner}/{name}/{window} timing: {history_json}"))
+    };
+    for (owner, name, window) in [
+        ("ocm", "preparation", "preparation"),
+        ("ocm", "snapshotPreparation", "preparation"),
+        ("ocm", "quiescenceSnapshot", "stopped"),
+        ("ocm", "targetConfigValidation", "stopped"),
+        ("openclaw", "targetConfigValidation", "stopped"),
+        ("openclaw", "configSnapshot", "stopped"),
+        ("openclaw", "doctor", "stopped"),
+        ("openclaw", "plugins", "stopped"),
+        ("openclaw", "targetConfigConvergence", "stopped"),
+        ("openclaw", "completionCache", "stopped"),
+        ("ocm", "bindingPublish", "stopped"),
+        ("ocm", "supervisorConvergence", "stopped"),
+        ("ocm", "processSpawn", "stopped"),
+        ("ocm", "httpReady", "stopped"),
+        ("ocm", "completionCache", "post-ready"),
+        ("ocm", "deepVerification", "post-ready"),
+    ] {
+        let _ = phase(owner, name, window);
+    }
+    assert_eq!(
+        phase("openclaw", "completionCache", "stopped")["outcome"],
+        "deferred"
+    );
+    assert_eq!(
+        phase("ocm", "completionCache", "post-ready")["outcome"],
+        "completed"
+    );
+    for (name, expected_duration_ms) in [
+        ("targetConfigValidation", 110),
+        ("configSnapshot", 130),
+        ("doctor", 170),
+        ("plugins", 190),
+        ("targetConfigConvergence", 230),
+    ] {
+        assert_eq!(
+            phase("openclaw", name, "stopped")["durationMs"],
+            expected_duration_ms,
+            "controlled delay was attributed to the wrong phase"
+        );
+    }
+    let phase_start = |owner: &str, name: &str, window: &str| {
+        phase(owner, name, window)["startedOffsetMs"]
+            .as_u64()
+            .unwrap()
+    };
+    let phase_end = |owner: &str, name: &str, window: &str| {
+        let timing = phase(owner, name, window);
+        timing["startedOffsetMs"].as_u64().unwrap() + timing["durationMs"].as_u64().unwrap()
+    };
+    assert!(
+        phase_end("ocm", "preparation", "preparation")
+            <= phase_start("ocm", "snapshotPreparation", "preparation")
+    );
+    assert!(
+        phase_end("ocm", "snapshotPreparation", "preparation")
+            <= phase_start("ocm", "quiescenceSnapshot", "stopped")
+    );
+    assert!(
+        phase_end("openclaw", "targetConfigConvergence", "stopped")
+            <= phase_start("ocm", "bindingPublish", "stopped")
+    );
+    assert!(
+        phase_end("ocm", "httpReady", "stopped")
+            <= phase_start("ocm", "completionCache", "post-ready")
+    );
+    assert!(
+        phase_end("ocm", "completionCache", "post-ready")
+            <= phase_start("ocm", "deepVerification", "post-ready")
     );
 }

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -930,6 +930,10 @@ fn upgrade_updates_a_tracked_runtime_and_refreshes_the_service() {
         !command_log.contains("plugins update --all\n"),
         "{command_log}"
     );
+    assert!(
+        !command_log.contains("completion --write-state"),
+        "a finalizer without the structured defer receipt must not trigger duplicate completion work: {command_log}"
+    );
 
     let snapshots = run_ocm(&cwd, &env, &["env", "snapshot", "list", "demo", "--json"]);
     assert!(snapshots.status.success(), "{}", stderr(&snapshots));


### PR DESCRIPTION
## Problem

OCM upgrade history records whole-transaction timestamps but cannot attribute the listener-stopped interval across snapshotting, target validation, OpenClaw Doctor/plugins/completions, binding publication, supervisor convergence, process spawn, HTTP readiness, and deep verification. Two managed upgrades showed roughly 193-208 seconds of listener interruption, but the dominant phase remains unproven.

## Solution

- Persist stable, numeric, secret-free phase timings in upgrade history and raw output.
- Record preparation and snapshot preparation before quiescence, then required stopped-window and post-ready phases.
- Consume only allowlisted OpenClaw finalizer phase names/outcomes and retain a whole-finalizer fallback for older OpenClaw versions.
- Use the canonical readiness poller to distinguish process observation from HTTP readiness.
- Request completion deferral through the existing post-core capability handshake, but run the refresh after readiness only when the OpenClaw receipt explicitly reports deferred.
- Keep config repair, Doctor, plugins, publication, readiness, deep verification, history persistence, and rollback as required success gates. Completion remains best effort.

## Evidence

Red on canonical main:
- the deterministic managed upgrade preserved old health through preparation but persisted no structured phases;
- completion remained inside finalization.

Green source-blind fixture:
- stop-to-ready: 5.097 s, asserted by ordering rather than a pass/fail duration threshold;
- preparation 2050 ms and snapshot preparation 211 ms completed before quiescence;
- quiescence/snapshot 2449 ms;
- target validation 345 ms;
- OpenClaw controlled phases 110/130/170/190/230 ms;
- completion deferred at 0 ms in the stopped window;
- binding publish 7 ms, supervisor convergence 2193 ms, spawn 304 ms, HTTP ready 106 ms;
- fresh completion 565 ms after readiness, then deep verification 67 ms.

The fixture changes completion input from prepared to committed state and requires the post-ready command to consume the committed value. No config or plugin artifact is staged, so a mutable prepared-input fingerprint is not applicable.

Focused validation:
- cargo check --all-targets
- deterministic availability and ordering fixture
- finalization-failure rollback fixture
- upgrade-history compatibility and secret-safe label tests
- finalizer receipt allowlist parser test
- cargo fmt --check and git diff --check
- source-blind behavior-validator pass
- autoreview and secret scan clean

Local clippy with warnings denied remains blocked by pre-existing current-main warnings in untouched service/manage.rs and store/runtimes.rs.

## Coordination

Companion OpenClaw PR: https://github.com/openclaw/openclaw/pull/126107

This PR can land first: older OpenClaw ignores the capability environment and returns no deferred receipt, so OCM leaves completion in the existing finalizer path. The OpenClaw PR can also land first without changing public update repair behavior.

## Remaining uncertainty

This proves visibility and the narrow completion ordering improvement. It does not identify the dominant phase in the real 193-208 second interruptions and does not move config validation, Doctor, plugin work, or migrations before quiescence without production receipt evidence.

AI-assisted: yes. The implementation and tests were reviewed locally, and no agent transcript is included.