### PR TITLE
fix: isolate external workspaces during adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to OCM are documented here.
 ## Unreleased
 
 - Require successful exact-SHA `main` CI before signed release tags can be created or packaged.
+- Copy repo-backed and symlinked plain-home agent workspaces into an adopted
+  environment and rewrite the imported config to keep the fixture isolated.
 
 ## 0.2.30 - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ ocm adopt plan --name mira
 
 `migrate` preserves config, auth, sessions, logs, and other durable user state, rewrites env-scoped paths for the new managed root, and clears only live runtime residue like locks, pid files, and sockets. If `openclaw` is already available on `PATH`, it also binds the imported env to an env-local migrated launcher so you can keep using it through OCM immediately.
 
+When a configured agent workspace is a repository checkout outside the plain
+OpenClaw home, including through a symlink, migration copies that workspace into
+the new environment and rewrites the imported config to use the copy. The source
+home and repository remain unchanged. Config `$include` files still must remain
+inside the plain home because OCM does not take ownership of external config.
+
 Environment clone, export, and import flows preserve managed OpenClaw plugin
 payloads under the legacy, extension, npm, and Git install roots. Clone and
 import still clear live sessions, logs, backups, and process residue so the new

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -11,7 +11,8 @@ use crate::store::{
     OpenClawWorkspaceRuntime, copy_dir_recursive, default_env_root, derive_env_paths, display_path,
     list_environments, normalize_new_environment_sandbox_origin, prepare_migrated_runtime_state,
     reject_include_owned_agent_workspaces, reject_include_owned_sandbox_origin,
-    resolve_plain_openclaw_workspaces, resolve_user_home, rewrite_openclaw_config_for_migration,
+    resolve_plain_openclaw_workspaces, resolve_user_home,
+    rewrite_external_workspace_paths_for_migration, rewrite_openclaw_config_for_migration,
     validate_name,
 };
 
