### PR TITLE
fix(env): clone state containing Unix sockets

### DIFF
--- a/src/store/common.rs
+++ b/src/store/common.rs
@@ -7,6 +7,8 @@ use fs2::FileExt;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+#[cfg(unix)]
+use std::os::unix::fs::FileTypeExt;
 #[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
 #[cfg(windows)]
@@ -83,6 +85,10 @@ pub(crate) fn copy_path(source: &Path, destination: &Path) -> Result<(), String>
     }
     if file_type.is_dir() {
         return copy_dir_recursive(source, destination);
+    }
+    #[cfg(unix)]
+    if file_type.is_socket() {
+        return Ok(());
     }
     if let Some(parent) = destination.parent() {
         ensure_dir(parent)?;
@@ -280,6 +286,32 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_dir_recursive_skips_unix_sockets() {
+        use std::os::unix::net::UnixListener;
+
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let root = PathBuf::from("/tmp").join(format!("ocm-socket-{}-{id}", std::process::id()));
+        let source = root.join("source");
+        let destination = root.join("destination");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("note.txt"), "copied\n").unwrap();
+        let socket_path = source.join("service.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+
+        copy_dir_recursive(&source, &destination).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination.join("note.txt")).unwrap(),
+            "copied\n"
+        );
+        assert!(!destination.join("service.sock").exists());
+
+        drop(listener);
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Problem

`ocm env clone` could not clone a running environment when its state tree
contained a live Unix-domain socket.

The recursive state copier handled directories and symlinks specially, but
sent every other file type to `fs::copy`. A service-owned socket such as:

```text
.openclaw/tailscale/tailscaled.sock
```

therefore caused the entire clone command to fail before the target environment
was registered. This blocked canary, recovery, and migration workflows for
otherwise healthy environments.

## Why the socket should not be copied

A Unix socket is a live process endpoint, not durable environment data. Its
contents cannot be copied into another environment, and the owning service must
create a new socket when that environment starts.

The correct clone behavior is therefore:

- copy regular files, directories, and symlinks with their existing semantics
- omit Unix sockets
- allow the cloned environment's services to recreate their own sockets

## Fix

`copy_path` now detects Unix sockets with `FileTypeExt::is_socket()` and skips
them. A Unix-only regression test binds a real `UnixListener`, clones the
source tree, and verifies that:

- an ordinary file is copied
- the socket path is omitted
- the recursive clone completes successfully

Closes #108

## Testing

- `cargo test copy_dir_recursive_skips_unix_sockets -- --nocapture`
- `cargo test --test env_clone_tests -- --nocapture`
- `cargo test --test daemon_runtime_tests -- --test-threads=1 --nocapture`
- `cargo test --workspace -- --test-threads=1 --skip bin_wrapper_runs_with_an_overridden_home`
- `cargo build --release`
- `cargo fmt --check`
- `git diff --check`

The local host lacks `rustup`, so its unrelated wrapper fixture was excluded
from the broad local run. GitHub CI ran the complete suite, including that
fixture, successfully on macOS and Ubuntu.

## Live proof

- before the fix, `ocm env clone main main-ecf-canary --json` failed on
  Main's live `.openclaw/tailscale/tailscaled.sock`
- with the fix installed, the same clone completed without manually stopping
  Tailscale or deleting the socket
- ordinary state was copied and the socket was omitted
- all five production gateway PID, restart-count, and binding identities were
  unchanged immediately after clone and after supervisor convergence

## Worked on by

- Hannes Rudolph
