### PR TITLE
fix(supervisor): preserve siblings during targeted lifecycle

### DIFF
--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -234,7 +234,7 @@ impl<'a> EnvironmentService<'a> {
 
     pub fn clone(&self, options: CloneEnvironmentOptions) -> Result<EnvMeta, String> {
         let meta = clone_environment(options, self.env, self.cwd)?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, &meta.name)?;
         Ok(meta)
     }
 
@@ -243,7 +243,7 @@ impl<'a> EnvironmentService<'a> {
         options: CloneEnvironmentOptions,
     ) -> Result<EnvMeta, String> {
         let meta = clone_environment_for_simulation(options, self.env, self.cwd)?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, &meta.name)?;
         Ok(meta)
     }
 
@@ -258,7 +258,7 @@ impl<'a> EnvironmentService<'a> {
             self.env,
             self.cwd,
         )?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, &result.meta.name)?;
         Ok(result)
     }
 

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -228,7 +228,7 @@ impl<'a> EnvironmentService<'a> {
 
     pub fn create(&self, options: CreateEnvironmentOptions) -> Result<EnvMeta, String> {
         let meta = create_environment_with_validated_runtime(options, self.env, self.cwd)?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, &meta.name)?;
         Ok(meta)
     }
 

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -268,7 +268,7 @@ impl<'a> EnvironmentService<'a> {
 
     pub fn import(&self, options: ImportEnvironmentOptions) -> Result<EnvImportSummary, String> {
         let summary = import_environment(options, self.env, self.cwd)?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, &summary.name)?;
         Ok(summary)
     }
 
@@ -283,7 +283,7 @@ impl<'a> EnvironmentService<'a> {
             self.env,
             self.cwd,
         )?;
-        sync_supervisor_if_present(self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, &result.summary.name)?;
         Ok(result)
     }
 

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -466,9 +466,9 @@ fn update_service(
     let daemon_before = supervisor.daemon_status()?;
     let change = set_environment_service_policy(name, service_enabled, service_running, env, cwd)?;
     let update_result = match supervisor_policy {
-        ServiceSupervisorPolicy::EnsureRunning => {
-            ensure_supervisor_running_locked(&supervisor, env)
-        }
+        ServiceSupervisorPolicy::EnsureRunning => sync_supervisor_env_if_present(env, cwd, name)
+            .map(|_| ())
+            .and_then(|()| ensure_supervisor_running_locked(&supervisor, env)),
         ServiceSupervisorPolicy::LeaveAsIs => {
             sync_supervisor_env_if_present(env, cwd, name).map(|_| ())
         }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -480,10 +480,13 @@ impl<'a> SupervisorService<'a> {
     pub(crate) fn ensure_daemon_running_locked(&self) -> Result<SupervisorDaemonSummary, String> {
         let definition = self.supervisor_daemon_definition()?;
         validate_managed_service_owner(&definition, self.env)?;
-        let _ = self.sync()?;
         let status = self.daemon_status()?;
         if status.running {
             return Ok(status);
+        }
+        let state_path = supervisor_state_path(self.env, self.cwd)?;
+        if !state_path.exists() {
+            let _ = self.sync()?;
         }
         self.activate_daemon("install")
     }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -484,10 +484,7 @@ impl<'a> SupervisorService<'a> {
         if status.running {
             return Ok(status);
         }
-        let state_path = supervisor_state_path(self.env, self.cwd)?;
-        if !state_path.exists() {
-            let _ = self.sync()?;
-        }
+        let _ = self.sync()?;
         self.activate_daemon("install")
     }
 

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -621,6 +621,80 @@ fn env_changes_refresh_persisted_service_state_without_extra_commands() {
 }
 
 #[test]
+fn start_create_preserves_running_siblings_despite_caller_environment_drift() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("start-create-preserves-supervisor-siblings");
+    let (cwd, mut env, _, _) = setup_daemon_run_fixture_with_child_sleep(&root, 3600);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+
+    // Start two supervised siblings and capture the exact persisted and runtime identities.
+    service.sync().unwrap();
+    let initial_state = read_persisted_service_state(&state_path);
+    let initial_children = initial_state["children"].clone();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let initial_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(5))
+        .expect("daemon runtime state did not report both children");
+    let demo_pid = runtime_child_pid(&initial_runtime, "demo").unwrap();
+    let prod_pid = runtime_child_pid(&initial_runtime, "prod").unwrap();
+
+    env.insert(
+        "NODE_OPTIONS".to_string(),
+        "--max-old-space-size=2048".to_string(),
+    );
+    // Reproduce the incident-shaped no-service creation under caller-environment drift.
+    let started = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "start",
+            "pr121799-macos-proof",
+            "--command",
+            "node openclaw.mjs",
+            "--cwd",
+            &path_string(&cwd),
+            "--port",
+            "19079",
+            "--no-service",
+            "--json",
+        ],
+    );
+    assert!(started.status.success(), "{}", stderr(&started));
+    sleep(Duration::from_millis(800));
+
+    let final_state = read_persisted_service_state(&state_path);
+    let final_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(2))
+        .expect("daemon runtime state stopped reporting both children");
+
+    // The new disabled env may be recorded, but neither running sibling may change.
+    assert_eq!(
+        final_state["children"], initial_children,
+        "creating a no-service env changed unrelated child specs"
+    );
+    assert_eq!(
+        runtime_child_pid(&final_runtime, "demo"),
+        Some(demo_pid),
+        "creating a no-service env restarted the demo child"
+    );
+    assert_eq!(
+        runtime_child_pid(&final_runtime, "prod"),
+        Some(prod_pid),
+        "creating a no-service env restarted the prod child"
+    );
+    assert!(
+        final_state["skippedEnvs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["envName"] == "pr121799-macos-proof")
+    );
+
+    stop_process(&mut daemon);
+}
+
+#[test]
 fn env_clone_preserves_unrelated_supervisor_child_specs() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("env-clone-preserves-supervisor-siblings");

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -665,6 +665,62 @@ fn env_clone_preserves_unrelated_supervisor_child_specs() {
 }
 
 #[test]