@@ -54,6 +55,130 @@ struct MigratedLauncherSpec {
     name: String,
     command_path: String,
     needs_creation: bool,
+}
+
+#[derive(Clone, Debug)]
+struct ExternalWorkspaceCopy {
+    source: PathBuf,
+    target: PathBuf,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ExternalWorkspaceCopyPlan {
+    default_workspace: Option<ExternalWorkspaceCopy>,
+    agent_workspaces: BTreeMap<String, ExternalWorkspaceCopy>,
+}
+
+impl ExternalWorkspaceCopyPlan {
+    fn for_migration(
+        source_home: &Path,
+        target_paths: &crate::store::EnvPaths,
+        env: &BTreeMap<String, String>,
+    ) -> Result<Self, String> {
+        let source_home = fs::canonicalize(source_home).map_err(|error| {
+            format!(
+                "failed to resolve plain OpenClaw home {}: {error}",
+                display_path(source_home)
+            )
+        })?;
+        let sources = resolve_plain_openclaw_workspaces(&source_home, env)?
+            .external_workspace_sources_for_migration(&source_home)?;
+        let canonical_target_root = canonicalize_path_allow_missing(&target_paths.root)?;
+        let mut plan = Self::default();
+        if let Some(source) = sources.default_workspace {
+            plan.default_workspace = Some(ExternalWorkspaceCopy {
+                target: target_paths.state_dir.join("workspaces/default"),
+                source,
+            });
+        }
+        for (agent_id, source) in sources.agent_workspaces {
+            plan.agent_workspaces.insert(
+                agent_id.clone(),
+                ExternalWorkspaceCopy {
+                    target: target_paths
+                        .state_dir
+                        .join("workspaces/agents")
+                        .join(agent_id),
+                    source,
+                },
+            );
+        }
+        for workspace in plan
+            .default_workspace
+            .iter()
+            .chain(plan.agent_workspaces.values())
+        {
+            if workspace.source.starts_with(&canonical_target_root)
+                || canonical_target_root.starts_with(&workspace.source)
+            {
+                return Err(format!(
+                    "external OpenClaw workspace and migration target must not overlap: workspace={} target={}",
+                    display_path(&workspace.source),
+                    display_path(&canonical_target_root)
+                ));
+            }
+        }
+        Ok(plan)
+    }
+
+    fn copy_and_rewrite_config(&self, config_path: &Path) -> Result<(), String> {
+        remove_copied_external_default_workspace_link(config_path)?;
+        if let Some(workspace) = &self.default_workspace {
+            copy_dir_recursive(&workspace.source, &workspace.target)?;
+        }
+        for workspace in self.agent_workspaces.values() {
+            copy_dir_recursive(&workspace.source, &workspace.target)?;
+        }
+        let agent_workspaces = self
+            .agent_workspaces
+            .iter()
+            .map(|(agent_id, workspace)| (agent_id.clone(), workspace.target.clone()))
+            .collect::<BTreeMap<_, _>>();
+        rewrite_external_workspace_paths_for_migration(
+            config_path,
+            self.default_workspace
+                .as_ref()
+                .map(|workspace| workspace.target.as_path()),
+            &agent_workspaces,
+        )?;
+        Ok(())
+    }
+}
+
+fn remove_copied_external_default_workspace_link(config_path: &Path) -> Result<(), String> {
+    let Some(state_dir) = config_path.parent() else {
+        return Ok(());
+    };
+    let workspace = state_dir.join("workspace");
+    let Ok(metadata) = fs::symlink_metadata(&workspace) else {
+        return Ok(());
+    };
+    if !metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    let resolved = fs::canonicalize(&workspace).map_err(|error| {
+        format!(
+            "failed to resolve copied OpenClaw workspace symlink {}: {error}",
+            display_path(&workspace)
+        )
+    })?;
+    let canonical_state_dir = fs::canonicalize(state_dir).map_err(|error| {
+        format!(
+            "failed to resolve imported OpenClaw state directory {}: {error}",
+            display_path(state_dir)
+        )
+    })?;
+    if resolved.starts_with(&canonical_state_dir) {
+        return Ok(());
+    }
+    fs::remove_file(&workspace)
+        .or_else(|_| fs::remove_dir(&workspace))
+        .map_err(|error| {
+            format!(
+                "failed to remove copied external OpenClaw workspace symlink {}: {error}",
+                display_path(&workspace)
+            )
+        })
 }
 
 pub fn default_migration_source_home(env: &BTreeMap<String, String>) -> PathBuf {
@@ -162,14 +287,9 @@ fn migrate_plain_openclaw_home_inner(
         })?
         .to_string();
     reject_overlapping_migration_paths(&source_home, &target_root)?;
-    let workspace_source_home = fs::canonicalize(&source_home).map_err(|error| {
-        format!(
-            "failed to resolve plain OpenClaw home {}: {error}",
-            display_path(&source_home)
-        )
-    })?;
-    resolve_plain_openclaw_workspaces(&workspace_source_home, env)?
-        .archive_relative_roots(&workspace_source_home)?;
+    let target_paths = derive_env_paths(&target_root);
+    let external_workspace_plan =
+        ExternalWorkspaceCopyPlan::for_migration(&source_home, &target_paths, env)?;
     let migrated_launcher = preflight_migrated_launcher(&env_name, env, cwd)?;
 
     let created = service.create(CreateEnvironmentOptions {
@@ -190,6 +310,7 @@ fn migrate_plain_openclaw_home_inner(
         created,
         &target_paths,
         &source_home,
+        &external_workspace_plan,
         sandbox_origin.as_deref(),
         migrated_launcher.as_ref(),
         env,
@@ -255,6 +376,7 @@ fn complete_migration_import(
     created: crate::env::EnvMeta,
     target_paths: &crate::store::EnvPaths,
     source_home: &Path,
+    external_workspace_plan: &ExternalWorkspaceCopyPlan,
     sandbox_origin: Option<&str>,
     migrated_launcher: Option<&MigratedLauncherSpec>,
     env: &BTreeMap<String, String>,
@@ -265,6 +387,7 @@ fn complete_migration_import(
     }
 
     copy_dir_recursive(source_home, &target_paths.state_dir)?;
+    external_workspace_plan.copy_and_rewrite_config(&target_paths.config_path)?;
     reject_include_owned_sandbox_origin(&target_paths.config_path)?;
     let config_rewrite = rewrite_openclaw_config_for_migration(
         target_paths,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -57,10 +57,10 @@ pub(crate) use openclaw_config::{
     ensure_minimum_local_openclaw_config, normalize_new_environment_sandbox_origin,
     openclaw_config_include_paths, openclaw_config_uses_includes,
     reject_include_owned_agent_workspaces, reject_include_owned_sandbox_origin,
-    repair_openclaw_config, rewrite_identity_bound_workspace_paths_for_target,
-    rewrite_openclaw_config_for_migration, rewrite_openclaw_config_for_new_environment,
-    rewrite_openclaw_config_for_simulation, rewrite_openclaw_config_for_target,
-    rewrite_openclaw_config_includes_for_target,
+    repair_openclaw_config, rewrite_external_workspace_paths_for_migration,
+    rewrite_identity_bound_workspace_paths_for_target, rewrite_openclaw_config_for_migration,
+    rewrite_openclaw_config_for_new_environment, rewrite_openclaw_config_for_simulation,
+    rewrite_openclaw_config_for_target, rewrite_openclaw_config_includes_for_target,
 };
 pub(crate) use openclaw_state::{
     OpenClawStateAudit, audit_openclaw_state, clear_nonportable_runtime_state,

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -12,7 +12,9 @@ use crate::env::EnvMeta;
 use super::common::{ensure_dir, path_exists, write_file_replacing_path};
 use super::gateway_ports::read_port_number;
 use super::layout::{EnvPaths, clean_path, derive_env_paths, display_path};
-use super::openclaw_workspaces::{OpenClawWorkspaceInventory, load_effective_openclaw_config};
+use super::openclaw_workspaces::{
+    OpenClawWorkspaceInventory, load_effective_openclaw_config, normalize_agent_id,
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct OpenClawConfigAudit {
@@ -149,6 +151,71 @@ pub(crate) fn rewrite_openclaw_config_for_migration(
         gateway_port,
         SandboxOriginPolicy::NewEnvironment(sandbox_origin),
     )
+}
+
+pub(crate) fn rewrite_external_workspace_paths_for_migration(
+    config_path: &Path,
+    default_workspace: Option<&Path>,
+    agent_workspaces: &BTreeMap<String, PathBuf>,
+) -> Result<bool, String> {
+    if default_workspace.is_none() && agent_workspaces.is_empty() {
+        return Ok(false);
+    }
+    let Some(mut value) = read_config_value(config_path)? else {
+        return Ok(false);
+    };
+    let Some(agents) = value.get_mut("agents").and_then(Value::as_object_mut) else {
+        return Ok(false);
+    };
+
+    let mut changed = false;
+    if let Some(default_workspace) = default_workspace {
+        changed |= set_workspace_path(agents.get_mut("defaults"), default_workspace);
+    }
+    if let Some(entries) = agents.get_mut("entries").and_then(Value::as_object_mut) {
+        for (agent_id, entry) in entries {
+            let Some(workspace) = agent_workspaces.get(&normalize_agent_id(agent_id)) else {
+                continue;
+            };
+            changed |= set_workspace_path(Some(entry), workspace);
+        }
+    }
+    if let Some(entries) = agents.get_mut("list").and_then(Value::as_array_mut) {
+        for entry in entries {
+            let Some(agent_id) = entry
+                .as_object()
+                .and_then(|entry| entry.get("id"))
+                .and_then(Value::as_str)
+            else {
+                continue;
+            };
+            let Some(workspace) = agent_workspaces.get(&normalize_agent_id(agent_id)) else {
+                continue;
+            };
+            changed |= set_workspace_path(Some(entry), workspace);
+        }
+    }
+
+    if changed {
+        write_config_value(config_path, &value)?;
+    }
+    Ok(changed)
+}
+
+fn set_workspace_path(value: Option<&mut Value>, workspace: &Path) -> bool {
+    let Some(value) = value.and_then(Value::as_object_mut) else {
+        return false;
+    };
+    let workspace = display_path(workspace);
+    if value
+        .get("workspace")
+        .and_then(Value::as_str)
+        .is_some_and(|current| current == workspace)
+    {
+        return false;
+    }
+    value.insert("workspace".to_string(), Value::String(workspace));
+    true
 }
 
 pub(crate) fn normalize_new_environment_sandbox_origin(

--- a/src/store/openclaw_workspaces.rs
+++ b/src/store/openclaw_workspaces.rs
@@ -43,7 +43,15 @@ pub(crate) struct OpenClawWorkspaceInventory {
     workspace_roots: BTreeSet<PathBuf>,
     config_include_paths: BTreeSet<PathBuf>,
     agent_workspace_roots: BTreeMap<String, PathBuf>,
+    configured_default_workspace: Option<PathBuf>,
+    configured_agent_workspace_roots: BTreeMap<String, PathBuf>,
     default_agent_id: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ExternalOpenClawWorkspaceSources {
+    pub(crate) default_workspace: Option<PathBuf>,
+    pub(crate) agent_workspaces: BTreeMap<String, PathBuf>,
 }
 
 impl OpenClawWorkspaceInventory {
@@ -121,6 +129,114 @@ impl OpenClawWorkspaceInventory {
     pub(crate) fn workspace_roots(&self) -> impl Iterator<Item = &Path> {
         self.workspace_roots.iter().map(PathBuf::as_path)
     }
+
+    /// An adopted plain home may use a repository checkout outside its state
+    /// directory. Those configured workspace roots are copied into the new
+    /// environment; config includes remain owned by their original config tree.
+    pub(crate) fn external_workspace_sources_for_migration(
+        &self,
+        source_root: &Path,
+    ) -> Result<ExternalOpenClawWorkspaceSources, String> {
+        let source_root = clean_path(source_root);
+        let canonical_source_root = canonicalize_path_allow_missing(&source_root)?;
+
+        for include_path in &self.config_include_paths {
+            validate_internal_migration_path(
+                include_path,
+                &source_root,
+                &canonical_source_root,
+                "config include",
+            )?;
+        }
+
+        let default_workspace = self
+            .configured_default_workspace
+            .as_deref()
+            .map(|workspace| {
+                migration_workspace_source(workspace, &source_root, &canonical_source_root)
+            })
+            .transpose()?
+            .flatten();
+        let mut agent_workspaces = BTreeMap::new();
+        for (agent_id, workspace) in &self.configured_agent_workspace_roots {
+            if let Some(source) =
+                migration_workspace_source(workspace, &source_root, &canonical_source_root)?
+            {
+                agent_workspaces.insert(agent_id.clone(), source);
+            }
+        }
+
+        Ok(ExternalOpenClawWorkspaceSources {
+            default_workspace,
+            agent_workspaces,
+        })
+    }
+}
+
+fn validate_internal_migration_path(
+    path: &Path,
+    source_root: &Path,
+    canonical_source_root: &Path,
+    label: &str,
+) -> Result<(), String> {
+    let canonical_path = canonicalize_path_allow_missing(path)?;
+    if canonical_path == canonical_source_root || !canonical_path.starts_with(canonical_source_root)
+    {
+        return Err(format!(
+            "cannot safely preserve configured OpenClaw {label} that resolves outside the environment root: {} (resolved: {}; environment root resolves to: {})",
+            display_path(path),
+            display_path(&canonical_path),
+            display_path(canonical_source_root)
+        ));
+    }
+    let canonical_relative = canonical_path
+        .strip_prefix(canonical_source_root)
+        .map_err(|error| error.to_string())?;
+    if let Ok(relative) = path.strip_prefix(source_root)
+        && relative != canonical_relative
+    {
+        return Err(format!(
+            "cannot safely preserve configured OpenClaw {label} through a symlink: {}",
+            display_path(path)
+        ));
+    }
+    Ok(())
+}
+
+fn migration_workspace_source(
+    workspace: &Path,
+    source_root: &Path,
+    canonical_source_root: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let canonical_workspace = canonicalize_path_allow_missing(workspace)?;
+    if canonical_workspace == canonical_source_root {
+        return Err(format!(
+            "configured OpenClaw workspace cannot be the state directory itself: {}",
+            display_path(workspace)
+        ));
+    }
+    if canonical_workspace.starts_with(canonical_source_root) {
+        validate_internal_migration_path(
+            workspace,
+            source_root,
+            canonical_source_root,
+            "workspace",
+        )?;
+        return Ok(None);
+    }
+    let metadata = fs::metadata(&canonical_workspace).map_err(|error| {
+        format!(
+            "failed to inspect external OpenClaw workspace {}: {error}",
+            display_path(workspace)
+        )
+    })?;
+    if !metadata.is_dir() {
+        return Err(format!(
+            "configured external OpenClaw workspace must be a directory: {}",
+            display_path(workspace)
+        ));
+    }
+    Ok(Some(canonical_workspace))
 }
 
 pub(crate) fn resolve_env_openclaw_workspaces(
@@ -209,6 +325,9 @@ fn resolve_openclaw_workspaces(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    let configured_default_workspace = default_workspace
+        .map(|workspace| resolve_workspace_path(workspace, openclaw_home))
+        .transpose()?;
 
     let mut agent_ids = entries
         .iter()
@@ -219,6 +338,7 @@ fn resolve_openclaw_workspaces(
 
     let mut workspace_roots = BTreeSet::new();
     let mut agent_workspace_roots = BTreeMap::new();
+    let mut configured_agent_workspace_roots = BTreeMap::new();
     for agent_id in agent_ids {
         let explicit = entries
             .iter()
@@ -232,6 +352,12 @@ fn resolve_openclaw_workspaces(
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|value| !value.is_empty());
+        let configured_workspace = explicit
+            .map(|workspace| resolve_workspace_path(workspace, openclaw_home))
+            .transpose()?;
+        if let Some(workspace) = configured_workspace.as_ref() {
+            configured_agent_workspace_roots.insert(agent_id.clone(), workspace.clone());
+        }
         let raw = if let Some(explicit) = explicit {
             explicit.to_string()
         } else if agent_id == default_agent_id {
@@ -257,6 +383,8 @@ fn resolve_openclaw_workspaces(
         workspace_roots,
         config_include_paths,
         agent_workspace_roots,
+        configured_default_workspace,
+        configured_agent_workspace_roots,
         default_agent_id,
     })
 }
@@ -629,7 +757,7 @@ fn resolve_default_agent_id(entries: &[Map<String, Value>]) -> String {
         .unwrap_or_else(|| DEFAULT_AGENT_ID.to_string())
 }
 
-fn normalize_agent_id(value: &str) -> String {
+pub(crate) fn normalize_agent_id(value: &str) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return DEFAULT_AGENT_ID.to_string();

--- a/tests/migrate_command_tests.rs
+++ b/tests/migrate_command_tests.rs
@@ -885,7 +885,7 @@ fn migrate_validates_the_target_origin_before_reading_the_source_home() {
 }
 
 #[test]
-fn migrate_rejects_external_workspaces_before_creating_the_environment() {
+fn adopt_import_copies_an_external_workspace_into_the_disposable_environment() {
     let root = TestDir::new("migrate-external-workspace");
     let cwd = root.child("workspace");
     let source_home = root.child("legacy-home/.openclaw");
@@ -902,23 +902,102 @@ fn migrate_rejects_external_workspaces_before_creating_the_environment() {
         ),
     )
     .unwrap();
-    let env = ocm_env(&root);
+    let mut env = ocm_env(&root);
+    install_fake_openclaw_on_path(&root, &mut env);
 
     let output = run_ocm(
         &cwd,
         &env,
-        &["migrate", "mira", source_home.to_string_lossy().as_ref()],
+        &[
+            "adopt",
+            "import",
+            "--name",
+            "mira",
+            source_home.to_string_lossy().as_ref(),
+        ],
     );
-    assert_eq!(output.status.code(), Some(1));
-    assert!(
-        stderr(&output).contains("outside the environment root"),
-        "{}",
-        stderr(&output)
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let imported_workspace = root.child("ocm-home/envs/mira/.openclaw/workspaces/default");
+    assert_eq!(
+        fs::read_to_string(imported_workspace.join("notes.txt")).unwrap(),
+        "external data\n"
     );
-    assert!(!root.child("ocm-home/envs/mira").exists());
+    let imported_config: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.child("ocm-home/envs/mira/.openclaw/openclaw.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        imported_config["agents"]["defaults"]["workspace"].as_str(),
+        Some(imported_workspace.to_string_lossy().as_ref())
+    );
     assert_eq!(
         fs::read_to_string(external.join("notes.txt")).unwrap(),
         "external data\n"
+    );
+    assert_eq!(
+        fs::read_to_string(source_home.join("openclaw.json")).unwrap(),
+        format!(
+            r#"{{"agents":{{"defaults":{{"workspace":"{}"}}}}}}"#,
+            external.display()
+        )
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn adopt_import_copies_a_symlinked_external_workspace_into_the_disposable_environment() {
+    let root = TestDir::new("migrate-symlinked-external-workspace");
+    let cwd = root.child("workspace");
+    let source_home = root.child("legacy-home/.openclaw");
+    let external = root.child("lobster-workspace");
+    let linked_workspace = source_home.join("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(&source_home).unwrap();
+    fs::create_dir_all(&external).unwrap();
+    fs::write(external.join("notes.txt"), "repo-backed data\n").unwrap();
+    std::os::unix::fs::symlink(&external, &linked_workspace).unwrap();
+    fs::write(
+        source_home.join("openclaw.json"),
+        format!(
+            r#"{{"agents":{{"defaults":{{"workspace":"{}"}}}}}}"#,
+            linked_workspace.display()
+        ),
+    )
+    .unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_openclaw_on_path(&root, &mut env);
+
+    let output = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "adopt",
+            "import",
+            "--name",
+            "mira",
+            source_home.to_string_lossy().as_ref(),
+        ],
+    );
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let imported_workspace = root.child("ocm-home/envs/mira/.openclaw/workspaces/default");
+    assert_eq!(
+        fs::read_to_string(imported_workspace.join("notes.txt")).unwrap(),
+        "repo-backed data\n"
+    );
+    let imported_config: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.child("ocm-home/envs/mira/.openclaw/openclaw.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        imported_config["agents"]["defaults"]["workspace"].as_str(),
+        Some(imported_workspace.to_string_lossy().as_ref())
+    );
+    assert_eq!(fs::read_link(&linked_workspace).unwrap(), external);
+    assert_eq!(
+        fs::read_to_string(external.join("notes.txt")).unwrap(),
+        "repo-backed data\n"
     );
 }
 


### PR DESCRIPTION
## Summary
- copy configured external workspaces into the disposable adopted environment
- rewrite only fixture configuration to the copied workspace
- preserve source paths and fail closed for unsafe includes

## Validation
- `cargo test --test migrate_command_tests` (36 passed)
- external-workspace migration regression coverage

Fixes release-validation imports where `~/.openclaw` points at a repo-backed or symlinked workspace.