### PR TITLE
fix(migrate): reject external plugin paths during adoption

### DIFF
--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -402,6 +402,12 @@ fn relocate_installed_plugin_index_paths(
             external_plugin_ids.insert(plugin_id.clone());
         }
     }
+    if !external_plugin_ids.is_empty() {
+        return Err(format!(
+            "imported OpenClaw plugin path(s) could not be isolated inside the env state: {}",
+            external_plugin_ids.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+    }
     if !changed {
         return Ok(MigratedRuntimeStateResult {
             changed: false,

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -405,7 +405,10 @@ fn relocate_installed_plugin_index_paths(
     if !external_plugin_ids.is_empty() {
         return Err(format!(
             "imported OpenClaw plugin path(s) could not be isolated inside the env state: {}",
-            external_plugin_ids.into_iter().collect::<Vec<_>>().join(", ")
+            external_plugin_ids
+                .into_iter()
+                .collect::<Vec<_>>()
+                .join(", ")
         ));
     }
     if !changed {

--- a/tests/migrate_command_tests.rs
+++ b/tests/migrate_command_tests.rs
@@ -1240,7 +1240,7 @@ fn adopt_import_rejects_a_symlinked_plugin_database_without_mutating_its_target(
 }
 
 #[test]
-fn adopt_import_preserves_external_plugin_checkouts_with_an_isolation_warning() {
+fn adopt_import_rejects_external_plugin_paths_without_mutating_the_source() {
     let root = TestDir::new("adopt-import-external-plugin");
     let cwd = root.child("workspace");
     let source_home = root.child("legacy-home/.openclaw");
@@ -1260,6 +1260,8 @@ fn adopt_import_preserves_external_plugin_checkouts_with_an_isolation_warning() 
             }
         }),
     );
+    let source_database = source_home.join("state/openclaw.sqlite");
+    let source_database_before = fs::read(&source_database).unwrap();
 
     let env = ocm_env(&root);
     let output = run_ocm(
@@ -1274,28 +1276,20 @@ fn adopt_import_preserves_external_plugin_checkouts_with_an_isolation_warning() 
             "--json",
         ],
     );
-    assert!(output.status.success(), "{}", stderr(&output));
+
+    assert_eq!(output.status.code(), Some(1));
     assert!(
         stderr(&output).contains(
-            "warning: imported plugin external-dev could not be isolated inside the env state; OCM preserved but did not copy or modify its external location"
+            "imported OpenClaw plugin path(s) could not be isolated inside the env state: external-dev"
         ),
         "{}",
         stderr(&output)
     );
-
-    let imported_records = read_imported_plugin_install_records(&root, "mira");
-    assert_eq!(
-        imported_records["external-dev"]["installPath"].as_str(),
-        Some(external_plugin.to_string_lossy().as_ref())
-    );
+    assert!(!root.child("ocm-home/envs/mira").exists());
+    assert_eq!(fs::read(&source_database).unwrap(), source_database_before);
     assert_eq!(
         fs::read_to_string(external_plugin.join("marker.txt")).unwrap(),
         "external checkout\n"
-    );
-    assert!(
-        !root
-            .child("ocm-home/envs/mira/.openclaw/external-checkout")
-            .exists()
     );
 }
 


### PR DESCRIPTION
## What Problem This Solves

`ocm adopt import` can retain absolute `sourcePath` or `installPath` values for path plugins outside the adopted environment. The import currently succeeds with a warning, so a candidate runtime can still receive a writable reference to source-owned state even though the environment is intended to be disposable.

## Why This Change Was Made

Containment is a safety boundary, not a compatibility warning. The import now fails before publishing relocated plugin records when any plugin path cannot be isolated inside the target state root. The existing migration transaction then removes the partially created environment.

## User Impact

Adoption no longer produces a runnable environment with external plugin references. Operators must relocate or remove external path plugins before importing. Managed ClawHub and npm plugin records continue to relocate into the adopted state as before.

## Verification

### Targeted regression test

```text
$ cargo test --test migrate_command_tests adopt_import_rejects_external_plugin_paths_without_mutating_the_source -- --exact --nocapture
running 1 test
test adopt_import_rejects_external_plugin_paths_without_mutating_the_source ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 39 filtered out
```

### Real CLI behavior with a safe temporary fixture

The fixture contains a path plugin outside the source OpenClaw home. Paths are redacted below. The source database and external plugin marker were hashed before and after the production `ocm` command.

```text
$ ocm adopt import --name proof-external-plugin <fixture>/source/.openclaw --json
ocm: imported OpenClaw plugin path(s) could not be isolated inside the env state: external-dev
Run "ocm help" for usage.

exit: 1
target environment removed: yes
source sqlite unchanged: yes (6a5285e2a14ca9cf4df66734c93ef52404fa218b7a8b2fe2f912e3672ad87bc9)
external plugin unchanged: yes (09d7425c9be6e7eae3c094a5884bba879aef74adb6193f54175898965ed44393)
```

Additional CI-equivalent verification on commit `9695362`:

- `cargo fmt --check` passes.
- `cargo test --locked` passes in a clean WSL-native Linux checkout.
- `cargo +1.88.0 check --workspace --all-targets --locked` passes.
- `git diff --check upstream/main...HEAD` passes.

## Maintainer Decision Requested

Please confirm that fail-closed adoption is the intended policy when a path plugin cannot be contained. This intentionally changes the previous warning-and-continue behavior: operators must relocate or remove the external path plugin before retrying adoption.

Related: #98
Related: openclaw/openclaw#129673
