### PR TITLE
fix: harden release publication integrity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,16 +128,6 @@ jobs:
           RELEASE_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          verified_commit="$(
-            ./scripts/verify-release-tag.sh \
-              --repo "$RELEASE_REPO" \
-              --tag "$RELEASE_TAG" \
-              --commit "$RELEASE_COMMIT"
-          )"
-          [[ "$verified_commit" == "$RELEASE_COMMIT" ]]
-          ./scripts/verify-release-ci.sh \
-            --repo "$RELEASE_REPO" \
-            --commit "$RELEASE_COMMIT"
           ./scripts/publish-release.sh \
             --repo "$RELEASE_REPO" \
             --tag "$RELEASE_TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,25 @@
 name: Release
+run-name: Release ${{ inputs.tag }}
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Signed release tag
+        required: true
+        type: string
+      commit:
+        description: Exact merged release commit
+        required: true
+        type: string
 
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  group: release-${{ inputs.tag }}
   cancel-in-progress: false
 
 env:
@@ -19,6 +28,7 @@ env:
 jobs:
   verify:
     name: Verify release tag
+    if: github.repository == 'openclaw/ocm' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       commit: ${{ steps.verify.outputs.commit }}
@@ -32,13 +42,15 @@ jobs:
         id: verify
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           verified_commit="$(
             ./scripts/verify-release-tag.sh \
               --repo "$RELEASE_REPO" \
-              --tag "$RELEASE_TAG"
+              --tag "$RELEASE_TAG" \
+              --commit "$RELEASE_COMMIT"
           )"
           ./scripts/verify-release-ci.sh \
             --repo "$RELEASE_REPO" \
