### PR TITLE
fix(runtime): select OpenClaw source build profile

### DIFF
--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -37,6 +37,9 @@ use super::layout::{
 use super::now_utc;
 use super::openclaw_workspaces::load_effective_openclaw_config;
 
+const OPENCLAW_OCM_RUNTIME_BUILD_PROFILE_ENV: &str = "OPENCLAW_OCM_RUNTIME_BUILD_PROFILE";
+const OPENCLAW_OCM_SOURCE_PERFORMANCE_BUILD_PROFILE: &str = "sourcePerformance";
+
 fn trim_description(description: Option<String>) -> Option<String> {
     description
         .map(|value| value.trim().to_string())
@@ -1005,6 +1008,10 @@ fn pack_local_openclaw_repo(
         .stderr(Stdio::piped());
     if let Some(local_adapter) = local_adapter {
         local_adapter.apply_environment(&mut command);
+        command.env(
+            OPENCLAW_OCM_RUNTIME_BUILD_PROFILE_ENV,
+            OPENCLAW_OCM_SOURCE_PERFORMANCE_BUILD_PROFILE,
+        );
     }
     let output = command.output().map_err(|error| {
         format!(

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -178,6 +178,7 @@ if [ "$1" = "--version" ]; then
   printf '10.0.0\n'
   exit 0
 fi
+printf 'build-profile-%s=%s\n' "$1" "${{OPENCLAW_OCM_RUNTIME_BUILD_PROFILE-unset}}" >> "{}"
 
 if [ "$1" = "pack" ]; then
   case " $* " in
@@ -277,6 +278,7 @@ if grep -q '"chokidar"' "$prefix/node_modules/openclaw/package.json"; then
   printf '{{"name":"@scope/tool","version":"1.0.0"}}\n' > "$prefix/node_modules/@scope/tool/package.json"
 fi
 "#,
+        path_string(&log_path),
         path_string(&log_path),
         path_string(&log_path),
         path_string(&log_path),
@@ -606,6 +608,8 @@ fn runtime_build_local_packs_and_installs_release_shaped_package() {
     assert!(npm_log.contains("ignore-scripts-lower=false"));
     assert!(npm_log.contains("ignore-scripts-upper=unset"));
     assert!(npm_log.contains("install --prefix"));
+    assert!(npm_log.contains("build-profile-pack=unset"));
+    assert!(npm_log.contains("build-profile-install=unset"));
 
     let install_root = runtime_install_root("main-local", &env, &cwd).unwrap();
     let expected_binary = installed_openclaw_runtime_entrypoint(&install_root);
@@ -1248,8 +1252,10 @@ printf 'adapter={adapter_extension}\n' >> "{}"
 printf 'args=%s\n' "$*" >> "{}"
 printf 'real-npm=%s\n' "$OPENCLAW_OCM_REAL_NPM_BIN" >> "{}"
 printf 'workspace-dirs=%s\n' "$OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS" >> "{}"
+printf 'build-profile=%s:%s\n' "$1" "${{OPENCLAW_OCM_RUNTIME_BUILD_PROFILE-unset}}" >> "{}"
 exec "$OPENCLAW_OCM_REAL_NPM_BIN" "$@"
 "#,
+            path_string(&adapter_log),
             path_string(&adapter_log),
             path_string(&adapter_log),
             path_string(&adapter_log),
@@ -1297,6 +1303,14 @@ exec "$OPENCLAW_OCM_REAL_NPM_BIN" "$@"
     assert!(adapter_log.contains("args=install --prefix"));
     assert!(adapter_log.contains("real-npm=npm"));
     assert!(adapter_log.contains(&format!("adapter={adapter_extension}")));
+    assert_eq!(
+        adapter_log
+            .lines()
+            .filter_map(|line| line.strip_prefix("build-profile="))
+            .collect::<Vec<_>>(),
+        ["pack:sourcePerformance", "install:unset"],
+        "{adapter_log}"
+    );
     if include_legacy_adapter {
         assert!(!adapter_log.contains("adapter=mjs"));
     }


### PR DESCRIPTION
## Verdict and owner

OCM owns selection of the OpenClaw runtime-packaging profile when `ocm runtime build-local` deliberately invokes OpenClaw's repository adapter. OpenClaw owns the profile's build contents and fallback behavior.

This completes the existing adapter contract for direct OCM callers. It is not a generic environment workaround and does not change release-shaped direct npm packaging.

## What

When a local OpenClaw checkout exposes `scripts/ocm-npm-workspace-deps.mts` or the legacy `.mjs` adapter, set:

`OPENCLAW_OCM_RUNTIME_BUILD_PROFILE=sourcePerformance`

only on the core `npm pack` adapter command.

The subsequent package install remains unselected. Direct npm pack/install paths remain unselected.

## Why

Without the profile, current OpenClaw adapters intentionally fall back to the full release build, including declaration groups that are unnecessary for OCM's source-extension runtime package. The same exact OpenClaw source was observed taking roughly 32 minutes before an incomplete pack/orphaned build state, versus about 9 minutes 35 seconds with `sourcePerformance`.

Adapter presence is the compatibility gate: current OpenClaw consumes the profile, while older adapters ignore the unknown key and continue normally. No adapter source parsing, version table, new CLI option, or OpenClaw-side default is required.

## Durable invariant

An adapter-mediated core runtime pack requests the adapter-owned runtime profile. Install, source-extension pack, and non-adapter paths preserve their existing package correctness and environment.

## Proof

Base: `fdf7badf039fc36b459cfda6302c33cc1093f7a4`
Head: `4e044863a220e5b852ce9e585a40178b223696a0`

Red on unmodified base, isolated fake repo/OCM store:

- adapter core pack: `pack:unset`
- adapter install: `install:unset`

Green on this head:

- current `.mts` adapter: `pack:sourcePerformance`, `install:unset`
- actual pre-profile OpenClaw `.mjs` adapter from commit `451d6314`: build succeeds; `pack:sourcePerformance`, `install:unset`
- direct npm/no adapter: `pack:unset`, `install:unset`

Tests:

- `cargo fmt --all -- --check`
- `cargo test --locked --test runtime_command_tests -- --test-threads=1` (51 passed)
- source-blind behavior validation: all current/historical/direct adapter clauses passed
- fresh branch-scoped TruffleHog/autoreview: clean, no accepted/actionable findings

All proof used disposable state under `/tmp`; no installed OCM store or fleet environment was touched.
