### PR TITLE
feat(runtime): package commit-matched companion plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to OCM are documented here.
 - Copy repo-backed and symlinked plain-home agent workspaces into an adopted
   environment and rewrite the imported config to keep the fixture isolated.
 
+### Added
+
+- Let `runtime build-local` assemble repeatable, commit-matched official companion plugins through OpenClaw's release packaging contract, stage them as trusted runtime-owned bundled plugins with isolated dependencies, and record artifact and entrypoint hashes for verification.
+
 ### Changed
 
 - Make `ocm service restart <env>` restart immediately through OpenClaw's protocol-v1 recovery handoff so eligible interrupted sessions and subagents resume after startup, preserve the legacy direct-restart behavior with a warning when recovery is unavailable, keep `--force` as an explicit bypass for an unhealthy handoff, and avoid self-restart deadlocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to OCM are documented here.
 ### Changed
 
 - Make `ocm service restart <env>` restart immediately through OpenClaw's protocol-v1 recovery handoff so eligible interrupted sessions and subagents resume after startup, preserve the legacy direct-restart behavior with a warning when recovery is unavailable, keep `--force` as an explicit bypass for an unhealthy handoff, and avoid self-restart deadlocks.
+- Resolve and package the complete transitive closure of private OpenClaw `workspace:*` dependencies during `runtime build-local`, rewriting nested workspace specs only inside scratch archives so current source graphs install without mutating the checkout.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ operations reject that runtime. Use `ocm upgrade <env>` so the environment gets
 the snapshot, OpenClaw migration, rollback, and verification path, or clear the
 binding first when intentionally managing an unused runtime.
 
+For unreleased OpenClaw workspaces, `runtime build-local` follows the complete
+transitive closure of private `workspace:*` packages. It rewrites nested
+workspace specs only inside scratch archives before installation; the source
+checkout remains unchanged.
+
 `upgrade simulate` clones the source env, leaves the real env untouched, and
 cleans temporary simulation envs and runtimes when the run finishes. For
 published targets it first validates that the target exists, then runs OpenClaw's own

--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ transitive closure of private `workspace:*` packages. It rewrites nested
 workspace specs only inside scratch archives before installation; the source
 checkout remains unchanged.
 
+For unreleased source builds with separately published, version-bound official
+plugins, repeat `runtime build-local --companion <plugin-id>`. OCM packages each
+selected plugin through OpenClaw's own package-local release contract, requires
+exact host-version parity, stages it as a runtime-owned bundled plugin with
+isolated dependencies, and records artifact and entrypoint hashes for runtime
+verification.
+
 `upgrade simulate` clones the source env, leaves the real env untouched, and
 cleans temporary simulation envs and runtimes when the run finishes. For
 published targets it first validates that the target exists, then runs OpenClaw's own

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -102,6 +102,7 @@ If you run `ocm setup` from inside an OpenClaw checkout, local mode can detect t
 
 ```bash
 ocm runtime build-local main-local --repo /path/to/openclaw --force
+ocm runtime build-local main-with-codex --repo /path/to/openclaw --companion codex --force
 ocm start luna --runtime main-local
 ocm upgrade luna --runtime main-local
 ```
@@ -113,10 +114,13 @@ their complete transitive closure. Its build-only npm proxy rewrites nested
 workspace specs to exact local versions only inside scratch archives, leaving
 the selected checkout unchanged.
 
+Repeat `--companion <plugin-id>` when the checkout contains an official plugin that is version-bound to the selected OpenClaw build but published separately. OCM uses OpenClaw's package-local plugin release contract, requires the plugin package version and `openclaw.build.openclawVersion` to match the root package exactly, installs its dependencies in an isolated runtime-owned tree, and stages it under `dist/extensions/<plugin-id>` so OpenClaw discovers it as bundled. The runtime record stores the package version plus artifact and entrypoint hashes, and `runtime verify` checks the installed entrypoint hash. OCM refuses missing, mismatched, non-publishable, duplicate, or already-bundled companion selections before publishing the runtime.
+
 The installed runtime uses the same package layout as published OpenClaw runtimes:
 
 ```text
 files/node_modules/openclaw/openclaw.mjs
+files/node_modules/openclaw/dist/extensions/codex/
 ```
 
 That matters for release and upgrade testing because it avoids source/Jiti execution paths and exercises the built package files that users install.