@@ -81,7 +93,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-${{ matrix.target }}
-          path: ./dist/*.tar.gz
+          path: ./dist/ocm-${{ matrix.target }}.tar.gz
           if-no-files-found: error
           retention-days: 1
 
@@ -92,11 +104,13 @@ jobs:
       - build
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.verify.outputs.commit }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           persist-credentials: false
       - name: Download release archives
@@ -112,14 +126,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_COMMIT: ${{ needs.verify.outputs.commit }}
           RELEASE_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          ./scripts/verify-release-tag.sh \
+          verified_commit="$(
+            ./scripts/verify-release-tag.sh \
+              --repo "$RELEASE_REPO" \
+              --tag "$RELEASE_TAG" \
+              --commit "$RELEASE_COMMIT"
+          )"
+          [[ "$verified_commit" == "$RELEASE_COMMIT" ]]
+          ./scripts/verify-release-ci.sh \
             --repo "$RELEASE_REPO" \
-            --tag "$RELEASE_TAG" \
-            --commit "$RELEASE_COMMIT" \
-            >/dev/null
+            --commit "$RELEASE_COMMIT"
           ./scripts/publish-release.sh \
             --repo "$RELEASE_REPO" \
             --tag "$RELEASE_TAG" \
+            --commit "$RELEASE_COMMIT" \
             --asset-dir ./dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Verify signed tag and package version
@@ -110,8 +110,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.verify.outputs.commit }}
+          path: release-source
           persist-credentials: false
       - name: Download release archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -120,7 +126,7 @@ jobs:
           path: ./dist
           merge-multiple: true
       - name: Stage versioned installer
-        run: cp ./install.sh ./dist/install.sh
+        run: cp ./release-source/install.sh ./dist/install.sh
       - name: Publish verified release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -128,7 +134,7 @@ jobs:
           RELEASE_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          ./scripts/publish-release.sh \
+          ./trusted/scripts/publish-release.sh \
             --repo "$RELEASE_REPO" \
             --tag "$RELEASE_TAG" \
             --commit "$RELEASE_COMMIT" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to OCM are documented here.
   requests. Thanks @shakkernerd.
 - Require exact complete release archives and keep failed release settlement
   unpublished or draft. Thanks @shakkernerd.
+- Bind release identity to canonical producer, tag, pull request, CI, and
+  protected-main workflow inputs. Thanks @shakkernerd.
 - Require successful exact-SHA `main` CI before signed release tags can be created or packaged.
 - Copy repo-backed and symlinked plain-home agent workspaces into an adopted
   environment and rewrite the imported config to keep the fixture isolated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to OCM are documented here.
 
 ## Unreleased
 
+- Use the canonical `openclaw/ocm` repository for installation and self-update
+  requests. Thanks @shakkernerd.
 - Require successful exact-SHA `main` CI before signed release tags can be created or packaged.
 - Copy repo-backed and symlinked plain-home agent workspaces into an adopted
   environment and rewrite the imported config to keep the fixture isolated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to OCM are documented here.
   unpublished or draft. Thanks @shakkernerd.
 - Bind release identity to canonical producer, tag, pull request, CI, and
   protected-main workflow inputs. Thanks @shakkernerd.
+- Recheck tag identity and exact-SHA CI inside the publisher before any release
+  API mutation. Thanks @shakkernerd.
 - Require successful exact-SHA `main` CI before signed release tags can be created or packaged.
 - Copy repo-backed and symlinked plain-home agent workspaces into an adopted
   environment and rewrite the imported config to keep the fixture isolated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to OCM are documented here.
 
 - Use the canonical `openclaw/ocm` repository for installation and self-update
   requests. Thanks @shakkernerd.
+- Require exact complete release archives and keep failed release settlement
+  unpublished or draft. Thanks @shakkernerd.
 - Require successful exact-SHA `main` CI before signed release tags can be created or packaged.
 - Copy repo-backed and symlinked plain-home agent workspaces into an adopted
   environment and rewrite the imported config to keep the fixture isolated.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ rust-version = "1.88"
 description = "OpenClaw Manager: the local control plane for isolated OpenClaw environments, launchers, runtimes, and services."
 readme = "README.md"
 license-file = "LICENSE"
-repository = "https://github.com/shakkernerd/ocm"
-homepage = "https://github.com/shakkernerd/ocm"
+repository = "https://github.com/openclaw/ocm"
+homepage = "https://github.com/openclaw/ocm"
 keywords = ["openclaw", "cli", "manager", "environment", "service"]
 categories = ["command-line-utilities", "development-tools"]
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Use `ocm` when you want:
 Install the latest release:
 
 ```bash
-curl -fsSL https://github.com/shakkernerd/ocm/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/openclaw/ocm/releases/latest/download/install.sh | bash
 ```
 
 Install a specific release:
 
 ```bash
-curl -fsSL https://github.com/shakkernerd/ocm/releases/download/v<ocm-version>/install.sh | bash -s -- --version v<ocm-version>
+curl -fsSL https://github.com/openclaw/ocm/releases/download/v<ocm-version>/install.sh | bash -s -- --version v<ocm-version>
 ```
 
 Update an existing install:

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="shakkernerd/ocm"
+REPO="openclaw/ocm"
 DEFAULT_PREFIX="${HOME}/.local"
 
 usage() {

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -46,6 +46,13 @@ done
 
 [[ -n "$target" ]] || { echo "error: --target is required" >&2; exit 1; }
 [[ -n "$binary" ]] || { echo "error: --binary is required" >&2; exit 1; }
+case "$target" in
+  aarch64-apple-darwin|x86_64-apple-darwin|x86_64-unknown-linux-gnu) ;;
+  *)
+    echo "error: unsupported release target: $target" >&2
+    exit 1
+    ;;
+esac
 [[ -f "$binary" ]] || { echo "error: binary not found: $binary" >&2; exit 1; }
 
 mkdir -p "$output_dir"

--- a/scripts/prepare-release-assets.sh
+++ b/scripts/prepare-release-assets.sh
@@ -16,6 +16,7 @@ expected_archives=(
   "ocm-x86_64-apple-darwin.tar.gz"
   "ocm-x86_64-unknown-linux-gnu.tar.gz"
 )
+expected_members="$(printf '%s\n' "LICENSE" "README.md" "ocm")"
 install_script="${asset_dir}/install.sh"
 
 if [[ ! -f "$install_script" || -L "$install_script" ]]; then
@@ -33,11 +34,34 @@ for archive in "${expected_archives[@]}"; do
     echo "error: release archive is not a valid tarball: $archive" >&2
     exit 1
   fi
+  actual_members="$(tar -tzf "$path" | LC_ALL=C sort)"
+  if [[ "$actual_members" != "$expected_members" ]]; then
+    echo "error: release archive has invalid members: $archive" >&2
+    printf 'expected:\n%s\nactual:\n%s\n' "$expected_members" "$actual_members" >&2
+    exit 1
+  fi
+  if ! tar -tvzf "$path" | awk '
+    BEGIN { count = 0 }
+    {
+      count += 1
+      if (substr($0, 1, 1) != "-") {
+        exit 1
+      }
+    }
+    END {
+      if (count != 3) {
+        exit 1
+      }
+    }
+  '; then
+    echo "error: release archive members must be regular files: $archive" >&2
+    exit 1
+  fi
 done
 
 expected_archive_list="$(printf '%s\n' "${expected_archives[@]}")"
 actual_archive_list="$(
-  find "$asset_dir" -maxdepth 1 -type f -name 'ocm-*.tar.gz' -exec basename {} \; | sort
+  find "$asset_dir" -maxdepth 1 -name 'ocm-*.tar.gz' -exec basename {} \; | sort
 )"
 if [[ "$actual_archive_list" != "$expected_archive_list" ]]; then
   echo "error: release archive set does not match the supported target matrix" >&2

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -41,35 +41,44 @@ done
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 "${script_dir}/prepare-release-assets.sh" "$asset_dir" >/dev/null
 
-if release_state="$(gh release view "$tag" --repo "$repo" --json isDraft --jq '.isDraft' 2>/dev/null)"; then
+lookup_error="$(mktemp "${TMPDIR:-/tmp}/ocm-release-lookup.XXXXXX")"
+cleanup() {
+  rm -f "$lookup_error"
+}
+trap cleanup EXIT
+
+if release_state="$(gh release view "$tag" --repo "$repo" --json isDraft --jq '.isDraft' 2>"$lookup_error")"; then
   if [[ "$release_state" != "true" ]]; then
     echo "error: release ${tag} is already public; refusing to replace published assets" >&2
     exit 1
   fi
-else
+elif grep -Fxq 'release not found' "$lookup_error"; then
   gh release create "$tag" \
     --repo "$repo" \
     --draft \
     --verify-tag \
     --title "$tag" \
     --generate-notes
+else
+  cat "$lookup_error" >&2
+  echo "error: failed to inspect existing release ${tag}" >&2
+  exit 1
 fi
 
-assets=(
-  "${asset_dir}/ocm-aarch64-apple-darwin.tar.gz"
-  "${asset_dir}/ocm-x86_64-apple-darwin.tar.gz"
-  "${asset_dir}/ocm-x86_64-unknown-linux-gnu.tar.gz"
-  "${asset_dir}/install.sh"
-  "${asset_dir}/SHA256SUMS"
+asset_names=(
+  "ocm-aarch64-apple-darwin.tar.gz"
+  "ocm-x86_64-apple-darwin.tar.gz"
+  "ocm-x86_64-unknown-linux-gnu.tar.gz"
+  "install.sh"
+  "SHA256SUMS"
 )
+assets=()
+for name in "${asset_names[@]}"; do
+  assets+=("${asset_dir}/${name}")
+done
 gh release upload "$tag" --repo "$repo" --clobber "${assets[@]}"
 
-expected_assets="$(printf '%s\n' \
-  "SHA256SUMS" \
-  "ocm-aarch64-apple-darwin.tar.gz" \
-  "ocm-x86_64-apple-darwin.tar.gz" \
-  "ocm-x86_64-unknown-linux-gnu.tar.gz" \
-  "install.sh" | sort)"
+expected_assets="$(printf '%s\n' "${asset_names[@]}" | sort)"
 actual_assets="$(gh release view "$tag" --repo "$repo" --json assets --jq '.assets[].name' | sort)"
 if [[ "$actual_assets" != "$expected_assets" ]]; then
   echo "error: draft release assets are incomplete; leaving ${tag} as a draft" >&2

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -42,6 +42,10 @@ done
 
 [[ -n "$repo" ]] || { usage; exit 1; }
 [[ -n "$tag" ]] || { usage; exit 1; }
+if [[ "$repo" != "openclaw/ocm" ]]; then
+  echo "error: release repository must be openclaw/ocm: $repo" >&2
+  exit 1
+fi
 [[ "$commit" =~ ^[0-9a-fA-F]{40}$ ]] || {
   echo "error: --commit requires a full commit SHA" >&2
   exit 1
@@ -49,7 +53,28 @@ done
 [[ -n "$asset_dir" ]] || { usage; exit 1; }
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+verified_commit="$(
+  "${script_dir}/verify-release-tag.sh" \
+    --repo "$repo" \
+    --tag "$tag" \
+    --commit "$commit"
+)"
+[[ "$verified_commit" == "$commit" ]] || {
+  echo "error: initial release tag verification returned an unexpected commit" >&2
+  exit 1
+}
+"${script_dir}/verify-release-ci.sh" --repo "$repo" --commit "$commit"
 "${script_dir}/prepare-release-assets.sh" "$asset_dir" >/dev/null
+verified_commit="$(
+  "${script_dir}/verify-release-tag.sh" \
+    --repo "$repo" \
+    --tag "$tag" \
+    --commit "$commit"
+)"
+[[ "$verified_commit" == "$commit" ]] || {
+  echo "error: final release tag verification returned an unexpected commit" >&2
+  exit 1
+}
 
 lookup_error="$(mktemp "${TMPDIR:-/tmp}/ocm-release-lookup.XXXXXX")"
 cleanup() {

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: scripts/publish-release.sh --repo <owner/repo> --tag <tag> --asset-dir <dir>" >&2
+  echo "Usage: scripts/publish-release.sh --repo <owner/repo> --tag <tag> --commit <sha> --asset-dir <dir>" >&2
 }
 
 repo=""
 tag=""
+commit=""
 asset_dir=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -19,6 +20,11 @@ while [[ $# -gt 0 ]]; do
       shift
       [[ $# -gt 0 ]] || { echo "error: --tag requires a value" >&2; exit 1; }
       tag="$1"
+      ;;
+    --commit)
+      shift
+      [[ $# -gt 0 ]] || { echo "error: --commit requires a value" >&2; exit 1; }
+      commit="$1"
       ;;
     --asset-dir)
       shift
@@ -36,6 +42,10 @@ done
 
 [[ -n "$repo" ]] || { usage; exit 1; }
 [[ -n "$tag" ]] || { usage; exit 1; }
+[[ "$commit" =~ ^[0-9a-fA-F]{40}$ ]] || {
+  echo "error: --commit requires a full commit SHA" >&2
+  exit 1
+}
 [[ -n "$asset_dir" ]] || { usage; exit 1; }
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -121,6 +121,17 @@ if [[ "$actual_assets" != "$expected_assets" ]]; then
   exit 1
 fi
 
+verified_commit="$(
+  "${script_dir}/verify-release-tag.sh" \
+    --repo "$repo" \
+    --tag "$tag" \
+    --commit "$commit"
+)"
+[[ "$verified_commit" == "$commit" ]] || {
+  echo "error: pre-publication release tag verification returned an unexpected commit" >&2
+  exit 1
+}
+
 release_flags=(--draft=false)
 version_without_build="${tag#v}"
 version_without_build="${version_without_build%%+*}"

--- a/scripts/read-package-version.sh
+++ b/scripts/read-package-version.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: scripts/read-package-version.sh <Cargo.toml> <Cargo.lock>" >&2
+  exit 1
+fi
+
+manifest="$1"
+lockfile="$2"
+
+[[ -f "$manifest" && ! -L "$manifest" ]] || {
+  echo "error: package manifest is missing or invalid: $manifest" >&2
+  exit 1
+}
+[[ -f "$lockfile" && ! -L "$lockfile" ]] || {
+  echo "error: package lockfile is missing or invalid: $lockfile" >&2
+  exit 1
+}
+
+manifest_version="$(
+  perl -0e '
+    use strict;
+    use warnings;
+
+    local $/;
+    my $content = <>;
+    my @sections = split(/(?=^\[)/m, $content);
+    my @package_sections = grep { /^\[package\]\s*$/m } @sections;
+    die "expected exactly one [package] section\n" unless @package_sections == 1;
+
+    my $section = $package_sections[0];
+    my @names = ($section =~ /^name\s*=\s*"([^"]+)"\s*$/mg);
+    my @versions = ($section =~ /^version\s*=\s*"([^"]+)"\s*$/mg);
+    die "expected exactly one package name\n" unless @names == 1;
+    die "package name must be ocm\n" unless $names[0] eq "ocm";
+    die "expected exactly one package version\n" unless @versions == 1;
+    print "$versions[0]\n";
+  ' "$manifest"
+)" || {
+  echo "error: could not read a unique ocm package version from $manifest" >&2
+  exit 1
+}
+
+lock_version="$(
+  perl -0e '
+    use strict;
+    use warnings;
+
+    local $/;
+    my $content = <>;
+    my @matches;
+    while ($content =~ /(?:\A|\n)\[\[package\]\]\s*\n(.*?)(?=\n\[\[package\]\]\s*\n|\z)/sg) {
+      my $block = $1;
+      my @names = ($block =~ /^name\s*=\s*"([^"]+)"\s*$/mg);
+      next unless grep { $_ eq "ocm" } @names;
+      push @matches, $block;
+    }
+    die "expected exactly one ocm package record\n" unless @matches == 1;
+
+    my $block = $matches[0];
+    my @names = ($block =~ /^name\s*=\s*"([^"]+)"\s*$/mg);
+    my @versions = ($block =~ /^version\s*=\s*"([^"]+)"\s*$/mg);
+    die "expected one ocm package name\n" unless @names == 1 && $names[0] eq "ocm";
+    die "expected one ocm package version\n" unless @versions == 1;
+    die "ocm package record must be local\n" if $block =~ /^(?:source|checksum)\s*=/m;
+    print "$versions[0]\n";
+  ' "$lockfile"
+)" || {
+  echo "error: could not read a unique local ocm package version from $lockfile" >&2
+  exit 1
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+"${script_dir}/validate-version.sh" "$manifest_version"
+"${script_dir}/validate-version.sh" "$lock_version"
+
+if [[ "$manifest_version" != "$lock_version" ]]; then
+  echo "error: Cargo.toml and Cargo.lock ocm versions do not match" >&2
+  exit 1
+fi
+
+printf '%s\n' "$manifest_version"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,8 +13,15 @@ run_step() {
   local description="$1"
   shift
   local started_at="$SECONDS"
+  local status
   log_step "$description"
-  "$@"
+  if "$@"; then
+    status=0
+  else
+    status=$?
+    log_step "failed: ${description} ($((SECONDS - started_at))s)"
+    return "$status"
+  fi
   log_step "done: ${description} ($((SECONDS - started_at))s)"
 }
 
@@ -268,10 +275,9 @@ ensure_release_pr() {
 }
 
 verify_existing_remote_tag() {
-  local remote_main_sha remote_tag_commit_sha remote_tag_object_sha local_tag_object_sha tagged_version
+  local remote_tag_commit_sha="$1"
+  local remote_main_sha remote_tag_object_sha local_tag_object_sha tagged_version
   local repository verified_commit release_state gh_bin
-  remote_tag_commit_sha="$(remote_tag_commit)"
-  [[ -n "$remote_tag_commit_sha" ]] || return 1
   remote_tag_object_sha="$(remote_tag_object)"
 
   if git show-ref --verify --quiet "refs/tags/${tag}"; then
@@ -307,8 +313,8 @@ verify_existing_remote_tag() {
   run_step "Verifying exact-SHA main CI" \
     "${script_dir}/verify-release-ci.sh" \
     --repo "$repository" \
-    --commit "$remote_tag_commit_sha"
-  verified_commit="$(verify_published_tag "$repository" "$remote_tag_commit_sha")"
+    --commit "$remote_tag_commit_sha" || return
+  verified_commit="$(verify_published_tag "$repository" "$remote_tag_commit_sha")" || return
   gh_bin="$(github_cli)"
   release_state="$(
     "$gh_bin" release view "$tag" \
@@ -318,7 +324,7 @@ verify_existing_remote_tag() {
       2>/dev/null || true
   )"
   if [[ "$release_state" != "false" ]]; then
-    dispatch_release_workflow "$repository" "$verified_commit"
+    dispatch_release_workflow "$repository" "$verified_commit" || return
   fi
 
   cat <<EOF
@@ -386,7 +392,9 @@ release_branch="release/${tag}"
 release_commit_message="chore(release): bump version to ${version}"
 branch="$(git symbolic-ref --quiet --short HEAD || true)"
 
-if verify_existing_remote_tag; then
+existing_remote_tag_commit="$(remote_tag_commit)"
+if [[ -n "$existing_remote_tag_commit" ]]; then
+  verify_existing_remote_tag "$existing_remote_tag_commit" || exit $?
   exit 0
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,17 +32,24 @@ EOF
 }
 
 package_version() {
-  perl -ne 'print "$1\n" if /^version = "([^"]+)"$/' Cargo.toml | head -n1
-}
-
-lockfile_version() {
-  perl -0ne 'print "$1\n" if /\[\[package\]\]\nname = "ocm"\nversion = "([^"]+)"/s' Cargo.lock | head -n1
+  "${script_dir}/read-package-version.sh" Cargo.toml Cargo.lock
 }
 
 version_at_ref() {
-  git show "$1:Cargo.toml" |
-    perl -ne 'print "$1\n" if /^version = "([^"]+)"$/' |
-    head -n1
+  local reference="$1"
+  local version_dir version_status
+  version_dir="$(mktemp -d "${TMPDIR:-/tmp}/ocm-release-version.XXXXXX")"
+  if git show "${reference}:Cargo.toml" >"${version_dir}/Cargo.toml" &&
+    git show "${reference}:Cargo.lock" >"${version_dir}/Cargo.lock" &&
+    "${script_dir}/read-package-version.sh" \
+      "${version_dir}/Cargo.toml" \
+      "${version_dir}/Cargo.lock"; then
+    version_status=0
+  else
+    version_status=$?
+  fi
+  rm -rf "$version_dir"
+  return "$version_status"
 }
 
 remote_ref_commit() {
@@ -196,11 +203,41 @@ github_repository() {
     esac
     repository="${repository%.git}"
   fi
-  if [[ ! "$repository" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
-    echo "error: invalid GitHub repository: ${repository}" >&2
+  if [[ "$repository" != "$canonical_repository" ]]; then
+    echo "error: release repository must be ${canonical_repository}: ${repository}" >&2
     return 1
   fi
   printf '%s\n' "$repository"
+}
+
+verify_published_tag() {
+  local repository="$1"
+  local commit="$2"
+  local verified_commit
+  verified_commit="$(
+    "${script_dir}/verify-release-tag.sh" \
+      --repo "$repository" \
+      --tag "$tag" \
+      --commit "$commit"
+  )"
+  if [[ ! "$verified_commit" =~ ^[0-9a-fA-F]{40}$ || "$verified_commit" != "$commit" ]]; then
+    echo "error: release tag verification returned an unexpected commit" >&2
+    return 1
+  fi
+  printf '%s\n' "$verified_commit"
+}
+
+dispatch_release_workflow() {
+  local repository="$1"
+  local commit="$2"
+  local gh_bin
+  gh_bin="$(github_cli)"
+  run_step "Dispatching trusted release workflow for ${tag}" \
+    "$gh_bin" workflow run release.yml \
+    --repo "$repository" \
+    --ref main \
+    -f "tag=${tag}" \
+    -f "commit=${commit}"
 }
 
 ensure_release_pr() {
@@ -232,6 +269,7 @@ ensure_release_pr() {
 
 verify_existing_remote_tag() {
   local remote_main_sha remote_tag_commit_sha remote_tag_object_sha local_tag_object_sha tagged_version
+  local repository verified_commit release_state gh_bin
   remote_tag_commit_sha="$(remote_tag_commit)"
   [[ -n "$remote_tag_commit_sha" ]] || return 1
   remote_tag_object_sha="$(remote_tag_object)"
@@ -265,9 +303,27 @@ verify_existing_remote_tag() {
     exit 1
   fi
 
+  repository="$(github_repository)"
+  run_step "Verifying exact-SHA main CI" \
+    "${script_dir}/verify-release-ci.sh" \
+    --repo "$repository" \
+    --commit "$remote_tag_commit_sha"
+  verified_commit="$(verify_published_tag "$repository" "$remote_tag_commit_sha")"
+  gh_bin="$(github_cli)"
+  release_state="$(
+    "$gh_bin" release view "$tag" \
+      --repo "$repository" \
+      --json isDraft \
+      --jq '.isDraft' \
+      2>/dev/null || true
+  )"
+  if [[ "$release_state" != "false" ]]; then
+    dispatch_release_workflow "$repository" "$verified_commit"
+  fi
+
   cat <<EOF
 Release tag ${tag} is already published from verified commit ${remote_tag_commit_sha}.
-The tag-push workflow owns artifact publication.
+The protected-main release workflow owns artifact publication.
 EOF
 }
 
@@ -315,6 +371,7 @@ fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
+canonical_repository="openclaw/ocm"
 cd "$repo_root"
 
 "${script_dir}/validate-version.sh" "$version"
@@ -334,15 +391,6 @@ if verify_existing_remote_tag; then
 fi
 
 current_version="$(package_version)"
-current_lock_version="$(lockfile_version)"
-if [[ -z "$current_version" || -z "$current_lock_version" ]]; then
-  echo "error: could not read the ocm version from Cargo.toml and Cargo.lock" >&2
-  exit 1
-fi
-if [[ "$current_version" != "$current_lock_version" ]]; then
-  echo "error: Cargo.toml and Cargo.lock are out of sync" >&2
-  exit 1
-fi
 
 case "$branch" in
   main)
@@ -380,9 +428,12 @@ case "$branch" in
         exit 1
       fi
       run_step "Pushing signed tag ${tag}" git push "$remote" "$tag"
+      repository="$(github_repository)"
+      verified_commit="$(verify_published_tag "$repository" "$head_sha")"
+      dispatch_release_workflow "$repository" "$verified_commit"
       cat <<EOF
 Release tag ${tag} pushed from $(git rev-parse HEAD).
-The tag-push workflow will verify, build, and publish the release.
+The protected-main workflow will verify, build, and publish the release.
 EOF
       exit 0
     fi

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -27,11 +27,7 @@ cd "$repo_root"
 
 "${script_dir}/validate-version.sh" "$new_version"
 
-current_version="$(perl -ne 'print "$1\n" if /^version = "([^"]+)"$/' Cargo.toml | head -n1)"
-if [[ -z "$current_version" ]]; then
-  echo "error: could not read the package version from Cargo.toml" >&2
-  exit 1
-fi
+current_version="$("${script_dir}/read-package-version.sh" Cargo.toml Cargo.lock)"
 
 if [[ "$current_version" == "$new_version" ]]; then
   echo "ocm is already on ${new_version}"
@@ -61,10 +57,8 @@ perl -0pi -e 's/^(version = ")[^"]+(")/$1.$ENV{OCM_NEW_VERSION}.$2/me' Cargo.tom
 
 perl -0pi -e 's/(\[\[package\]\]\nname = "ocm"\nversion = ")[^"]+(")/$1.$ENV{OCM_NEW_VERSION}.$2/se' Cargo.lock
 
-updated_toml_version="$(perl -ne 'print "$1\n" if /^version = "([^"]+)"$/' Cargo.toml | head -n1)"
-updated_lock_version="$(perl -0ne 'print "$1\n" if /\[\[package\]\]\nname = "ocm"\nversion = "([^"]+)"/s' Cargo.lock | head -n1)"
-
-if [[ "$updated_toml_version" != "$new_version" || "$updated_lock_version" != "$new_version" ]]; then
+updated_version="$("${script_dir}/read-package-version.sh" Cargo.toml Cargo.lock)"
+if [[ "$updated_version" != "$new_version" ]]; then
   echo "error: version files did not update cleanly" >&2
   exit 1
 fi

--- a/scripts/verify-release-ci.sh
+++ b/scripts/verify-release-ci.sh
@@ -20,6 +20,7 @@ github() {
 
 repo=""
 commit=""
+canonical_repo="openclaw/ocm"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
@@ -47,8 +48,8 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-if [[ ! "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
-  echo "error: invalid GitHub repository: ${repo:-empty}" >&2
+if [[ "$repo" != "$canonical_repo" ]]; then
+  echo "error: release CI repository must be ${canonical_repo}: ${repo:-empty}" >&2
   exit 1
 fi
 if [[ ! "$commit" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -59,7 +60,7 @@ fi
 endpoint="repos/${repo}/actions/workflows/ci.yml/runs?branch=main&event=push&head_sha=${commit}&per_page=20"
 run_data="$(
   github api "$endpoint" \
-    --jq "(.workflow_runs | map(select(.head_sha == \"${commit}\")) | .[0]) // empty | [.id, .head_sha, .status, (.conclusion // \"\"), .html_url] | map(tostring) | join(\"|\")"
+    --jq "(.workflow_runs // []) as \$runs | [(\$runs | length), ((\$runs[0].id // \"\") | tostring), (\$runs[0].head_sha // \"\"), (\$runs[0].event // \"\"), (\$runs[0].head_branch // \"\"), (\$runs[0].status // \"\"), (\$runs[0].conclusion // \"\"), (\$runs[0].html_url // \"\")] | join(\"|\")"
 )"
 if [[ -z "$run_data" ]]; then
   echo "error: no main-branch CI push run exists for exact commit ${commit}" >&2
@@ -67,7 +68,30 @@ if [[ -z "$run_data" ]]; then
   exit 1
 fi
 
-IFS='|' read -r run_id run_head_sha run_status run_conclusion run_url <<<"$run_data"
+IFS='|' read -r run_count run_id run_head_sha run_event run_branch run_status run_conclusion run_url run_extra <<<"$run_data"
+if [[ -n "${run_extra:-}" || ! "$run_count" =~ ^[0-9]+$ ]]; then
+  echo "error: malformed CI run selection response" >&2
+  exit 1
+fi
+if [[ "$run_count" == "0" ]]; then
+  echo "error: no main-branch CI push run exists for exact commit ${commit}" >&2
+  echo "hint: wait for CI to start and finish, then retry the release" >&2
+  exit 1
+fi
+if [[ "$run_count" != "1" ]]; then
+  echo "error: expected exactly one main-branch CI push run for ${commit}, found ${run_count}" >&2
+  exit 1
+fi
+if [[ ! "$run_id" =~ ^[0-9]+$ ||
+  ! "$run_head_sha" =~ ^[0-9a-fA-F]{40}$ ||
+  "$run_event" != "push" ||
+  "$run_branch" != "main" ||
+  ! "$run_status" =~ ^(queued|in_progress|completed)$ ||
+  ! "$run_conclusion" =~ ^(success|failure|cancelled|skipped|timed_out|action_required|neutral|stale|startup_failure)?$ ||
+  ! "$run_url" =~ ^https://github\.com/openclaw/ocm/actions/runs/[0-9]+$ ]]; then
+  echo "error: malformed or unrelated CI run response" >&2
+  exit 1
+fi
 if [[ "$run_head_sha" != "$commit" ]]; then
   echo "error: CI run ${run_id:-unknown} is for ${run_head_sha:-unknown}, not ${commit}" >&2
   exit 1

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -5,9 +5,32 @@ usage() {
   echo "Usage: scripts/verify-release-tag.sh --repo <owner/repo> --tag <tag> [--commit <sha>]" >&2
 }
 
+github() {
+  if [[ -n "${OCM_GH_BIN:-}" ]]; then
+    "$OCM_GH_BIN" "$@"
+  elif command -v ghx >/dev/null 2>&1; then
+    ghx --no-cache "$@"
+  elif command -v gh >/dev/null 2>&1; then
+    gh "$@"
+  else
+    echo "error: ghx or gh is required to verify release tags" >&2
+    return 1
+  fi
+}
+
+is_sha() {
+  [[ "$1" =~ ^[0-9a-fA-F]{40}$ ]]
+}
+
+is_branch() {
+  [[ -n "$1" && "$1" != *[[:space:]]* ]] &&
+    git check-ref-format --branch "$1" >/dev/null 2>&1
+}
+
 repo=""
 tag=""
 expected_commit=""
+canonical_repo="openclaw/ocm"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
@@ -35,31 +58,45 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$repo" && -n "$tag" ]] || { usage; exit 1; }
-if [[ -n "$expected_commit" && ! "$expected_commit" =~ ^[0-9a-fA-F]{40}$ ]]; then
+if [[ "$repo" != "$canonical_repo" ]]; then
+  echo "error: release tag repository must be ${canonical_repo}: ${repo}" >&2
+  exit 1
+fi
+if [[ "$tag" != v* || "$tag" == "v" ]]; then
+  echo "error: release tag must be a v-prefixed semantic version: ${tag}" >&2
+  exit 1
+fi
+version="${tag#v}"
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+"${script_dir}/validate-version.sh" "$version"
+
+if [[ -n "$expected_commit" ]] && ! is_sha "$expected_commit"; then
   echo "error: invalid release commit SHA: $expected_commit" >&2
   exit 1
 fi
 
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(cd -- "${script_dir}/.." && pwd)"
-
 ref_data="$(
-  gh api "repos/${repo}/git/ref/tags/${tag}" \
+  github api "repos/${repo}/git/ref/tags/${tag}" \
     --jq '[.object.type, .object.sha] | @tsv'
 )"
-IFS=$'\t' read -r ref_type tag_object_sha <<<"$ref_data"
-if [[ "$ref_type" != "tag" || ! "$tag_object_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
-  echo "error: release tag ${tag} must be an annotated tag" >&2
+IFS=$'\t' read -r ref_type tag_object_sha ref_extra <<<"$ref_data"
+if [[ -n "${ref_extra:-}" || "$ref_type" != "tag" ]] || ! is_sha "$tag_object_sha"; then
+  echo "error: release tag ${tag} must be an annotated tag with a valid object" >&2
   exit 1
 fi
 
 tag_data="$(
-  gh api "repos/${repo}/git/tags/${tag_object_sha}" \
+  github api "repos/${repo}/git/tags/${tag_object_sha}" \
     --jq '[.tag, .object.type, .object.sha, (.verification.verified | tostring)] | @tsv'
 )"
-IFS=$'\t' read -r verified_tag target_type target_sha signature_verified <<<"$tag_data"
-if [[ "$verified_tag" != "$tag" || "$target_type" != "commit" ]]; then
-  echo "error: release tag ${tag} does not point directly at a commit" >&2
+IFS=$'\t' read -r verified_tag target_type target_sha signature_verified tag_extra <<<"$tag_data"
+if [[ -n "${tag_extra:-}" ||
+  "$verified_tag" != "$tag" ||
+  "$target_type" != "commit" ]] ||
+  ! is_sha "$target_sha"; then
+  echo "error: release tag ${tag} does not identify one valid commit" >&2
   exit 1
 fi
 if [[ "$signature_verified" != "true" ]]; then
@@ -71,15 +108,23 @@ if [[ -n "$expected_commit" && "$target_sha" != "$expected_commit" ]]; then
   exit 1
 fi
 
-default_branch="$(gh api "repos/${repo}" --jq '.default_branch')"
+default_branch="$(github api "repos/${repo}" --jq '.default_branch')"
+if [[ "$default_branch" != "main" ]] || ! is_branch "$default_branch"; then
+  echo "error: invalid protected default branch: ${default_branch:-empty}" >&2
+  exit 1
+fi
 default_head="$(
-  gh api "repos/${repo}/git/ref/heads/${default_branch}" --jq '.object.sha'
+  github api "repos/${repo}/git/ref/heads/${default_branch}" --jq '.object.sha'
 )"
+if ! is_sha "$default_head"; then
+  echo "error: invalid protected branch head SHA" >&2
+  exit 1
+fi
 compare_status="$(
-  gh api "repos/${repo}/compare/${target_sha}...${default_head}" --jq '.status'
+  github api "repos/${repo}/compare/${target_sha}...${default_head}" --jq '.status'
 )"
 if [[ "$compare_status" != "ahead" && "$compare_status" != "identical" ]]; then
-  echo "error: release commit ${target_sha} is not on the protected ${default_branch} branch" >&2
+  echo "error: release commit ${target_sha} is not on protected ${default_branch}" >&2
   exit 1
 fi
 
@@ -87,14 +132,89 @@ if ! git -C "$repo_root" cat-file -e "${target_sha}^{commit}" 2>/dev/null; then
   echo "error: verified release commit is not available locally: ${target_sha}" >&2
   exit 1
 fi
+
+target_dir="$(mktemp -d "${TMPDIR:-/tmp}/ocm-release-target.XXXXXX")"
+cleanup() {
+  rm -rf "$target_dir"
+}
+trap cleanup EXIT
+git -C "$repo_root" show "${target_sha}:Cargo.toml" >"${target_dir}/Cargo.toml"
+git -C "$repo_root" show "${target_sha}:Cargo.lock" >"${target_dir}/Cargo.lock"
 package_version="$(
-  git -C "$repo_root" show "${target_sha}:Cargo.toml" |
-    perl -ne 'print "$1\n" if /^version = "([^"]+)"$/' |
-    head -n1
+  "${script_dir}/read-package-version.sh" \
+    "${target_dir}/Cargo.toml" \
+    "${target_dir}/Cargo.lock"
 )"
-if [[ "$tag" != "v${package_version}" ]]; then
+if [[ "$package_version" != "$version" ]]; then
   echo "error: release tag ${tag} does not match package version ${package_version}" >&2
   exit 1
 fi
 
-echo "$target_sha"
+parent_data="$(git -C "$repo_root" rev-list --parents -n1 "$target_sha")"
+read -r commit_sha parent_sha parent_extra <<<"$parent_data"
+if [[ -n "${parent_extra:-}" ||
+  "$commit_sha" != "$target_sha" ]] ||
+  ! is_sha "$parent_sha"; then
+  echo "error: release commit ${target_sha} must have exactly one parent" >&2
+  exit 1
+fi
+changed_files="$(
+  git -C "$repo_root" diff-tree \
+    --no-commit-id \
+    --name-only \
+    -r \
+    "$parent_sha" \
+    "$target_sha" |
+    LC_ALL=C sort -u
+)"
+if [[ "$changed_files" != $'Cargo.lock\nCargo.toml' ]]; then
+  echo "error: release commit ${target_sha} must change only Cargo.toml and Cargo.lock" >&2
+  exit 1
+fi
+
+subject="$(git -C "$repo_root" log -1 --format=%s "$target_sha")"
+subject_prefix="chore(release): bump version to ${version} (#"
+if [[ "$subject" != "${subject_prefix}"*")" ]]; then
+  echo "error: release commit has invalid subject: ${subject}" >&2
+  exit 1
+fi
+pr_number="${subject#"$subject_prefix"}"
+pr_number="${pr_number%)}"
+if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ ||
+  "$subject" != "${subject_prefix}${pr_number})" ]]; then
+  echo "error: release commit subject has invalid pull request number" >&2
+  exit 1
+fi
+
+pr_data="$(
+  github api \
+    -H 'Accept: application/vnd.github+json' \
+    "repos/${repo}/commits/${target_sha}/pulls" \
+    --jq '.[] | [.number, .state, (.merged_at // ""), .base.ref, .head.ref, .merge_commit_sha, .title] | @tsv'
+)"
+pr_line_count="$(printf '%s\n' "$pr_data" | awk 'NF { count += 1 } END { print count + 0 }')"
+if [[ "$pr_line_count" != "1" ]]; then
+  echo "error: release commit must be associated with exactly one pull request" >&2
+  exit 1
+fi
+IFS=$'\t' read -r api_pr_number pr_state merged_at base_branch head_branch merge_commit pr_title pr_extra <<<"$pr_data"
+if [[ -n "${pr_extra:-}" ||
+  ! "$api_pr_number" =~ ^[1-9][0-9]*$ ||
+  "$api_pr_number" != "$pr_number" ||
+  "$pr_state" != "closed" ||
+  ! "$merged_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] ||
+  ! is_branch "$base_branch" ||
+  ! is_branch "$head_branch" ||
+  ! is_sha "$merge_commit"; then
+  echo "error: release pull request metadata is invalid" >&2
+  exit 1
+fi
+if [[ "$base_branch" != "$default_branch" ||
+  "$head_branch" != "release/${tag}" ||
+  "$merge_commit" != "$target_sha" ||
+  "$pr_title" != "chore(release): bump version to ${version}" ]]; then
+  echo "error: release pull request does not match the release commit" >&2
+  exit 1
+fi
+
+printf '%s\n' "$target_sha"

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -217,4 +217,29 @@ if [[ "$base_branch" != "$default_branch" ||
   exit 1
 fi
 
+final_ref_data="$(
+  github api "repos/${repo}/git/ref/tags/${tag}" \
+    --jq '[.object.type, .object.sha] | @tsv'
+)"
+IFS=$'\t' read -r final_ref_type final_tag_object_sha final_ref_extra <<<"$final_ref_data"
+if [[ -n "${final_ref_extra:-}" ||
+  "$final_ref_type" != "tag" ||
+  "$final_tag_object_sha" != "$tag_object_sha" ]]; then
+  echo "error: release tag ${tag} changed during verification" >&2
+  exit 1
+fi
+final_tag_data="$(
+  github api "repos/${repo}/git/tags/${final_tag_object_sha}" \
+    --jq '[.tag, .object.type, .object.sha, (.verification.verified | tostring)] | @tsv'
+)"
+IFS=$'\t' read -r final_verified_tag final_target_type final_target_sha final_signature_verified final_tag_extra <<<"$final_tag_data"
+if [[ -n "${final_tag_extra:-}" ||
+  "$final_verified_tag" != "$tag" ||
+  "$final_target_type" != "commit" ||
+  "$final_target_sha" != "$target_sha" ||
+  "$final_signature_verified" != "true" ]]; then
+  echo "error: release tag ${tag} changed during verification" >&2
+  exit 1
+fi
+
 printf '%s\n' "$target_sha"

--- a/src/cli/self_cmd.rs
+++ b/src/cli/self_cmd.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -12,7 +13,7 @@ use crate::store::resolve_ocm_home;
 
 use super::{Cli, render};
 
-const RELEASE_REPO: &str = "shakkernerd/ocm";
+const RELEASE_REPO: &str = "openclaw/ocm";
 const INTERNAL_SELF_UPDATE_RELEASE_URL_ENV: &str = "OCM_INTERNAL_SELF_UPDATE_RELEASE_URL";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -387,22 +388,7 @@ impl Cli {
     }
 
     fn fetch_self_release(&self, version: Option<&str>) -> Result<GitHubRelease, String> {
-        let url = if let Some(override_url) = self
-            .env
-            .get(INTERNAL_SELF_UPDATE_RELEASE_URL_ENV)
-            .map(String::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            override_url.to_string()
-        } else if let Some(version) = version {
-            format!(
-                "https://api.github.com/repos/{RELEASE_REPO}/releases/tags/{}",
-                normalize_release_tag(version)
-            )
-        } else {
-            format!("https://api.github.com/repos/{RELEASE_REPO}/releases/latest")
-        };
+        let url = self_release_url(&self.env, version);
 
         let response = http_agent()
             .get(&url)
@@ -413,6 +399,24 @@ impl Cli {
             .map_err(|error| format!("failed to query ocm releases: {error}"))?;
         serde_json::from_reader(response.into_body().into_reader())
             .map_err(|error| format!("failed to parse ocm release metadata: {error}"))
+    }
+}
+
+fn self_release_url(env: &BTreeMap<String, String>, version: Option<&str>) -> String {
+    if let Some(override_url) = env
+        .get(INTERNAL_SELF_UPDATE_RELEASE_URL_ENV)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        override_url.to_string()
+    } else if let Some(version) = version {
+        format!(
+            "https://api.github.com/repos/{RELEASE_REPO}/releases/tags/{}",
+            normalize_release_tag(version)
+        )
+    } else {
+        format!("https://api.github.com/repos/{RELEASE_REPO}/releases/latest")
     }
 }
 
@@ -531,13 +535,58 @@ fn should_treat_target_as_current(
 mod tests {
     use super::{
         SelfUpdateTempDir, display_version_from_tag, normalize_release_tag, parse_release_version,
-        release_asset_name, should_treat_target_as_current,
+        release_asset_name, self_release_url, should_treat_target_as_current,
     };
+    use std::collections::BTreeMap;
 
     #[test]
     fn normalize_release_tag_accepts_prefixed_and_bare_versions() {
         assert_eq!(normalize_release_tag("0.2.1"), "v0.2.1");
         assert_eq!(normalize_release_tag("v0.2.1"), "v0.2.1");
+    }
+
+    #[test]
+    fn self_release_urls_use_the_canonical_repository() {
+        let env = BTreeMap::new();
+        assert_eq!(
+            self_release_url(&env, None),
+            "https://api.github.com/repos/openclaw/ocm/releases/latest"
+        );
+        assert_eq!(
+            self_release_url(&env, Some("0.2.33")),
+            "https://api.github.com/repos/openclaw/ocm/releases/tags/v0.2.33"
+        );
+    }
+
+    #[test]
+    fn self_release_url_override_requires_a_non_empty_value() {
+        let mut env = BTreeMap::new();
+        env.insert(
+            super::INTERNAL_SELF_UPDATE_RELEASE_URL_ENV.to_string(),
+            " https://example.test/internal-release.json ".to_string(),
+        );
+        assert_eq!(
+            self_release_url(&env, Some("0.2.33")),
+            "https://example.test/internal-release.json"
+        );
+
+        env.insert(
+            super::INTERNAL_SELF_UPDATE_RELEASE_URL_ENV.to_string(),
+            String::new(),
+        );
+        assert_eq!(
+            self_release_url(&env, None),
+            "https://api.github.com/repos/openclaw/ocm/releases/latest"
+        );
+
+        env.insert(
+            super::INTERNAL_SELF_UPDATE_RELEASE_URL_ENV.to_string(),
+            " \t\n ".to_string(),
+        );
+        assert_eq!(
+            self_release_url(&env, Some("v0.2.33")),
+            "https://api.github.com/repos/openclaw/ocm/releases/tags/v0.2.33"
+        );
     }
 
     #[test]

--- a/tests/install_script_tests.rs
+++ b/tests/install_script_tests.rs
@@ -7,7 +7,80 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::support::{TestDir, stderr};
+use crate::support::{TestDir, path_string, stderr, write_executable_script};
+
+fn installer_requested_urls(version: Option<&str>) -> Vec<String> {
+    let root = TestDir::new("install-release-urls");
+    let fake_bin = root.child("bin");
+    let url_log = root.child("urls");
+    fs::create_dir_all(&fake_bin).unwrap();
+    write_executable_script(
+        &fake_bin.join("uname"),
+        "#!/bin/sh\ncase \"$1\" in\n  -s) printf 'Darwin\\n' ;;\n  -m) printf 'x86_64\\n' ;;\n  *) exit 1 ;;\nesac\n",
+    );
+    write_executable_script(
+        &fake_bin.join("curl"),
+        r#"#!/bin/sh
+set -eu
+url=""
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; output="$1" ;;
+    http*) url="$1" ;;
+  esac
+  shift
+done
+printf '%s\n' "$url" >>"$TEST_URL_LOG"
+: >"$output"
+"#,
+    );
+
+    let system_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut command = Command::new("bash");
+    command
+        .arg(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .args(["--bin-dir", &path_string(&root.child("installed"))])
+        .env("HOME", root.child("home"))
+        .env("TEST_URL_LOG", &url_log)
+        .env(
+            "PATH",
+            format!("{}:{}", fake_bin.display(), system_path.to_string_lossy()),
+        );
+    if let Some(version) = version {
+        command.args(["--version", version]);
+    }
+
+    let output = command.output().unwrap();
+    assert!(!output.status.success());
+    fs::read_to_string(url_log)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn installer_uses_canonical_latest_release_urls() {
+    assert_eq!(
+        installer_requested_urls(None),
+        [
+            "https://github.com/openclaw/ocm/releases/latest/download/ocm-x86_64-apple-darwin.tar.gz",
+            "https://github.com/openclaw/ocm/releases/latest/download/SHA256SUMS",
+        ]
+    );
+}
+
+#[test]
+fn installer_uses_canonical_versioned_release_urls() {
+    assert_eq!(
+        installer_requested_urls(Some("v0.2.33")),
+        [
+            "https://github.com/openclaw/ocm/releases/download/v0.2.33/ocm-x86_64-apple-darwin.tar.gz",
+            "https://github.com/openclaw/ocm/releases/download/v0.2.33/SHA256SUMS",
+        ]
+    );
+}
 
 #[test]
 fn installer_rejects_linux_aarch64_before_downloading() {

--- a/tests/install_script_tests.rs
+++ b/tests/install_script_tests.rs
@@ -9,14 +9,16 @@ use std::process::Command;
 
 use crate::support::{TestDir, path_string, stderr, write_executable_script};
 
-fn installer_requested_urls(version: Option<&str>) -> Vec<String> {
+fn installer_requested_urls(os: &str, arch: &str, version: Option<&str>) -> Vec<String> {
     let root = TestDir::new("install-release-urls");
     let fake_bin = root.child("bin");
     let url_log = root.child("urls");
     fs::create_dir_all(&fake_bin).unwrap();
     write_executable_script(
         &fake_bin.join("uname"),
-        "#!/bin/sh\ncase \"$1\" in\n  -s) printf 'Darwin\\n' ;;\n  -m) printf 'x86_64\\n' ;;\n  *) exit 1 ;;\nesac\n",
+        &format!(
+            "#!/bin/sh\ncase \"$1\" in\n  -s) printf '{os}\\n' ;;\n  -m) printf '{arch}\\n' ;;\n  *) exit 1 ;;\nesac\n"
+        ),
     );
     write_executable_script(
         &fake_bin.join("curl"),
@@ -63,7 +65,7 @@ printf '%s\n' "$url" >>"$TEST_URL_LOG"
 #[test]
 fn installer_uses_canonical_latest_release_urls() {
     assert_eq!(
-        installer_requested_urls(None),
+        installer_requested_urls("Darwin", "x86_64", None),
         [
             "https://github.com/openclaw/ocm/releases/latest/download/ocm-x86_64-apple-darwin.tar.gz",
             "https://github.com/openclaw/ocm/releases/latest/download/SHA256SUMS",
@@ -74,12 +76,33 @@ fn installer_uses_canonical_latest_release_urls() {
 #[test]
 fn installer_uses_canonical_versioned_release_urls() {
     assert_eq!(
-        installer_requested_urls(Some("v0.2.33")),
+        installer_requested_urls("Darwin", "x86_64", Some("v0.2.33")),
         [
             "https://github.com/openclaw/ocm/releases/download/v0.2.33/ocm-x86_64-apple-darwin.tar.gz",
             "https://github.com/openclaw/ocm/releases/download/v0.2.33/SHA256SUMS",
         ]
     );
+}
+
+#[test]
+fn installer_selects_every_supported_release_target() {
+    for (os, arch, target) in [
+        ("Darwin", "arm64", "aarch64-apple-darwin"),
+        ("Darwin", "x86_64", "x86_64-apple-darwin"),
+        ("Linux", "x86_64", "x86_64-unknown-linux-gnu"),
+    ] {
+        let urls = installer_requested_urls(os, arch, Some("v0.2.33"));
+        assert_eq!(
+            urls[0],
+            format!(
+                "https://github.com/openclaw/ocm/releases/download/v0.2.33/ocm-{target}.tar.gz"
+            )
+        );
+        assert_eq!(
+            urls[1],
+            "https://github.com/openclaw/ocm/releases/download/v0.2.33/SHA256SUMS"
+        );
+    }
 }
 
 #[test]

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -498,7 +498,7 @@ if [[ "${1:-}" == "api" ]]; then
       verified="true"
       [[ "$TEST_AUTHORITY" != "initial-tag-fail" ]] || verified="false"
       if [[ "$TEST_AUTHORITY" == "retarget" && "$count" -gt 1 ]] ||
-        [[ "$TEST_AUTHORITY" == "post-upload-retarget" && "$count" -gt 2 ]]; then
+        [[ "$TEST_AUTHORITY" == "post-upload-retarget" && "$count" -gt 4 ]]; then
         target="0000000000000000000000000000000000000000"
       fi
       printf 'v0.2.32\tcommit\t%s\t%s\n' "$target" "$verified"
@@ -628,15 +628,17 @@ fn publish_release_settles_stable_draft_after_authority_and_asset_verification()
         .match_indices("/git/tags/")
         .map(|(index, _)| index)
         .collect::<Vec<_>>();
-    assert_eq!(tag_checks.len(), 3);
+    assert_eq!(tag_checks.len(), 6);
     let ci = commands.find("actions/workflows/ci.yml/runs").unwrap();
     let create = commands.find("release create").unwrap();
     let upload = commands.find("release upload").unwrap();
     let query = commands.find("--json assets").unwrap();
     let publish = commands.find("release edit").unwrap();
-    assert!(tag_checks[0] < ci && ci < tag_checks[1]);
-    assert!(tag_checks[1] < create && create < upload && upload < query);
-    assert!(query < tag_checks[2] && tag_checks[2] < publish);
+    assert!(tag_checks[0] < tag_checks[1] && tag_checks[1] < ci);
+    assert!(ci < tag_checks[2] && tag_checks[2] < tag_checks[3]);
+    assert!(tag_checks[3] < create && create < upload && upload < query);
+    assert!(query < tag_checks[4] && tag_checks[4] < tag_checks[5]);
+    assert!(tag_checks[5] < publish);
     let publish_command = commands
         .lines()
         .find(|line| line.starts_with("release edit"))

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -620,7 +620,13 @@ esac
 fn publish_release_settles_stable_draft_after_authority_and_asset_verification() {
     let result = run_publish_scenario("v0.2.32", "success", "missing", "success", "success", true);
     assert!(result.output.status.success(), "{}", stderr(&result.output));
-    assert_eq!(result.assets, RELEASE_ASSETS);
+    assert_eq!(
+        result.assets.into_iter().collect::<BTreeSet<_>>(),
+        RELEASE_ASSETS
+            .into_iter()
+            .map(str::to_string)
+            .collect::<BTreeSet<_>>()
+    );
     assert_eq!(result.draft.as_deref(), Some("false\n"));
 
     let commands = result.commands;
@@ -739,7 +745,13 @@ fn publish_release_stops_before_release_api_when_asset_preparation_fails() {
 fn publish_release_upload_set_matches_checksum_payloads() {
     let result = run_publish_scenario("v0.2.32", "success", "missing", "success", "success", true);
     assert!(result.output.status.success(), "{}", stderr(&result.output));
-    assert_eq!(result.assets, RELEASE_ASSETS);
+    assert_eq!(
+        result.assets.into_iter().collect::<BTreeSet<_>>(),
+        RELEASE_ASSETS
+            .into_iter()
+            .map(str::to_string)
+            .collect::<BTreeSet<_>>()
+    );
 
     let root = TestDir::new("publish-checksum-payloads");
     let asset_dir = root.child("dist");

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -36,6 +36,102 @@ fn script(name: &str) -> PathBuf {
         .join(name)
 }
 
+struct ReleaseCommitFixture {
+    _root: TestDir,
+    repo: PathBuf,
+    commit: String,
+}
+
+impl ReleaseCommitFixture {
+    fn new(label: &str) -> Self {
+        let root = TestDir::new(label);
+        let repo = root.child("repo");
+        fs::create_dir_all(repo.join("scripts")).unwrap();
+        for name in [
+            "prepare-release-assets.sh",
+            "publish-release.sh",
+            "read-package-version.sh",
+            "validate-version.sh",
+            "verify-release-ci.sh",
+            "verify-release-tag.sh",
+        ] {
+            write_executable_script(
+                &repo.join("scripts").join(name),
+                &fs::read_to_string(script(name)).unwrap(),
+            );
+        }
+        fs::write(
+            repo.join("Cargo.toml"),
+            "[package]\nname = \"ocm\"\nversion = \"0.2.31\"\nrepository = \"https://github.com/shakkernerd/ocm\"\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("Cargo.lock"),
+            "version = 4\n\n[[package]]\nname = \"ocm\"\nversion = \"0.2.31\"\n",
+        )
+        .unwrap();
+
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["config", "user.name", "Test User"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "commit.gpgsign", "false"],
+            vec!["add", "."],
+            vec!["commit", "-m", "chore: seed release fixture"],
+        ] {
+            let output = Command::new("git")
+                .current_dir(&repo)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "{}", stderr(&output));
+        }
+
+        fs::write(
+            repo.join("Cargo.toml"),
+            "[package]\nname = \"ocm\"\nversion = \"0.2.32\"\nrepository = \"https://github.com/shakkernerd/ocm\"\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("Cargo.lock"),
+            "version = 4\n\n[[package]]\nname = \"ocm\"\nversion = \"0.2.32\"\n",
+        )
+        .unwrap();
+        for args in [
+            vec!["add", "Cargo.toml", "Cargo.lock"],
+            vec![
+                "commit",
+                "-m",
+                "chore(release): bump version to 0.2.32 (#81)",
+            ],
+        ] {
+            let output = Command::new("git")
+                .current_dir(&repo)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "{}", stderr(&output));
+        }
+        let output = Command::new("git")
+            .current_dir(&repo)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{}", stderr(&output));
+        let commit = String::from_utf8(output.stdout).unwrap().trim().to_string();
+
+        Self {
+            _root: root,
+            repo,
+            commit,
+        }
+    }
+
+    fn script(&self, name: &str) -> PathBuf {
+        self.repo.join("scripts").join(name)
+    }
+}
+
 fn stderr(output: &Output) -> String {
     String::from_utf8(output.stderr.clone()).unwrap()
 }
@@ -449,6 +545,7 @@ fn run_publish_scenario(
     query: &str,
     valid_assets: bool,
 ) -> PublishResult {
+    let verification = ReleaseCommitFixture::new("publish-release-verification");
     let root = TestDir::new("publish-release-draft-first");
     let asset_dir = root.child("dist");
     let fake_bin = root.child("bin");
@@ -573,27 +670,21 @@ esac
         std::env::var("PATH").unwrap()
     );
 
-    let commit_output = Command::new("git")
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .args(["rev-parse", "v0.2.32^{}"])
-        .output()
-        .unwrap();
-    assert!(commit_output.status.success());
-    let commit = String::from_utf8(commit_output.stdout).unwrap();
-    let output = Command::new(script("publish-release.sh"))
+    let output = Command::new(verification.script("publish-release.sh"))
+        .current_dir(&verification.repo)
         .args([
             "--repo",
             "openclaw/ocm",
             "--tag",
             tag,
             "--commit",
-            commit.trim(),
+            &verification.commit,
             "--asset-dir",
         ])
         .arg(&asset_dir)
         .env("PATH", path)
         .env("TEST_GH_STATE", &state_dir)
-        .env("TEST_EXPECTED_COMMIT", commit.trim())
+        .env("TEST_EXPECTED_COMMIT", &verification.commit)
         .env("TEST_AUTHORITY", authority)
         .env("TEST_LOOKUP", lookup)
         .env("TEST_UPLOAD", upload)
@@ -827,19 +918,11 @@ fn package_version_reader_requires_one_matching_local_ocm_record() {
 
 #[test]
 fn verify_release_tag_requires_a_verified_annotated_tag_matching_the_package() {
+    let verification = ReleaseCommitFixture::new("verify-release-tag-repo");
     let root = TestDir::new("verify-release-tag");
     let fake_bin = root.child("bin");
     fs::create_dir_all(&fake_bin).unwrap();
-    let expected_commit_output = Command::new("git")
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .args(["rev-parse", "v0.2.32^{}"])
-        .output()
-        .unwrap();
-    assert!(expected_commit_output.status.success());
-    let expected_commit = String::from_utf8(expected_commit_output.stdout)
-        .unwrap()
-        .trim()
-        .to_string();
+    let expected_commit = verification.commit.clone();
     let package_tag = "v0.2.32";
     let tag_object = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     write_executable_script(
@@ -871,7 +954,8 @@ esac
         std::env::var("PATH").unwrap()
     );
 
-    let verified = Command::new(script("verify-release-tag.sh"))
+    let verified = Command::new(verification.script("verify-release-tag.sh"))
+        .current_dir(&verification.repo)
         .args(["--repo", "openclaw/ocm", "--tag"])
         .arg(&package_tag)
         .args(["--commit", &expected_commit])
@@ -880,7 +964,8 @@ esac
         .unwrap();
     assert!(verified.status.success(), "{}", stderr(&verified));
 
-    let unsigned = Command::new(script("verify-release-tag.sh"))
+    let unsigned = Command::new(verification.script("verify-release-tag.sh"))
+        .current_dir(&verification.repo)
         .args(["--repo", "openclaw/ocm", "--tag"])
         .arg(&package_tag)
         .args(["--commit", &expected_commit])
@@ -891,7 +976,8 @@ esac
     assert_eq!(unsigned.status.code(), Some(1));
     assert!(stderr(&unsigned).contains("did not verify the signature"));
 
-    let mismatched = Command::new(script("verify-release-tag.sh"))
+    let mismatched = Command::new(verification.script("verify-release-tag.sh"))
+        .current_dir(&verification.repo)
         .args([
             "--repo",
             "openclaw/ocm",
@@ -907,7 +993,8 @@ esac
     assert_eq!(mismatched.status.code(), Some(1));
     assert!(stderr(&mismatched).contains("does not match package version"));
 
-    let unreviewed = Command::new(script("verify-release-tag.sh"))
+    let unreviewed = Command::new(verification.script("verify-release-tag.sh"))
+        .current_dir(&verification.repo)
         .args(["--repo", "openclaw/ocm", "--tag"])
         .arg(&package_tag)
         .args(["--commit", &expected_commit])

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -520,8 +520,23 @@ esac
         std::env::var("PATH").unwrap()
     );
 
+    let commit_output = Command::new("git")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    assert!(commit_output.status.success());
+    let commit = String::from_utf8(commit_output.stdout).unwrap();
     let output = Command::new(script("publish-release.sh"))
-        .args(["--repo", "example/ocm", "--tag", tag, "--asset-dir"])
+        .args([
+            "--repo",
+            "example/ocm",
+            "--tag",
+            tag,
+            "--commit",
+            commit.trim(),
+            "--asset-dir",
+        ])
         .arg(&asset_dir)
         .env("PATH", path)
         .env("TEST_GH_STATE", &state_dir)
@@ -655,13 +670,64 @@ fn publish_release_upload_set_matches_checksum_payloads() {
 }
 
 #[test]
+fn package_version_reader_requires_one_matching_local_ocm_record() {
+    let root = TestDir::new("package-version-reader");
+    let manifest = root.child("Cargo.toml");
+    let lockfile = root.child("Cargo.lock");
+    fs::write(
+        &manifest,
+        "[package]\nname = \"ocm\"\nversion = \"1.2.3\"\n",
+    )
+    .unwrap();
+    fs::write(
+        &lockfile,
+        "version = 4\n\n[[package]]\nname = \"ocm\"\nversion = \"1.2.3\"\n",
+    )
+    .unwrap();
+
+    let valid = Command::new(script("read-package-version.sh"))
+        .args([&manifest, &lockfile])
+        .output()
+        .unwrap();
+    assert!(valid.status.success(), "{}", stderr(&valid));
+    assert_eq!(String::from_utf8(valid.stdout).unwrap(), "1.2.3\n");
+
+    for (label, contents) in [
+        (
+            "mismatch",
+            "version = 4\n\n[[package]]\nname = \"ocm\"\nversion = \"1.2.4\"\n",
+        ),
+        (
+            "duplicate",
+            "version = 4\n\n[[package]]\nname = \"ocm\"\nversion = \"1.2.3\"\n\n[[package]]\nname = \"ocm\"\nversion = \"1.2.3\"\n",
+        ),
+        (
+            "sourced",
+            "version = 4\n\n[[package]]\nname = \"ocm\"\nversion = \"1.2.3\"\nsource = \"registry+https://example.test/index\"\n",
+        ),
+        (
+            "checksum",
+            "version = 4\n\n[[package]]\nname = \"ocm\"\nversion = \"1.2.3\"\nchecksum = \"abc\"\n",
+        ),
+        ("missing", "version = 4\n"),
+    ] {
+        fs::write(&lockfile, contents).unwrap();
+        let rejected = Command::new(script("read-package-version.sh"))
+            .args([&manifest, &lockfile])
+            .output()
+            .unwrap();
+        assert_eq!(rejected.status.code(), Some(1), "{label}");
+    }
+}
+
+#[test]
 fn verify_release_tag_requires_a_verified_annotated_tag_matching_the_package() {
     let root = TestDir::new("verify-release-tag");
     let fake_bin = root.child("bin");
     fs::create_dir_all(&fake_bin).unwrap();
     let expected_commit_output = Command::new("git")
         .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .args(["rev-parse", "HEAD"])
+        .args(["rev-parse", "v0.2.32^{}"])
         .output()
         .unwrap();
     assert!(expected_commit_output.status.success());
@@ -669,33 +735,26 @@ fn verify_release_tag_requires_a_verified_annotated_tag_matching_the_package() {
         .unwrap()
         .trim()
         .to_string();
-    let committed_manifest_output = Command::new("git")
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .args(["show", &format!("{expected_commit}:Cargo.toml")])
-        .output()
-        .unwrap();
-    assert!(committed_manifest_output.status.success());
-    let committed_manifest = String::from_utf8(committed_manifest_output.stdout).unwrap();
-    let committed_version = committed_manifest
-        .lines()
-        .find_map(|line| {
-            line.strip_prefix("version = \"")
-                .and_then(|value| value.strip_suffix('"'))
-        })
-        .unwrap();
-    let package_tag = format!("v{committed_version}");
+    let package_tag = "v0.2.32";
     let tag_object = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     write_executable_script(
         &fake_bin.join("gh"),
         &format!(
             r#"#!/usr/bin/env bash
 set -euo pipefail
-case "$*" in
-  *"/git/ref/tags/"*) printf 'tag\t{tag_object}\n' ;;
-  *"/git/tags/"*) printf '%s\tcommit\t{expected_commit}\t%s\n' "${{TEST_TAG:-{package_tag}}}" "${{TEST_TAG_VERIFIED:-true}}" ;;
-  *"/git/ref/heads/main"*) printf '{expected_commit}\n' ;;
-  *"/compare/"*) printf '%s\n' "${{TEST_COMPARE_STATUS:-identical}}" ;;
-  "api repos/example/ocm --jq .default_branch") printf 'main\n' ;;
+endpoint=""
+for arg in "$@"; do
+  case "$arg" in
+    repos/*) endpoint="$arg" ;;
+  esac
+done
+case "$endpoint" in
+  repos/openclaw/ocm/git/ref/tags/*) printf 'tag\t{tag_object}\n' ;;
+  repos/openclaw/ocm/git/tags/*) printf '%s\tcommit\t{expected_commit}\t%s\n' "${{TEST_TAG:-{package_tag}}}" "${{TEST_TAG_VERIFIED:-true}}" ;;
+  repos/openclaw/ocm/git/ref/heads/main) printf '{expected_commit}\n' ;;
+  repos/openclaw/ocm/compare/*) printf '%s\n' "${{TEST_COMPARE_STATUS:-identical}}" ;;
+  repos/openclaw/ocm/commits/*/pulls) printf '81\tclosed\t2026-08-16T01:41:59Z\tmain\trelease/v0.2.32\t{expected_commit}\tchore(release): bump version to 0.2.32\n' ;;
+  repos/openclaw/ocm) printf 'main\n' ;;
   *) exit 1 ;;
 esac
 "#
