### PR TITLE
fix: harden gateway restart, cleanup, and child temp dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to OCM are documented here.
 - Copy repo-backed and symlinked plain-home agent workspaces into an adopted
   environment and rewrite the imported config to keep the fixture isolated.
 
+### Changed
+
+- Make `ocm service restart <env>` restart immediately through OpenClaw's protocol-v1 recovery handoff so eligible interrupted sessions and subagents resume after startup, preserve the legacy direct-restart behavior with a warning when recovery is unavailable, keep `--force` as an explicit bypass for an unhealthy handoff, and avoid self-restart deadlocks.
+
 ## 0.2.30 - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to OCM are documented here.
 ### Fixed
 
 - Keep unrelated supervised gateways on their persisted child specifications when an environment is destroyed, removed, or pruned, so latent metadata or process-environment drift cannot restart sibling gateways during cleanup.
+- Resolve `TMPDIR` from the live OCM daemon whenever a gateway is spawned, create a daemon-scoped private temporary directory, and fall back to a private directory under `/tmp` instead of persisting a per-login path across reboots.
 
 ## 0.2.30 - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to OCM are documented here.
 
 - Make `ocm service restart <env>` restart immediately through OpenClaw's protocol-v1 recovery handoff so eligible interrupted sessions and subagents resume after startup, preserve the legacy direct-restart behavior with a warning when recovery is unavailable, keep `--force` as an explicit bypass for an unhealthy handoff, and avoid self-restart deadlocks.
 
+### Fixed
+
+- Keep unrelated supervised gateways on their persisted child specifications when an environment is destroyed, removed, or pruned, so latent metadata or process-environment drift cannot restart sibling gateways during cleanup.
+
 ## 0.2.30 - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -268,10 +268,19 @@ OCM negotiates fresh-process restart support only when it executes an
 `openclaw.mjs` entrypoint directly or through OCM's managed Node.js toolchain,
 so the gateway PID is the process OCM owns. `ocm service status <env>` reports
 `protocol v1` when OpenClaw can hand restart intent back to OCM atomically.
+With that protocol, `ocm service restart <env>` asks OpenClaw to restart
+immediately through its recovery handoff. OpenClaw records eligible active
+sessions and subagents before exiting, OCM starts the replacement gateway, and
+OpenClaw resumes that recoverable work after startup. This does not wait for an
+in-flight turn to finish before replacing the gateway process.
+
 Package-manager, shell, host-Node, and other wrapper-backed bindings run in
 legacy compatibility mode without OCM's native service identity or detached