+fn env_import_preserves_unrelated_supervisor_child_specs() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("env-import-preserves-supervisor-siblings");
+    let (cwd, mut env) = setup_service_fixture(&root);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+
+    service.sync().unwrap();
+    let exported = run_ocm(&cwd, &env, &["env", "export", "demo"]);
+    assert!(exported.status.success(), "{}", stderr(&exported));
+
+    env.insert(
+        "NODE_OPTIONS".to_string(),
+        "--max-old-space-size=2048".to_string(),
+    );
+    let imported = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "import",
+            "./demo.ocm-env.tar",
+            "--name",
+            "demo-import",
+        ],
+    );
+    assert!(imported.status.success(), "{}", stderr(&imported));
+
+    let state = read_persisted_service_state(&state_path);
+    let demo = state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "demo")
+        .expect("demo child spec should remain present");
+    assert!(
+        demo["processEnv"]["NODE_OPTIONS"].is_null(),
+        "import must not rebuild unrelated child specs from caller environment"
+    );
+    assert!(
+        state["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|child| child["envName"] != "demo-import")
+    );
+    assert!(
+        state["skippedEnvs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["envName"] == "demo-import")
+    );
+}
+
+#[test]
 fn child_restart_request_rebuilds_missing_or_stale_state() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("restart-request-rebuilds-state");

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -621,6 +621,50 @@ fn env_changes_refresh_persisted_service_state_without_extra_commands() {
 }
 
 #[test]
+fn env_clone_preserves_unrelated_supervisor_child_specs() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("env-clone-preserves-supervisor-siblings");
+    let (cwd, mut env) = setup_service_fixture(&root);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+
+    service.sync().unwrap();
+    env.insert(
+        "NODE_OPTIONS".to_string(),
+        "--max-old-space-size=2048".to_string(),
+    );
+
+    let cloned = run_ocm(&cwd, &env, &["env", "clone", "demo", "demo-clone"]);
+    assert!(cloned.status.success(), "{}", stderr(&cloned));
+
+    let state = read_persisted_service_state(&state_path);
+    let demo = state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "demo")
+        .expect("demo child spec should remain present");
+    assert!(
+        demo["processEnv"]["NODE_OPTIONS"].is_null(),
+        "clone must not rebuild unrelated child specs from caller environment"
+    );
+    assert!(
+        state["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|child| child["envName"] != "demo-clone")
+    );
+    assert!(
+        state["skippedEnvs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["envName"] == "demo-clone")
+    );
+}
+
+#[test]
 fn child_restart_request_rebuilds_missing_or_stale_state() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("restart-request-rebuilds-state");

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1179,6 +1179,89 @@ fn service_uninstall_removes_only_target_child_despite_unrelated_drift() {
 }
 
 #[test]
+fn service_start_preserves_running_siblings_despite_unrelated_drift() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-targeted-service-start");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_systemd_tools(&root, &mut env);
+    let service = SupervisorService::new(&env, &cwd);
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+    let state_path = root.child("ocm-home/supervisor/state.json");
+
+    for (runtime_name, env_name) in [("target-runtime", "target"), ("sibling-runtime", "sibling")] {
+        let runtime = root.child(format!("bin/{runtime_name}"));
+        write_legacy_openclaw_script(
+            &runtime,
+            "#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+        );
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                runtime_name,
+                "--path",
+                &path_string(&runtime),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+        let create = run_ocm(
+            &cwd,
+            &env,
+            &["env", "create", env_name, "--runtime", runtime_name],
+        );
+        assert!(create.status.success(), "{}", stderr(&create));
+        set_service_enabled(&cwd, &env, env_name, true);
+    }
+    service.sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let initial_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(5))
+        .expect("daemon runtime state did not report both children");
+    let target_pid = runtime_child_pid(&initial_runtime, "target").unwrap();
+    let sibling_pid = runtime_child_pid(&initial_runtime, "sibling").unwrap();
+
+    let sibling_meta_path = root.child("ocm-home/runtimes/sibling-runtime.json");
+    let mut sibling_meta = read_persisted_service_state(&sibling_meta_path);
+    sibling_meta["releaseVersion"] = Value::String("latent-sibling-v2".to_string());
+    write_persisted_service_state(&sibling_meta_path, &sibling_meta);
+
+    let start = run_ocm(&cwd, &env, &["service", "start", "target", "--json"]);
+    assert!(start.status.success(), "{}", stderr(&start));
+    sleep(Duration::from_millis(800));
+
+    let final_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(2))
+        .expect("daemon runtime state stopped reporting both children");
+    let final_state = read_persisted_service_state(&state_path);
+    let persisted_sibling = final_state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "sibling")
+        .unwrap();
+
+    assert_eq!(
+        runtime_child_pid(&final_runtime, "target"),
+        Some(target_pid),
+        "already-running target child PID changed"
+    );
+    assert_eq!(
+        runtime_child_pid(&final_runtime, "sibling"),
+        Some(sibling_pid),
+        "sibling child PID changed"
+    );
+    assert!(
+        persisted_sibling["runtimeReleaseVersion"].is_null(),
+        "target start applied unrelated sibling drift"
+    );
+
+    stop_process(&mut daemon);
+}
+
+#[test]
 fn env_destroy_removes_only_target_child_despite_unrelated_drift() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("daemon-targeted-env-destroy");

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -884,7 +884,7 @@ fn publishing_an_unbound_runtime_preserves_unrelated_active_child_spec_and_pid()
     write_legacy_openclaw_script(
         &runtime_a,
         &format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 3600; done\n",
             path_string(&started),
             path_string(&stopped),
         ),