@@ -708,7 +767,7 @@ esac
     );
 
     let verified = Command::new(script("verify-release-tag.sh"))
-        .args(["--repo", "example/ocm", "--tag"])
+        .args(["--repo", "openclaw/ocm", "--tag"])
         .arg(&package_tag)
         .args(["--commit", &expected_commit])
         .env("PATH", &path)
@@ -717,7 +776,7 @@ esac
     assert!(verified.status.success(), "{}", stderr(&verified));
 
     let unsigned = Command::new(script("verify-release-tag.sh"))
-        .args(["--repo", "example/ocm", "--tag"])
+        .args(["--repo", "openclaw/ocm", "--tag"])
         .arg(&package_tag)
         .args(["--commit", &expected_commit])
         .env("PATH", &path)
@@ -730,21 +789,21 @@ esac
     let mismatched = Command::new(script("verify-release-tag.sh"))
         .args([
             "--repo",
-            "example/ocm",
+            "openclaw/ocm",
             "--tag",
-            "v999.999.999",
+            "v0.2.31",
             "--commit",
             &expected_commit,
         ])
         .env("PATH", &path)
-        .env("TEST_TAG", "v999.999.999")
+        .env("TEST_TAG", "v0.2.31")
         .output()
         .unwrap();
     assert_eq!(mismatched.status.code(), Some(1));
     assert!(stderr(&mismatched).contains("does not match package version"));
 
     let unreviewed = Command::new(script("verify-release-tag.sh"))
