### PR TITLE
fix(ci): isolate release builds from shared caches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,6 @@ jobs:
         with:
           toolchain: 1.88.0
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build release binary
         run: cargo build --locked --release --target "${{ matrix.target }}"
       - name: Package release archive

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -1129,6 +1129,7 @@ fn workflows_pin_actions_lock_dependencies_and_gate_the_msrv() {
     assert!(release.contains("cp ./release-source/install.sh ./dist/install.sh"));
     assert!(release.contains("./trusted/scripts/publish-release.sh"));
     assert!(release.contains("--commit \"$RELEASE_COMMIT\""));
+    assert!(!release.contains("Swatinem/rust-cache"));
     assert!(!release.contains("push:\n    tags:"));
     assert!(!release.contains("repository_dispatch:"));
     assert!(!release.contains("github.event.client_payload.tag"));


### PR DESCRIPTION
## Summary

- remove the GitHub-backed Rust cache from the manually dispatched release build
- keep cache credentials out of jobs that execute the verified dispatch-selected release commit
- lock the privileged release workflow as cache-free in its existing contract test

## Root cause

The release workflow verifies the signed tag, exact commit, and successful main CI before building. However, the build job then restored and saved a GitHub Actions cache before executing code from `needs.verify.outputs.commit`. A dispatch-selected commit could therefore access the cache service token and poison default-branch caches even though release publication itself remained verified.

The release workflow is the security owner for this boundary. Normal push and pull-request CI keeps `Swatinem/rust-cache`; only the sensitive release job stops using shared caches.

Fixes:
- https://github.com/openclaw/ocm/security/code-scanning/1
- https://github.com/openclaw/ocm/security/code-scanning/2

## Validation

- `cargo test --locked --test release_asset_tests workflows_pin_actions_lock_dependencies_and_gate_the_msrv -- --exact --nocapture`
- `cargo fmt --check`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

## Size

Production LOC: +0/-1 (net -1) | Tests: +1/-0

## Release note

Release builds no longer use shared GitHub Actions caches, closing the default-branch cache-poisoning path without changing release inputs or artifacts.
