### PR TITLE
fix(env): destroy works from wrappers that mention the target path

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -1708,6 +1708,40 @@ fn associated_processes(meta: &EnvMeta) -> Result<Vec<EnvDestroyProcessIdentity>
 }
 
 #[cfg(unix)]
+fn active_invocation_processes(
+    current_pid: u32,
+    parent_map: &std::collections::HashMap<u32, u32>,
+    children_map: &std::collections::HashMap<u32, Vec<u32>>,
+) -> BTreeSet<u32> {
+    // The destroy command and its caller/inspection tree can mention the target
+    // path without being owned by that environment.
+    let mut excluded = BTreeSet::new();
+    let mut cursor = current_pid;
+    while cursor > 1 && excluded.insert(cursor) {
+        let Some(parent) = parent_map.get(&cursor).copied() else {
+            break;
+        };
+        if parent == cursor {
+            break;
+        }
+        cursor = parent;
+    }
+
+    let mut queue = vec![current_pid];
+    while let Some(pid) = queue.pop() {
+        let Some(children) = children_map.get(&pid) else {
+            continue;
+        };
+        for child in children {
+            if excluded.insert(*child) {
+                queue.push(*child);
+            }
+        }
+    }
+    excluded
+}
+
+#[cfg(unix)]
 fn associated_processes_once(meta: &EnvMeta) -> Result<Vec<EnvDestroyProcessIdentity>, String> {
     let processes = process_table()?;
     let cwd_map = process_cwd_map(&processes)?;
@@ -1722,10 +1756,14 @@ fn associated_processes_once(meta: &EnvMeta) -> Result<Vec<EnvDestroyProcessIden
             .or_default()
             .push(process.pid);
     }