-respawn; use `ocm service restart <env>` or bind a directly invoked OpenClaw
-runtime for gateway-initiated fresh-process restarts.
+respawn. `ocm service restart <env>` preserves their existing direct-supervisor
+restart behavior and warns that in-flight work cannot be recovered. Bind a
+directly invoked OpenClaw runtime to gain recovery-aware restarts. Use
+`ocm service restart <env> --force` only to explicitly bypass a recovery
+handoff that is advertised but unhealthy.
 
 ## Why not just run OpenClaw directly?
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -344,6 +344,31 @@ ocm service stop mira
 ocm service restart mira
 ```
 
+Normal restart is gateway-aware when `ocm service status mira` reports restart
+handoff `protocol v1`: OpenClaw records eligible active sessions and subagents,
+hands the fresh-process restart back to OCM immediately, and resumes recoverable
+work after the replacement gateway starts. The old gateway process does not wait
+for an in-flight turn to finish.
+
+When a binding cannot negotiate the restart handoff, OCM preserves the existing
+direct-supervisor restart behavior and prints a warning that in-flight work may
+have been interrupted. Existing restart commands therefore remain compatible.
+
+Use the forced path only when a gateway advertises recovery support but is too
+unhealthy to accept the restart handoff:
+
+```bash
+ocm service restart mira --force
+```
+
+Forced restart explicitly replaces the supervised child directly. It bypasses
+OpenClaw's restart-recovery handoff and can lose in-flight work, so it is
+intentionally an emergency override rather than a compatibility requirement.
+
+Recovery is limited to work OpenClaw knows how to persist and resume. It does
+not make arbitrary child processes or non-idempotent external side effects
+transactional.
+
 ### Remove the service
 
 ```bash

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -2149,9 +2149,15 @@ pub fn service_command_help(cmd: &str, action: &str) -> Option<String> {
         ),
         "restart" => render_leaf(
             "Restart an env under the background service",
-            "Restart one env under the shared OCM background service.",
-            vec![format!("{cmd} service restart <env> [--raw] [--json]")],
+            "Restart one env immediately through OpenClaw's recovery handoff so eligible interrupted work can resume after startup.",
+            vec![format!(
+                "{cmd} service restart <env> [--force] [--raw] [--json]"
+            )],
             &[
+                (
+                    "--force",
+                    "Bypass OpenClaw restart recovery and replace the supervised child directly",
+                ),
                 (
                     "--raw",
                     "Force plain line output instead of the TTY receipt view",
@@ -2159,7 +2165,11 @@ pub fn service_command_help(cmd: &str, action: &str) -> Option<String> {
                 ("--json", "Print the action summary as JSON"),
             ],
             vec![format!("{cmd} service restart mira")],
-            &[],
+            &[
+                "The default restart does not wait for active work; OpenClaw records eligible interrupted work for recovery before exiting.",
+                "Gateways without recovery handoff support keep the legacy direct-restart behavior and emit a warning.",
+                "Use --force only to bypass a recovery handoff that is advertised but unhealthy.",
+            ],
         ),
         "refresh-daemon" => render_leaf(
             "Refresh the OCM background service",

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -110,12 +110,15 @@ impl Cli {
     pub(super) fn handle_service_restart(&self, args: Vec<String>) -> Result<i32, String> {
         let (args, json_flag, profile) =
             self.consume_human_output_flags(args, "service restart")?;
+        let (args, force) = Self::consume_flag(args, "--force");
         let Some(name) = args.first() else {
             return Err("service restart requires <env>".to_string());
         };
         Self::assert_no_extra_args(&args[1..])?;
 
-        let summary = self.service_service().restart_action(name)?;
+        let summary = self
+            .service_service()
+            .restart_action_with_options(name, crate::service::ServiceRestartOptions { force })?;
         let code = if summary.gateway_ready == Some(false) {
             1
         } else {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -3112,9 +3112,12 @@ impl Cli {
 
         if service.running {
             let convergence_started = timings.start();
-            let restart_result = self
-                .with_progress(format!("Restarting service for {env_name}"), || {
-                    self.service_service().restart_locked(env_name)
+            let restart_result =
+                self.with_progress(format!("Restarting service for {env_name}"), || {
+                    self.service_service().restart_locked_with_options(
+                        env_name,
+                        crate::service::ServiceRestartOptions { force: true },
+                    )
                 });
             timings.finish(
                 "ocm",

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -11,7 +11,7 @@ use crate::store::{
     now_utc, remove_environment, resolve_config_gateway_port, resolve_effective_gateway_ports,
     resolve_env_gateway_port, save_environment, set_environment_service_policy,
 };
-use crate::supervisor::sync_supervisor_if_present;
+use crate::supervisor::{sync_supervisor_env_if_present, sync_supervisor_if_present};
 
 pub fn default_service_enabled() -> bool {
     true
@@ -362,7 +362,7 @@ impl<'a> EnvironmentService<'a> {
 
     pub(crate) fn remove_locked(&self, name: &str, force: bool) -> Result<EnvMeta, String> {
         let meta = remove_environment(name, force, self.env, self.cwd)?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, name)?;
         Ok(meta)
     }
 
@@ -376,10 +376,7 @@ impl<'a> EnvironmentService<'a> {
         let mut removed = Vec::with_capacity(candidates.len());
         for meta in candidates {
             let _lock = self.lock_operation(&meta.name)?;
-            removed.push(remove_environment(&meta.name, false, self.env, self.cwd)?);
-        }
-        if !removed.is_empty() {
-            sync_supervisor_if_present(self.env, self.cwd)?;
+            removed.push(self.remove_locked(&meta.name, false)?);
         }
         Ok(removed)
     }

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -16,7 +16,7 @@ use crate::env::{EnvironmentService, ResolvedExecution};
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::managed_node::apply_path_prepend_to_environment;
 use crate::store::{restore_environment_service_policy, set_environment_service_policy};
-use crate::supervisor::{SupervisorService, sync_supervisor_if_present};
+use crate::supervisor::{SupervisorService, sync_supervisor_env_if_present};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -461,7 +461,9 @@ fn update_service(
         ServiceSupervisorPolicy::EnsureRunning => {
             ensure_supervisor_running_locked(&supervisor, env)
         }
-        ServiceSupervisorPolicy::LeaveAsIs => sync_supervisor_if_present(env, cwd).map(|_| ()),
+        ServiceSupervisorPolicy::LeaveAsIs => {
+            sync_supervisor_env_if_present(env, cwd, name).map(|_| ())
+        }
     };
     if let Err(error) = update_result {
         return Err(rollback_service_update(
@@ -519,7 +521,10 @@ fn rollback_service_update(
     let mut rollback_errors = Vec::new();
     match restore_environment_service_policy(change, env, cwd) {
         Ok(restored) => {
-            if restored && let Err(rollback_error) = sync_supervisor_if_present(env, cwd) {
+            if restored
+                && let Err(rollback_error) =
+                    sync_supervisor_env_if_present(env, cwd, &change.applied.name)
+            {
                 rollback_errors.push(rollback_error);
             }
         }

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -71,6 +71,14 @@ pub struct ServiceRestartOptions {
     pub force: bool,
 }
 
+pub(crate) fn restart_originates_inside_gateway(
+    name: &str,
+    env: &BTreeMap<String, String>,
+) -> bool {
+    env.get("OCM_ACTIVE_ENV").map(String::as_str) == Some(name)
+        && env.get("OPENCLAW_SERVICE_KIND").map(String::as_str) == Some("gateway")
+}
+
 #[derive(Clone, Copy)]
 enum ServiceSupervisorPolicy {
     LeaveAsIs,
@@ -206,7 +214,7 @@ pub fn restart_service(
 
     spawn_recovery_aware_restart(name, env, cwd)?;
 
-    if env.get("OCM_ACTIVE_ENV").map(String::as_str) == Some(name) {
+    if restart_originates_inside_gateway(name, env) {
         let mut warnings = vec![
             "recovery-aware restart was scheduled without waiting because the request originated inside the target gateway; OpenClaw will preserve and resume eligible interrupted work after restart"
                 .to_string(),

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -1,14 +1,20 @@
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use serde::Serialize;
 
 use super::inspect::ServiceSummary;
 use super::readiness::GatewayReadiness;
 use super::service_backend_support_error;
-use crate::env::EnvironmentService;
+use crate::env::{EnvironmentService, ResolvedExecution};
+use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
+use crate::managed_node::apply_path_prepend_to_environment;
 use crate::store::{restore_environment_service_policy, set_environment_service_policy};
 use crate::supervisor::{SupervisorService, sync_supervisor_if_present};
 
@@ -58,6 +64,11 @@ impl ServiceActionSummary {
             Ok(())
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ServiceRestartOptions {
+    pub force: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -157,6 +168,7 @@ pub fn stop_service(
 
 pub fn restart_service(
     name: &str,
+    options: ServiceRestartOptions,
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<ServiceActionSummary, String> {
@@ -172,6 +184,59 @@ pub fn restart_service(
         return update_service(name, ServiceUpdate::Restart, env, cwd);
     }
 
+    if options.force {
+        return restart_running_service_directly(
+            name,
+            before,
+            env,
+            cwd,
+            "forced supervisor restart bypassed OpenClaw restart recovery handoff",
+        );
+    }
+
+    if before.restart_handoff.as_deref() != Some("protocol-v1") {
+        return restart_running_service_directly(
+            name,
+            before,
+            env,
+            cwd,
+            "OpenClaw restart recovery handoff protocol v1 is unavailable; used the legacy direct supervisor restart path, so in-flight work may have been interrupted",
+        );
+    }
+
+    spawn_recovery_aware_restart(name, env, cwd)?;
+
+    if env.get("OCM_ACTIVE_ENV").map(String::as_str) == Some(name) {
+        let mut warnings = vec![
+            "recovery-aware restart was scheduled without waiting because the request originated inside the target gateway; OpenClaw will preserve and resume eligible interrupted work after restart"
+                .to_string(),
+        ];
+        let summary = super::inspect::service_status_fast(name, env, cwd)?;
+        if !summary.running {
+            warnings
+                .push("gateway is already transitioning to its replacement process".to_string());
+        }
+        return Ok(service_action_summary("restart", summary, warnings));
+    }
+
+    let status = wait_for_restart_action_summary(name, before.child_pid, env, cwd)?;
+    let mut warnings = status.warnings;
+    if !status.observed_restart {
+        warnings.push(
+            "recovery-aware restart was accepted, but OCM did not observe a replacement gateway within 30 seconds; no direct supervisor restart was attempted"
+                .to_string(),
+        );
+    }
+    Ok(service_action_summary("restart", status.summary, warnings))
+}
+
+fn restart_running_service_directly(
+    name: &str,
+    before: ServiceSummary,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+    restart_warning: &str,
+) -> Result<ServiceActionSummary, String> {
     let supervisor = SupervisorService::new(env, cwd);
     let mut request_id = supervisor.request_child_restart(name)?;
     let restart_result = wait_for_restart_action_summary(name, before.child_pid, env, cwd);
@@ -208,6 +273,7 @@ pub fn restart_service(
                     "restart completed, but failed to clear restart request: {clear_error}"
                 ));
             }
+            status.warnings.push(restart_warning.to_string());
             Ok(service_action_summary(
                 "restart",
                 status.summary,
@@ -215,6 +281,132 @@ pub fn restart_service(
             ))
         }
         Err(restart_error) => Err(restart_error),
+    }
+}
+
+fn spawn_recovery_aware_restart(
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<(), String> {
+    let args = vec![
+        "gateway".to_string(),
+        "restart".to_string(),
+        "--force".to_string(),
+        "--json".to_string(),
+    ];
+    let resolved = EnvironmentService::new(env, cwd).resolve(name, None, None, &args)?;
+    let command = resolved_restart_command(resolved, env)?;
+    let mut process = Command::new(&command.program);
+    process
+        .args(&command.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .env_clear()
+        .envs(&command.env)
+        .current_dir(&command.cwd);
+    #[cfg(unix)]
+    process.process_group(0);
+    let mut child = process
+        .spawn()
+        .map_err(|error| format!("failed to run \"{}\": {error}", command.program))?;
+
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return Ok(()),
+            Ok(Some(status)) => {
+                return Err(format!(
+                    "OpenClaw rejected the recovery-aware restart for env \"{name}\" (exit code {}); no direct supervisor restart was attempted. Inspect the gateway logs or use \"ocm service restart {name} --force\" to bypass OpenClaw recovery handoff",
+                    status.code().unwrap_or(1)
+                ));
+            }
+            Ok(None) => sleep(Duration::from_millis(25)),
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect the recovery-aware restart helper for env \"{name}\": {error}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+struct ResolvedRestartCommand {
+    program: String,
+    args: Vec<String>,
+    env: BTreeMap<String, String>,
+    cwd: PathBuf,
+}
+
+fn resolved_restart_command(
+    resolved: ResolvedExecution,
+    process_env: &BTreeMap<String, String>,
+) -> Result<ResolvedRestartCommand, String> {
+    match resolved {
+        ResolvedExecution::Launcher {
+            env,
+            command,
+            run_dir,
+            ..
+        } => {
+            let openclaw_env = build_openclaw_env(&env, process_env);
+            if cfg!(windows) {
+                Ok(ResolvedRestartCommand {
+                    program: "cmd".to_string(),
+                    args: vec!["/C".to_string(), command],
+                    env: openclaw_env,
+                    cwd: run_dir,
+                })
+            } else {
+                Ok(ResolvedRestartCommand {
+                    program: "sh".to_string(),
+                    args: vec!["-lc".to_string(), command],
+                    env: openclaw_env,
+                    cwd: run_dir,
+                })
+            }
+        }
+        ResolvedExecution::Runtime {
+            env,
+            program,
+            program_args,
+            path_prepend,
+            run_dir,
+            ..
+        } => {
+            let mut openclaw_env = build_openclaw_env(&env, process_env);
+            apply_path_prepend_to_environment(&mut openclaw_env, path_prepend.as_deref())?;
+            Ok(ResolvedRestartCommand {
+                program,
+                args: program_args,
+                env: openclaw_env,
+                cwd: run_dir,
+            })
+        }
+        ResolvedExecution::Dev {
+            env,
+            program,
+            program_args,
+            run_dir,
+            ..
+        }
+        | ResolvedExecution::SourceWatch {
+            env,
+            program,
+            program_args,
+            run_dir,
+            ..
+        } => {
+            let openclaw_env = build_openclaw_dev_source_env(&env, process_env, &run_dir);
+            Ok(ResolvedRestartCommand {
+                program,
+                args: program_args,
+                env: openclaw_env,
+                cwd: run_dir,
+            })
+        }
     }
 }
 
@@ -264,11 +456,7 @@ fn update_service(
     let _lifecycle_lock = supervisor.lock_daemon_lifecycle()?;
     supervisor.validate_daemon_owner_locked()?;
     let daemon_before = supervisor.daemon_status()?;
-    let change =
-        match set_environment_service_policy(name, service_enabled, service_running, env, cwd) {
-            Ok(change) => change,
-            Err(error) => return Err(error),
-        };
+    let change = set_environment_service_policy(name, service_enabled, service_running, env, cwd)?;
     let update_result = match supervisor_policy {
         ServiceSupervisorPolicy::EnsureRunning => {
             ensure_supervisor_running_locked(&supervisor, env)

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -229,7 +229,7 @@ impl<'a> ServiceService<'a> {
     ) -> Result<ServiceActionSummary, String> {
         let _lock = crate::env::EnvironmentService::new(self.env, self.cwd).lock_operation(name)?;
         let mut summary = self.restart_locked_with_options(name, options)?;
-        if self.env.get("OCM_ACTIVE_ENV").map(String::as_str) != Some(name) {
+        if !manage::restart_originates_inside_gateway(name, self.env) {
             self.apply_gateway_readiness(name, &mut summary)?;
         }
         Ok(summary)

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -9,7 +9,7 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 pub use inspect::{ServiceSummary, ServiceSummaryList};
-pub use manage::{ServiceActionSummary, ServiceInstallSummary};
+pub use manage::{ServiceActionSummary, ServiceInstallSummary, ServiceRestartOptions};
 pub(crate) use platform::{
     ServiceManagerKind, service_backend_support_error, service_manager_kind,
 };
@@ -209,20 +209,38 @@ impl<'a> ServiceService<'a> {
     }
 
     pub fn restart(&self, name: &str) -> Result<ServiceActionSummary, String> {
-        let summary = self.restart_action(name)?;
+        self.restart_with_options(name, ServiceRestartOptions::default())
+    }
+
+    pub fn restart_with_options(
+        &self,
+        name: &str,
+        options: ServiceRestartOptions,
+    ) -> Result<ServiceActionSummary, String> {
+        let summary = self.restart_action_with_options(name, options)?;
         summary.ensure_gateway_ready()?;
         Ok(summary)
     }
 
-    pub(crate) fn restart_action(&self, name: &str) -> Result<ServiceActionSummary, String> {
+    pub(crate) fn restart_action_with_options(
+        &self,
+        name: &str,
+        options: ServiceRestartOptions,
+    ) -> Result<ServiceActionSummary, String> {
         let _lock = crate::env::EnvironmentService::new(self.env, self.cwd).lock_operation(name)?;
-        let mut summary = self.restart_locked(name)?;
-        self.apply_gateway_readiness(name, &mut summary)?;
+        let mut summary = self.restart_locked_with_options(name, options)?;
+        if self.env.get("OCM_ACTIVE_ENV").map(String::as_str) != Some(name) {
+            self.apply_gateway_readiness(name, &mut summary)?;
+        }
         Ok(summary)
     }
 
-    pub(crate) fn restart_locked(&self, name: &str) -> Result<ServiceActionSummary, String> {
-        manage::restart_service(name, self.env, self.cwd)
+    pub(crate) fn restart_locked_with_options(
+        &self,
+        name: &str,
+        options: ServiceRestartOptions,
+    ) -> Result<ServiceActionSummary, String> {
+        manage::restart_service(name, options, self.env, self.cwd)
     }
 
     fn apply_gateway_readiness(

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, OpenOptions};
 #[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -56,8 +56,7 @@ const SERVICE_PROXY_ENV_KEYS: [&str; 8] = [
     "all_proxy",
 ];
 const SERVICE_EXTRA_ENV_KEYS: [&str; 2] = ["NODE_EXTRA_CA_CERTS", "NODE_USE_SYSTEM_CA"];
-const SUPERVISED_CHILD_BASE_ENV_KEYS: [&str; 6] =
-    ["HOME", "PATH", "TMPDIR", "OCM_HOME", "OCM_SELF", "SHELL"];
+const SUPERVISED_CHILD_BASE_ENV_KEYS: [&str; 5] = ["HOME", "PATH", "OCM_HOME", "OCM_SELF", "SHELL"];
 const SUPERVISED_CHILD_RUNTIME_ENV_KEYS: [&str; 4] =
     ["NODE_OPTIONS", "NODE_ENV", "NODE_PATH", "PNPM_HOME"];
 const SERVICE_EXECUTABLE_OVERRIDE: &str = "OCM_SERVICE_EXECUTABLE";
@@ -1034,6 +1033,11 @@ fn spawn_supervisor_child(spec: &SupervisorChildSpec) -> Result<Child, String> {
                 spec.env_name
             )
         })?;
+    let mut process_env = spec.process_env.clone();
+    process_env.insert(
+        "TMPDIR".to_string(),
+        display_path(&prepare_supervisor_child_tmpdir()?),
+    );
 
     let mut command = Command::new(program);
     command
@@ -1042,7 +1046,7 @@ fn spawn_supervisor_child(spec: &SupervisorChildSpec) -> Result<Child, String> {
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr))
         .env_clear()
-        .envs(&spec.process_env)
+        .envs(&process_env)
         .current_dir(Path::new(&spec.run_dir));
     #[cfg(unix)]
     {
@@ -1055,6 +1059,74 @@ fn spawn_supervisor_child(spec: &SupervisorChildSpec) -> Result<Child, String> {
             child_binding_label(spec)
         )
     })
+}
+
+fn prepare_supervisor_child_tmpdir() -> Result<PathBuf, String> {
+    let preferred = std::env::var_os("TMPDIR")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute() && path.is_dir());
+    if let Some(preferred) = preferred
+        && let Ok(path) = ensure_supervisor_child_tmpdir(&preferred)
+    {
+        return Ok(path);
+    }
+
+    #[cfg(unix)]
+    let fallback = PathBuf::from("/tmp");
+    #[cfg(not(unix))]
+    let fallback = std::env::temp_dir();
+    ensure_supervisor_child_tmpdir(&fallback)
+}
+
+fn ensure_supervisor_child_tmpdir(base: &Path) -> Result<PathBuf, String> {
+    if !base.is_absolute() || !base.is_dir() {
+        return Err(format!(
+            "temporary directory base is unavailable: {}",
+            display_path(base)
+        ));
+    }
+
+    let path = base.join(format!("ocm-supervisor-{}", std::process::id()));
+    match fs::create_dir(&path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(format!(
+                "failed creating supervised child temporary directory {}: {error}",
+                display_path(&path)
+            ));
+        }
+    }
+
+    let metadata = fs::symlink_metadata(&path).map_err(|error| {
+        format!(
+            "failed inspecting supervised child temporary directory {}: {error}",
+            display_path(&path)
+        )
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "supervised child temporary path is not a directory: {}",
+            display_path(&path)
+        ));
+    }
+    #[cfg(unix)]
+    {
+        let current_uid = unsafe { libc::geteuid() };
+        if metadata.uid() != current_uid {
+            return Err(format!(
+                "supervised child temporary directory is not owned by the current user: {}",
+                display_path(&path)
+            ));
+        }
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).map_err(|error| {
+            format!(
+                "failed securing supervised child temporary directory {}: {error}",
+                display_path(&path)
+            )
+        })?;
+    }
+    Ok(path)
 }
 
 fn supervisor_program_arguments(spec: &SupervisorChildSpec) -> Vec<String> {
@@ -2011,12 +2083,6 @@ fn supervisor_service_environment(
             .map(|value| value.trim().to_string())
             .unwrap_or_else(|| DEFAULT_SERVICE_PATH.to_string()),
     );
-    if let Some(tmpdir) = process_env
-        .get("TMPDIR")
-        .filter(|value| !value.trim().is_empty())
-    {
-        service_env.insert("TMPDIR".to_string(), tmpdir.trim().to_string());
-    }
     for key in SERVICE_PROXY_ENV_KEYS {
         if let Some(value) = process_env
             .get(key)
@@ -3284,6 +3350,7 @@ mod tests {
             process_env.get("PATH").map(String::as_str),
             Some("/usr/bin:/bin")
         );
+        assert!(!process_env.contains_key("TMPDIR"));
         assert!(!process_env.contains_key("GH_TOKEN"));
         assert!(!process_env.contains_key("PWD"));
         assert!(!process_env.contains_key("XPC_SERVICE_NAME"));

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1482,9 +1482,10 @@ fn process_exited_children(
     let mut runtime_dirty = false;
 
     for exited_child in exited {
-        let Some(previous_child) = running.remove(&exited_child.env_name) else {
+        let Some(mut previous_child) = running.remove(&exited_child.env_name) else {
             continue;
         };
+        stop_supervisor_child(&mut previous_child);
         runtime_dirty = true;
         results.push(child_run_result(
             &previous_child.spec,
@@ -1811,20 +1812,46 @@ fn stop_supervisor_child(running_child: &mut RunningSupervisorChild) {
         let process_group = format!("-{}", running_child.child.id());
         let _ = Command::new("kill")
             .args(["-TERM", "--", &process_group])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status();
         for _ in 0..20 {
-            match running_child.child.try_wait() {
-                Ok(Some(_)) => return,
-                Ok(None) => sleep(Duration::from_millis(50)),
-                Err(_) => break,
+            let _ = running_child.child.try_wait();
+            if !supervisor_process_group_exists(&process_group) {
+                break;
+            }
+            sleep(Duration::from_millis(50));
+        }
+        if supervisor_process_group_exists(&process_group) {
+            let _ = Command::new("kill")
+                .args(["-KILL", "--", &process_group])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+            for _ in 0..20 {
+                let _ = running_child.child.try_wait();
+                if !supervisor_process_group_exists(&process_group) {
+                    break;
+                }
+                sleep(Duration::from_millis(50));
             }
         }
-        let _ = Command::new("kill")
-            .args(["-KILL", "--", &process_group])
-            .status();
     }
+    // Always wait on the process-group leader. It can exit after try_wait()
+    // reports None but before the group-existence probe; returning in that
+    // window leaves a zombie that can block OpenClaw's single-instance lock.
     let _ = running_child.child.kill();
     let _ = running_child.child.wait();
+}
+
+#[cfg(unix)]
+fn supervisor_process_group_exists(process_group: &str) -> bool {
+    Command::new("kill")
+        .args(["-0", "--", process_group])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
 }
 
 fn supervisor_state_equivalent(left: &SupervisorState, right: &SupervisorState) -> bool {
@@ -2913,6 +2940,94 @@ mod tests {
             decision.last_error.unwrap(),
             "process exited with 1; retrying after backoff"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_supervisor_child_cleans_remaining_process_group() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "ocm-supervisor-process-group-{}-{}",
+            std::process::id(),
+            now_millis()
+        ));
+        fs::create_dir_all(&test_dir).unwrap();
+        let descendant_pid_path = test_dir.join("descendant.pid");
+        let mut spec = child_spec("process-group-cleanup", 19_999);
+        spec.command = Some(
+            "trap '' HUP; sleep 60 & descendant=$!; printf '%s' \"$descendant\" > \"$OCM_TEST_DESCENDANT_PID_FILE\"; exit 1"
+                .to_string(),
+        );
+        spec.binary_path = None;
+        spec.run_dir = test_dir.to_string_lossy().into_owned();
+        spec.stdout_path = test_dir.join("stdout.log").to_string_lossy().into_owned();
+        spec.stderr_path = test_dir.join("stderr.log").to_string_lossy().into_owned();
+        spec.process_env.insert(
+            "OCM_TEST_DESCENDANT_PID_FILE".to_string(),
+            descendant_pid_path.to_string_lossy().into_owned(),
+        );
+
+        let mut running_child = spawn_running_child(spec, 0, 0).unwrap();
+        let process_group = format!("-{}", running_child.child.id());
+        let status = running_child.child.wait().unwrap();
+        assert_eq!(status.code(), Some(1));
+
+        for _ in 0..100 {
+            if descendant_pid_path.exists() {
+                break;
+            }
+            sleep(Duration::from_millis(10));
+        }
+        let descendant_pid = fs::read_to_string(&descendant_pid_path).unwrap();
+        assert!(supervisor_process_group_exists(&process_group));
+
+        stop_supervisor_child(&mut running_child);
+
+        for _ in 0..100 {
+            let descendant_alive = Command::new("kill")
+                .args(["-0", "--", descendant_pid.trim()])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .is_ok_and(|status| status.success());
+            if !descendant_alive {
+                break;
+            }
+            sleep(Duration::from_millis(10));
+        }
+        assert!(!supervisor_process_group_exists(&process_group));
+        let _ = fs::remove_dir_all(test_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stopped_supervisor_child_reaps_process_group_leader() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "ocm-supervisor-child-reap-{}-{}",
+            std::process::id(),
+            now_millis()
+        ));
+        fs::create_dir_all(&test_dir).unwrap();
+        let mut spec = child_spec("process-group-leader-reap", 19_998);
+        spec.command = Some("trap 'exit 0' TERM; while :; do sleep 1; done".to_string());
+        spec.binary_path = None;
+        spec.run_dir = test_dir.to_string_lossy().into_owned();
+        spec.stdout_path = test_dir.join("stdout.log").to_string_lossy().into_owned();
+        spec.stderr_path = test_dir.join("stderr.log").to_string_lossy().into_owned();
+
+        let mut running_child = spawn_running_child(spec, 0, 0).unwrap();
+        let child_pid = running_child.child.id().to_string();
+        sleep(Duration::from_millis(50));
+
+        stop_supervisor_child(&mut running_child);
+
+        let child_still_exists = Command::new("kill")
+            .args(["-0", "--", &child_pid])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success());
+        assert!(!child_still_exists, "supervised child was not reaped");
+        let _ = fs::remove_dir_all(test_dir);
     }
 
     #[test]

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1062,6 +1062,123 @@ fn targeted_runtime_refresh_ignores_unrelated_drift_and_restarts_effective_chang
 }
 
 #[test]
+fn service_uninstall_removes_only_target_child_despite_unrelated_drift() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-targeted-service-uninstall");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_systemd_tools(&root, &mut env);
+    let service = SupervisorService::new(&env, &cwd);
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let target_started = root.child("target-started.txt");
+    let target_stopped = root.child("target-stopped.txt");
+    let sibling_started = root.child("sibling-started.txt");
+    let sibling_stopped = root.child("sibling-stopped.txt");
+
+    let target_runtime = root.child("bin/target-runtime");
+    write_legacy_openclaw_script(
+        &target_runtime,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&target_started),
+            path_string(&target_stopped),
+        ),
+    );
+    let sibling_runtime = root.child("bin/sibling-runtime");
+    write_legacy_openclaw_script(
+        &sibling_runtime,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&sibling_started),
+            path_string(&sibling_stopped),
+        ),
+    );
+
+    for (runtime_name, runtime_path, env_name) in [
+        ("target-runtime", &target_runtime, "target"),
+        ("sibling-runtime", &sibling_runtime, "sibling"),
+    ] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                runtime_name,
+                "--path",
+                &path_string(runtime_path),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+        let create = run_ocm(
+            &cwd,
+            &env,
+            &["env", "create", env_name, "--runtime", runtime_name],
+        );
+        assert!(create.status.success(), "{}", stderr(&create));
+        set_service_enabled(&cwd, &env, env_name, true);
+    }
+    service.sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let initial_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(5))
+        .expect("daemon runtime state did not report both children");
+    let target_pid = runtime_child_pid(&initial_runtime, "target").unwrap();
+    let sibling_pid = runtime_child_pid(&initial_runtime, "sibling").unwrap();
+
+    let sibling_meta_path = root.child("ocm-home/runtimes/sibling-runtime.json");
+    let mut sibling_meta = read_persisted_service_state(&sibling_meta_path);
+    sibling_meta["releaseVersion"] = Value::String("latent-sibling-v2".to_string());
+    write_persisted_service_state(&sibling_meta_path, &sibling_meta);
+
+    let uninstall = run_ocm(&cwd, &env, &["service", "uninstall", "target", "--json"]);
+    assert!(uninstall.status.success(), "{}", stderr(&uninstall));
+
+    let final_runtime =
+        wait_for_runtime_children(&runtime_path, 1, Some("sibling"), Duration::from_secs(5))
+            .expect("daemon runtime state did not retain only the sibling");
+    let final_state = read_persisted_service_state(&state_path);
+    let persisted_sibling = final_state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "sibling")
+        .unwrap();
+
+    assert_eq!(
+        runtime_child_pid(&final_runtime, "sibling"),
+        Some(sibling_pid),
+        "sibling child PID changed"
+    );
+    assert_ne!(
+        runtime_child_pid(&final_runtime, "target"),
+        Some(target_pid),
+        "target child remained active"
+    );
+    assert!(wait_for_file(&target_stopped, Duration::from_secs(5)));
+    assert!(
+        !sibling_stopped.exists(),
+        "sibling child was stopped by target uninstall"
+    );
+    assert_eq!(
+        fs::read_to_string(&sibling_started)
+            .unwrap()
+            .lines()
+            .count(),
+        1,
+        "sibling child restarted"
+    );
+    assert!(
+        persisted_sibling["runtimeReleaseVersion"].is_null(),
+        "target uninstall applied unrelated sibling drift"
+    );
+
+    stop_process(&mut daemon);
+}
+
+#[test]
 fn service_restart_preserves_legacy_fallback_and_restarts_only_the_target_child() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("daemon-targeted-service-restart");

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -13,7 +13,7 @@ use ocm::supervisor::{SupervisorService, sync_supervisor_binding_if_present};
 use serde_json::{Value, to_value};
 
 use crate::support::{
-    TestDir, install_fake_systemd_tools, ocm_env, path_string, run_ocm, stderr,
+    TestDir, install_fake_systemd_tools, ocm_env, path_string, run_ocm, stderr, stdout,
     write_executable_script,
 };
 
@@ -1173,6 +1173,146 @@ fn service_uninstall_removes_only_target_child_despite_unrelated_drift() {
     assert!(
         persisted_sibling["runtimeReleaseVersion"].is_null(),
         "target uninstall applied unrelated sibling drift"
+    );
+
+    stop_process(&mut daemon);
+}
+
+#[test]
+fn env_destroy_removes_only_target_child_despite_unrelated_drift() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-targeted-env-destroy");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_systemd_tools(&root, &mut env);
+    let service = SupervisorService::new(&env, &cwd);
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let target_started = root.child("target-started.txt");
+    let target_stopped = root.child("target-stopped.txt");
+    let sibling_started = root.child("sibling-started.txt");
+    let sibling_stopped = root.child("sibling-stopped.txt");
+
+    let target_runtime = root.child("bin/target-runtime");
+    write_legacy_openclaw_script(
+        &target_runtime,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&target_started),
+            path_string(&target_stopped),
+        ),
+    );
+    let sibling_runtime = root.child("bin/sibling-runtime");
+    write_legacy_openclaw_script(
+        &sibling_runtime,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            path_string(&sibling_started),
+            path_string(&sibling_stopped),
+        ),
+    );
+
+    for (runtime_name, runtime_path, env_name) in [
+        ("target-runtime", &target_runtime, "target"),
+        ("sibling-runtime", &sibling_runtime, "sibling"),
+    ] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                runtime_name,
+                "--path",
+                &path_string(runtime_path),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+        let create = run_ocm(
+            &cwd,
+            &env,
+            &["env", "create", env_name, "--runtime", runtime_name],
+        );
+        assert!(create.status.success(), "{}", stderr(&create));
+        set_service_enabled(&cwd, &env, env_name, true);
+    }
+    service.sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let initial_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(5))
+        .expect("daemon runtime state did not report both children");
+    let target_pid = runtime_child_pid(&initial_runtime, "target").unwrap();
+    let sibling_pid = runtime_child_pid(&initial_runtime, "sibling").unwrap();
+
+    let sibling_meta_path = root.child("ocm-home/runtimes/sibling-runtime.json");
+    let mut sibling_meta = read_persisted_service_state(&sibling_meta_path);
+    sibling_meta["releaseVersion"] = Value::String("latent-sibling-v2".to_string());
+    write_persisted_service_state(&sibling_meta_path, &sibling_meta);
+
+    let preview = run_ocm(&cwd, &env, &["env", "destroy", "target", "--json"]);
+    assert!(preview.status.success(), "{}", stderr(&preview));
+    let preview_json: Value = serde_json::from_str(&stdout(&preview)).unwrap();
+    let state_token = preview_json["stateToken"].as_str().unwrap();
+    let destroy = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "destroy",
+            "target",
+            "--yes",
+            "--if-state-token",
+            state_token,
+            "--json",
+        ],
+    );
+    assert!(destroy.status.success(), "{}", stderr(&destroy));
+
+    let final_runtime =
+        wait_for_runtime_children(&runtime_path, 1, Some("sibling"), Duration::from_secs(5))
+            .expect("daemon runtime state did not retain only the sibling");
+    let final_state = read_persisted_service_state(&state_path);
+    let persisted_sibling = final_state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "sibling")
+        .unwrap();
+
+    assert_eq!(
+        runtime_child_pid(&final_runtime, "sibling"),
+        Some(sibling_pid),
+        "sibling child PID changed"
+    );
+    assert_ne!(
+        runtime_child_pid(&final_runtime, "target"),
+        Some(target_pid),
+        "target child remained active"
+    );
+    assert!(wait_for_file(&target_stopped, Duration::from_secs(5)));
+    assert!(
+        !sibling_stopped.exists(),
+        "sibling child was stopped by target environment destroy"
+    );
+    assert_eq!(
+        fs::read_to_string(&sibling_started)
+            .unwrap()
+            .lines()
+            .count(),
+        1,
+        "sibling child restarted"
+    );
+    assert!(
+        persisted_sibling["runtimeReleaseVersion"].is_null(),
+        "target environment destroy applied unrelated sibling drift"
+    );
+    assert!(
+        EnvironmentService::new(&env, &cwd)
+            .find("target")
+            .unwrap()
+            .is_none(),
+        "target environment metadata remained after destroy"
     );
 
     stop_process(&mut daemon);

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1508,7 +1508,7 @@ fn service_restart_requeues_a_stopped_desired_child() {
 fn service_start_and_restart_wait_for_gateway_health() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("service-readiness-healthy");
-    let (cwd, env) = setup_gateway_readiness_fixture(&root, "healthy", 0, 5_000);
+    let (cwd, mut env) = setup_gateway_readiness_fixture(&root, "healthy", 0, 5_000);
     let mut daemon = spawn_daemon_process(&cwd, &env);
 
     let started = run_ocm(&cwd, &env, &["service", "start", "demo", "--json"]);
@@ -1518,6 +1518,7 @@ fn service_start_and_restart_wait_for_gateway_health() {
     assert_eq!(started_body["gatewayState"], "running");
     assert_eq!(started_body["issue"], Value::Null);
 
+    env.insert("OCM_ACTIVE_ENV".to_string(), "demo".to_string());
     let restarted = run_ocm(&cwd, &env, &["service", "restart", "demo", "--json"]);
     assert!(restarted.status.success(), "{}", stderr(&restarted));
     let restarted_body: Value = serde_json::from_slice(&restarted.stdout).unwrap();

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1062,7 +1062,7 @@ fn targeted_runtime_refresh_ignores_unrelated_drift_and_restarts_effective_chang
 }
 
 #[test]
-fn service_restart_restarts_only_the_target_child() {
+fn service_restart_preserves_legacy_fallback_and_restarts_only_the_target_child() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("daemon-targeted-service-restart");
     let cwd = root.child("workspace");
@@ -1156,6 +1156,17 @@ fn service_restart_restarts_only_the_target_child() {
         &["service", "restart", "rescue", "--json"],
     );
     assert!(restart.status.success(), "{}", stderr(&restart));
+    let restart_body: serde_json::Value = serde_json::from_slice(&restart.stdout).unwrap();
+    assert!(
+        restart_body["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .unwrap()
+                .contains("used the legacy direct supervisor restart path"))
+    );
     let restarted = wait_for_runtime_child_pid_change(
         &runtime_path,
         "rescue",
@@ -1220,7 +1231,11 @@ fn service_restart_requeues_a_stopped_desired_child() {
         .expect("daemon runtime state did not report the quick clean exit as stopped");
     assert!(!started.exists());
 
-    let restart = run_ocm(&cwd, &env, &["service", "restart", "demo", "--json"]);
+    let restart = run_ocm(
+        &cwd,
+        &env,
+        &["service", "restart", "demo", "--force", "--json"],
+    );
     assert!(restart.status.success(), "{}", stderr(&restart));
     let runtime =
         wait_for_runtime_children(&runtime_path, 1, Some("demo"), Duration::from_secs(10))

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1532,6 +1532,62 @@ fn daemon_stops_the_full_dev_process_tree_after_service_stop() {
     stop_process(&mut daemon);
 }
 
+#[cfg(unix)]
+#[test]
+fn daemon_cleans_descendants_after_a_child_exits_before_restart() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-exit-process-group-cleanup");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+    let service = SupervisorService::new(&env, &cwd);
+
+    let starts = root.child("starts.txt");
+    let descendant_pid_file = root.child("descendant.pid");
+    let script = root.child("bin/openclaw.mjs");
+    write_legacy_openclaw_script(
+        &script,
+        &format!(
+            "#!/bin/sh\ncount=0\nif [ -f '{starts}' ]; then count=$(cat '{starts}'); fi\ncount=$((count + 1))\nprintf '%s\n' \"$count\" > '{starts}'\nif [ \"$count\" -eq 1 ]; then\n  trap '' HUP\n  sleep 60 &\n  printf '%s\n' \"$!\" > '{descendant_pid_file}'\n  sleep 1\n  exit 1\nfi\nsleep 10\n",
+            starts = path_string(&starts),
+            descendant_pid_file = path_string(&descendant_pid_file),
+        ),
+    );
+
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "dev", "--command", &path_string(&script)],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+
+    let created = run_ocm(&cwd, &env, &["env", "create", "demo", "--launcher", "dev"]);
+    assert!(created.status.success(), "{}", stderr(&created));
+    set_service_enabled(&cwd, &env, "demo", true);
+    service.sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    assert!(wait_for_file(&descendant_pid_file, Duration::from_secs(5)));
+    let descendant_pid = fs::read_to_string(&descendant_pid_file)
+        .unwrap()
+        .trim()
+        .parse::<u32>()
+        .unwrap();
+    assert!(process_exists(descendant_pid));
+
+    assert!(wait_for_file_value(&starts, "2", Duration::from_secs(5)));
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && process_exists(descendant_pid) {
+        sleep(Duration::from_millis(50));
+    }
+    assert!(
+        !process_exists(descendant_pid),
+        "background descendant still alive after supervised child exit"
+    );
+
+    stop_process(&mut daemon);
+}
+
 #[test]
 fn daemon_restarts_quick_clean_exit_with_openclaw_handoff() {
     let _guard = daemon_runtime_test_lock();

--- a/tests/env_destroy_tests.rs
+++ b/tests/env_destroy_tests.rs
@@ -333,23 +333,33 @@ fn env_destroy_state_token_refuses_stale_service_state_without_teardown() {
         true
     );
 
-    let fresh_preview = run_ocm(&cwd, &env, &["env", "destroy", "demo", "--json"]);
-    assert!(fresh_preview.status.success(), "{}", stderr(&fresh_preview));
-    let fresh_json: serde_json::Value = serde_json::from_str(&stdout(&fresh_preview)).unwrap();
-    let fresh_guard = fresh_json["stateToken"].as_str().unwrap();
-    let destroy = run_ocm(
-        &cwd,
-        &env,
-        &[
-            "env",
-            "destroy",
-            "demo",
-            "--yes",
-            "--if-state-token",
-            fresh_guard,
-            "--json",
-        ],
-    );
+    let mut destroy = None;
+    for _ in 0..2 {
+        let fresh_preview = run_ocm(&cwd, &env, &["env", "destroy", "demo", "--json"]);
+        assert!(fresh_preview.status.success(), "{}", stderr(&fresh_preview));
+        let fresh_json: serde_json::Value = serde_json::from_str(&stdout(&fresh_preview)).unwrap();
+        let fresh_guard = fresh_json["stateToken"].as_str().unwrap();
+        let attempt = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "env",
+                "destroy",
+                "demo",
+                "--yes",
+                "--if-state-token",
+                fresh_guard,
+                "--json",
+            ],
+        );
+        if attempt.status.success() {
+            destroy = Some(attempt);
+            break;
+        }
+        let output: serde_json::Value = serde_json::from_str(&stdout(&attempt)).unwrap();
+        assert_eq!(output["code"], "state_changed");
+    }
+    let destroy = destroy.expect("fresh guarded destroy should converge after one state refresh");
     assert!(destroy.status.success(), "{}", stderr(&destroy));
     let destroy_json: serde_json::Value = serde_json::from_str(&stdout(&destroy)).unwrap();
     assert_eq!(destroy_json["removed"], true);

--- a/tests/service_command_tests.rs
+++ b/tests/service_command_tests.rs
@@ -59,6 +59,88 @@ fn setup_launcher_env(cwd: &Path, env: &BTreeMap<String, String>) {
     assert!(created.status.success(), "{}", stderr(&created));
 }
 
+fn setup_gateway_aware_restart_fixture(
+    root: &TestDir,
+    restart_handoff: &str,
+) -> (
+    std::path::PathBuf,
+    BTreeMap<String, String>,
+    std::path::PathBuf,
+) {
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = launchd_env(root);
+    let invocation_log = root.child("gateway-restart-invocations.log");
+    let launcher = root.child("bin/openclaw");
+    write_executable_script(
+        &launcher,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nprintf '{{\"ok\":true}}\\n'\n",
+            path_string(&invocation_log)
+        ),
+    );
+
+    let added = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "launcher",
+            "add",
+            "stable",
+            "--command",
+            &path_string(&launcher),
+        ],
+    );
+    assert!(added.status.success(), "{}", stderr(&added));
+    let created = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--launcher", "stable"],
+    );
+    assert!(created.status.success(), "{}", stderr(&created));
+    let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let runtime = SupervisorRuntimeState {
+        kind: "ocm-supervisor-runtime".to_string(),
+        ocm_home: env.get("OCM_HOME").unwrap().clone(),
+        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        updated_at: now_utc(),
+        services: vec![SupervisorRuntimeService {
+            env_name: "demo".to_string(),
+            binding_kind: "launcher".to_string(),
+            binding_name: "stable".to_string(),
+            gateway_state: "running".to_string(),
+            restart_handoff: Some(restart_handoff.to_string()),
+            restart_count: 0,
+            child_port: 18789,
+            pid: Some(4242),
+            stdout_path: path_string(&root.child("demo.stdout.log")),
+            stderr_path: path_string(&root.child("demo.stderr.log")),
+            last_exit_code: None,
+            last_error: None,
+            last_event_at: None,
+            next_retry_at: None,
+        }],
+        children: vec![SupervisorRuntimeChild {
+            env_name: "demo".to_string(),
+            binding_kind: "launcher".to_string(),
+            binding_name: "stable".to_string(),
+            pid: 4242,
+            restart_count: 0,
+            child_port: 18789,
+            stdout_path: path_string(&root.child("demo.stdout.log")),
+            stderr_path: path_string(&root.child("demo.stderr.log")),
+        }],
+    };
+    fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
+    env.insert("OCM_ACTIVE_ENV".to_string(), "demo".to_string());
+
+    (cwd, env, invocation_log)
+}
+
 fn json_output(output: &std::process::Output) -> Value {
     serde_json::from_slice(&output.stdout).unwrap()
 }
@@ -473,6 +555,28 @@ fn service_restart_restores_running_policy() {
     let body = json_output(&output);
     assert_eq!(body["installed"], true);
     assert_eq!(body["desiredRunning"], true);
+}
+
+#[test]
+fn service_restart_requests_immediate_recovery_handoff_without_self_deadlock() {
+    let root = TestDir::new("service-restart-gateway-aware");
+    let (cwd, env, invocation_log) = setup_gateway_aware_restart_fixture(&root, "protocol-v1");
+
+    let output = run_ocm(&cwd, &env, &["service", "restart", "demo", "--json"]);
+    assert!(output.status.success(), "{}", stderr(&output));
+    let body = json_output(&output);
+    assert_eq!(body["action"], "restart");
+    assert_eq!(body["running"], true);
+    assert!(body["warnings"].as_array().unwrap().iter().any(|warning| {
+        warning
+            .as_str()
+            .unwrap()
+            .contains("scheduled without waiting")
+    }));
+    assert_eq!(
+        fs::read_to_string(invocation_log).unwrap(),
+        "gateway restart --force --json\n"
+    );
 }
 
 #[test]

--- a/tests/service_command_tests.rs
+++ b/tests/service_command_tests.rs
@@ -137,6 +137,7 @@ fn setup_gateway_aware_restart_fixture(
     };
     fs::write(runtime_path, serde_json::to_vec(&runtime).unwrap()).unwrap();
     env.insert("OCM_ACTIVE_ENV".to_string(), "demo".to_string());
+    env.insert("OPENCLAW_SERVICE_KIND".to_string(), "gateway".to_string());
 
     (cwd, env, invocation_log)
 }


### PR DESCRIPTION
Related: #60

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

`ocm service restart` directly replaces a supervised gateway even when OpenClaw advertises restart-handoff support, so eligible active sessions and subagents can be interrupted without receiving OpenClaw's recovery marker. A restart issued from inside the target gateway can also wait on its own replacement.

Environment removal and service uninstall currently reconcile the complete supervisor registry. If sibling runtime metadata or inherited process environment has drifted, deleting one environment can rewrite or restart unrelated gateways. Exited children can leave descendants or an unreaped process-group leader behind, and persisted macOS per-login `TMPDIR` values can become invalid before a later gateway spawn.

## Why This Change Was Made

Use OpenClaw restart-handoff protocol v1 for normal service restarts, return immediately for a self-restart, retain a warned direct-restart fallback for legacy bindings, and expose `--force` as the explicit recovery bypass.

Make uninstall, guarded destroy, direct removal, and prune reconcile only the affected environment. Clean the complete child process group with TERM, bounded polling, KILL fallback, and an unconditional leader wait. Stop persisting `TMPDIR`; each child spawn receives a private daemon-scoped mode-`0700` directory derived from the daemon's current temp base, with a safe fallback when that base is unavailable.

Local companion packaging and named Tailscale Service ingress changes are intentionally outside this PR.

## User Impact

Gateway restarts preserve OpenClaw's eligible recovery behavior instead of blindly interrupting active work. Removing or stopping one environment leaves sibling gateway definitions and PIDs unchanged despite unrelated drift. Gateway descendants are cleaned up reliably, and future child spawns no longer inherit stale temporary-directory paths after login, reboot, or daemon replacement.

Legacy gateways remain restartable through the existing direct supervisor path and receive an explicit warning; operators can deliberately select that path with `--force`.

## Evidence

- Isolated split branch based directly on current `main`; it contains no companion-packaging or Tailscale ingress changes.
- `cargo fmt --all -- --check`: passed.
- `git diff --check origin/main..HEAD`: passed.
- `cargo test --locked --test daemon_runtime_tests --test env_destroy_tests --test service_command_tests --test upgrade_command_tests`: 126 passed, 0 failed.
- Hosted CI passed on macOS, Ubuntu, Windows, formatting, and the Rust 1.88 minimum lane.
- The original umbrella head also passed 183 focused tests and its complete hosted CI matrix after rebasing.
- No OCM binary was installed locally, and no resident daemon or managed gateway was restarted.
