### PR TITLE
fix(env): status stalls on large packaged runtimes

### DIFF
--- a/src/env/inspect.rs
+++ b/src/env/inspect.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::launcher::resolve_launcher_run_dir;
 use crate::service::ServiceService;
-use crate::store::{get_launcher, runtime_integrity_issue};
+use crate::store::{get_launcher, runtime_operational_issue};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -103,7 +103,9 @@ impl<'a> EnvironmentService<'a> {
                             Some(runtime.source_kind.as_str().to_string());
                         summary.runtime_release_version = runtime.release_version.clone();
                         summary.runtime_release_channel = runtime.release_channel.clone();
-                        match runtime_integrity_issue(&runtime, self.env) {
+                        // Status checks whether the runtime can execute. Full-tree integrity remains
+                        // an explicit `runtime verify` operation because packaged trees can be large.
+                        match runtime_operational_issue(&runtime, self.env) {
                             None => summary.runtime_health = Some("ok".to_string()),
                             Some(error) => {
                                 summary.runtime_health = Some("broken".to_string());

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -74,6 +74,7 @@ pub(crate) use runtimes::install_runtime_from_selected_official_openclaw_release
 pub(crate) use runtimes::{
     BuildLocalRuntimeOptions, InstallContext, PreparedRuntimeInstall, RuntimeReleaseDetails,
     prepare_runtime_from_selected_official_openclaw_release, prepare_runtime_from_selected_release,
+    runtime_operational_issue,
 };
 pub use runtimes::{
     add_runtime, get_runtime, get_runtime_verified, install_runtime,

--- a/src/store/runtimes.rs
+++ b/src/store/runtimes.rs
@@ -2975,7 +2975,7 @@ fn runtime_companion_integrity_issue(meta: &RuntimeMeta) -> Option<String> {
     None
 }
 
-pub fn runtime_integrity_issue(
+pub(crate) fn runtime_operational_issue(
     meta: &RuntimeMeta,
     env: &BTreeMap<String, String>,
 ) -> Option<String> {
@@ -2983,6 +2983,17 @@ pub fn runtime_integrity_issue(
         return Some(issue);
     }
     if let Some(issue) = runtime_companion_integrity_issue(meta) {
+        return Some(issue);
+    }
+
+    None
+}
+
+pub fn runtime_integrity_issue(
+    meta: &RuntimeMeta,
+    env: &BTreeMap<String, String>,
+) -> Option<String> {
+    if let Some(issue) = runtime_operational_issue(meta, env) {
         return Some(issue);
     }
 

--- a/tests/runtime_command_tests.rs
+++ b/tests/runtime_command_tests.rs
@@ -15,7 +15,8 @@ use sha2::{Digest, Sha512};
 use tar::{Builder, Header};
 
 use crate::support::{
-    TestDir, TestHttpServer, install_fake_managed_node_archive, install_fake_node_and_npm, ocm_env,
+    TestDir, TestHttpServer, install_fake_managed_node_archive, install_fake_node_and_npm,
+    install_fake_service_manager, ocm_env,
     openclaw_package_tarball as openclaw_package_tarball_with_version, path_string, run_ocm,
     stderr, stdout, write_executable_script,
 };
@@ -895,7 +896,7 @@ fn runtime_build_local_rejects_dangling_dependency_link_before_pack() {
 }
 
 #[test]
-fn runtime_verify_reports_package_tree_drift() {
+fn runtime_status_stays_operational_while_verify_reports_package_tree_drift() {
     let root = TestDir::new("runtime-verify-package-tree-drift");
     let cwd = root.child("workspace");
     let repo = cwd.join("openclaw");
@@ -916,6 +917,7 @@ fn runtime_verify_reports_package_tree_drift() {
     .unwrap();
 
     let mut env = ocm_env(&root);
+    install_fake_service_manager(&root, &mut env);
     let _npm_log = install_fake_node_and_packing_npm(&root, &mut env, &archive_path);
     let build = run_ocm(
         &cwd,
@@ -930,6 +932,13 @@ fn runtime_verify_reports_package_tree_drift() {
     );
     assert!(build.status.success(), "{}", stderr(&build));
 
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &["env", "create", "demo", "--runtime", "main-local"],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+
     let install_root = runtime_install_root("main-local", &env, &cwd).unwrap();
     fs::write(
         install_root.join("files/node_modules/openclaw/package.json"),
@@ -942,6 +951,27 @@ fn runtime_verify_reports_package_tree_drift() {
         tree_drift_which.status.success(),
         "{}",
         stderr(&tree_drift_which)
+    );
+
+    let tree_drift_status = run_ocm(&cwd, &env, &["env", "status", "demo", "--json"]);
+    assert!(
+        tree_drift_status.status.success(),
+        "{}",
+        stderr(&tree_drift_status)
+    );
+    let status_value: Value = serde_json::from_str(&stdout(&tree_drift_status)).unwrap();
+    assert_eq!(status_value["runtimeHealth"], "ok");
+    assert_eq!(status_value["issue"], Value::Null);
+
+    let doctor = run_ocm(&cwd, &env, &["env", "doctor", "demo", "--json"]);
+    assert!(doctor.status.success(), "{}", stderr(&doctor));
+    let doctor_value: Value = serde_json::from_str(&stdout(&doctor)).unwrap();
+    assert_eq!(doctor_value["runtimeStatus"], "broken");
+    assert!(
+        doctor_value["issues"][0]
+            .as_str()
+            .unwrap()
+            .contains("runtime sha256 mismatch:")
     );
 
     let verify = run_ocm(&cwd, &env, &["runtime", "verify", "main-local", "--json"]);
@@ -974,6 +1004,21 @@ fn runtime_verify_reports_package_tree_drift() {
     let launcher_which = run_ocm(&cwd, &env, &["runtime", "which", "main-local", "--raw"]);
     assert_eq!(launcher_which.status.code(), Some(1));
     assert!(stderr(&launcher_which).contains("sha256 mismatch:"));
+
+    let launcher_status = run_ocm(&cwd, &env, &["env", "status", "demo", "--json"]);
+    assert!(
+        launcher_status.status.success(),
+        "{}",
+        stderr(&launcher_status)
+    );
+    let status_value: Value = serde_json::from_str(&stdout(&launcher_status)).unwrap();
+    assert_eq!(status_value["runtimeHealth"], "broken");
+    assert!(
+        status_value["issue"]
+            .as_str()
+            .unwrap()
+            .contains("sha256 mismatch:")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `ocm env status` could appear hung for minutes when an environment used a packaged runtime with a recorded tree digest. Status rehashed the runtime's entire `node_modules` tree before printing anything.

## Why This Change Was Made

Environment status now checks whether the runtime is operational, including its executable, dependency layout, and companion entrypoints. Exhaustive package-tree verification remains with `runtime verify`, environment doctor, install reuse, upgrades, and rollback checks.

This keeps the routine status path bounded without weakening the integrity gates that protect runtime selection and lifecycle changes.

## User Impact

Operators can inspect environments backed by large packaged runtimes without waiting for a multi-gigabyte tree scan. `ocm runtime verify <name>` remains the explicit deep-integrity command.

## Evidence

Current `main` at `420100f3d7c6a540ba4e88e62f0a5afdaf5ffd1f`, against Rosita's 3.0 GiB runtime:

- `ocm service status rosita --json`: 1.06 seconds.
- `ocm env status rosita --json`: no output after 142.03 seconds; the task-owned process was stopped. It had consumed 119.85 seconds of user CPU, and a process sample showed the full stack in `tree_sha256`.
- Patched `ocm env status rosita --json`: 0.26 seconds with `runtimeHealth: ok`, `managedServiceState: running`, and `openclawState: running`. This is at least 546 times faster than the incomplete baseline run.

Regression coverage proves that non-executable package drift does not block operational status, while both environment doctor and `runtime verify` still report the tree-digest mismatch. Launcher checksum drift still makes environment status report the runtime as broken.

Validation:

- `cargo fmt --check`
- `cargo check --workspace --all-targets --locked`
- `cargo test --locked --test runtime_command_tests runtime_status_stays_operational_while_verify_reports_package_tree_drift -- --exact --nocapture`
- `cargo test --locked --test env_status_tests`
- `cargo test --locked -- --skip bin_wrapper_runs_with_an_overridden_home --skip env_destroy_removes_only_target_child_despite_unrelated_drift`
- Source-blind CLI contract: 3 passed, 0 failed; status completed in 1.356 seconds under the validator's isolated wrapper.
- Autoreview: clean, no accepted or actionable findings.

The unfiltered local suite also exposed two unchanged host-specific baseline failures: the wrapper test invokes Homebrew `rustup` as `cargo`, and one daemon destroy test hits its existing state-token race. The exact base SHA's GitHub CI is green: https://github.com/openclaw/ocm/actions/runs/33035021859