@@ -241,6 +245,7 @@ Examples:
 ```bash
 ocm release install --channel stable
 ocm runtime build-local main-local --repo /path/to/openclaw --force
+ocm runtime build-local main-with-codex --repo /path/to/openclaw --companion codex --force
 ocm runtime list
 ocm runtime show stable
 ocm runtime verify stable

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -108,6 +108,11 @@ ocm upgrade luna --runtime main-local
 
 Use this when you need to test what users will run after an OpenClaw release, but from a local checkout before publishing. OCM runs `npm pack` in the OpenClaw repo, which triggers OpenClaw's package prepack path instead of registering a source checkout command.
 
+When the root package depends on private `workspace:*` packages, OCM resolves
+their complete transitive closure. Its build-only npm proxy rewrites nested
+workspace specs to exact local versions only inside scratch archives, leaving
+the selected checkout unchanged.
+
 The installed runtime uses the same package layout as published OpenClaw runtimes:
 
 ```text

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1887,7 +1887,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
             "Build a local OpenClaw package runtime",
             "Run the local OpenClaw package build/pack path and install the produced tarball as an OCM-managed runtime.",
             vec![format!(
-                "{cmd} runtime build-local <name> --repo <openclaw-repo> [--include-source-extensions | --for-env <env>] [--description <text>] [--force] [--raw] [--json]"
+                "{cmd} runtime build-local <name> --repo <openclaw-repo> [--companion <plugin-id>]... [--include-source-extensions | --for-env <env>] [--description <text>] [--force] [--raw] [--json]"
             )],
             &[
                 (
@@ -1901,6 +1901,10 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 (
                     "--for-env <env>",
                     "Include the source-plugin closure required by one target environment",
+                ),
+                (
+                    "--companion <plugin-id>",
+                    "Build and bundle a commit-matched official plugin; repeatable",
                 ),
                 ("--description <text>", "Optional human description"),
                 (
@@ -1921,6 +1925,9 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 format!(
                     "{cmd} runtime build-local primary-test --repo /path/to/openclaw --for-env primary --force"
                 ),
+                format!(
+                    "{cmd} runtime build-local upstream-main --repo /path/to/openclaw --companion codex --force"
+                ),
             ],
             &[
                 "`build-local` uses `npm pack` so OpenClaw's prepack script performs the release-style build, UI build, package inventory, and built entry smoke checks.",
@@ -1928,6 +1935,7 @@ pub fn runtime_command_help(cmd: &str, action: &str) -> Option<String> {
                 "`--for-env` resolves the target config before the build, validates its plugin references against the selected checkout and installed-plugin records, and adds only required omitted source plugins plus transitive local plugin dependencies.",
                 "`--for-env` and `--include-source-extensions` are mutually exclusive.",
                 "Source-extension runtimes can take longer to build and use substantially more disk space than the release-shaped default.",
+                "Each `--companion` uses OpenClaw's package-local plugin release build, requires exact host-version parity, installs dependencies in an isolated plugin tree, and records artifact and entrypoint hashes.",
                 "The resulting runtime is installed under OCM's package runtime layout: files/node_modules/openclaw/openclaw.mjs.",
                 "Use this when testing release and upgrade behavior from a local checkout without source/Jiti execution paths.",
                 "A runtime bound to an environment cannot be replaced directly. Clear the binding first or use `ocm upgrade <env>` for published OpenClaw releases.",

--- a/src/cli/render/runtime.rs
+++ b/src/cli/render/runtime.rs
@@ -258,6 +258,23 @@ pub fn runtime_show(
     }
     push_card(&mut lines, "Source details", source_rows, profile.color);
 
+    if !meta.companions.is_empty() {
+        push_card(
+            &mut lines,
+            "Companions",
+            meta.companions
+                .iter()
+                .map(|companion| {
+                    KeyValueRow::accent(
+                        companion.id.clone(),
+                        format!("{}@{}", companion.package_name, companion.version),
+                    )
+                })
+                .collect(),
+            profile.color,
+        );
+    }
+
     push_card(
         &mut lines,
         "Metadata",
@@ -351,6 +368,16 @@ fn runtime_show_raw(meta: &RuntimeMeta) -> Result<Vec<String>, String> {
     }
     if let Some(install_root) = meta.install_root.as_deref() {
         lines.insert("installRoot".to_string(), install_root.to_string());
+    }
+    if !meta.companions.is_empty() {
+        lines.insert(
+            "companions".to_string(),
+            meta.companions
+                .iter()
+                .map(|companion| format!("{}@{}", companion.package_name, companion.version))
+                .collect::<Vec<_>>()
+                .join(","),
+        );
     }
     Ok(format_key_value_lines(lines))
 }
@@ -953,6 +980,12 @@ fn runtime_verify_raw(summary: &RuntimeVerifySummary) -> Vec<String> {
     if let Some(install_root) = summary.install_root.as_deref() {
         lines.push(format!("installRoot: {install_root}"));
     }
+    for companion in &summary.companions {
+        lines.push(format!(
+            "companion: {} {}@{}",
+            companion.id, companion.package_name, companion.version
+        ));
+    }
     if let Some(issue) = summary.issue.as_deref() {
         lines.push(format!("issue: {issue}"));
     }
@@ -1201,6 +1234,7 @@ mod tests {
             release_selector_kind: Some(RuntimeReleaseSelectorKind::Channel),
             release_selector_value: Some("stable".to_string()),
             install_root: Some("/tmp/ocm/runtimes/stable".to_string()),
+            companions: Vec::new(),
             description: None,
             created_at: OffsetDateTime::UNIX_EPOCH,
             updated_at: OffsetDateTime::UNIX_EPOCH,
@@ -1225,6 +1259,7 @@ mod tests {
             release_selector_kind: Some(RuntimeReleaseSelectorKind::Channel),
             release_selector_value: Some("stable".to_string()),
             install_root: Some("/tmp/ocm/runtimes/stable".to_string()),
+            companions: Vec::new(),
             healthy: true,
             issue: None,
         }

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -301,6 +301,21 @@ impl Cli {
         let Some(repo) = repo else {
             return Err("--repo is required".to_string());
         };
+        let mut args = args;
+        let mut companions = Vec::new();
+        loop {
+            let (remaining, companion) = Self::consume_option(args, "--companion")?;
+            let Some(companion) = companion else {
+                args = remaining;
+                break;
+            };
+            let Some(companion) = Self::require_option_value(Some(companion), "--companion")?
+            else {
+                return Err("--companion is required".to_string());
+            };
+            companions.push(companion);
+            args = remaining;
+        }
         let (args, description) = Self::consume_option(args, "--description")?;
         let Some(name) = args.first() else {
             return Err("runtime name is required".to_string());
@@ -312,6 +327,7 @@ impl Cli {
                 .build_local(BuildLocalRuntimeOptions {
                     name: name.clone(),
                     repo: repo.clone(),
+                    companions,
                     description,
                     force,
                     include_source_extensions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,5 +37,9 @@ fn run() -> Result<i32, String> {
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    if ocm::runtime::is_internal_npm_proxy(&env_map) {
+        return ocm::runtime::run_internal_npm_proxy(&args, &env_map, &cwd);
+    }
+
     Ok(Cli { env: env_map, cwd }.run(args))
 }

--- a/src/runtime/install.rs
+++ b/src/runtime/install.rs
@@ -54,6 +54,7 @@ pub struct InstallRuntimeFromOfficialReleaseOptions {
 pub struct BuildLocalRuntimeOptions {
     pub name: String,
     pub repo: String,
+    pub companions: Vec<String>,
     pub description: Option<String>,
     pub force: bool,
     pub include_source_extensions: bool,
@@ -433,6 +434,7 @@ impl<'a> RuntimeService<'a> {
                 StoreBuildLocalRuntimeOptions {
                     name: options.name,
                     repo: options.repo,
+                    companions: options.companions,
                     description: options.description,
                     force: options.force,
                     include_source_extensions: options.include_source_extensions,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,6 @@
 mod install;
 mod launch;
+mod npm_proxy;
 mod registry;
 pub mod releases;
 mod verify;
@@ -14,6 +15,12 @@ pub use install::{
 pub(crate) use launch::{
     is_official_openclaw_package_runtime, is_openclaw_package_runtime, resolve_runtime_launch,
 };
+pub(crate) use npm_proxy::{
+    INTERNAL_NPM_PROXY_REAL_BIN_ENV, INTERNAL_NPM_PROXY_WORKSPACE_DIRS_ENV,
+    INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS_ENV,
+};
+#[doc(hidden)]
+pub use npm_proxy::{is_internal_npm_proxy, run_internal_npm_proxy};
 pub use registry::{
     AddRuntimeOptions, RuntimeMeta, RuntimeReleaseSelectorKind, RuntimeService, RuntimeSourceKind,
 };

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -22,7 +22,8 @@ pub(crate) use npm_proxy::{
 #[doc(hidden)]
 pub use npm_proxy::{is_internal_npm_proxy, run_internal_npm_proxy};
 pub use registry::{
-    AddRuntimeOptions, RuntimeMeta, RuntimeReleaseSelectorKind, RuntimeService, RuntimeSourceKind,
+    AddRuntimeOptions, RuntimeCompanionMeta, RuntimeMeta, RuntimeReleaseSelectorKind,
+    RuntimeService, RuntimeSourceKind,
 };
 pub use releases::{
     OpenClawRelease, OpenClawReleaseCatalogEntry, RuntimeRelease, RuntimeReleaseManifest,

--- a/src/runtime/npm_proxy.rs
+++ b/src/runtime/npm_proxy.rs
@@ -1,0 +1,295 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use flate2::{Compression, read::GzDecoder, write::GzEncoder};
+use tar::{Archive, Builder};
+use tempfile::{NamedTempFile, tempdir};
+
+pub(crate) const INTERNAL_NPM_PROXY_REAL_BIN_ENV: &str = "OCM_INTERNAL_NPM_PROXY_REAL_BIN";
+pub(crate) const INTERNAL_NPM_PROXY_WORKSPACE_DIRS_ENV: &str =
+    "OCM_INTERNAL_NPM_PROXY_WORKSPACE_DIRS";
+pub(crate) const INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS_ENV: &str =
+    "OCM_INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS";
+
+pub fn is_internal_npm_proxy(env: &BTreeMap<String, String>) -> bool {
+    env.get(INTERNAL_NPM_PROXY_REAL_BIN_ENV)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn resolve_path(cwd: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn workspace_pack_request(
+    args: &[String],
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<Option<PathBuf>, String> {
+    if args.first().map(String::as_str) != Some("pack") {
+        return Ok(None);
+    }
+    let Some(package_arg) = args.get(1).filter(|value| !value.starts_with('-')) else {
+        return Ok(None);
+    };
+    let package_dir = resolve_path(cwd, package_arg)
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve npm pack directory {package_arg}: {error}"))?;
+    let workspace_dirs = env
+        .get(INTERNAL_NPM_PROXY_WORKSPACE_DIRS_ENV)
+        .map(|value| std::env::split_paths(value).collect::<Vec<_>>())
+        .unwrap_or_default();
+    if !workspace_dirs.into_iter().any(|dir| {
+        dir.canonicalize()
+            .is_ok_and(|candidate| candidate == package_dir)
+    }) {
+        return Ok(None);
+    }
+    let destination = args
+        .iter()
+        .position(|value| value == "--pack-destination")
+        .and_then(|index| args.get(index + 1))
+        .ok_or_else(|| "workspace npm pack requires --pack-destination".to_string())?;
+    Ok(Some(resolve_path(cwd, destination)))
+}
+
+fn tarballs_in(dir: &Path) -> Result<BTreeSet<PathBuf>, String> {
+    Ok(fs::read_dir(dir)
+        .map_err(|error| {
+            format!(
+                "failed to read workspace npm pack destination {}: {error}",
+                dir.display()
+            )
+        })?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("tgz"))
+        .collect())
+}
+
+fn rewrite_workspace_dependency_versions(
+    package: &mut serde_json::Value,
+    versions: &BTreeMap<String, String>,
+) -> Result<usize, String> {
+    let mut rewritten = 0;
+    for section in [
+        "dependencies",
+        "optionalDependencies",
+        "peerDependencies",
+        "devDependencies",
+    ] {
+        let Some(dependencies) = package
+            .get_mut(section)
+            .and_then(serde_json::Value::as_object_mut)
+        else {
+            continue;
+        };
+        for (name, spec_value) in dependencies {
+            let Some(spec) = spec_value.as_str() else {
+                continue;
+            };
+            if !spec.starts_with("workspace:") {
+                continue;
+            }
+            let version = versions.get(name).ok_or_else(|| {
+                format!("workspace package archive references unconfigured dependency {name}")
+            })?;
+            *spec_value = serde_json::Value::String(version.clone());
+            rewritten += 1;
+        }
+    }
+    Ok(rewritten)
+}
+
+fn patch_workspace_package_archive(
+    archive_path: &Path,
+    versions: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let unpacked = tempdir().map_err(|error| error.to_string())?;
+    let archive_file = fs::File::open(archive_path).map_err(|error| {
+        format!(
+            "failed to open workspace package archive {}: {error}",
+            archive_path.display()
+        )
+    })?;
+    Archive::new(GzDecoder::new(archive_file))
+        .unpack(unpacked.path())
+        .map_err(|error| {
+            format!(
+                "failed to unpack workspace package archive {}: {error}",
+                archive_path.display()
+            )
+        })?;
+    let package_dir = unpacked.path().join("package");
+    let package_json_path = package_dir.join("package.json");
+    let raw = fs::read_to_string(&package_json_path).map_err(|error| {
+        format!(
+            "failed to read packed workspace package.json at {}: {error}",
+            package_json_path.display()
+        )
+    })?;
+    let mut package: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
+        format!(
+            "failed to parse packed workspace package.json at {}: {error}",
+            package_json_path.display()
+        )
+    })?;
+    if rewrite_workspace_dependency_versions(&mut package, versions)? == 0 {
+        return Ok(());
+    }
+    fs::write(
+        &package_json_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&package).map_err(|error| error.to_string())?
+        ),
+    )
+    .map_err(|error| {
+        format!(
+            "failed to rewrite packed workspace package.json at {}: {error}",
+            package_json_path.display()
+        )
+    })?;
+
+    let parent = archive_path
+        .parent()
+        .ok_or_else(|| "workspace package archive has no parent directory".to_string())?;
+    let rewritten = NamedTempFile::new_in(parent).map_err(|error| error.to_string())?;
+    let output = rewritten.reopen().map_err(|error| error.to_string())?;
+    let encoder = GzEncoder::new(output, Compression::default());
+    let mut builder = Builder::new(encoder);
+    builder.follow_symlinks(false);
+    builder
+        .append_dir_all("package", &package_dir)
+        .map_err(|error| error.to_string())?;
+    let encoder = builder.into_inner().map_err(|error| error.to_string())?;
+    encoder.finish().map_err(|error| error.to_string())?;
+    fs::copy(rewritten.path(), archive_path).map_err(|error| {
+        format!(
+            "failed to replace workspace package archive {}: {error}",
+            archive_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+pub fn run_internal_npm_proxy(
+    args: &[String],
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<i32, String> {
+    let real_npm = env
+        .get(INTERNAL_NPM_PROXY_REAL_BIN_ENV)
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "internal npm proxy is missing its real npm program".to_string())?;
+    let pack_destination = workspace_pack_request(args, env, cwd)?;
+    let before = pack_destination
+        .as_deref()
+        .map(tarballs_in)
+        .transpose()?
+        .unwrap_or_default();
+
+    let mut command = Command::new(real_npm);
+    command.args(args).current_dir(cwd);
+    for (key, value) in env {
+        if ![
+            INTERNAL_NPM_PROXY_REAL_BIN_ENV,
+            INTERNAL_NPM_PROXY_WORKSPACE_DIRS_ENV,
+            INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS_ENV,
+        ]
+        .contains(&key.as_str())
+        {
+            command.env(key, value);
+        }
+    }
+    for key in [
+        INTERNAL_NPM_PROXY_REAL_BIN_ENV,
+        INTERNAL_NPM_PROXY_WORKSPACE_DIRS_ENV,
+        INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS_ENV,
+    ] {
+        command.env_remove(key);
+    }
+    let status = command
+        .status()
+        .map_err(|error| format!("failed to run real npm program {real_npm}: {error}"))?;
+    let code = status.code().unwrap_or(1);
+    if !status.success() {
+        return Ok(code);
+    }
+
+    if let Some(pack_destination) = pack_destination {
+        let after = tarballs_in(&pack_destination)?;
+        let mut created = after.difference(&before).cloned().collect::<Vec<_>>();
+        if created.len() != 1 {
+            return Err(format!(
+                "workspace npm pack created {} new archives in {}; expected one",
+                created.len(),
+                pack_destination.display()
+            ));
+        }
+        let versions_raw = env
+            .get(INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS_ENV)
+            .ok_or_else(|| "internal npm proxy is missing workspace versions".to_string())?;
+        let versions = serde_json::from_str::<BTreeMap<String, String>>(versions_raw)
+            .map_err(|error| format!("failed to parse internal workspace versions: {error}"))?;
+        patch_workspace_package_archive(&created.remove(0), &versions)?;
+    }
+    Ok(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::patch_workspace_package_archive;
+    use flate2::{Compression, read::GzDecoder, write::GzEncoder};
+    use std::collections::BTreeMap;
+    use std::fs;
+    use tar::{Archive, Builder};
+
+    #[test]
+    fn workspace_archive_rewrites_transitive_workspace_dependencies() {
+        let root = tempfile::tempdir().unwrap();
+        let package_dir = root.path().join("source/package");
+        fs::create_dir_all(&package_dir).unwrap();
+        fs::write(
+            package_dir.join("package.json"),
+            br#"{"name":"@openclaw/session-url-contract","version":"0.0.0-private","dependencies":{"@openclaw/normalization-core":"workspace:*"}}"#,
+        )
+        .unwrap();
+        fs::write(package_dir.join("index.js"), "export {};\n").unwrap();
+        let archive_path = root.path().join("workspace.tgz");
+        let output = fs::File::create(&archive_path).unwrap();
+        let mut builder = Builder::new(GzEncoder::new(output, Compression::default()));
+        builder.append_dir_all("package", &package_dir).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        patch_workspace_package_archive(
+            &archive_path,
+            &BTreeMap::from([(
+                "@openclaw/normalization-core".to_string(),
+                "0.0.0-private".to_string(),
+            )]),
+        )
+        .unwrap();
+
+        let unpacked = tempfile::tempdir().unwrap();
+        Archive::new(GzDecoder::new(fs::File::open(&archive_path).unwrap()))
+            .unpack(unpacked.path())
+            .unwrap();
+        let package: serde_json::Value = serde_json::from_slice(
+            &fs::read(unpacked.path().join("package/package.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            package["dependencies"]["@openclaw/normalization-core"],
+            "0.0.0-private"
+        );
+        assert!(unpacked.path().join("package/index.js").is_file());
+    }
+}

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -47,6 +47,17 @@ impl RuntimeReleaseSelectorKind {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct RuntimeCompanionMeta {
+    pub id: String,
+    pub package_name: String,
+    pub version: String,
+    pub artifact_sha256: String,
+    pub entrypoint: String,
+    pub entrypoint_sha256: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RuntimeMeta {
     pub kind: String,
     pub name: String,
@@ -75,6 +86,8 @@ pub struct RuntimeMeta {
     pub release_selector_value: Option<String>,
     #[serde(default)]
     pub install_root: Option<String>,
+    #[serde(default)]
+    pub companions: Vec<RuntimeCompanionMeta>,
     pub description: Option<String>,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,

--- a/src/runtime/verify.rs
+++ b/src/runtime/verify.rs
@@ -1,4 +1,4 @@
-use super::{RuntimeMeta, RuntimeReleaseSelectorKind, RuntimeService};
+use super::{RuntimeCompanionMeta, RuntimeMeta, RuntimeReleaseSelectorKind, RuntimeService};
 use crate::store::{get_runtime, get_runtime_verified, list_runtimes, runtime_integrity_issue};
 use serde::Serialize;
 
@@ -19,6 +19,7 @@ pub struct RuntimeVerifySummary {
     pub release_selector_kind: Option<RuntimeReleaseSelectorKind>,
     pub release_selector_value: Option<String>,
     pub install_root: Option<String>,
+    pub companions: Vec<RuntimeCompanionMeta>,
     pub healthy: bool,
     pub issue: Option<String>,
 }
@@ -85,6 +86,7 @@ fn build_verify_summary(
         release_selector_kind: meta.release_selector_kind,
         release_selector_value: meta.release_selector_value,
         install_root: meta.install_root,
+        companions: meta.companions,
         healthy: issue.is_none(),
         issue,
     }

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -21,9 +21,11 @@ use crate::runtime::releases::{
     select_release,
 };
 use crate::runtime::{
-    AddRuntimeOptions, InstallRuntimeFromOfficialReleaseOptions, InstallRuntimeFromReleaseOptions,
-    InstallRuntimeFromUrlOptions, InstallRuntimeOptions, RuntimeMeta, RuntimeReleaseSelectorKind,
-    RuntimeSourceKind, is_official_openclaw_package_runtime, is_openclaw_package_runtime,
+    AddRuntimeOptions, INTERNAL_NPM_PROXY_REAL_BIN_ENV, INTERNAL_NPM_PROXY_WORKSPACE_DIRS_ENV,
+    INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS_ENV, InstallRuntimeFromOfficialReleaseOptions,
+    InstallRuntimeFromReleaseOptions, InstallRuntimeFromUrlOptions, InstallRuntimeOptions,
+    RuntimeMeta, RuntimeReleaseSelectorKind, RuntimeSourceKind,
+    is_official_openclaw_package_runtime, is_openclaw_package_runtime,
 };
 
 use super::common::{
@@ -388,7 +390,22 @@ fn configured_npm_program(env: &BTreeMap<String, String>) -> Option<String> {
 struct LocalBuildNpmAdapter {
     command: CommandSpec,
     real_npm: String,
+    npm_proxy: String,
     workspace_dependency_dirs: Option<OsString>,
+    workspace_dependency_versions: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct LocalWorkspacePackage {
+    dir: PathBuf,
+    version: Option<String>,
+    workspace_dependencies: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug)]
+struct LocalWorkspaceDependencyPlan {
+    dirs: OsString,
+    versions_json: String,
 }
 
 #[derive(Clone, Debug)]
@@ -421,11 +438,22 @@ struct SourcePluginInventory {
 
 impl LocalBuildNpmAdapter {
     fn apply_environment(&self, command: &mut Command) {
-        command.env("OPENCLAW_OCM_REAL_NPM_BIN", &self.real_npm);
+        command.env("OPENCLAW_OCM_REAL_NPM_BIN", &self.npm_proxy);
+        command.env(INTERNAL_NPM_PROXY_REAL_BIN_ENV, &self.real_npm);
         if let Some(workspace_dependency_dirs) = &self.workspace_dependency_dirs {
             command.env(
                 "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS",
                 workspace_dependency_dirs,
+            );
+            command.env(
+                INTERNAL_NPM_PROXY_WORKSPACE_DIRS_ENV,
+                workspace_dependency_dirs,
+            );
+        }
+        if let Some(workspace_dependency_versions) = &self.workspace_dependency_versions {
+            command.env(
+                INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS_ENV,
+                workspace_dependency_versions,
             );
         }
     }
@@ -756,7 +784,9 @@ fn resolve_target_source_plugin_closure(
     source_plugin_dependency_closure(direct, &inventory)
 }
 
-fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>, String> {
+fn local_workspace_dependency_plan(
+    repo_path: &Path,
+) -> Result<Option<LocalWorkspaceDependencyPlan>, String> {
     let package_json_path = repo_path.join("package.json");
     let raw = fs::read_to_string(&package_json_path).map_err(|error| {
         format!(
@@ -775,12 +805,19 @@ fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>,
     if pending.is_empty() {
         return Ok(None);
     }
-    let mut visited = root_package
+    let root_name = root_package
         .get("name")
         .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-        .into_iter()
-        .collect::<BTreeSet<_>>();
+        .unwrap_or("openclaw")
+        .to_string();
+    let root_version = root_package
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "OpenClaw package.json is missing a non-empty version".to_string())?
+        .to_string();
+    let mut visited = BTreeSet::from([root_name.clone()]);
 
     let mut packages = BTreeMap::new();
     for package_dir in local_workspace_package_dirs(repo_path)? {
@@ -799,27 +836,52 @@ fn local_workspace_dependency_dirs(repo_path: &Path) -> Result<Option<OsString>,
             .get("name")
             .and_then(serde_json::Value::as_str)
         {
-            packages.insert(name.to_string(), (package_dir, package_value));
+            packages.insert(
+                name.to_string(),
+                LocalWorkspacePackage {
+                    dir: package_dir,
+                    version: package_value
+                        .get("version")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(str::to_string),
+                    workspace_dependencies: workspace_dependency_names(&package_value, true),
+                },
+            );
         }
     }
 
     let mut selected = BTreeMap::new();
+    let mut versions = BTreeMap::from([(root_name, root_version)]);
     while let Some(name) = pending.pop_first() {
         if !visited.insert(name.clone()) {
             continue;
         }
-        let (package_dir, package_value) = packages.get(&name).ok_or_else(|| {
+        let package = packages.get(&name).cloned().ok_or_else(|| {
             format!(
                 "OpenClaw workspace dependency \"{name}\" is not declared by pnpm-workspace.yaml"
             )
         })?;
-        selected.insert(name, package_dir.clone());
-        pending.extend(workspace_dependency_names(package_value, true));
+        let version = package.version.clone().ok_or_else(|| {
+            format!("selected OpenClaw workspace dependency \"{name}\" is missing a version")
+        })?;
+        pending.extend(package.workspace_dependencies.iter().cloned());
+        versions.insert(name.clone(), version);
+        selected.insert(name, package);
     }
 
-    std::env::join_paths(selected.into_values())
-        .map(Some)
-        .map_err(|error| format!("failed to encode OpenClaw workspace dependency paths: {error}"))
+    let dirs =
+        std::env::join_paths(selected.values().map(|package| &package.dir)).map_err(|error| {
+            format!("failed to encode OpenClaw workspace dependency paths: {error}")
+        })?;
+    let versions_json = serde_json::to_string(&versions).map_err(|error| {
+        format!("failed to encode OpenClaw workspace dependency versions: {error}")
+    })?;
+    Ok(Some(LocalWorkspaceDependencyPlan {
+        dirs,
+        versions_json,
+    }))
 }
 
 fn local_build_npm_adapter(
@@ -838,6 +900,9 @@ fn local_build_npm_adapter(
         return Ok(None);
     };
 
+    let workspace_dependencies = local_workspace_dependency_plan(repo_path)?;
+    let npm_proxy = std::env::current_exe()
+        .map_err(|error| format!("failed to resolve OCM npm proxy executable: {error}"))?;
     Ok(Some(LocalBuildNpmAdapter {
         command: CommandSpec {
             program: "node".to_string(),
@@ -845,7 +910,11 @@ fn local_build_npm_adapter(
             path_prepend: None,
         },
         real_npm: "npm".to_string(),
-        workspace_dependency_dirs: local_workspace_dependency_dirs(repo_path)?,
+        npm_proxy: display_path(&npm_proxy),
+        workspace_dependency_dirs: workspace_dependencies
+            .as_ref()
+            .map(|plan| plan.dirs.clone()),
+        workspace_dependency_versions: workspace_dependencies.map(|plan| plan.versions_json),
     }))
 }
 
@@ -1309,6 +1378,70 @@ fn pack_local_source_extensions(
     Ok(archives)
 }
 
+fn remove_path_if_present(path: &Path) -> Result<(), String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.to_string()),
+    };
+    if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path).map_err(|error| error.to_string())
+    } else {
+        fs::remove_file(path).map_err(|error| error.to_string())
+    }
+}
+
+fn link_or_copy_openclaw_host(source: &Path, target: &Path) -> Result<(), String> {
+    if let Some(parent) = target.parent() {
+        ensure_dir(parent)?;
+    }
+    #[cfg(unix)]
+    {
+        let link_target = relative_symlink_target(source, target).unwrap_or_else(|| source.into());
+        if std::os::unix::fs::symlink(link_target, target).is_ok() {
+            return Ok(());
+        }
+    }
+    #[cfg(windows)]
+    {
+        let link_target = relative_symlink_target(source, target).unwrap_or_else(|| source.into());
+        if std::os::windows::fs::symlink_dir(link_target, target).is_ok() {
+            return Ok(());
+        }
+    }
+
+    // The target is nested inside the host package, so stage the fallback outside
+    // that tree before copying to avoid recursively copying the destination.
+    let staged = tempfile::tempdir().map_err(|error| error.to_string())?;
+    let staged_host = staged.path().join("openclaw");
+    copy_dir_recursive(source, &staged_host)?;
+    copy_dir_recursive(&staged_host, target)
+}
+
+fn ensure_local_source_extension_openclaw_peer(
+    host_package: &Path,
+    extension_root: &Path,
+) -> Result<(), String> {
+    let package_json_path = extension_root.join("package.json");
+    let package: serde_json::Value = read_json(&package_json_path).map_err(|error| {
+        format!(
+            "failed to inspect installed source extension package at {}: {error}",
+            display_path(&package_json_path)
+        )
+    })?;
+    if package
+        .pointer("/peerDependencies/openclaw")
+        .and_then(serde_json::Value::as_str)
+        .is_none()
+    {
+        return Ok(());
+    }
+
+    let peer_path = extension_root.join("node_modules/openclaw");
+    remove_path_if_present(&peer_path)?;
+    link_or_copy_openclaw_host(host_package, &peer_path)
+}
+
 fn materialize_local_source_extensions(
     install_files: &Path,
     extensions: &[LocalSourceExtensionArchive],
@@ -1343,6 +1476,10 @@ fn materialize_local_source_extensions(
             ));
         }
         copy_dir_recursive(&installed_package, &target)?;
+        ensure_local_source_extension_openclaw_peer(
+            &installed_openclaw_package_root(install_files),
+            &target,
+        )?;
     }
     Ok(())
 }
@@ -1577,6 +1714,7 @@ fn prepare_runtime_from_openclaw_package(
     })()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn stage_runtime_from_openclaw_package_archive(
     target: &RuntimeInstallTarget,
     archive_path: &Path,
@@ -2051,6 +2189,7 @@ pub fn install_runtime_from_release(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn install_runtime_from_selected_release(
     name: String,
     force: bool,

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -1048,6 +1048,7 @@ fn default_local_build_description(version: &str, commit: Option<&str>) -> Strin
 #[derive(Clone, Debug)]
 struct LocalCompanionSpec {
     id: String,
+    directory_name: String,
     package_name: String,
     version: String,
 }
@@ -1086,13 +1087,14 @@ fn load_local_companion_spec(
     openclaw_version: &str,
 ) -> Result<LocalCompanionSpec, String> {
     let id = validate_local_companion_id(raw_id)?;
-    let package_dir = repo_path.join("extensions").join(&id);
-    if !package_dir.is_dir() {
-        return Err(format!(
-            "local companion \"{id}\" does not exist at {}",
-            display_path(&package_dir)
-        ));
-    }
+    let inventory = source_plugin_inventory(repo_path)?;
+    let companion = inventory.by_id.get(&id).ok_or_else(|| {
+        format!(
+            "local companion plugin id \"{id}\" does not exist under {}",
+            display_path(&repo_path.join("extensions"))
+        )
+    })?;
+    let package_dir = repo_path.join("extensions").join(&companion.directory_name);
     let package = load_json_value(&package_dir.join("package.json"), "companion package.json")?;
     let package_name = package
         .get("name")
@@ -1128,19 +1130,6 @@ fn load_local_companion_spec(
             "local companion \"{id}\" is not an official npm-publishable plugin"
         ));
     }
-    let plugin_manifest = load_json_value(
-        &package_dir.join("openclaw.plugin.json"),
-        "companion plugin manifest",
-    )?;
-    let manifest_id = plugin_manifest
-        .get("id")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or_default();
-    if manifest_id != id {
-        return Err(format!(
-            "local companion directory \"{id}\" contains plugin manifest id \"{manifest_id}\""
-        ));
-    }
     for relative in [
         "scripts/lib/plugin-npm-runtime-build.mjs",
         "scripts/generate-npm-package-lock.mjs",
@@ -1154,6 +1143,7 @@ fn load_local_companion_spec(
     }
     Ok(LocalCompanionSpec {
         id,
+        directory_name: companion.directory_name.clone(),
         package_name: package_name.to_string(),
         version: version.to_string(),
     })
@@ -1189,7 +1179,7 @@ fn pack_local_openclaw_companion(
     spec: LocalCompanionSpec,
     env: &BTreeMap<String, String>,
 ) -> Result<PackedLocalCompanion, String> {
-    let package_dir = format!("extensions/{}", spec.id);
+    let package_dir = format!("extensions/{}", spec.directory_name);
     let output_dir = pack_dir.join("companions").join(&spec.id);
     ensure_dir(&output_dir)?;
 
@@ -1373,6 +1363,7 @@ fn install_local_openclaw_companion(
         .arg("--prefix")
         .arg(&install_root)
         .arg("--omit=dev")
+        .arg("--omit=peer")
         .arg("--no-save")
         .arg("--package-lock=false")
         .arg(&packed.archive_path)
@@ -1430,6 +1421,7 @@ fn install_local_openclaw_companion(
         &target_package_root.join("node_modules"),
         &package_path,
     )?;
+    ensure_local_extension_openclaw_peer(&openclaw_package_root, &target_package_root)?;
 
     let installed = load_json_value(
         &target_package_root.join("package.json"),
@@ -1862,7 +1854,7 @@ fn link_or_copy_openclaw_host(source: &Path, target: &Path) -> Result<(), String
     copy_dir_recursive(&staged_host, target)
 }
 
-fn ensure_local_source_extension_openclaw_peer(
+fn ensure_local_extension_openclaw_peer(
     host_package: &Path,
     extension_root: &Path,
 ) -> Result<(), String> {
@@ -1920,7 +1912,7 @@ fn materialize_local_source_extensions(
             ));
         }
         copy_dir_recursive(&installed_package, &target)?;
-        ensure_local_source_extension_openclaw_peer(
+        ensure_local_extension_openclaw_peer(
             &installed_openclaw_package_root(install_files),
             &target,
         )?;

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -2618,6 +2618,7 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
+        meta.runtime_sha256 = Some(tree_sha256(&target.install_files.join("node_modules"))?);
         publish_runtime(target, meta)
     })();
 
@@ -2904,11 +2905,92 @@ fn runtime_execution_issue(meta: &RuntimeMeta, env: &BTreeMap<String, String>) -
     None
 }
 
+fn runtime_companion_integrity_issue(meta: &RuntimeMeta) -> Option<String> {
+    let package_root = openclaw_package_root_from_binary(Path::new(&meta.binary_path))?;
+    for companion in &meta.companions {
+        if validate_local_companion_id(&companion.id).is_err() {
+            return Some(format!(
+                "runtime companion has invalid plugin id: {}",
+                companion.id
+            ));
+        }
+        if normalize_sha256(&companion.artifact_sha256).is_err() {
+            return Some(format!(
+                "runtime companion {} has invalid artifact sha256",
+                companion.id
+            ));
+        }
+        let entrypoint_prefix = format!("dist/extensions/{}/", companion.id);
+        let Some(entrypoint_relative) = companion.entrypoint.strip_prefix(&entrypoint_prefix)
+        else {
+            return Some(format!(
+                "runtime companion {} has invalid entrypoint path: {}",
+                companion.id, companion.entrypoint
+            ));
+        };
+        let entrypoint_relative = match safe_companion_runtime_entrypoint(entrypoint_relative) {
+            Ok(path) => path,
+            Err(error) => return Some(error),
+        };
+        let expected_entrypoint = PathBuf::from("dist/extensions")
+            .join(&companion.id)
+            .join(entrypoint_relative);
+        if display_path(&expected_entrypoint) != companion.entrypoint {
+            return Some(format!(
+                "runtime companion {} has invalid entrypoint path: {}",
+                companion.id, companion.entrypoint
+            ));
+        }
+        let companion_root = package_root.join("dist/extensions").join(&companion.id);
+        let package_json_path = companion_root.join("package.json");
+        let package = match load_json_value(&package_json_path, "runtime companion package.json") {
+            Ok(value) => value,
+            Err(error) => return Some(error),
+        };
+        if package.get("name").and_then(serde_json::Value::as_str)
+            != Some(companion.package_name.as_str())
+            || package.get("version").and_then(serde_json::Value::as_str)
+                != Some(companion.version.as_str())
+        {
+            return Some(format!(
+                "runtime companion {} package metadata does not match its runtime record",
+                companion.id
+            ));
+        }
+        let entrypoint_path = package_root.join(&companion.entrypoint);
+        if !entrypoint_path.is_file() {
+            return Some(format!(
+                "runtime companion {} entrypoint does not exist: {}",
+                companion.id,
+                display_path(&entrypoint_path)
+            ));
+        }
+        let expected_entrypoint_sha256 = match normalize_sha256(&companion.entrypoint_sha256) {
+            Ok(value) => value,
+            Err(error) => return Some(error),
+        };
+        let actual_entrypoint_sha256 = match file_sha256(&entrypoint_path) {
+            Ok(value) => value,
+            Err(error) => return Some(error),
+        };
+        if actual_entrypoint_sha256 != expected_entrypoint_sha256 {
+            return Some(format!(
+                "runtime companion {} entrypoint sha256 mismatch: expected {}, got {}",
+                companion.id, expected_entrypoint_sha256, actual_entrypoint_sha256
+            ));
+        }
+    }
+    None
+}
+
 pub fn runtime_integrity_issue(
     meta: &RuntimeMeta,
     env: &BTreeMap<String, String>,
 ) -> Option<String> {
     if let Some(issue) = runtime_execution_issue(meta, env) {
+        return Some(issue);
+    }
+    if let Some(issue) = runtime_companion_integrity_issue(meta) {
         return Some(issue);
     }
 
@@ -2929,85 +3011,6 @@ pub fn runtime_integrity_issue(
             return Some(format!(
                 "runtime sha256 mismatch: expected {expected_runtime_sha256}, got {actual_runtime_sha256}"
             ));
-        }
-    }
-
-    if (is_official_openclaw_package_runtime(meta, env) || is_openclaw_package_runtime(meta))
-        && let Some(package_root) = openclaw_package_root_from_binary(Path::new(&meta.binary_path))
-    {
-        for companion in &meta.companions {
-            if validate_local_companion_id(&companion.id).is_err() {
-                return Some(format!(
-                    "runtime companion has invalid plugin id: {}",
-                    companion.id
-                ));
-            }
-            if normalize_sha256(&companion.artifact_sha256).is_err() {
-                return Some(format!(
-                    "runtime companion {} has invalid artifact sha256",
-                    companion.id
-                ));
-            }
-            let entrypoint_prefix = format!("dist/extensions/{}/", companion.id);
-            let Some(entrypoint_relative) = companion.entrypoint.strip_prefix(&entrypoint_prefix)
-            else {
-                return Some(format!(
-                    "runtime companion {} has invalid entrypoint path: {}",
-                    companion.id, companion.entrypoint
-                ));
-            };
-            let entrypoint_relative = match safe_companion_runtime_entrypoint(entrypoint_relative) {
-                Ok(path) => path,
-                Err(error) => return Some(error),
-            };
-            let expected_entrypoint = PathBuf::from("dist/extensions")
-                .join(&companion.id)
-                .join(entrypoint_relative);
-            if display_path(&expected_entrypoint) != companion.entrypoint {
-                return Some(format!(
-                    "runtime companion {} has invalid entrypoint path: {}",
-                    companion.id, companion.entrypoint
-                ));
-            }
-            let companion_root = package_root.join("dist/extensions").join(&companion.id);
-            let package_json_path = companion_root.join("package.json");
-            let package =
-                match load_json_value(&package_json_path, "runtime companion package.json") {
-                    Ok(value) => value,
-                    Err(error) => return Some(error),
-                };
-            if package.get("name").and_then(serde_json::Value::as_str)
-                != Some(companion.package_name.as_str())
-                || package.get("version").and_then(serde_json::Value::as_str)
-                    != Some(companion.version.as_str())
-            {
-                return Some(format!(
-                    "runtime companion {} package metadata does not match its runtime record",
-                    companion.id
-                ));
-            }
-            let entrypoint_path = package_root.join(&companion.entrypoint);
-            if !entrypoint_path.is_file() {
-                return Some(format!(
-                    "runtime companion {} entrypoint does not exist: {}",
-                    companion.id,
-                    display_path(&entrypoint_path)
-                ));
-            }
-            let expected_entrypoint_sha256 = match normalize_sha256(&companion.entrypoint_sha256) {
-                Ok(value) => value,
-                Err(error) => return Some(error),
-            };
-            let actual_entrypoint_sha256 = match file_sha256(&entrypoint_path) {
-                Ok(value) => value,
-                Err(error) => return Some(error),
-            };
-            if actual_entrypoint_sha256 != expected_entrypoint_sha256 {
-                return Some(format!(
-                    "runtime companion {} entrypoint sha256 mismatch: expected {}, got {}",
-                    companion.id, expected_entrypoint_sha256, actual_entrypoint_sha256
-                ));
-            }
         }
     }
 

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -24,13 +24,13 @@ use crate::runtime::{
     AddRuntimeOptions, INTERNAL_NPM_PROXY_REAL_BIN_ENV, INTERNAL_NPM_PROXY_WORKSPACE_DIRS_ENV,
     INTERNAL_NPM_PROXY_WORKSPACE_VERSIONS_ENV, InstallRuntimeFromOfficialReleaseOptions,
     InstallRuntimeFromReleaseOptions, InstallRuntimeFromUrlOptions, InstallRuntimeOptions,
-    RuntimeMeta, RuntimeReleaseSelectorKind, RuntimeSourceKind,
+    RuntimeCompanionMeta, RuntimeMeta, RuntimeReleaseSelectorKind, RuntimeSourceKind,
     is_official_openclaw_package_runtime, is_openclaw_package_runtime,
 };
 
 use super::common::{
-    ExclusiveFileLock, copy_dir_recursive, ensure_dir, load_json_files, lock_file, path_exists,
-    read_json, write_json,
+    ExclusiveFileLock, copy_dir_recursive, copy_path, ensure_dir, load_json_files, lock_file,
+    path_exists, read_json, write_json,
 };
 use super::envs::get_environment;
 use super::layout::{
@@ -362,6 +362,7 @@ pub(crate) struct InstallContext<'a> {
 pub struct BuildLocalRuntimeOptions {
     pub name: String,
     pub repo: String,
+    pub companions: Vec<String>,
     pub description: Option<String>,
     pub force: bool,
     pub include_source_extensions: bool,
@@ -1044,6 +1045,449 @@ fn default_local_build_description(version: &str, commit: Option<&str>) -> Strin
     }
 }
 
+#[derive(Clone, Debug)]
+struct LocalCompanionSpec {
+    id: String,
+    package_name: String,
+    version: String,
+}
+
+#[derive(Clone, Debug)]
+struct PackedLocalCompanion {
+    spec: LocalCompanionSpec,
+    archive_path: PathBuf,
+}
+
+fn validate_local_companion_id(id: &str) -> Result<String, String> {
+    let id = id.trim();
+    let valid = !id.is_empty()
+        && id.bytes().all(|value| {
+            value.is_ascii_lowercase() || value.is_ascii_digit() || b"._-".contains(&value)
+        })
+        && id.as_bytes()[0].is_ascii_alphanumeric();
+    if !valid || id == "." || id == ".." {
+        return Err(format!(
+            "invalid local companion plugin id \"{id}\"; expected lowercase letters, digits, dots, underscores, or hyphens"
+        ));
+    }
+    Ok(id.to_string())
+}
+
+fn load_json_value(path: &Path, label: &str) -> Result<serde_json::Value, String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {label} at {}: {error}", display_path(path)))?;
+    serde_json::from_str(&raw)
+        .map_err(|error| format!("failed to parse {label} at {}: {error}", display_path(path)))
+}
+
+fn load_local_companion_spec(
+    repo_path: &Path,
+    raw_id: &str,
+    openclaw_version: &str,
+) -> Result<LocalCompanionSpec, String> {
+    let id = validate_local_companion_id(raw_id)?;
+    let package_dir = repo_path.join("extensions").join(&id);
+    if !package_dir.is_dir() {
+        return Err(format!(
+            "local companion \"{id}\" does not exist at {}",
+            display_path(&package_dir)
+        ));
+    }
+    let package = load_json_value(&package_dir.join("package.json"), "companion package.json")?;
+    let package_name = package
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("local companion \"{id}\" package.json is missing a name"))?;
+    let version = package
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("local companion \"{id}\" package.json is missing a version"))?;
+    let build_version = package
+        .pointer("/openclaw/build/openclawVersion")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            format!("local companion \"{id}\" must declare openclaw.build.openclawVersion")
+        })?;
+    if version != openclaw_version || build_version != openclaw_version {
+        return Err(format!(
+            "local companion \"{id}\" is not commit-matched: OpenClaw is {openclaw_version}, package version is {version}, and openclaw.build.openclawVersion is {build_version}"
+        ));
+    }
+    if package
+        .pointer("/openclaw/release/publishToNpm")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+    {
+        return Err(format!(
+            "local companion \"{id}\" is not an official npm-publishable plugin"
+        ));
+    }
+    let plugin_manifest = load_json_value(
+        &package_dir.join("openclaw.plugin.json"),
+        "companion plugin manifest",
+    )?;
+    let manifest_id = plugin_manifest
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    if manifest_id != id {
+        return Err(format!(
+            "local companion directory \"{id}\" contains plugin manifest id \"{manifest_id}\""
+        ));
+    }
+    for relative in [
+        "scripts/lib/plugin-npm-runtime-build.mjs",
+        "scripts/generate-npm-package-lock.mjs",
+        "scripts/lib/plugin-npm-package-manifest.mjs",
+    ] {
+        if !repo_path.join(relative).is_file() {
+            return Err(format!(
+                "OpenClaw checkout does not provide the local companion packaging contract: missing {relative}"
+            ));
+        }
+    }
+    Ok(LocalCompanionSpec {
+        id,
+        package_name: package_name.to_string(),
+        version: version.to_string(),
+    })
+}
+
+fn run_local_companion_command(command: &mut Command, label: &str) -> Result<(), String> {
+    command
+        .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+        .env("npm_config_fund", "false")
+        .env("npm_config_audit", "false")
+        .env("npm_config_update_notifier", "false")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let output = command
+        .output()
+        .map_err(|error| format!("failed to run {label}: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let detail = summarize_command_output(&output.stdout, &output.stderr).unwrap_or_else(|| {
+        format!(
+            "command exited with code {}",
+            output.status.code().unwrap_or(1)
+        )
+    });
+    Err(format!("{label} failed: {detail}"))
+}
+
+fn pack_local_openclaw_companion(
+    repo_path: &Path,
+    pack_dir: &Path,
+    spec: LocalCompanionSpec,
+    env: &BTreeMap<String, String>,
+) -> Result<PackedLocalCompanion, String> {
+    let package_dir = format!("extensions/{}", spec.id);
+    let output_dir = pack_dir.join("companions").join(&spec.id);
+    ensure_dir(&output_dir)?;
+
+    let mut build = Command::new("node");
+    build
+        .arg("scripts/lib/plugin-npm-runtime-build.mjs")
+        .arg(&package_dir)
+        .current_dir(repo_path);
+    run_local_companion_command(
+        &mut build,
+        &format!("local companion runtime build for {}", spec.id),
+    )?;
+
+    let mut lock_check = Command::new("node");
+    lock_check
+        .arg("scripts/generate-npm-package-lock.mjs")
+        .arg("--package-dir")
+        .arg(&package_dir)
+        .current_dir(repo_path);
+    run_local_companion_command(
+        &mut lock_check,
+        &format!("local companion package-lock check for {}", spec.id),
+    )?;
+
+    let mut pack = Command::new("node");
+    pack.arg("scripts/lib/plugin-npm-package-manifest.mjs")
+        .arg("--run")
+        .arg(&package_dir)
+        .arg("--")
+        .arg(npm_program(env))
+        .arg("pack")
+        .arg("--json")
+        .arg("--ignore-scripts")
+        .arg("--pack-destination")
+        .arg(&output_dir)
+        .current_dir(repo_path);
+    run_local_companion_command(
+        &mut pack,
+        &format!("local companion package build for {}", spec.id),
+    )?;
+
+    let mut archives = fs::read_dir(&output_dir)
+        .map_err(|error| error.to_string())?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("tgz"))
+        .collect::<Vec<_>>();
+    archives.sort();
+    let archive_path = match archives.len() {
+        1 => archives.remove(0),
+        0 => {
+            return Err(format!(
+                "local companion package build for {} did not produce an archive",
+                spec.id
+            ));
+        }
+        _ => {
+            return Err(format!(
+                "local companion package build for {} produced multiple archives",
+                spec.id
+            ));
+        }
+    };
+    Ok(PackedLocalCompanion { spec, archive_path })
+}
+
+fn npm_package_path(package_name: &str) -> Result<PathBuf, String> {
+    let parts = package_name.split('/').collect::<Vec<_>>();
+    let valid_segment = |value: &str| {
+        !value.is_empty()
+            && value != "."
+            && value != ".."
+            && value.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"@._-".contains(&byte)
+            })
+    };
+    if parts.len() == 1 && valid_segment(parts[0]) && !parts[0].starts_with('@') {
+        return Ok(PathBuf::from(parts[0]));
+    }
+    if parts.len() == 2
+        && parts[0].starts_with('@')
+        && valid_segment(parts[0])
+        && valid_segment(parts[1])
+    {
+        return Ok(PathBuf::from(parts[0]).join(parts[1]));
+    }
+    Err(format!(
+        "local companion package name \"{package_name}\" is not a safe npm package name"
+    ))
+}
+
+fn copy_companion_runtime_dependencies(
+    source_node_modules: &Path,
+    destination_node_modules: &Path,
+    own_package_path: &Path,
+) -> Result<(), String> {
+    ensure_dir(destination_node_modules)?;
+    let own_scope = (own_package_path.components().count() == 2)
+        .then(|| own_package_path.parent())
+        .flatten();
+    for entry in fs::read_dir(source_node_modules).map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let source = entry.path();
+        let relative = PathBuf::from(entry.file_name());
+        if relative == Path::new(".package-lock.json") {
+            continue;
+        }
+        if own_scope == Some(relative.as_path()) {
+            let scope_destination = destination_node_modules.join(&relative);
+            ensure_dir(&scope_destination)?;
+            for scoped_entry in fs::read_dir(&source).map_err(|error| error.to_string())? {
+                let scoped_entry = scoped_entry.map_err(|error| error.to_string())?;
+                let scoped_relative = relative.join(scoped_entry.file_name());
+                if scoped_relative == own_package_path {
+                    continue;
+                }
+                copy_path(
+                    &scoped_entry.path(),
+                    &destination_node_modules.join(scoped_relative),
+                )?;
+            }
+            continue;
+        }
+        if relative == own_package_path {
+            continue;
+        }
+        copy_path(&source, &destination_node_modules.join(relative))?;
+    }
+    Ok(())
+}
+
+fn safe_companion_runtime_entrypoint(value: &str) -> Result<PathBuf, String> {
+    let normalized = value.trim().strip_prefix("./").unwrap_or(value.trim());
+    let path = PathBuf::from(normalized);
+    if normalized.is_empty()
+        || normalized.contains('\\')
+        || path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(format!(
+            "unsafe local companion runtime entrypoint \"{value}\""
+        ));
+    }
+    Ok(path)
+}
+
+fn install_local_openclaw_companion(
+    packed: &PackedLocalCompanion,
+    install_files: &Path,
+    scratch_dir: &Path,
+    context: InstallContext<'_>,
+    local_adapter: Option<&LocalBuildNpmAdapter>,
+) -> Result<RuntimeCompanionMeta, String> {
+    let install_root = scratch_dir.join("companion-installs").join(&packed.spec.id);
+    ensure_dir(&install_root)?;
+    let install_command = if let Some(local_adapter) = local_adapter {
+        CommandSpec {
+            program: local_adapter.real_npm.clone(),
+            args: Vec::new(),
+            path_prepend: None,
+        }
+    } else if verify_official_openclaw_runtime_host(context.env).is_ok() {
+        CommandSpec {
+            program: npm_program(context.env),
+            args: Vec::new(),
+            path_prepend: None,
+        }
+    } else {
+        managed_runtime_install_command(context.env, context.cwd)?
+    };
+    let mut command = Command::new(&install_command.program);
+    command
+        .args(&install_command.args)
+        .arg("install")
+        .arg("--prefix")
+        .arg(&install_root)
+        .arg("--omit=dev")
+        .arg("--no-save")
+        .arg("--package-lock=false")
+        .arg(&packed.archive_path)
+        .env("npm_config_fund", "false")
+        .env("npm_config_audit", "false")
+        .env("npm_config_update_notifier", "false")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    install_command.apply_environment(&mut command, context.env)?;
+    let output = command.output().map_err(|error| {
+        format!(
+            "failed to install local companion {} with {}: {error}",
+            packed.spec.id, install_command.program
+        )
+    })?;
+    if !output.status.success() {
+        let detail =
+            summarize_command_output(&output.stdout, &output.stderr).unwrap_or_else(|| {
+                format!(
+                    "{} exited with code {}",
+                    install_command.program,
+                    output.status.code().unwrap_or(1)
+                )
+            });
+        return Err(format!(
+            "failed to install local companion {}: {detail}",
+            packed.spec.id
+        ));
+    }
+
+    let package_path = npm_package_path(&packed.spec.package_name)?;
+    let source_package_root = install_root.join("node_modules").join(&package_path);
+    if !source_package_root.join("package.json").is_file() {
+        return Err(format!(
+            "local companion {} install is missing {}",
+            packed.spec.id,
+            display_path(&source_package_root.join("package.json"))
+        ));
+    }
+    let openclaw_package_root = installed_openclaw_package_root(install_files);
+    let target_package_root = openclaw_package_root
+        .join("dist/extensions")
+        .join(&packed.spec.id);
+    if path_exists(&target_package_root) {
+        return Err(format!(
+            "local companion {} collides with a plugin already bundled at {}",
+            packed.spec.id,
+            display_path(&target_package_root)
+        ));
+    }
+    copy_dir_recursive(&source_package_root, &target_package_root)?;
+    copy_companion_runtime_dependencies(
+        &install_root.join("node_modules"),
+        &target_package_root.join("node_modules"),
+        &package_path,
+    )?;
+
+    let installed = load_json_value(
+        &target_package_root.join("package.json"),
+        "installed companion package.json",
+    )?;
+    let installed_name = installed
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let installed_version = installed
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let installed_build_version = installed
+        .pointer("/openclaw/build/openclawVersion")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    if installed_name != packed.spec.package_name
+        || installed_version != packed.spec.version
+        || installed_build_version != packed.spec.version
+    {
+        return Err(format!(
+            "installed local companion {} failed parity verification",
+            packed.spec.id
+        ));
+    }
+    let entrypoint = installed
+        .pointer("/openclaw/runtimeExtensions/0")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            format!(
+                "installed local companion {} does not declare openclaw.runtimeExtensions",
+                packed.spec.id
+            )
+        })?;
+    let entrypoint_relative = safe_companion_runtime_entrypoint(entrypoint)?;
+    let entrypoint_path = target_package_root.join(&entrypoint_relative);
+    if !entrypoint_path.is_file() {
+        return Err(format!(
+            "installed local companion {} is missing runtime entrypoint {}",
+            packed.spec.id,
+            display_path(&entrypoint_path)
+        ));
+    }
+    Ok(RuntimeCompanionMeta {
+        id: packed.spec.id.clone(),
+        package_name: packed.spec.package_name.clone(),
+        version: packed.spec.version.clone(),
+        artifact_sha256: file_sha256(&packed.archive_path)?,
+        entrypoint: display_path(
+            &PathBuf::from("dist/extensions")
+                .join(&packed.spec.id)
+                .join(entrypoint_relative),
+        ),
+        entrypoint_sha256: file_sha256(&entrypoint_path)?,
+    })
+}
+
 fn pack_local_openclaw_repo(
     repo_path: &Path,
     pack_dir: &Path,
@@ -1513,6 +1957,7 @@ fn build_installed_runtime_meta(
         release_selector_kind: release.selector_kind.clone(),
         release_selector_value: release.selector_value.clone(),
         install_root: Some(display_path(&target.final_install_root)),
+        companions: Vec::new(),
         description,
         created_at,
         updated_at: created_at,
@@ -1933,6 +2378,7 @@ pub fn add_runtime(
         release_selector_kind: None,
         release_selector_value: None,
         install_root: None,
+        companions: Vec::new(),
         description,
         created_at,
         updated_at: created_at,
@@ -2061,6 +2507,16 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
     let repo_path = fs::canonicalize(&repo_path).map_err(|error| error.to_string())?;
     ensure_checkout_owned_dependencies(&repo_path)?;
     let version = load_openclaw_repo_version(&repo_path)?;
+    let mut companion_specs = BTreeMap::new();
+    for companion in &options.companions {
+        let spec = load_local_companion_spec(&repo_path, companion, &version)?;
+        if companion_specs.insert(spec.id.clone(), spec).is_some() {
+            return Err(format!(
+                "local companion plugin \"{}\" was selected more than once",
+                companion.trim()
+            ));
+        }
+    }
     let commit = git_short_commit(&repo_path);
     let target_source_plugins = options
         .target_env
@@ -2120,6 +2576,10 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
         } else {
             Vec::new()
         };
+        let packed_companions = companion_specs
+            .into_values()
+            .map(|spec| pack_local_openclaw_companion(&repo_path, &pack_dir, spec, context.env))
+            .collect::<Result<Vec<_>, _>>()?;
         let target = prepare_runtime_install_target(name, options.force, context.env, context.cwd)?;
         if path_exists(&target.install_root) {
             return Err(format!(
@@ -2130,7 +2590,7 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
         ensure_dir(&target.install_files)?;
         let description = trim_description(options.description)
             .or_else(|| Some(default_local_build_description(&version, commit.as_deref())));
-        let meta = stage_runtime_from_openclaw_package_archive(
+        let mut meta = stage_runtime_from_openclaw_package_archive(
             &target,
             &archive_path,
             RuntimeSourceDetails {
@@ -2146,6 +2606,18 @@ pub(crate) fn install_runtime_from_local_openclaw_build(
             local_adapter.as_ref(),
             &source_extensions,
         )?;
+        meta.companions = packed_companions
+            .iter()
+            .map(|packed| {
+                install_local_openclaw_companion(
+                    packed,
+                    &target.install_files,
+                    &pack_dir,
+                    context,
+                    local_adapter.as_ref(),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         publish_runtime(target, meta)
     })();
 
@@ -2457,6 +2929,85 @@ pub fn runtime_integrity_issue(
             return Some(format!(
                 "runtime sha256 mismatch: expected {expected_runtime_sha256}, got {actual_runtime_sha256}"
             ));
+        }
+    }
+
+    if (is_official_openclaw_package_runtime(meta, env) || is_openclaw_package_runtime(meta))
+        && let Some(package_root) = openclaw_package_root_from_binary(Path::new(&meta.binary_path))
+    {
+        for companion in &meta.companions {
+            if validate_local_companion_id(&companion.id).is_err() {
+                return Some(format!(
+                    "runtime companion has invalid plugin id: {}",
+                    companion.id
+                ));
+            }
+            if normalize_sha256(&companion.artifact_sha256).is_err() {
+                return Some(format!(
+                    "runtime companion {} has invalid artifact sha256",
+                    companion.id
+                ));
+            }
+            let entrypoint_prefix = format!("dist/extensions/{}/", companion.id);
+            let Some(entrypoint_relative) = companion.entrypoint.strip_prefix(&entrypoint_prefix)
+            else {
+                return Some(format!(
+                    "runtime companion {} has invalid entrypoint path: {}",
+                    companion.id, companion.entrypoint
+                ));
+            };
+            let entrypoint_relative = match safe_companion_runtime_entrypoint(entrypoint_relative) {
+                Ok(path) => path,
+                Err(error) => return Some(error),
+            };
+            let expected_entrypoint = PathBuf::from("dist/extensions")
+                .join(&companion.id)
+                .join(entrypoint_relative);
+            if display_path(&expected_entrypoint) != companion.entrypoint {
+                return Some(format!(
+                    "runtime companion {} has invalid entrypoint path: {}",
+                    companion.id, companion.entrypoint
+                ));
+            }
+            let companion_root = package_root.join("dist/extensions").join(&companion.id);
+            let package_json_path = companion_root.join("package.json");
+            let package =
+                match load_json_value(&package_json_path, "runtime companion package.json") {
+                    Ok(value) => value,
+                    Err(error) => return Some(error),
+                };
+            if package.get("name").and_then(serde_json::Value::as_str)
+                != Some(companion.package_name.as_str())
+                || package.get("version").and_then(serde_json::Value::as_str)
+                    != Some(companion.version.as_str())
+            {
+                return Some(format!(
+                    "runtime companion {} package metadata does not match its runtime record",
+                    companion.id
+                ));
+            }
+            let entrypoint_path = package_root.join(&companion.entrypoint);
+            if !entrypoint_path.is_file() {
+                return Some(format!(
+                    "runtime companion {} entrypoint does not exist: {}",
+                    companion.id,
+                    display_path(&entrypoint_path)
+                ));
+            }
+            let expected_entrypoint_sha256 = match normalize_sha256(&companion.entrypoint_sha256) {
+                Ok(value) => value,
+                Err(error) => return Some(error),
+            };
+            let actual_entrypoint_sha256 = match file_sha256(&entrypoint_path) {
+                Ok(value) => value,
+                Err(error) => return Some(error),
+            };
+            if actual_entrypoint_sha256 != expected_entrypoint_sha256 {
+                return Some(format!(
+                    "runtime companion {} entrypoint sha256 mismatch: expected {}, got {}",
+                    companion.id, expected_entrypoint_sha256, actual_entrypoint_sha256
+                ));
+            }
         }
     }
 

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -615,6 +615,7 @@ mod tests {
             release_selector_kind: None,
             release_selector_value: None,
             install_root: Some(expected_install_root.to_string_lossy().into_owned()),
+            companions: Vec::new(),
             description: None,
             created_at,
             updated_at: created_at,

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -155,7 +155,7 @@ fn companion_package_tarball(id: &str, package_name: &str, version: &str) -> Vec
             &mut builder,
             "package/package.json",
             format!(
-                "{{\"name\":\"{package_name}\",\"version\":\"{version}\",\"type\":\"module\",\"openclaw\":{{\"build\":{{\"openclawVersion\":\"{version}\"}},\"runtimeExtensions\":[\"./dist/index.js\"]}}}}"
+                "{{\"name\":\"{package_name}\",\"version\":\"{version}\",\"type\":\"module\",\"peerDependencies\":{{\"openclaw\":\">={version}\"}},\"openclaw\":{{\"build\":{{\"openclawVersion\":\"{version}\"}},\"runtimeExtensions\":[\"./dist/index.js\"]}}}}"
             )
             .as_bytes(),
             0o644,
@@ -275,7 +275,7 @@ while [ "$#" -gt 0 ]; do
       shift
       prefix="$1"
       ;;
-    install|--omit=dev|--no-save|--package-lock=false)
+    install|--omit=dev|--omit=peer|--no-save|--package-lock=false)
       ;;
     *)
       source_extension_archive="$archive"
@@ -420,6 +420,8 @@ case "$(basename "$archive")" in
     tar -xzf "$archive" -C "$prefix/node_modules/@openclaw/codex" --strip-components=1 package
     mkdir -p "$prefix/node_modules/@openai/codex"
     printf '{{"name":"@openai/codex","version":"0.147.0"}}\n' > "$prefix/node_modules/@openai/codex/package.json"
+    mkdir -p "$prefix/node_modules/openclaw"
+    printf '{{"name":"openclaw","version":"9999.0.0","registryPeer":true}}\n' > "$prefix/node_modules/openclaw/package.json"
     ;;
   *)
     mkdir -p "$prefix/node_modules/openclaw"
@@ -1407,11 +1409,11 @@ fn runtime_build_local_rejects_conflicting_source_plugin_modes() {
 }
 
 #[test]
-fn runtime_build_local_bundles_commit_matched_companion_with_isolated_dependencies() {
+fn runtime_build_local_resolves_companion_manifest_id_and_staged_host_peer() {
     let root = TestDir::new("runtime-build-local-companion");
     let cwd = root.child("workspace");
     let repo = cwd.join("openclaw");
-    fs::create_dir_all(repo.join("extensions/codex")).unwrap();
+    fs::create_dir_all(repo.join("extensions/codex-published")).unwrap();
     for relative in [
         "scripts/lib/plugin-npm-runtime-build.mjs",
         "scripts/generate-npm-package-lock.mjs",
@@ -1427,12 +1429,12 @@ fn runtime_build_local_bundles_commit_matched_companion_with_isolated_dependenci
     )
     .unwrap();
     fs::write(
-        repo.join("extensions/codex/package.json"),
-        br#"{"name":"@openclaw/codex","version":"2026.8.1","openclaw":{"build":{"openclawVersion":"2026.8.1"},"release":{"publishToNpm":true}}}"#,
+        repo.join("extensions/codex-published/package.json"),
+        br#"{"name":"@openclaw/codex","version":"2026.8.1","peerDependencies":{"openclaw":">=2026.8.1"},"openclaw":{"build":{"openclawVersion":"2026.8.1"},"release":{"publishToNpm":true}}}"#,
     )
     .unwrap();
     fs::write(
-        repo.join("extensions/codex/openclaw.plugin.json"),
+        repo.join("extensions/codex-published/openclaw.plugin.json"),
         br#"{"id":"codex","configSchema":{}}"#,
     )
     .unwrap();
@@ -1481,6 +1483,12 @@ fn runtime_build_local_bundles_commit_matched_companion_with_isolated_dependenci
             .is_file()
     );
     assert!(!companion_root.join("node_modules/@openclaw/codex").exists());
+    let host_peer = companion_root.join("node_modules/openclaw");
+    assert!(host_peer.join("openclaw.mjs").is_file());
+    let host_peer_package: Value =
+        serde_json::from_slice(&fs::read(host_peer.join("package.json")).unwrap()).unwrap();
+    assert_eq!(host_peer_package["version"], "2026.8.1");
+    assert!(host_peer_package.get("registryPeer").is_none());
 
     let show = run_ocm(
         &cwd,
@@ -1538,9 +1546,11 @@ fn runtime_build_local_bundles_commit_matched_companion_with_isolated_dependenci
     );
 
     let tool_log = fs::read_to_string(tool_log).unwrap();
-    assert!(tool_log.contains("plugin-npm-runtime-build.mjs extensions/codex"));
-    assert!(tool_log.contains("generate-npm-package-lock.mjs --package-dir extensions/codex"));
-    assert!(tool_log.contains("plugin-npm-package-manifest.mjs --run extensions/codex"));
+    assert!(tool_log.contains("plugin-npm-runtime-build.mjs extensions/codex-published"));
+    assert!(
+        tool_log.contains("generate-npm-package-lock.mjs --package-dir extensions/codex-published")
+    );
+    assert!(tool_log.contains("plugin-npm-package-manifest.mjs --run extensions/codex-published"));
 }
 
 #[test]

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -127,7 +127,7 @@ fn source_extension_package_tarball() -> Vec<u8> {
         append_tar_file(
             &mut builder,
             "package/package.json",
-            br#"{"name":"@openclaw/codex","version":"2026.4.25","dependencies":{"codex-runtime":"1.0.0"}}"#,
+            br#"{"name":"@openclaw/codex","version":"2026.4.25","dependencies":{"codex-runtime":"1.0.0"},"peerDependencies":{"openclaw":"*"}}"#,
             0o644,
         );
         append_tar_file(
@@ -1115,6 +1115,36 @@ fn runtime_build_local_derives_source_plugins_from_target_env_before_pack() {
         fs::read_to_string(runtime_root.join("dist/extensions/codex/index.js")).unwrap(),
         "export const build = 'source';\n"
     );
+
+    let host_peer = runtime_root.join("dist/extensions/codex/node_modules/openclaw");
+    let peer_package: Value = serde_json::from_slice(
+        &fs::read(host_peer.join("package.json"))
+            .expect("Codex-like companion must resolve its OpenClaw host peer"),
+    )
+    .unwrap();
+    assert_eq!(peer_package["name"], "openclaw");
+
+    let verify = run_ocm(&cwd, &env, &["runtime", "verify", "primary-test", "--json"]);
+    assert!(verify.status.success(), "{}", stderr(&verify));
+    let verification: Value = serde_json::from_str(&stdout(&verify)).unwrap();
+    assert_eq!(verification["healthy"], true);
+
+    let metadata = fs::symlink_metadata(&host_peer).unwrap();
+    if metadata.file_type().is_symlink() {
+        fs::remove_file(&host_peer).unwrap();
+    } else {
+        fs::remove_dir_all(&host_peer).unwrap();
+    }
+    let verify_missing_peer = run_ocm(&cwd, &env, &["runtime", "verify", "primary-test", "--json"]);
+    assert_eq!(verify_missing_peer.status.code(), Some(1));
+    let missing_peer: Value = serde_json::from_str(&stdout(&verify_missing_peer)).unwrap();
+    assert_eq!(missing_peer["healthy"], false);
+    assert!(
+        missing_peer["issue"]
+            .as_str()
+            .unwrap()
+            .contains("runtime sha256 mismatch")
+    );
 }
 
 #[test]
@@ -1384,7 +1414,10 @@ exec "$OPENCLAW_OCM_REAL_NPM_BIN" "$@"
     let adapter_log = fs::read_to_string(adapter_log).unwrap();
     assert!(adapter_log.contains("args=pack --pack-destination"));
     assert!(adapter_log.contains("args=install --prefix"));
-    assert!(adapter_log.contains("real-npm=npm"));
+    assert!(adapter_log.lines().any(|line| {
+        line.strip_prefix("real-npm=")
+            .is_some_and(|value| value.ends_with("/ocm") || value.ends_with("\\ocm.exe"))
+    }));
     assert!(adapter_log.contains(&format!("adapter={adapter_extension}")));
     assert_eq!(
         adapter_log

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -147,6 +147,36 @@ fn source_extension_package_tarball() -> Vec<u8> {
     encoder.finish().unwrap()
 }
 
+fn companion_package_tarball(id: &str, package_name: &str, version: &str) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut builder = Builder::new(&mut encoder);
+        append_tar_file(
+            &mut builder,
+            "package/package.json",
+            format!(
+                "{{\"name\":\"{package_name}\",\"version\":\"{version}\",\"type\":\"module\",\"openclaw\":{{\"build\":{{\"openclawVersion\":\"{version}\"}},\"runtimeExtensions\":[\"./dist/index.js\"]}}}}"
+            )
+            .as_bytes(),
+            0o644,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/openclaw.plugin.json",
+            format!("{{\"id\":\"{id}\",\"configSchema\":{{}}}}").as_bytes(),
+            0o644,
+        );
+        append_tar_file(
+            &mut builder,
+            "package/dist/index.js",
+            b"export default { id: 'codex' };\n",
+            0o644,
+        );
+        builder.finish().unwrap();
+    }
+    encoder.finish().unwrap()
+}
+
 fn sha512_integrity(body: &[u8]) -> String {
     let digest = Sha512::digest(body);
     format!(
@@ -295,6 +325,121 @@ fi
         format!("{}:{existing_path}", path_string(&bin_dir))
     };
     env.insert("PATH".to_string(), combined_path);
+    log_path
+}
+
+fn install_fake_companion_build_tools(
+    root: &TestDir,
+    env: &mut BTreeMap<String, String>,
+    root_archive: &Path,
+    companion_archive: &Path,
+) -> PathBuf {
+    let bin_dir = root.child("fake-companion-bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let log_path = root.child("fake-companion-tools.log");
+    write_executable_script(
+        &bin_dir.join("node"),
+        &format!(
+            r#"#!/bin/sh
+printf 'node %s\n' "$*" >> "{}"
+if [ "$1" = "--version" ]; then
+  printf 'v22.22.3\n'
+  exit 0
+fi
+case "$1" in
+  scripts/lib/plugin-npm-runtime-build.mjs|scripts/generate-npm-package-lock.mjs)
+    exit 0
+    ;;
+  scripts/lib/plugin-npm-package-manifest.mjs)
+    destination=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--pack-destination" ]; then
+        shift
+        destination="$1"
+      fi
+      shift
+    done
+    mkdir -p "$destination"
+    cp "{}" "$destination/openclaw-codex-2026.8.1.tgz"
+    exit 0
+    ;;
+esac
+printf 'unexpected fake node invocation: %s\n' "$*" >&2
+exit 1
+"#,
+            path_string(&log_path),
+            path_string(companion_archive),
+        ),
+    );
+    write_executable_script(
+        &bin_dir.join("npm"),
+        &format!(
+            r#"#!/bin/sh
+printf 'npm %s\n' "$*" >> "{}"
+if [ "$1" = "--version" ]; then
+  printf '10.0.0\n'
+  exit 0
+fi
+if [ "$1" = "pack" ]; then
+  destination=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--pack-destination" ]; then
+      shift
+      destination="$1"
+    fi
+    shift
+  done
+  mkdir -p "$destination"
+  cp "{}" "$destination/openclaw-2026.8.1.tgz"
+  printf 'openclaw-2026.8.1.tgz\n'
+  exit 0
+fi
+prefix=""
+archive=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prefix)
+      shift
+      prefix="$1"
+      ;;
+    install|--omit=dev|--no-save|--package-lock=false)
+      ;;
+    *)
+      archive="$1"
+      ;;
+  esac
+  shift
+done
+if [ -z "$prefix" ] || [ -z "$archive" ]; then
+  echo "fake npm expected --prefix and archive path" >&2
+  exit 1
+fi
+case "$(basename "$archive")" in
+  openclaw-codex-2026.8.1.tgz)
+    mkdir -p "$prefix/node_modules/@openclaw/codex"
+    tar -xzf "$archive" -C "$prefix/node_modules/@openclaw/codex" --strip-components=1 package
+    mkdir -p "$prefix/node_modules/@openai/codex"
+    printf '{{"name":"@openai/codex","version":"0.147.0"}}\n' > "$prefix/node_modules/@openai/codex/package.json"
+    ;;
+  *)
+    mkdir -p "$prefix/node_modules/openclaw"
+    tar -xzf "$archive" -C "$prefix/node_modules/openclaw" --strip-components=1 package
+    ;;
+esac
+"#,
+            path_string(&log_path),
+            path_string(root_archive),
+        ),
+    );
+    let existing_path = env.get("PATH").cloned().unwrap_or_default();
+    env.insert(
+        "PATH".to_string(),
+        if existing_path.is_empty() {
+            path_string(&bin_dir)
+        } else {
+            format!("{}:{existing_path}", path_string(&bin_dir))
+        },
+    );
     log_path
 }
 
@@ -1259,6 +1404,177 @@ fn runtime_build_local_rejects_conflicting_source_plugin_modes() {
         "{}",
         stderr(&build)
     );
+}
+
+#[test]
+fn runtime_build_local_bundles_commit_matched_companion_with_isolated_dependencies() {
+    let root = TestDir::new("runtime-build-local-companion");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    fs::create_dir_all(repo.join("extensions/codex")).unwrap();
+    for relative in [
+        "scripts/lib/plugin-npm-runtime-build.mjs",
+        "scripts/generate-npm-package-lock.mjs",
+        "scripts/lib/plugin-npm-package-manifest.mjs",
+    ] {
+        let path = repo.join(relative);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, "// fake packaging contract\n").unwrap();
+    }
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.8.1","bin":{"openclaw":"openclaw.mjs"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("extensions/codex/package.json"),
+        br#"{"name":"@openclaw/codex","version":"2026.8.1","openclaw":{"build":{"openclawVersion":"2026.8.1"},"release":{"publishToNpm":true}}}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("extensions/codex/openclaw.plugin.json"),
+        br#"{"id":"codex","configSchema":{}}"#,
+    )
+    .unwrap();
+
+    let root_archive = root.child("packed-openclaw.tgz");
+    fs::write(
+        &root_archive,
+        openclaw_package_tarball_with_version(
+            "#!/usr/bin/env node\nconsole.log('local companion runtime');\n",
+            "2026.8.1",
+        ),
+    )
+    .unwrap();
+    let companion_archive = root.child("packed-codex.tgz");
+    fs::write(
+        &companion_archive,
+        companion_package_tarball("codex", "@openclaw/codex", "2026.8.1"),
+    )
+    .unwrap();
+
+    let mut env = ocm_env(&root);
+    let tool_log =
+        install_fake_companion_build_tools(&root, &mut env, &root_archive, &companion_archive);
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "main-with-codex",
+            "--repo",
+            "./openclaw",
+            "--companion",
+            "codex",
+            "--raw",
+        ],
+    );
+    assert!(build.status.success(), "{}", stderr(&build));
+
+    let install_root = runtime_install_root("main-with-codex", &env, &cwd).unwrap();
+    let companion_root = install_root.join("files/node_modules/openclaw/dist/extensions/codex");
+    assert!(companion_root.join("dist/index.js").is_file());
+    assert!(
+        companion_root
+            .join("node_modules/@openai/codex/package.json")
+            .is_file()
+    );
+    assert!(!companion_root.join("node_modules/@openclaw/codex").exists());
+
+    let show = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "show", "main-with-codex", "--json"],
+    );
+    assert!(show.status.success(), "{}", stderr(&show));
+    let value: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    assert_eq!(value["companions"][0]["id"], "codex");
+    assert_eq!(value["companions"][0]["packageName"], "@openclaw/codex");
+    assert_eq!(value["companions"][0]["version"], "2026.8.1");
+    assert_eq!(
+        value["companions"][0]["artifactSha256"]
+            .as_str()
+            .unwrap()
+            .len(),
+        64
+    );
+    assert_eq!(
+        value["companions"][0]["entrypointSha256"]
+            .as_str()
+            .unwrap()
+            .len(),
+        64
+    );
+
+    let verify = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "verify", "main-with-codex", "--json"],
+    );
+    assert!(verify.status.success(), "{}", stderr(&verify));
+    let verification: Value = serde_json::from_str(&stdout(&verify)).unwrap();
+    assert_eq!(verification["healthy"], true);
+
+    fs::write(companion_root.join("dist/index.js"), "tampered\n").unwrap();
+    let verify_tampered = run_ocm(
+        &cwd,
+        &env,
+        &["runtime", "verify", "main-with-codex", "--json"],
+    );
+    assert_eq!(verify_tampered.status.code(), Some(1));
+    let tampered: Value = serde_json::from_str(&stdout(&verify_tampered)).unwrap();
+    assert_eq!(tampered["healthy"], false);
+    assert!(
+        tampered["issue"]
+            .as_str()
+            .unwrap()
+            .contains("entrypoint sha256 mismatch")
+    );
+
+    let tool_log = fs::read_to_string(tool_log).unwrap();
+    assert!(tool_log.contains("plugin-npm-runtime-build.mjs extensions/codex"));
+    assert!(tool_log.contains("generate-npm-package-lock.mjs --package-dir extensions/codex"));
+    assert!(tool_log.contains("plugin-npm-package-manifest.mjs --run extensions/codex"));
+}
+
+#[test]
+fn runtime_build_local_rejects_mismatched_companion_before_packing() {
+    let root = TestDir::new("runtime-build-local-companion-mismatch");
+    let cwd = root.child("workspace");
+    let repo = cwd.join("openclaw");
+    fs::create_dir_all(repo.join("extensions/codex")).unwrap();
+    fs::write(
+        repo.join("package.json"),
+        br#"{"name":"openclaw","version":"2026.8.1"}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("extensions/codex/package.json"),
+        br#"{"name":"@openclaw/codex","version":"2026.7.2","openclaw":{"build":{"openclawVersion":"2026.7.2"},"release":{"publishToNpm":true}}}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("extensions/codex/openclaw.plugin.json"),
+        br#"{"id":"codex"}"#,
+    )
+    .unwrap();
+    let env = ocm_env(&root);
+    let build = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "runtime",
+            "build-local",
+            "mismatched",
+            "--repo",
+            "./openclaw",
+            "--companion",
+            "codex",
+        ],
+    );
+    assert!(!build.status.success());
+    assert!(stderr(&build).contains("is not commit-matched"));
 }
 
 #[test]

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -1512,7 +1512,12 @@ fn runtime_build_local_bundles_commit_matched_companion_with_isolated_dependenci
         &env,
         &["runtime", "verify", "main-with-codex", "--json"],
     );
-    assert!(verify.status.success(), "{}", stderr(&verify));
+    assert!(
+        verify.status.success(),
+        "stderr:\n{}\nstdout:\n{}",
+        stderr(&verify),
+        stdout(&verify)
+    );
     let verification: Value = serde_json::from_str(&stdout(&verify)).unwrap();
     assert_eq!(verification["healthy"], true);
 


### PR DESCRIPTION
Related: #60

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

`runtime build-local` can preserve bundled source extensions, but it cannot produce a complete release-shaped runtime when an official plugin is published separately from the OpenClaw package. Operators building an exact source runtime for plugins such as Codex, iMessage, or WhatsApp must otherwise assemble and verify those companion trees outside OCM.

Current OpenClaw source graphs can also contain nested private `workspace:*` dependencies. The existing adapter supplies direct workspace packages, but nested packed archives can retain unresolved workspace protocols and fail during isolated installation.

## Why This Change Was Made

Add repeatable `--companion <plugin-id>` selection to the existing local runtime builder. Each selected companion must use OpenClaw's package-local release contract, match the host version, be publishable, and remain separate from already bundled extensions. OCM installs each companion in a runtime-owned tree and records its package identity, artifact digest, entrypoint, entrypoint digest, and completed package-tree integrity.

Resolve the complete private workspace dependency closure and rewrite nested `workspace:*` protocols only inside scratch package archives. The source checkout remains unchanged. Existing `--for-env`, `--include-source-extensions`, build-profile selection, and full-tree verification remain authoritative and are not replaced.

Gateway lifecycle and named Tailscale Service ingress changes are intentionally outside this PR.

## User Impact

Operators can build one reproducible, release-shaped runtime from an OpenClaw checkout together with explicitly selected commit-matched companion plugins. Incomplete, mismatched, duplicate, non-publishable, or drifted companion trees fail closed during build or verification instead of surfacing later as runtime plugin failures.

Existing local builds that do not select companions retain their current behavior.

## Evidence

- Isolated split branch based directly on current `main`; it contains no gateway lifecycle or Tailscale ingress changes.
- `cargo fmt --all -- --check`: passed.
- `git diff --check origin/main..HEAD`: passed.
- `cargo test --locked --test runtime_command_tests --test store_compatibility_tests`: 58 passed, 0 failed.
- Hosted CI passed on macOS, Ubuntu, Windows, formatting, and the Rust 1.88 minimum lane.
- The split conflict was limited to `CHANGELOG.md`; current upstream release entries were retained and only the runtime packaging note was added.
- No OCM binary was installed locally, and no resident daemon or managed gateway was restarted.