-        .args(["--repo", "example/ocm", "--tag"])
+        .args(["--repo", "openclaw/ocm", "--tag"])
         .arg(&package_tag)
         .args(["--commit", &expected_commit])
         .env("PATH", path)
@@ -752,7 +811,7 @@ esac
         .output()
         .unwrap();
     assert_eq!(unreviewed.status.code(), Some(1));
-    assert!(stderr(&unreviewed).contains("is not on the protected main branch"));
+    assert!(stderr(&unreviewed).contains("is not on protected main"));
 }
 
 #[test]
@@ -864,14 +923,20 @@ fn workflows_pin_actions_lock_dependencies_and_gate_the_msrv() {
     assert!(release.contains("scripts/verify-release-ci.sh"));
     assert!(release.contains("scripts/publish-release.sh"));
     assert!(release.contains("actions: read"));
+    assert!(release.contains("pull-requests: read"));
     assert!(release.contains("cp ./install.sh ./dist/install.sh"));
-    assert!(release.contains("tags:"));
-    assert!(release.contains("- \"v*\""));
-    assert!(release.contains("github.ref_name"));
-    assert!(release.contains("group: release-${{ github.ref_name }}"));
+    assert!(release.contains("workflow_dispatch:"));
+    assert!(release.contains("group: release-${{ inputs.tag }}"));
+    assert!(release.contains("github.repository == 'openclaw/ocm'"));
+    assert!(release.contains("github.ref == 'refs/heads/main'"));
+    assert!(release.contains("RELEASE_COMMIT: ${{ inputs.commit }}"));
+    assert!(release.contains("RELEASE_TAG: ${{ inputs.tag }}"));
+    assert!(release.contains("ref: ${{ needs.verify.outputs.commit }}"));
+    assert!(release.contains("ref: ${{ github.event.repository.default_branch }}"));
+    assert!(release.contains("--commit \"$RELEASE_COMMIT\""));
+    assert!(!release.contains("push:\n    tags:"));
     assert!(!release.contains("repository_dispatch:"));
     assert!(!release.contains("github.event.client_payload.tag"));
-    assert!(!release.contains("workflow_dispatch:"));
     assert!(release.contains("os: macos-15-intel"));
     assert!(!release.contains("os: macos-13"));
 
@@ -881,7 +946,7 @@ fn workflows_pin_actions_lock_dependencies_and_gate_the_msrv() {
         .collect::<BTreeSet<_>>();
     assert_eq!(workflow_targets, SUPPORTED_TARGETS.into_iter().collect());
     assert!(release.contains("name: release-${{ matrix.target }}"));
-    assert!(release.contains("path: ./dist/*.tar.gz"));
+    assert!(release.contains("path: ./dist/ocm-${{ matrix.target }}.tar.gz"));
     assert!(release.contains("pattern: release-*"));
     assert!(release.contains("merge-multiple: true"));
     assert!(release.contains("--target \"${{ matrix.target }}\""));

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -1,10 +1,34 @@
 mod support;
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use flate2::{Compression, write::GzEncoder};
+use tar::{Builder, EntryType, Header};
+
 use crate::support::{TestDir, path_string, write_executable_script};
+
+const SUPPORTED_TARGETS: [&str; 3] = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+];
+
+const RELEASE_ARCHIVES: [&str; 3] = [
+    "ocm-aarch64-apple-darwin.tar.gz",
+    "ocm-x86_64-apple-darwin.tar.gz",
+    "ocm-x86_64-unknown-linux-gnu.tar.gz",
+];
+
+const RELEASE_ASSETS: [&str; 5] = [
+    "SHA256SUMS",
+    "install.sh",
+    "ocm-aarch64-apple-darwin.tar.gz",
+    "ocm-x86_64-apple-darwin.tar.gz",
+    "ocm-x86_64-unknown-linux-gnu.tar.gz",
+];
 
 fn script(name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -16,21 +40,102 @@ fn stderr(output: &Output) -> String {
     String::from_utf8(output.stderr.clone()).unwrap()
 }
 
-fn make_valid_archive(path: &Path, root: &TestDir) {
-    let contents = root.child("archive-contents");
-    fs::create_dir_all(&contents).unwrap();
-    fs::write(contents.join("ocm"), "binary").unwrap();
-    fs::write(contents.join("LICENSE"), "license").unwrap();
-    fs::write(contents.join("README.md"), "readme").unwrap();
-    let output = Command::new("tar")
-        .args(["-czf"])
+enum TestArchiveEntry<'a> {
+    Regular(&'a str),
+    Symlink(&'a str, &'a str),
+    HardLink(&'a str, &'a str),
+    Fifo(&'a str),
+}
+
+fn make_archive(path: &Path, entries: &[TestArchiveEntry<'_>]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let file = fs::File::create(path).unwrap();
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut builder = Builder::new(encoder);
+    for entry in entries {
+        let mut header = Header::new_gnu();
+        match entry {
+            TestArchiveEntry::Regular(name) => {
+                let contents = format!("contents for {name}\n");
+                header.set_size(contents.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, name, contents.as_bytes())
+                    .unwrap();
+            }
+            TestArchiveEntry::Symlink(name, target) => {
+                header.set_entry_type(EntryType::Symlink);
+                header.set_size(0);
+                header.set_mode(0o777);
+                header.set_link_name(target).unwrap();
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, name, std::io::empty())
+                    .unwrap();
+            }
+            TestArchiveEntry::HardLink(name, target) => {
+                header.set_entry_type(EntryType::Link);
+                header.set_size(0);
+                header.set_mode(0o644);
+                header.set_link_name(target).unwrap();
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, name, std::io::empty())
+                    .unwrap();
+            }
+            TestArchiveEntry::Fifo(name) => {
+                header.set_entry_type(EntryType::Fifo);
+                header.set_size(0);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, name, std::io::empty())
+                    .unwrap();
+            }
+        }
+    }
+    builder.finish().unwrap();
+    builder.into_inner().unwrap().finish().unwrap();
+}
+
+fn make_valid_archive(path: &Path, _root: &TestDir) {
+    make_archive(
+        path,
+        &[
+            TestArchiveEntry::Regular("ocm"),
+            TestArchiveEntry::Regular("LICENSE"),
+            TestArchiveEntry::Regular("README.md"),
+        ],
+    );
+}
+
+fn archive_listing(path: &Path, verbose: bool) -> Output {
+    Command::new("tar")
+        .arg(if verbose { "-tvzf" } else { "-tzf" })
         .arg(path)
-        .arg("-C")
-        .arg(&contents)
-        .args(["ocm", "LICENSE", "README.md"])
         .output()
-        .unwrap();
-    assert!(output.status.success(), "{}", stderr(&output));
+        .unwrap()
+}
+
+fn assert_exact_regular_archive(path: &Path) {
+    let names = archive_listing(path, false);
+    assert!(names.status.success(), "{}", stderr(&names));
+    let mut names = String::from_utf8(names.stdout)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    names.sort();
+    assert_eq!(names, ["LICENSE", "README.md", "ocm"]);
+
+    let verbose = archive_listing(path, true);
+    assert!(verbose.status.success(), "{}", stderr(&verbose));
+    let verbose = String::from_utf8(verbose.stdout).unwrap();
+    assert_eq!(verbose.lines().count(), 3);
+    assert!(verbose.lines().all(|line| line.starts_with('-')));
 }
 
 fn populate_release_archives(asset_dir: &Path, root: &TestDir) {
@@ -38,11 +143,7 @@ fn populate_release_archives(asset_dir: &Path, root: &TestDir) {
     fs::write(asset_dir.join("install.sh"), "#!/usr/bin/env bash\n").unwrap();
     let source = root.child("source.tar.gz");
     make_valid_archive(&source, root);
-    for name in [
-        "ocm-aarch64-apple-darwin.tar.gz",
-        "ocm-x86_64-apple-darwin.tar.gz",
-        "ocm-x86_64-unknown-linux-gnu.tar.gz",
-    ] {
+    for name in RELEASE_ARCHIVES {
         fs::copy(&source, asset_dir.join(name)).unwrap();
     }
 }
@@ -54,7 +155,7 @@ fn package_release_preserves_existing_archive_when_tar_fails() {
     let fake_bin = root.child("bin");
     fs::create_dir_all(&output_dir).unwrap();
     fs::create_dir_all(&fake_bin).unwrap();
-    let archive = output_dir.join("ocm-test-target.tar.gz");
+    let archive = output_dir.join("ocm-x86_64-apple-darwin.tar.gz");
     fs::write(&archive, "known-good").unwrap();
     let binary = root.child("ocm");
     fs::write(&binary, "binary").unwrap();
@@ -70,7 +171,7 @@ fn package_release_preserves_existing_archive_when_tar_fails() {
 
     let output = Command::new(script("package-release.sh"))
         .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .args(["--target", "test-target", "--binary"])
+        .args(["--target", "x86_64-apple-darwin", "--binary"])
         .arg(&binary)
         .arg("--output-dir")
         .arg(&output_dir)
@@ -90,6 +191,49 @@ fn package_release_preserves_existing_archive_when_tar_fails() {
 }
 
 #[test]
+fn package_release_accepts_only_the_supported_matrix_and_emits_exact_bundles() {
+    let root = TestDir::new("package-release-matrix");
+    let output_dir = root.child("dist");
+    let binary = root.child("ocm");
+    fs::write(&binary, "binary").unwrap();
+
+    for target in SUPPORTED_TARGETS {
+        let output = Command::new(script("package-release.sh"))
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .args(["--target", target, "--binary"])
+            .arg(&binary)
+            .arg("--output-dir")
+            .arg(&output_dir)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert_exact_regular_archive(&output_dir.join(format!("ocm-{target}.tar.gz")));
+    }
+
+    fs::write(output_dir.join("install.sh"), "#!/usr/bin/env bash\n").unwrap();
+    let prepared = Command::new(script("prepare-release-assets.sh"))
+        .arg(&output_dir)
+        .output()
+        .unwrap();
+    assert!(prepared.status.success(), "{}", stderr(&prepared));
+
+    for target in ["aarch64-unknown-linux-gnu", "test-target"] {
+        let rejected_dir = root.child(format!("rejected-{target}"));
+        let output = Command::new(script("package-release.sh"))
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .args(["--target", target, "--binary"])
+            .arg(&binary)
+            .arg("--output-dir")
+            .arg(&rejected_dir)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1));
+        assert!(stderr(&output).contains("unsupported release target"));
+        assert!(!rejected_dir.join(format!("ocm-{target}.tar.gz")).exists());
+    }
+}
+
+#[test]
 fn prepare_release_assets_requires_the_complete_matrix_and_writes_checksums() {
     let root = TestDir::new("prepare-release-assets");
     let asset_dir = root.child("dist");
@@ -103,14 +247,34 @@ fn prepare_release_assets_requires_the_complete_matrix_and_writes_checksums() {
 
     let checksums = fs::read_to_string(asset_dir.join("SHA256SUMS")).unwrap();
     assert_eq!(checksums.lines().count(), 4);
-    for name in [
-        "ocm-aarch64-apple-darwin.tar.gz",
-        "ocm-x86_64-apple-darwin.tar.gz",
-        "ocm-x86_64-unknown-linux-gnu.tar.gz",
-    ] {
-        assert!(checksums.contains(name));
-    }
-    assert!(checksums.contains("install.sh"));
+    let records = checksums
+        .lines()
+        .map(|line| {
+            let mut fields = line.split_whitespace();
+            let digest = fields.next().unwrap();
+            let name = fields.next().unwrap();
+            assert!(fields.next().is_none());
+            assert_eq!(digest.len(), 64);
+            assert!(
+                digest
+                    .chars()
+                    .all(|character| character.is_ascii_hexdigit())
+            );
+            name.to_string()
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        records,
+        [
+            "install.sh",
+            "ocm-aarch64-apple-darwin.tar.gz",
+            "ocm-x86_64-apple-darwin.tar.gz",
+            "ocm-x86_64-unknown-linux-gnu.tar.gz",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    );
 
     fs::remove_file(asset_dir.join("ocm-aarch64-apple-darwin.tar.gz")).unwrap();
     let missing = Command::new(script("prepare-release-assets.sh"))
@@ -122,7 +286,168 @@ fn prepare_release_assets_requires_the_complete_matrix_and_writes_checksums() {
 }
 
 #[test]
-fn publish_release_keeps_the_release_draft_until_every_asset_is_uploaded() {
+fn prepare_release_assets_rejects_invalid_members_without_replacing_checksums() {
+    let cases = [
+        (
+            "missing-ocm",
+            vec![
+                TestArchiveEntry::Regular("LICENSE"),
+                TestArchiveEntry::Regular("README.md"),
+            ],
+        ),
+        (
+            "missing-license",
+            vec![
+                TestArchiveEntry::Regular("ocm"),
+                TestArchiveEntry::Regular("README.md"),
+            ],
+        ),
+        (
+            "missing-readme",
+            vec![
+                TestArchiveEntry::Regular("ocm"),
+                TestArchiveEntry::Regular("LICENSE"),
+            ],
+        ),
+        (
+            "qualified",
+            vec![
+                TestArchiveEntry::Regular("nested/ocm"),
+                TestArchiveEntry::Regular("LICENSE"),
+                TestArchiveEntry::Regular("README.md"),
+            ],
+        ),
+        (
+            "duplicate",
+            vec![
+                TestArchiveEntry::Regular("ocm"),
+                TestArchiveEntry::Regular("ocm"),
+                TestArchiveEntry::Regular("LICENSE"),
+                TestArchiveEntry::Regular("README.md"),
+            ],
+        ),
+        (
+            "symlink",
+            vec![
+                TestArchiveEntry::Symlink("ocm", "LICENSE"),
+                TestArchiveEntry::Regular("LICENSE"),
+                TestArchiveEntry::Regular("README.md"),
+            ],
+        ),
+        (
+            "hard-link",
+            vec![
+                TestArchiveEntry::HardLink("ocm", "LICENSE"),
+                TestArchiveEntry::Regular("LICENSE"),
+                TestArchiveEntry::Regular("README.md"),
+            ],
+        ),
+        (
+            "fifo",
+            vec![
+                TestArchiveEntry::Fifo("ocm"),
+                TestArchiveEntry::Regular("LICENSE"),
+                TestArchiveEntry::Regular("README.md"),
+            ],
+        ),
+        (
+            "extra",
+            vec![
+                TestArchiveEntry::Regular("ocm"),
+                TestArchiveEntry::Regular("LICENSE"),
+                TestArchiveEntry::Regular("README.md"),
+                TestArchiveEntry::Regular("NOTICE"),
+            ],
+        ),
+    ];
+
+    for (label, entries) in cases {
+        let root = TestDir::new(&format!("prepare-invalid-{label}"));
+        let asset_dir = root.child("dist");
+        populate_release_archives(&asset_dir, &root);
+        make_archive(&asset_dir.join("ocm-aarch64-apple-darwin.tar.gz"), &entries);
+        fs::write(asset_dir.join("SHA256SUMS"), "known-good\n").unwrap();
+
+        let output = Command::new(script("prepare-release-assets.sh"))
+            .arg(&asset_dir)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1), "{label}");
+        assert_eq!(
+            fs::read_to_string(asset_dir.join("SHA256SUMS")).unwrap(),
+            "known-good\n",
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn prepare_release_assets_preserves_checksums_for_invalid_installer_or_matrix() {
+    for case in [
+        "installer-missing",
+        "installer-symlink",
+        "extra-archive",
+        "extra-archive-symlink",
+        "extra-archive-directory",
+    ] {
+        let root = TestDir::new(&format!("prepare-invalid-{case}"));
+        let asset_dir = root.child("dist");
+        populate_release_archives(&asset_dir, &root);
+        fs::write(asset_dir.join("SHA256SUMS"), "known-good\n").unwrap();
+        if case == "installer-missing" {
+            fs::remove_file(asset_dir.join("install.sh")).unwrap();
+        } else if case == "installer-symlink" {
+            fs::remove_file(asset_dir.join("install.sh")).unwrap();
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(
+                asset_dir.join("ocm-aarch64-apple-darwin.tar.gz"),
+                asset_dir.join("install.sh"),
+            )
+            .unwrap();
+        } else if case == "extra-archive" {
+            fs::copy(
+                asset_dir.join("ocm-aarch64-apple-darwin.tar.gz"),
+                asset_dir.join("ocm-aarch64-unknown-linux-gnu.tar.gz"),
+            )
+            .unwrap();
+        } else if case == "extra-archive-symlink" {
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(
+                asset_dir.join("ocm-aarch64-apple-darwin.tar.gz"),
+                asset_dir.join("ocm-aarch64-unknown-linux-gnu.tar.gz"),
+            )
+            .unwrap();
+        } else {
+            fs::create_dir(asset_dir.join("ocm-aarch64-unknown-linux-gnu.tar.gz")).unwrap();
+        }
+
+        let output = Command::new(script("prepare-release-assets.sh"))
+            .arg(&asset_dir)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1), "{case}");
+        assert_eq!(
+            fs::read_to_string(asset_dir.join("SHA256SUMS")).unwrap(),
+            "known-good\n",
+            "{case}"
+        );
+    }
+}
+
+struct PublishResult {
+    output: Output,
+    commands: String,
+    draft: Option<String>,
+    assets: Vec<String>,
+}
+
+fn run_publish_scenario(
+    tag: &str,
+    lookup: &str,
+    upload: &str,
+    query: &str,
+    valid_assets: bool,
+) -> PublishResult {
     let root = TestDir::new("publish-release-draft-first");
     let asset_dir = root.child("dist");
     let fake_bin = root.child("bin");
@@ -130,6 +455,14 @@ fn publish_release_keeps_the_release_draft_until_every_asset_is_uploaded() {
     fs::create_dir_all(&fake_bin).unwrap();
     fs::create_dir_all(&state_dir).unwrap();
     populate_release_archives(&asset_dir, &root);
+    if !valid_assets {
+        fs::remove_file(asset_dir.join("ocm-aarch64-apple-darwin.tar.gz")).unwrap();
+    }
+    match lookup {
+        "draft" => fs::write(state_dir.join("draft"), "true\n").unwrap(),
+        "public" => fs::write(state_dir.join("draft"), "false\n").unwrap(),
+        _ => {}
+    }
 
     write_executable_script(
         &fake_bin.join("gh"),
@@ -139,9 +472,18 @@ printf '%s\n' "$*" >>"${TEST_GH_STATE}/commands"
 case "${1:-} ${2:-}" in
   "release view")
     if [[ "$*" == *"--json isDraft"* ]]; then
-      [[ -f "${TEST_GH_STATE}/draft" ]] || exit 1
-      cat "${TEST_GH_STATE}/draft"
+      case "$TEST_LOOKUP" in
+        missing) printf 'release not found\n' >&2; exit 1 ;;
+        error) printf 'authentication failed\n' >&2; exit 1 ;;
+        draft) printf 'true\n' ;;
+        public) printf 'false\n' ;;
+        *) exit 2 ;;
+      esac
     else
+      [[ "$TEST_QUERY" != "fail" ]] || {
+        printf 'asset query failed\n' >&2
+        exit 1
+      }
       cat "${TEST_GH_STATE}/assets"
     fi
     ;;
@@ -149,6 +491,10 @@ case "${1:-} ${2:-}" in
     printf 'true\n' >"${TEST_GH_STATE}/draft"
     ;;
   "release upload")
+    [[ "$TEST_UPLOAD" != "fail" ]] || {
+      printf 'upload failed\n' >&2
+      exit 1
+    }
     : >"${TEST_GH_STATE}/assets"
     for arg in "$@"; do
       case "$arg" in
@@ -156,6 +502,10 @@ case "${1:-} ${2:-}" in
       esac
     done
     sort -o "${TEST_GH_STATE}/assets" "${TEST_GH_STATE}/assets"
+    if [[ "$TEST_UPLOAD" == "mismatch" ]]; then
+      grep -v '^install\.sh$' "${TEST_GH_STATE}/assets" >"${TEST_GH_STATE}/assets.next"
+      mv "${TEST_GH_STATE}/assets.next" "${TEST_GH_STATE}/assets"
+    fi
     ;;
   "release edit")
     grep -q -- '--draft=false' <<<"$*"
@@ -171,36 +521,137 @@ esac
     );
 
     let output = Command::new(script("publish-release.sh"))
-        .args([
-            "--repo",
-            "example/ocm",
-            "--tag",
-            "v1.2.3+build-1",
-            "--asset-dir",
-        ])
+        .args(["--repo", "example/ocm", "--tag", tag, "--asset-dir"])
         .arg(&asset_dir)
         .env("PATH", path)
         .env("TEST_GH_STATE", &state_dir)
+        .env("TEST_LOOKUP", lookup)
+        .env("TEST_UPLOAD", upload)
+        .env("TEST_QUERY", query)
         .output()
         .unwrap();
-    assert!(output.status.success(), "{}", stderr(&output));
 
-    let commands = fs::read_to_string(state_dir.join("commands")).unwrap();
-    let create = commands.find("release create").unwrap();
-    let upload = commands.find("release upload").unwrap();
-    let publish = commands.find("release edit").unwrap();
-    assert!(create < upload && upload < publish);
-    let publish_command = commands
+    let commands = fs::read_to_string(state_dir.join("commands")).unwrap_or_default();
+    let draft = fs::read_to_string(state_dir.join("draft")).ok();
+    let assets = fs::read_to_string(state_dir.join("assets"))
+        .unwrap_or_default()
         .lines()
-        .find(|line| line.starts_with("release edit"))
+        .map(str::to_string)
+        .collect();
+    PublishResult {
+        output,
+        commands,
+        draft,
+        assets,
+    }
+}
+
+#[test]
+fn publish_release_settles_stable_and_prerelease_drafts_after_exact_asset_verification() {
+    for (tag, expected_flag, rejected_flag) in [
+        ("v1.2.3+build-1", "--latest", "--prerelease"),
+        (
+            "v1.2.3-beta.1+build-1",
+            "--prerelease --latest=false",
+            "--latest ",
+        ),
+    ] {
+        let result = run_publish_scenario(tag, "missing", "success", "success", true);
+        assert!(result.output.status.success(), "{}", stderr(&result.output));
+        assert_eq!(result.assets, RELEASE_ASSETS);
+        assert_eq!(result.draft.as_deref(), Some("false\n"));
+
+        let commands = result.commands;
+        let create = commands.find("release create").unwrap();
+        let upload = commands.find("release upload").unwrap();
+        let query = commands.find("--json assets").unwrap();
+        let publish = commands.find("release edit").unwrap();
+        assert!(create < upload && upload < query && query < publish);
+        let publish_command = commands
+            .lines()
+            .find(|line| line.starts_with("release edit"))
+            .unwrap();
+        assert!(publish_command.contains("--draft=false"));
+        assert!(publish_command.contains(expected_flag), "{publish_command}");
+        assert!(
+            !publish_command.contains(rejected_flag),
+            "{publish_command}"
+        );
+    }
+}
+
+#[test]
+fn publish_release_distinguishes_missing_lookup_errors_and_public_releases() {
+    let lookup_error = run_publish_scenario("v1.2.3", "error", "success", "success", true);
+    assert_eq!(lookup_error.output.status.code(), Some(1));
+    assert!(stderr(&lookup_error.output).contains("failed to inspect existing release"));
+    assert!(!lookup_error.commands.contains("release create"));
+    assert!(!lookup_error.commands.contains("release upload"));
+    assert!(!lookup_error.commands.contains("release edit"));
+
+    let public = run_publish_scenario("v1.2.3", "public", "success", "success", true);
+    assert_eq!(public.output.status.code(), Some(1));
+    assert!(stderr(&public.output).contains("already public"));
+    assert!(!public.commands.contains("release create"));
+    assert!(!public.commands.contains("release upload"));
+    assert!(!public.commands.contains("release edit"));
+    assert_eq!(public.draft.as_deref(), Some("false\n"));
+}
+
+#[test]
+fn publish_release_keeps_new_and_existing_releases_draft_on_failures() {
+    for (label, lookup, upload, query) in [
+        ("new-upload", "missing", "fail", "success"),
+        ("existing-upload", "draft", "fail", "success"),
+        ("existing-query", "draft", "success", "fail"),
+        ("existing-mismatch", "draft", "mismatch", "success"),
+    ] {
+        let result = run_publish_scenario("v1.2.3", lookup, upload, query, true);
+        assert_eq!(result.output.status.code(), Some(1), "{label}");
+        assert!(!result.commands.contains("release edit"), "{label}");
+        assert_eq!(result.draft.as_deref(), Some("true\n"), "{label}");
+        if lookup == "draft" {
+            assert!(!result.commands.contains("release create"), "{label}");
+        } else {
+            assert!(result.commands.contains("release create"), "{label}");
+        }
+    }
+}
+
+#[test]
+fn publish_release_does_not_contact_github_when_asset_preparation_fails() {
+    let result = run_publish_scenario("v1.2.3", "missing", "success", "success", false);
+    assert_eq!(result.output.status.code(), Some(1));
+    assert!(result.commands.is_empty());
+    assert!(result.draft.is_none());
+    assert!(result.assets.is_empty());
+}
+
+#[test]
+fn publish_release_upload_set_matches_checksum_payloads() {
+    let result = run_publish_scenario("v1.2.3", "missing", "success", "success", true);
+    assert!(result.output.status.success(), "{}", stderr(&result.output));
+    assert_eq!(result.assets, RELEASE_ASSETS);
+
+    let root = TestDir::new("publish-checksum-payloads");
+    let asset_dir = root.child("dist");
+    populate_release_archives(&asset_dir, &root);
+    let prepared = Command::new(script("prepare-release-assets.sh"))
+        .arg(&asset_dir)
+        .output()
         .unwrap();
-    assert!(publish_command.contains("--draft=false"));
-    assert!(publish_command.contains("--latest"));
-    assert!(!publish_command.contains("--prerelease"));
-    assert_eq!(
-        fs::read_to_string(state_dir.join("draft")).unwrap(),
-        "false\n"
-    );
+    assert!(prepared.status.success(), "{}", stderr(&prepared));
+    let checksum_names = fs::read_to_string(asset_dir.join("SHA256SUMS"))
+        .unwrap()
+        .lines()
+        .map(|line| line.split_whitespace().nth(1).unwrap().to_string())
+        .collect::<BTreeSet<_>>();
+    let upload_payloads = RELEASE_ASSETS
+        .into_iter()
+        .filter(|name| *name != "SHA256SUMS")
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(checksum_names, upload_payloads);
 }
 
 #[test]
@@ -423,4 +874,16 @@ fn workflows_pin_actions_lock_dependencies_and_gate_the_msrv() {
     assert!(!release.contains("workflow_dispatch:"));
     assert!(release.contains("os: macos-15-intel"));
     assert!(!release.contains("os: macos-13"));
+
+    let workflow_targets = release
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("target: "))
+        .collect::<BTreeSet<_>>();
+    assert_eq!(workflow_targets, SUPPORTED_TARGETS.into_iter().collect());
+    assert!(release.contains("name: release-${{ matrix.target }}"));
+    assert!(release.contains("path: ./dist/*.tar.gz"));
+    assert!(release.contains("pattern: release-*"));
+    assert!(release.contains("merge-multiple: true"));
+    assert!(release.contains("--target \"${{ matrix.target }}\""));
+    assert!(release.contains("--binary \"./target/${{ matrix.target }}/release/ocm\""));
 }

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -443,6 +443,7 @@ struct PublishResult {
 
 fn run_publish_scenario(
     tag: &str,
+    authority: &str,
     lookup: &str,
     upload: &str,
     query: &str,
@@ -469,6 +470,57 @@ fn run_publish_scenario(
         r#"#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${TEST_GH_STATE}/commands"
+if [[ "${1:-}" == "api" ]]; then
+  endpoint=""
+  for arg in "$@"; do
+    case "$arg" in
+      repos/*) endpoint="$arg" ;;
+    esac
+  done
+  case "$endpoint" in
+    repos/openclaw/ocm/actions/workflows/ci.yml/runs\?*)
+      conclusion="success"
+      [[ "$TEST_AUTHORITY" != "ci-fail" ]] || conclusion="failure"
+      printf '1|12345|%s|push|main|completed|%s|https://github.com/openclaw/ocm/actions/runs/12345\n' "$TEST_EXPECTED_COMMIT" "$conclusion"
+      exit 0
+      ;;
+    repos/openclaw/ocm/git/ref/tags/*)
+      printf 'tag\tbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n'
+      exit 0
+      ;;
+    repos/openclaw/ocm/git/tags/*)
+      count_file="${TEST_GH_STATE}/tag-verifier-count"
+      count=0
+      [[ ! -f "$count_file" ]] || count="$(cat "$count_file")"
+      count=$((count + 1))
+      printf '%s\n' "$count" >"$count_file"
+      target="$TEST_EXPECTED_COMMIT"
+      verified="true"
+      [[ "$TEST_AUTHORITY" != "initial-tag-fail" ]] || verified="false"
+      if [[ "$TEST_AUTHORITY" == "retarget" && "$count" -gt 1 ]]; then
+        target="0000000000000000000000000000000000000000"
+      fi
+      printf 'v0.2.32\tcommit\t%s\t%s\n' "$target" "$verified"
+      exit 0
+      ;;
+    repos/openclaw/ocm/git/ref/heads/main)
+      printf '%s\n' "$TEST_EXPECTED_COMMIT"
+      exit 0
+      ;;
+    repos/openclaw/ocm/compare/*)
+      printf 'identical\n'
+      exit 0
+      ;;
+    repos/openclaw/ocm/commits/*/pulls)
+      printf '81\tclosed\t2026-08-16T01:41:59Z\tmain\trelease/v0.2.32\t%s\tchore(release): bump version to 0.2.32\n' "$TEST_EXPECTED_COMMIT"
+      exit 0
+      ;;
+    repos/openclaw/ocm)
+      printf 'main\n'
+      exit 0
+      ;;
+  esac
+fi
 case "${1:-} ${2:-}" in
   "release view")
     if [[ "$*" == *"--json isDraft"* ]]; then