+    let invocation_processes =
+        active_invocation_processes(std::process::id(), &parent_map, &children_map);
 
     let mut seeds = BTreeSet::new();
     for process in &processes {
-        if interactive_shell_command(&process.command) {
+        if invocation_processes.contains(&process.pid)
+            || interactive_shell_command(&process.command)
+        {
             continue;
         }
         if process_belongs_to_env(process.pid, &process.command, meta, &cwd_map) {
@@ -1745,7 +1783,9 @@ fn associated_processes_once(meta: &EnvMeta) -> Result<Vec<EnvDestroyProcessIden
                 let Some(process) = processes.iter().find(|process| process.pid == *child) else {
                     continue;
                 };
-                if interactive_shell_command(&process.command) {
+                if invocation_processes.contains(child)
+                    || interactive_shell_command(&process.command)
+                {
                     continue;
                 }
                 if related.insert(*child) {
@@ -2148,7 +2188,11 @@ fn process_alive(pid: u32) -> bool {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::{command_contains_process_path, process_path_is_within};
+    use std::collections::HashMap;
+
+    use super::{
+        active_invocation_processes, command_contains_process_path, process_path_is_within,
+    };
 
     #[test]
     fn process_path_containment_requires_component_boundaries() {
@@ -2174,5 +2218,22 @@ mod tests {
             "node /tmp/parent-demo/openclaw.mjs",
             "/tmp/demo"
         ));
+    }
+
+    #[test]
+    fn invocation_processes_include_ancestors_and_current_descendants_only() {
+        let parent_map = HashMap::from([(40, 20), (20, 10), (10, 1), (30, 20), (41, 40), (42, 41)]);
+        let children_map = HashMap::from([
+            (1, vec![10]),
+            (10, vec![20]),
+            (20, vec![30, 40]),
+            (40, vec![41]),
+            (41, vec![42]),
+        ]);
+
+        assert_eq!(
+            active_invocation_processes(40, &parent_map, &children_map),
+            [10, 20, 40, 41, 42].into_iter().collect()
+        );
     }
 }

--- a/tests/env_destroy_tests.rs
+++ b/tests/env_destroy_tests.rs
@@ -132,6 +132,29 @@ fn prepend_fake_bin(env: &mut BTreeMap<String, String>, bin_dir: &Path) {
     env.insert("PATH".to_string(), combined_path);
 }
 
+#[cfg(unix)]
+fn run_ocm_through_path_wrapper(
+    cwd: &Path,
+    env: &BTreeMap<String, String>,
+    target_root: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    let mut command = Command::new("/bin/sh");
+    command
+        .current_dir(cwd)
+        .arg("-c")
+        .arg(
+            "target_root=$1; shift; binary=$1; shift; \"$binary\" \"$@\"; status=$?; : \"$target_root\"; exit \"$status\"",
+        )
+        .arg("ocm-destroy-wrapper")
+        .arg(target_root)
+        .arg(env!("CARGO_BIN_EXE_ocm"))
+        .args(args)
+        .env_clear()
+        .envs(env);
+    command.output().unwrap()
+}
+
 fn install_fake_dev_runners(root: &TestDir, env: &mut BTreeMap<String, String>) {
     let bin_dir = root.child("fake-dev-bin");
     fs::create_dir_all(&bin_dir).unwrap();
@@ -726,6 +749,67 @@ fn env_destroy_ignores_processes_in_sibling_prefix_paths() {
     assert!(
         sibling_process.try_wait().unwrap().is_none(),
         "destroy preview must not terminate a process from a sibling prefix path"
+    );
+
+    sibling_process.kill().unwrap();
+    sibling_process.wait().unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn env_destroy_ignores_its_invocation_wrapper_when_the_command_mentions_the_target_root() {
+    let root = TestDir::new("env-destroy-invocation-wrapper");
+    let cwd = root.child("workspace");
+    let sibling_root = root.child("ocm-home/envs/demo-sibling");
+    fs::create_dir_all(&cwd).unwrap();
+    fs::create_dir_all(&sibling_root).unwrap();
+    let env = ocm_launchd_env(&root);
+
+    let created = run_ocm(&cwd, &env, &["env", "create", "demo"]);
+    assert!(created.status.success(), "{}", stderr(&created));
+    let stopped = run_ocm(&cwd, &env, &["service", "stop", "demo"]);
+    assert!(stopped.status.success(), "{}", stderr(&stopped));
+    let target_root = PathBuf::from(get_environment("demo", &env, &cwd).unwrap().root);
+
+    let mut sibling_process = Command::new("python3")
+        .current_dir(&sibling_root)
+        .args(["-c", "import time; time.sleep(60)"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    sleep(Duration::from_millis(100));
+
+    let preview = run_ocm_through_path_wrapper(
+        &cwd,
+        &env,
+        &target_root,
+        &["env", "destroy", "demo", "--json"],
+    );
+    assert!(preview.status.success(), "{}", stderr(&preview));
+    let preview_json: serde_json::Value = serde_json::from_str(&stdout(&preview)).unwrap();
+    assert_eq!(preview_json["processCount"], 0);
+    let guard = preview_json["stateToken"].as_str().unwrap();
+
+    let destroy = run_ocm_through_path_wrapper(
+        &cwd,
+        &env,
+        &target_root,
+        &[
+            "env",
+            "destroy",
+            "demo",
+            "--yes",
+            "--if-state-token",
+            guard,
+            "--json",
+        ],
+    );
+    assert!(destroy.status.success(), "{}", stderr(&destroy));
+    assert!(
+        sibling_process.try_wait().unwrap().is_none(),
+        "destroy must not terminate an independent sibling process"
     );
 
     sibling_process.kill().unwrap();


### PR DESCRIPTION
Closes #104

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

`ocm env destroy` can classify its own caller wrapper as a process owned by the target environment when the wrapper command line mentions the environment root. Descendant expansion then pulls the active OCM invocation and transient inspection processes into the candidate set, so the two guarded process scans can disagree and fail with:

```text
environment process state changed during inspection; retry the command
```

This blocks preview and guarded destroy even when the target service is stopped and no target-owned process is running.

## Why This Change Was Made

Exclude the active OCM invocation from environment ownership discovery: the current OCM process, its caller ancestry, and descendants spawned by that OCM process are ignored as candidate seeds and during descendant expansion.

The exclusion deliberately does not remove siblings or all descendants of the caller wrapper, and it does not weaken path-based ownership matching. Independent processes whose command line or working directory belongs to the target environment remain detectable and terminable. This keeps the repair scoped to the invocation tree that cannot safely be treated as destroyable target work.

## User Impact

Operators can preview and perform guarded environment destruction from shell wrappers, maintenance scripts, and diagnostic flows whose command lines mention the target path. The destroy guard remains stable instead of counting its own invocation.

Genuinely target-owned processes are still discovered, while independent sibling-environment processes remain untouched.

## Evidence

- The new wrapper regression failed on unchanged `main` with the exact reported inspection-state error.
- After the fix, the same wrapper preview reports `processCount: 0`, guarded destroy succeeds, and an independent sibling process remains running.
- `cargo test --locked invocation_processes_include_ancestors_and_current_descendants_only -- --nocapture`: passed.
- `cargo test --locked --test env_destroy_tests`: 14 passed, 0 failed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check origin/main..HEAD`: passed.
- Hosted CI passed on macOS, Ubuntu, Windows, formatting, and the Rust 1.88 minimum lane.
- No OCM binary was installed locally, and no resident daemon or managed gateway was restarted.