@@ -984,7 +984,7 @@ fn targeted_runtime_refresh_ignores_unrelated_drift_and_restarts_effective_chang
     write_legacy_openclaw_script(
         &runtime_a,
         &format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" >> '{}'\ntrap 'printf \"%s\\n\" \"$$\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 3600; done\n",
             path_string(&runtime_a_started),
             path_string(&runtime_a_stopped),
         ),

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -13,8 +13,8 @@ use ocm::supervisor::{SupervisorService, sync_supervisor_binding_if_present};
 use serde_json::{Value, to_value};
 
 use crate::support::{
-    TestDir, install_fake_systemd_tools, ocm_env, path_string, run_ocm, stderr, stdout,
-    write_executable_script,
+    TestDir, install_fake_launchctl, install_fake_systemd_tools, ocm_env, path_string, run_ocm,
+    stderr, stdout, write_executable_script,
 };
 
 static DAEMON_RUNTIME_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -1185,7 +1185,11 @@ fn service_start_preserves_running_siblings_despite_unrelated_drift() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
-    install_fake_systemd_tools(&root, &mut env);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
     let service = SupervisorService::new(&env, &cwd);
     let runtime_path = root.child("ocm-home/supervisor/runtime.json");
     let state_path = root.child("ocm-home/supervisor/state.json");