@@ -522,7 +574,7 @@ esac
 
     let commit_output = Command::new("git")
         .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .args(["rev-parse", "HEAD"])
+        .args(["rev-parse", "v0.2.32^{}"])
         .output()
         .unwrap();
     assert!(commit_output.status.success());
@@ -530,7 +582,7 @@ esac
     let output = Command::new(script("publish-release.sh"))
         .args([
             "--repo",
-            "example/ocm",
+            "openclaw/ocm",
             "--tag",
             tag,
             "--commit",
@@ -540,6 +592,8 @@ esac
         .arg(&asset_dir)
         .env("PATH", path)
         .env("TEST_GH_STATE", &state_dir)
+        .env("TEST_EXPECTED_COMMIT", commit.trim())
+        .env("TEST_AUTHORITY", authority)
         .env("TEST_LOOKUP", lookup)
         .env("TEST_UPLOAD", upload)
         .env("TEST_QUERY", query)
@@ -562,49 +616,57 @@ esac
 }
 
 #[test]
-fn publish_release_settles_stable_and_prerelease_drafts_after_exact_asset_verification() {
-    for (tag, expected_flag, rejected_flag) in [
-        ("v1.2.3+build-1", "--latest", "--prerelease"),
-        (
-            "v1.2.3-beta.1+build-1",
-            "--prerelease --latest=false",
-            "--latest ",
-        ),
-    ] {
-        let result = run_publish_scenario(tag, "missing", "success", "success", true);
-        assert!(result.output.status.success(), "{}", stderr(&result.output));
-        assert_eq!(result.assets, RELEASE_ASSETS);
-        assert_eq!(result.draft.as_deref(), Some("false\n"));
+fn publish_release_settles_stable_draft_after_authority_and_asset_verification() {
+    let result = run_publish_scenario("v0.2.32", "success", "missing", "success", "success", true);
+    assert!(result.output.status.success(), "{}", stderr(&result.output));
+    assert_eq!(result.assets, RELEASE_ASSETS);
+    assert_eq!(result.draft.as_deref(), Some("false\n"));
 
-        let commands = result.commands;
-        let create = commands.find("release create").unwrap();
-        let upload = commands.find("release upload").unwrap();
-        let query = commands.find("--json assets").unwrap();
-        let publish = commands.find("release edit").unwrap();
-        assert!(create < upload && upload < query && query < publish);
-        let publish_command = commands
-            .lines()
-            .find(|line| line.starts_with("release edit"))
-            .unwrap();
-        assert!(publish_command.contains("--draft=false"));
-        assert!(publish_command.contains(expected_flag), "{publish_command}");
-        assert!(
-            !publish_command.contains(rejected_flag),
-            "{publish_command}"
-        );
+    let commands = result.commands;
+    let ci = commands.find("actions/workflows/ci.yml/runs").unwrap();
+    let final_tag_check = commands.rfind("/git/tags/").unwrap();
+    let create = commands.find("release create").unwrap();
+    let upload = commands.find("release upload").unwrap();
+    let query = commands.find("--json assets").unwrap();
+    let publish = commands.find("release edit").unwrap();
+    assert!(ci < final_tag_check);
+    assert!(final_tag_check < create && create < upload && upload < query && query < publish);
+    let publish_command = commands
+        .lines()
+        .find(|line| line.starts_with("release edit"))
+        .unwrap();
+    assert!(publish_command.contains("--draft=false"));
+    assert!(publish_command.contains("--latest"));
+    assert!(!publish_command.contains("--prerelease"));
+
+    let publisher = fs::read_to_string(script("publish-release.sh")).unwrap();
+    assert!(publisher.contains("release_flags+=(--prerelease --latest=false)"));
+}
+
+#[test]
+fn publish_release_stops_before_release_api_when_authority_fails_or_tag_moves() {
+    for authority in ["initial-tag-fail", "ci-fail", "retarget"] {
+        let result =
+            run_publish_scenario("v0.2.32", authority, "missing", "success", "success", true);
+        assert_eq!(result.output.status.code(), Some(1), "{authority}");
+        assert!(!result.commands.contains("release view"), "{authority}");
+        assert!(!result.commands.contains("release create"), "{authority}");
+        assert!(!result.commands.contains("release upload"), "{authority}");
+        assert!(!result.commands.contains("release edit"), "{authority}");
     }
 }
 
 #[test]
 fn publish_release_distinguishes_missing_lookup_errors_and_public_releases() {
-    let lookup_error = run_publish_scenario("v1.2.3", "error", "success", "success", true);
+    let lookup_error =
+        run_publish_scenario("v0.2.32", "success", "error", "success", "success", true);
     assert_eq!(lookup_error.output.status.code(), Some(1));
     assert!(stderr(&lookup_error.output).contains("failed to inspect existing release"));
     assert!(!lookup_error.commands.contains("release create"));
     assert!(!lookup_error.commands.contains("release upload"));
     assert!(!lookup_error.commands.contains("release edit"));
 
-    let public = run_publish_scenario("v1.2.3", "public", "success", "success", true);
+    let public = run_publish_scenario("v0.2.32", "success", "public", "success", "success", true);
     assert_eq!(public.output.status.code(), Some(1));
     assert!(stderr(&public.output).contains("already public"));
     assert!(!public.commands.contains("release create"));
@@ -621,7 +683,7 @@ fn publish_release_keeps_new_and_existing_releases_draft_on_failures() {
         ("existing-query", "draft", "success", "fail"),
         ("existing-mismatch", "draft", "mismatch", "success"),
     ] {
-        let result = run_publish_scenario("v1.2.3", lookup, upload, query, true);
+        let result = run_publish_scenario("v0.2.32", "success", lookup, upload, query, true);
         assert_eq!(result.output.status.code(), Some(1), "{label}");
         assert!(!result.commands.contains("release edit"), "{label}");
         assert_eq!(result.draft.as_deref(), Some("true\n"), "{label}");
@@ -634,17 +696,22 @@ fn publish_release_keeps_new_and_existing_releases_draft_on_failures() {
 }
 
 #[test]
-fn publish_release_does_not_contact_github_when_asset_preparation_fails() {
-    let result = run_publish_scenario("v1.2.3", "missing", "success", "success", false);
+fn publish_release_stops_before_release_api_when_asset_preparation_fails() {
+    let result = run_publish_scenario("v0.2.32", "success", "missing", "success", "success", false);
     assert_eq!(result.output.status.code(), Some(1));
-    assert!(result.commands.is_empty());
+    assert!(result.commands.contains("/git/ref/tags/v0.2.32"));
+    assert!(result.commands.contains("actions/workflows/ci.yml/runs"));
+    assert!(!result.commands.contains("release view"));
+    assert!(!result.commands.contains("release create"));
+    assert!(!result.commands.contains("release upload"));
+    assert!(!result.commands.contains("release edit"));
     assert!(result.draft.is_none());
     assert!(result.assets.is_empty());
 }
 
 #[test]
 fn publish_release_upload_set_matches_checksum_payloads() {
-    let result = run_publish_scenario("v1.2.3", "missing", "success", "success", true);
+    let result = run_publish_scenario("v0.2.32", "success", "missing", "success", "success", true);
     assert!(result.output.status.success(), "{}", stderr(&result.output));
     assert_eq!(result.assets, RELEASE_ASSETS);
 

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -497,7 +497,8 @@ if [[ "${1:-}" == "api" ]]; then
       target="$TEST_EXPECTED_COMMIT"
       verified="true"
       [[ "$TEST_AUTHORITY" != "initial-tag-fail" ]] || verified="false"
-      if [[ "$TEST_AUTHORITY" == "retarget" && "$count" -gt 1 ]]; then
+      if [[ "$TEST_AUTHORITY" == "retarget" && "$count" -gt 1 ]] ||
+        [[ "$TEST_AUTHORITY" == "post-upload-retarget" && "$count" -gt 2 ]]; then
         target="0000000000000000000000000000000000000000"
       fi
       printf 'v0.2.32\tcommit\t%s\t%s\n' "$target" "$verified"
@@ -623,14 +624,19 @@ fn publish_release_settles_stable_draft_after_authority_and_asset_verification()
     assert_eq!(result.draft.as_deref(), Some("false\n"));
 
     let commands = result.commands;
+    let tag_checks = commands
+        .match_indices("/git/tags/")
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    assert_eq!(tag_checks.len(), 3);
     let ci = commands.find("actions/workflows/ci.yml/runs").unwrap();
-    let final_tag_check = commands.rfind("/git/tags/").unwrap();
     let create = commands.find("release create").unwrap();
     let upload = commands.find("release upload").unwrap();
     let query = commands.find("--json assets").unwrap();
     let publish = commands.find("release edit").unwrap();
-    assert!(ci < final_tag_check);
-    assert!(final_tag_check < create && create < upload && upload < query && query < publish);
+    assert!(tag_checks[0] < ci && ci < tag_checks[1]);
+    assert!(tag_checks[1] < create && create < upload && upload < query);
+    assert!(query < tag_checks[2] && tag_checks[2] < publish);
     let publish_command = commands
         .lines()
         .find(|line| line.starts_with("release edit"))
@@ -654,6 +660,24 @@ fn publish_release_stops_before_release_api_when_authority_fails_or_tag_moves() 
         assert!(!result.commands.contains("release upload"), "{authority}");
         assert!(!result.commands.contains("release edit"), "{authority}");
     }
+}
+
+#[test]
+fn publish_release_keeps_the_release_draft_when_tag_moves_after_upload() {
+    let result = run_publish_scenario(
+        "v0.2.32",
+        "post-upload-retarget",
+        "missing",
+        "success",
+        "success",
+        true,
+    );
+    assert_eq!(result.output.status.code(), Some(1));
+    assert!(result.commands.contains("release create"));
+    assert!(result.commands.contains("release upload"));
+    assert!(result.commands.contains("--json assets"));
+    assert!(!result.commands.contains("release edit"));
+    assert_eq!(result.draft.as_deref(), Some("true\n"));
 }
 
 #[test]
@@ -991,7 +1015,6 @@ fn workflows_pin_actions_lock_dependencies_and_gate_the_msrv() {
     assert!(release.contains("scripts/publish-release.sh"));
     assert!(release.contains("actions: read"));
     assert!(release.contains("pull-requests: read"));
-    assert!(release.contains("cp ./install.sh ./dist/install.sh"));
     assert!(release.contains("workflow_dispatch:"));
     assert!(release.contains("group: release-${{ inputs.tag }}"));
     assert!(release.contains("github.repository == 'openclaw/ocm'"));
@@ -999,7 +1022,11 @@ fn workflows_pin_actions_lock_dependencies_and_gate_the_msrv() {
     assert!(release.contains("RELEASE_COMMIT: ${{ inputs.commit }}"));
     assert!(release.contains("RELEASE_TAG: ${{ inputs.tag }}"));
     assert!(release.contains("ref: ${{ needs.verify.outputs.commit }}"));
-    assert!(release.contains("ref: ${{ github.event.repository.default_branch }}"));
+    assert!(release.contains("ref: ${{ github.sha }}"));
+    assert!(release.contains("path: trusted"));
+    assert!(release.contains("path: release-source"));
+    assert!(release.contains("cp ./release-source/install.sh ./dist/install.sh"));
+    assert!(release.contains("./trusted/scripts/publish-release.sh"));
     assert!(release.contains("--commit \"$RELEASE_COMMIT\""));
     assert!(!release.contains("push:\n    tags:"));
     assert!(!release.contains("repository_dispatch:"));

--- a/tests/release_script_tests.rs
+++ b/tests/release_script_tests.rs
@@ -41,7 +41,7 @@ impl ReleaseRepo {
             .env("HOME", &self.home)
             .env("PATH", &self.env_path)
             .env("OCM_GH_BIN", &self.ghx)
-            .env("OCM_GITHUB_REPOSITORY", "example/ocm");
+            .env("OCM_GITHUB_REPOSITORY", "openclaw/ocm");
         self.apply_toolchain_env(&mut command);
         command.output().unwrap()
     }
@@ -111,7 +111,7 @@ impl ReleaseRepo {
         fs::write(
             self.repo.join(".git/test-ci-run"),
             format!(
-                "12345|{head_sha}|{status}|{conclusion}|https://github.com/example/ocm/actions/runs/12345\n"
+                "1|12345|{head_sha}|push|main|{status}|{conclusion}|https://github.com/openclaw/ocm/actions/runs/12345\n"
             ),
         )
         .unwrap();
@@ -176,7 +176,9 @@ fn init_release_repo(label: &str) -> ReleaseRepo {
         "scripts/release.sh",
         "scripts/update-version.sh",
         "scripts/validate-version.sh",
+        "scripts/read-package-version.sh",
         "scripts/verify-release-ci.sh",
+        "scripts/verify-release-tag.sh",
     ] {
         copy_script(&repo, script);
     }
@@ -220,10 +222,52 @@ exec "$real_git" "$@"
         r#"#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>.git/test-ghx-commands
-if [[ "${1:-}" == "api" && "${2:-}" == repos/example/ocm/actions/workflows/ci.yml/runs\?* ]]; then
-  [[ -f .git/test-ci-run ]] || exit 0
-  cat .git/test-ci-run
-  exit 0
+if [[ "${1:-}" == "api" ]]; then
+  endpoint=""
+  for arg in "$@"; do
+    case "$arg" in
+      repos/*) endpoint="$arg" ;;
+    esac
+  done
+  case "$endpoint" in
+    repos/openclaw/ocm/actions/workflows/ci.yml/runs\?*)
+      [[ -f .git/test-ci-run ]] || {
+        printf '0|||||||\n'
+        exit 0
+      }
+      cat .git/test-ci-run
+      exit 0
+      ;;
+    repos/openclaw/ocm/git/ref/tags/*)
+      tag="${endpoint##*/}"
+      printf 'tag\t%s\n' "$(git rev-parse "${tag}^{tag}")"
+      exit 0
+      ;;
+    repos/openclaw/ocm/git/tags/*)
+      tag="$(git tag --points-at HEAD | head -n1)"
+      printf '%s\tcommit\t%s\ttrue\n' "$tag" "$(git rev-parse "${tag}^{commit}")"
+      exit 0
+      ;;
+    repos/openclaw/ocm)
+      printf 'main\n'
+      exit 0
+      ;;
+    repos/openclaw/ocm/git/ref/heads/main)
+      git rev-parse main
+      exit 0
+      ;;
+    repos/openclaw/ocm/compare/*)
+      printf 'identical\n'
+      exit 0
+      ;;
+  esac
+  if [[ "$endpoint" == *"/commits/"*"/pulls"* ]]; then
+    commit="$(git rev-parse HEAD)"
+    version="$(./scripts/read-package-version.sh Cargo.toml Cargo.lock)"
+    printf '42\tclosed\t2026-08-20T12:00:00Z\tmain\trelease/v%s\t%s\tchore(release): bump version to %s\n' \
+      "$version" "$commit" "$version"
+    exit 0
+  fi
 fi
 case "${1:-} ${2:-}" in
   "pr view")
@@ -233,7 +277,12 @@ case "${1:-} ${2:-}" in
     ;;
   "pr create")
     [[ ! -f .git/test-ghx-create-fails ]] || exit 1
-    printf '%s\n' 'https://github.com/example/ocm/pull/42' | tee .git/test-pr-url
+    printf '%s\n' 'https://github.com/openclaw/ocm/pull/42' | tee .git/test-pr-url
+    ;;
+  "release view")
+    exit 1
+    ;;
+  "workflow run")
     ;;
   *)
     exit 1
@@ -336,7 +385,7 @@ fn release_script_prepares_a_pull_request_without_mutating_remote_main() {
 
     let output = repo.run_release("0.2.8");
     assert!(output.status.success(), "{}", stderr(&output));
-    assert!(stdout(&output).contains("https://github.com/example/ocm/pull/42"));
+    assert!(stdout(&output).contains("https://github.com/openclaw/ocm/pull/42"));
     assert_eq!(
         repo.git_stdout(&["branch", "--show-current"]).trim(),
         "release/v0.2.8"
@@ -354,7 +403,7 @@ fn release_script_prepares_a_pull_request_without_mutating_remote_main() {
     assert!(
         fs::read_to_string(repo.repo.join(".git/test-ghx-commands"))
             .unwrap()
-            .contains("pr create --repo example/ocm")
+            .contains("pr create --repo openclaw/ocm")
     );
 }
 
@@ -381,7 +430,7 @@ fn release_script_tags_only_after_the_release_pr_is_squash_merged() {
 
     let output = repo.run_release("0.2.8");
     assert!(output.status.success(), "{}", stderr(&output));
-    assert!(stdout(&output).contains("tag-push workflow"));
+    assert!(stdout(&output).contains("protected-main workflow"));
     assert_eq!(repo.remote_ref("refs/heads/main"), merged_head);
     assert_eq!(repo.remote_ref("refs/tags/v0.2.8^{}"), merged_head);
 }

--- a/tests/release_script_tests.rs
+++ b/tests/release_script_tests.rs
@@ -472,6 +472,37 @@ fn release_script_accepts_an_already_pushed_verified_tag() {
 }
 
 #[test]
+fn release_script_propagates_existing_tag_ci_failure_without_dispatching() {
+    let repo = init_release_repo("release-existing-tag-ci-failure");
+    assert!(repo.run_release("0.2.8").status.success());
+    let merged_head = repo.merge_release_pr("0.2.8");
+    repo.record_ci(&merged_head, "completed", "success");
+    assert!(repo.run_release("0.2.8").status.success());
+    let commands_before = fs::read_to_string(repo.repo.join(".git/test-ghx-commands")).unwrap();
+    let dispatches_before = commands_before
+        .lines()
+        .filter(|line| line.starts_with("workflow run"))
+        .count();
+
+    repo.record_ci(&merged_head, "completed", "failure");
+    let output = repo.run_release("0.2.8");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(stderr(&output).contains("concluded failure"));
+    let commands_after = fs::read_to_string(repo.repo.join(".git/test-ghx-commands")).unwrap();
+    let dispatches_after = commands_after
+        .lines()
+        .filter(|line| line.starts_with("workflow run"))
+        .count();
+    assert_eq!(dispatches_after, dispatches_before);
+}
+
+#[test]
 fn release_script_refuses_to_tag_without_exact_sha_ci() {
     let repo = init_release_repo("release-ci-missing");
     assert!(repo.run_release("0.2.8").status.success());


### PR DESCRIPTION
## Summary
- use the canonical `openclaw/ocm` repository for installation and self-update
- require the exact supported release matrix, regular archive members, and matching checksums before publication
- bind release tags to a version-only merged release PR and exact successful `main` CI
- dispatch release automation from protected `main` and revalidate tag identity before public settlement

## Validation
- `cargo fmt --check`
- `cargo test --locked --test release_asset_tests --test release_script_tests --test install_script_tests`
- `cargo test --locked -- --skip concurrent_official_runtime_installs_reject_changed_integrity`
- `cargo test --locked --test runtime_command_tests concurrent_official_runtime_installs_reject_changed_integrity -- --exact --nocapture`
- `cargo build --locked --release`
- `./target/release/ocm --version`
- live verification of signed `v0.2.32` and exact current-main CI

## Compatibility
- no CLI syntax, environment metadata, or stored user state changes
- current repository access remains unchanged