@@ -1217,6 +1221,12 @@ fn service_start_preserves_running_siblings_despite_unrelated_drift() {
         set_service_enabled(&cwd, &env, env_name, true);
     }
     service.sync().unwrap();
+    service.install_daemon().unwrap();
+    let daemon_status = service.daemon_status().unwrap();
+    assert!(
+        daemon_status.running,
+        "fixture must report the managed daemon as running: {daemon_status:?}"
+    );
 
     let mut daemon = spawn_daemon_process(&cwd, &env);
     let initial_runtime = wait_for_runtime_children(&runtime_path, 2, None, Duration::from_secs(5))
@@ -1259,6 +1269,71 @@ fn service_start_preserves_running_siblings_despite_unrelated_drift() {
     );
 
     stop_process(&mut daemon);
+}
+
+#[test]
+fn service_start_reconciles_siblings_before_activating_stopped_daemon() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-stopped-targeted-service-start");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+
+    for (runtime_name, env_name) in [("target-runtime", "target"), ("sibling-runtime", "sibling")] {
+        let runtime = root.child(format!("bin/{runtime_name}"));
+        write_legacy_openclaw_script(
+            &runtime,
+            "#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+        );
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                runtime_name,
+                "--path",
+                &path_string(&runtime),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+        let create = run_ocm(
+            &cwd,
+            &env,
+            &["env", "create", env_name, "--runtime", runtime_name],
+        );
+        assert!(create.status.success(), "{}", stderr(&create));
+        set_service_enabled(&cwd, &env, env_name, true);
+    }
+    service.sync().unwrap();
+
+    let sibling_meta_path = root.child("ocm-home/runtimes/sibling-runtime.json");
+    let mut sibling_meta = read_persisted_service_state(&sibling_meta_path);
+    sibling_meta["releaseVersion"] = Value::String("latent-sibling-v2".to_string());
+    write_persisted_service_state(&sibling_meta_path, &sibling_meta);
+
+    let start = run_ocm(&cwd, &env, &["service", "start", "target", "--json"]);
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    let final_state = read_persisted_service_state(&state_path);
+    let persisted_sibling = final_state["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["envName"] == "sibling")
+        .expect("sibling child spec should remain present");
+
+    assert_eq!(
+        persisted_sibling["runtimeReleaseVersion"], "latent-sibling-v2",
+        "stopped-daemon activation must reconcile stale sibling state"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve unrelated running gateway specs and PIDs during targeted `service start`
- fully reconcile fleet state before activating a stopped daemon
- reconcile only the new environment during clone, simulation-clone, and import
- add regressions for running-daemon, stopped-daemon, and clone isolation

## Incidents

Two related fleet-isolation failures were reproduced:

1. A targeted `ocm service start openclaw` rebuilt complete fleet state and
   relaunched unrelated gateways when latent sibling drift was present.
2. `ocm env clone clawpatrol <canary>` rebuilt complete fleet state and
   reloaded production OpenClaw during supervisor convergence.

Both failures came from target-scoped commands invoking fleet-wide supervisor
synchronization.

## Behavior

- When the supervisor daemon is already running, service start synchronizes
  only the named environment.
- When the daemon is stopped, service start fully reconciles fleet state before
  activation so stale persisted sibling definitions are not launched.
- Clone/import paths synchronize only the newly created environment and do not
  regenerate sibling specs.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- focused regressions:
  - `service_start_preserves_running_siblings_despite_unrelated_drift`
  - `service_start_reconciles_siblings_before_activating_stopped_daemon`
  - `env_clone_preserves_unrelated_supervisor_child_specs`
  - `env_import_preserves_unrelated_supervisor_child_specs`
- `cargo test --test daemon_runtime_tests -- --test-threads=1`
- `cargo test --all-targets --locked -- --test-threads=1 --skip bin_wrapper_runs_with_an_overridden_home`
- `cargo build --release --locked`

The skipped wrapper test requires `rustup`, which is not installed on the
deployment host. Every executed test passed.
