### PR TITLE
feat: update selected gateways concurrently

### DIFF
--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -527,6 +527,9 @@ pub fn upgrade_help(cmd: &str) -> String {
             format!(
                 "{cmd} upgrade <env> [--version <version> | --channel <channel> | --runtime <runtime>] [--dry-run] [--no-rollback] [--raw] [--json]"
             ),
+            format!(
+                "{cmd} upgrade batch --runtime <runtime> --envs <env,env,...> [--parallel <count>] [--failure-policy rollback|continue] [--accept-fleet-outage] [--dry-run] [--raw] [--json]"
+            ),
             format!("{cmd} upgrade --all [--dry-run] [--raw] [--json]"),
         ],
         &[
@@ -543,6 +546,22 @@ pub fn upgrade_help(cmd: &str) -> String {
                 "Move one env to an already installed runtime, including a local build",
             ),
             ("--all", "Upgrade every env that can be updated safely"),
+            (
+                "--envs <env,env,...>",
+                "Select the environments for one coordinated fast batch",
+            ),
+            (
+                "--parallel <count>",
+                "Bound concurrent snapshot and upgrade workers; defaults to 4",
+            ),
+            (
+                "--failure-policy <mode>",
+                "rollback failed envs immediately or leave them stopped for external recovery",
+            ),
+            (
+                "--accept-fleet-outage",
+                "Acknowledge that selected gateways can be unavailable together",
+            ),
             (
                 "--dry-run",
                 "Preview an upgrade or rollback without changing runtime, env, service, snapshot, or history state",
@@ -578,6 +597,9 @@ pub fn upgrade_help(cmd: &str) -> String {
             format!("{cmd} upgrade mira --channel beta"),
             format!("{cmd} upgrade mira --version 2026.3.24"),
             format!("{cmd} upgrade mira --runtime origin-main-local"),
+            format!(
+                "{cmd} upgrade batch --runtime origin-main-local --envs alpha,beta --parallel 2 --failure-policy continue --accept-fleet-outage"
+            ),
             format!("{cmd} upgrade --all"),
         ],
         &[
@@ -596,6 +618,8 @@ pub fn upgrade_help(cmd: &str) -> String {
             "When current and target OpenClaw versions are known, older targets are rejected before snapshot creation or runtime mutation because config and SQLite state migrations cannot be reversed by switching binaries.",
             "An env upgrade will not replace runtime bytes shared with another env; use --runtime to reuse those bytes or an exact --version for an isolated target.",
             "Upgrades create a pre-upgrade snapshot before changing env state.",
+            "Batch upgrades create and verify a cold checkpoint for every selected environment before any runtime transition begins, then run bounded parallel per-environment upgrades under one coordinator lock.",
+            "Batch failure policy `continue` leaves failed gateways stopped with both fleet checkpoints and per-environment upgrade history available for external recovery.",
             "When an env moves to a new runtime, upgrade runs OpenClaw update finalization inside the env before service restart.",
             "Managed-service upgrades require both HTTP health and OpenClaw gateway reachability before reporting success.",
             "If service restart/start fails, ocm restores the snapshot and previous runtime unless --no-rollback is set.",

--- a/src/cli/render/upgrade.rs
+++ b/src/cli/render/upgrade.rs
@@ -1,6 +1,6 @@
 use crate::cli::upgrade::{
-    UpgradeBatchSummary, UpgradeEnvSummary, UpgradeRollbackSummary, UpgradeSimulationBatchSummary,
-    UpgradeSimulationSummary,
+    UpgradeBatchSummary, UpgradeEnvSummary, UpgradeFleetBatchSummary, UpgradeRollbackSummary,
+    UpgradeSimulationBatchSummary, UpgradeSimulationSummary,
 };
 use crate::infra::terminal::{
     Cell, KeyValueRow, Tone, paint, render_key_value_card, render_table, terminal_width,
@@ -295,6 +295,138 @@ pub fn upgrade_batch(
         lines.push(paint(
             &format!("Use {command_example} upgrade <env> or --raw for notes."),
             Tone::Muted,
+            profile.color,
+        ));
+    }
+    lines
+}
+
+pub fn upgrade_fleet_batch(
+    summary: &UpgradeFleetBatchSummary,
+    profile: RenderProfile,
+) -> Vec<String> {
+    if !profile.pretty {
+        let mut lines = vec![
+            format!("batchId: {}", summary.batch_id),
+            format!("runtime: {}", summary.runtime),
+            format!("outcome: {}", summary.outcome),
+            format!("parallel: {}", summary.parallel),
+            format!("failurePolicy: {}", summary.failure_policy),
+            format!(
+                "journal: {}",
+                summary.journal_path.as_deref().unwrap_or("not created")
+            ),
+        ];
+        for checkpoint in &summary.checkpoints {
+            lines.push(format!(
+                "checkpoint: {}={}",
+                checkpoint.env_name, checkpoint.snapshot_id
+            ));
+        }
+        for result in &summary.results {
+            lines.extend(upgrade_env_raw(result));
+        }
+        for error in &summary.errors {
+            lines.push(format!(
+                "error: {} {}: {}",
+                error.env_name.as_deref().unwrap_or("batch"),
+                error.phase,
+                error.message
+            ));
+        }
+        return lines;
+    }
+
+    let mut lines = render_key_value_card(
+        "Fast Fleet Upgrade",
+        &[
+            KeyValueRow::accent("Batch", &summary.batch_id),
+            KeyValueRow::accent("Runtime", &summary.runtime),
+            KeyValueRow::new("Outcome", &summary.outcome, outcome_tone(&summary.outcome)),
+            KeyValueRow::plain("Parallel", summary.parallel.to_string()),
+            KeyValueRow::plain("Failure policy", &summary.failure_policy),
+            KeyValueRow::plain(
+                "Journal",
+                summary.journal_path.as_deref().unwrap_or("not created"),
+            ),
+        ],
+        profile.color,
+    );
+    if !summary.checkpoints.is_empty() {
+        lines.push(String::new());
+        let rows = summary
+            .checkpoints
+            .iter()
+            .map(|checkpoint| {
+                vec![
+                    Cell::accent(checkpoint.env_name.clone()),
+                    Cell::plain(checkpoint.snapshot_id.clone()),
+                ]
+            })
+            .collect::<Vec<_>>();
+        lines.extend(render_table(
+            &["Env", "Fleet checkpoint"],
+            &rows,
+            profile.color,
+        ));
+    }
+    if !summary.results.is_empty() {
+        lines.push(String::new());
+        lines.extend(upgrade_batch(
+            &UpgradeBatchSummary {
+                count: summary.results.len(),
+                changed: summary
+                    .results
+                    .iter()
+                    .filter(|result| {
+                        matches!(
+                            result.outcome.as_str(),
+                            "switched" | "updated" | "installed"
+                        )
+                    })
+                    .count(),
+                current: summary
+                    .results
+                    .iter()
+                    .filter(|result| result.outcome == "up-to-date")
+                    .count(),
+                skipped: 0,
+                restarted: summary
+                    .results
+                    .iter()
+                    .filter(|result| result.service_action.is_some())
+                    .count(),
+                failed: summary
+                    .results
+                    .iter()
+                    .filter(|result| {
+                        matches!(
+                            result.outcome.as_str(),
+                            "failed" | "rolled-back" | "rollback-failed"
+                        )
+                    })
+                    .count(),
+                results: summary.results.clone(),
+            },
+            profile,
+            "ocm",
+        ));
+    }
+    if !summary.errors.is_empty() {
+        lines.push(String::new());
+        lines.extend(render_key_value_card(
+            "Errors",
+            &summary
+                .errors
+                .iter()
+                .map(|error| {
+                    KeyValueRow::new(
+                        error.env_name.as_deref().unwrap_or("Batch"),
+                        format!("{}: {}", error.phase, error.message),
+                        Tone::Danger,
+                    )
+                })
+                .collect::<Vec<_>>(),
             profile.color,
         ));
     }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1,7 +1,9 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -9,8 +11,8 @@ use serde_json::{Value, json};
 
 use super::{Cli, render};
 use crate::env::{
-    CloneEnvironmentOptions, CreateEnvSnapshotOptions, EnvDevMeta, RestoreEnvSnapshotOptions,
-    resolve_runtime_run_dir,
+    CloneEnvironmentOptions, CreateEnvSnapshotOptions, EnvDevMeta, EnvSnapshotSummary,
+    RestoreEnvSnapshotOptions, resolve_runtime_run_dir,
 };
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::openclaw_repo::{detect_openclaw_checkout, ensure_openclaw_worktree};
@@ -30,10 +32,10 @@ use crate::store::{
     display_path, ensure_minimum_local_openclaw_config, ensure_store, get_runtime,
     get_upgrade_history_record, get_upgrade_runtime_recovery,
     install_runtime_from_selected_official_openclaw_release, list_upgrade_history,
-    lock_env_registry, lock_upgrade_transaction, remove_runtime, remove_upgrade_recovery,
-    resolve_absolute_path, runtime_install_root, runtime_integrity_issue, runtime_meta_path,
-    save_environment, save_upgrade_history_record, upgrade_history_recovery_dir,
-    upgrade_history_runtime_recovery_dir, write_json,
+    lock_env_registry, lock_upgrade_batch, lock_upgrade_participant, lock_upgrade_transaction,
+    remove_runtime, remove_upgrade_recovery, resolve_absolute_path, runtime_install_root,
+    runtime_integrity_issue, runtime_meta_path, save_environment, save_upgrade_history_record,
+    upgrade_history_recovery_dir, upgrade_history_runtime_recovery_dir, write_json,
 };
 
 #[derive(Clone, Debug, Serialize)]
@@ -63,6 +65,36 @@ pub(crate) struct UpgradeBatchSummary {
     pub restarted: usize,
     pub failed: usize,
     pub results: Vec<UpgradeEnvSummary>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UpgradeFleetCheckpoint {
+    pub env_name: String,
+    pub snapshot_id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UpgradeFleetError {
+    pub env_name: Option<String>,
+    pub phase: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UpgradeFleetBatchSummary {
+    pub batch_id: String,
+    pub runtime: String,
+    pub envs: Vec<String>,
+    pub parallel: usize,
+    pub failure_policy: String,
+    pub outcome: String,
+    pub journal_path: Option<String>,
+    pub checkpoints: Vec<UpgradeFleetCheckpoint>,
+    pub results: Vec<UpgradeEnvSummary>,
+    pub errors: Vec<UpgradeFleetError>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -164,6 +196,39 @@ enum UpgradeSimulationScenario {
 struct UpgradeOptions {
     dry_run: bool,
     rollback_enabled: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UpgradeFleetFailurePolicy {
+    Rollback,
+    Continue,
+}
+
+impl UpgradeFleetFailurePolicy {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "rollback" => Ok(Self::Rollback),
+            "continue" => Ok(Self::Continue),
+            _ => Err("--failure-policy must be rollback or continue".to_string()),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Rollback => "rollback",
+            Self::Continue => "continue",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct UpgradeFleetOptions {
+    env_names: Vec<String>,
+    runtime: String,
+    parallel: usize,
+    failure_policy: UpgradeFleetFailurePolicy,
+    dry_run: bool,
+    accept_fleet_outage: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -362,6 +427,9 @@ impl Cli {
 
     pub(super) fn handle_upgrade_command(&self, args: Vec<String>) -> Result<i32, String> {
         let (args, json_flag, profile) = self.consume_human_output_flags(args, "upgrade")?;
+        if matches!(args.first().map(String::as_str), Some("batch")) {
+            return self.handle_upgrade_batch(args[1..].to_vec(), json_flag, profile);
+        }
         if matches!(args.first().map(String::as_str), Some("rollback")) {
             return self.handle_upgrade_rollback(args[1..].to_vec(), json_flag, profile);
         }
@@ -510,6 +578,378 @@ impl Cli {
         Ok(if failed { 1 } else { 0 })
     }
 
+    fn handle_upgrade_batch(
+        &self,
+        args: Vec<String>,
+        json_flag: bool,
+        profile: render::RenderProfile,
+    ) -> Result<i32, String> {
+        let options = Self::parse_upgrade_batch_options(args)?;
+        if !options.dry_run && !options.accept_fleet_outage {
+            return Err(
+                "upgrade batch requires --accept-fleet-outage because selected gateways can be unavailable together"
+                    .to_string(),
+            );
+        }
+
+        let _batch_lock = lock_upgrade_batch(&self.env, &self.cwd)?;
+        let mut lock_names = options.env_names.clone();
+        lock_names.sort();
+        let mut transaction_locks = Vec::with_capacity(lock_names.len());
+        let mut operation_locks = Vec::with_capacity(lock_names.len());
+        for env_name in &lock_names {
+            transaction_locks.push(lock_upgrade_transaction(env_name, &self.env, &self.cwd)?);
+            operation_locks.push(self.environment_service().lock_operation(env_name)?);
+        }
+        let target = UpgradeTarget {
+            version: None,
+            channel: None,
+            runtime: Some(options.runtime.clone()),
+        };
+        let preflight_options = UpgradeOptions {
+            dry_run: true,
+            rollback_enabled: options.failure_policy == UpgradeFleetFailurePolicy::Rollback,
+        };
+        let mut preflight = Vec::with_capacity(options.env_names.len());
+        for env_name in &options.env_names {
+            let result = self.upgrade_env_locked(env_name, &target, preflight_options)?;
+            if is_failed_upgrade_outcome(&result.outcome) {
+                return Err(format!(
+                    "upgrade batch preflight failed for env \"{env_name}\": {}",
+                    result
+                        .note
+                        .as_deref()
+                        .unwrap_or("target cannot be upgraded")
+                ));
+            }
+            preflight.push(result);
+        }
+
+        let batch_id = new_upgrade_batch_id();
+        let journal_path = if options.dry_run {
+            None
+        } else {
+            Some(self.upgrade_batch_journal_path(&batch_id)?)
+        };
+        let mut summary = UpgradeFleetBatchSummary {
+            batch_id: batch_id.clone(),
+            runtime: options.runtime.clone(),
+            envs: options.env_names.clone(),
+            parallel: options.parallel,
+            failure_policy: options.failure_policy.as_str().to_string(),
+            outcome: if options.dry_run {
+                "dry-run".to_string()
+            } else {
+                "preparing".to_string()
+            },
+            journal_path: journal_path.as_deref().map(display_path),
+            checkpoints: Vec::new(),
+            results: if options.dry_run {
+                preflight
+            } else {
+                Vec::new()
+            },
+            errors: Vec::new(),
+        };
+
+        if options.dry_run {
+            return self.finish_upgrade_batch(summary, json_flag, profile);
+        }
+        let journal_path = journal_path.expect("live batch journal path");
+        self.save_upgrade_batch_journal(&journal_path, &summary)?;
+
+        let checkpoint_label = format!("fast-batch-{batch_id}");
+        let checkpoint_results = self.run_parallel_batch_work(
+            &options.env_names,
+            options.parallel,
+            move |cli, env_name| {
+                cli.create_upgrade_batch_checkpoint_locked(env_name, &checkpoint_label)
+            },
+        );
+        for (env_name, result) in checkpoint_results {
+            match result {
+                Ok(snapshot) => summary.checkpoints.push(UpgradeFleetCheckpoint {
+                    env_name,
+                    snapshot_id: snapshot.id,
+                }),
+                Err(error) => summary.errors.push(UpgradeFleetError {
+                    env_name: Some(env_name),
+                    phase: "snapshot".to_string(),
+                    message: error,
+                }),
+            }
+        }
+        for env_name in &options.env_names {
+            let recorded = summary
+                .checkpoints
+                .iter()
+                .any(|checkpoint| &checkpoint.env_name == env_name)
+                || summary
+                    .errors
+                    .iter()
+                    .any(|error| error.env_name.as_ref() == Some(env_name));
+            if !recorded {
+                summary.errors.push(UpgradeFleetError {
+                    env_name: Some(env_name.clone()),
+                    phase: "snapshot".to_string(),
+                    message: "snapshot worker exited without a result".to_string(),
+                });
+            }
+        }
+        sort_batch_checkpoints(&mut summary.checkpoints, &options.env_names);
+        if !summary.errors.is_empty() {
+            summary.outcome = "snapshot-failed".to_string();
+            self.save_upgrade_batch_journal(&journal_path, &summary)?;
+            return self.finish_upgrade_batch(summary, json_flag, profile);
+        }
+
+        summary.outcome = "snapshotted".to_string();
+        self.save_upgrade_batch_journal(&journal_path, &summary)?;
+
+        let target_for_workers = target.clone();
+        let failure_policy = options.failure_policy;
+        let upgrade_results = self.run_parallel_batch_work(
+            &options.env_names,
+            options.parallel,
+            move |cli, env_name| {
+                let result = cli.upgrade_env_locked(
+                    env_name,
+                    &target_for_workers,
+                    UpgradeOptions {
+                        dry_run: false,
+                        rollback_enabled: failure_policy == UpgradeFleetFailurePolicy::Rollback,
+                    },
+                );
+                match result {
+                    Ok(mut result)
+                        if failure_policy == UpgradeFleetFailurePolicy::Continue
+                            && is_failed_upgrade_outcome(&result.outcome) =>
+                    {
+                        let stop_note = match cli.service_service().stop_locked(env_name) {
+                            Ok(_) => {
+                                "failure policy left the gateway stopped for external recovery"
+                                    .to_string()
+                            }
+                            Err(error) => format!(
+                                "failed to leave the gateway stopped for external recovery: {error}"
+                            ),
+                        };
+                        result.note = join_optional_warnings(result.note, Some(stop_note));
+                        Ok(result)
+                    }
+                    other => other,
+                }
+            },
+        );
+        for (env_name, result) in upgrade_results {
+            match result {
+                Ok(result) => summary.results.push(result),
+                Err(error) => summary.errors.push(UpgradeFleetError {
+                    env_name: Some(env_name),
+                    phase: "upgrade".to_string(),
+                    message: error,
+                }),
+            }
+        }
+        for env_name in &options.env_names {
+            let recorded = summary
+                .results
+                .iter()
+                .any(|result| &result.env_name == env_name)
+                || summary
+                    .errors
+                    .iter()
+                    .any(|error| error.env_name.as_ref() == Some(env_name));
+            if !recorded {
+                summary.errors.push(UpgradeFleetError {
+                    env_name: Some(env_name.clone()),
+                    phase: "upgrade".to_string(),
+                    message: "upgrade worker exited without a result".to_string(),
+                });
+            }
+        }
+        sort_batch_results(&mut summary.results, &options.env_names);
+        let failed = summary
+            .results
+            .iter()
+            .any(|result| is_failed_upgrade_outcome(&result.outcome))
+            || !summary.errors.is_empty();
+        summary.outcome = if failed {
+            "partial".to_string()
+        } else {
+            "completed".to_string()
+        };
+        self.save_upgrade_batch_journal(&journal_path, &summary)?;
+        self.finish_upgrade_batch(summary, json_flag, profile)
+    }
+
+    fn parse_upgrade_batch_options(args: Vec<String>) -> Result<UpgradeFleetOptions, String> {
+        let (args, dry_run) = Self::consume_flag(args, "--dry-run");
+        let (args, accept_fleet_outage) = Self::consume_flag(args, "--accept-fleet-outage");
+        let (args, envs) = Self::consume_option(args, "--envs")?;
+        let envs = Self::require_option_value(envs, "--envs")?
+            .ok_or_else(|| "upgrade batch requires --envs".to_string())?;
+        let (args, runtime) = Self::consume_option(args, "--runtime")?;
+        let runtime = Self::require_option_value(runtime, "--runtime")?
+            .ok_or_else(|| "upgrade batch requires --runtime".to_string())?;
+        let (args, parallel) = Self::consume_option(args, "--parallel")?;
+        let parallel = Self::require_option_value(parallel, "--parallel")?
+            .map(|value| {
+                value
+                    .parse::<usize>()
+                    .map_err(|_| "--parallel must be a positive integer".to_string())
+            })
+            .transpose()?;
+        let (args, failure_policy) = Self::consume_option(args, "--failure-policy")?;
+        let failure_policy = match Self::require_option_value(failure_policy, "--failure-policy")? {
+            Some(value) => UpgradeFleetFailurePolicy::parse(&value)?,
+            None => UpgradeFleetFailurePolicy::Continue,
+        };
+        Self::assert_no_extra_args(&args)?;
+
+        let mut seen = BTreeSet::new();
+        let env_names = envs
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string())
+            .filter(|value| seen.insert(value.clone()))
+            .collect::<Vec<_>>();
+        if env_names.len() < 2 {
+            return Err("upgrade batch requires at least two unique environments".to_string());
+        }
+        let parallel = parallel.unwrap_or_else(|| env_names.len().min(4));
+        if parallel == 0 {
+            return Err("--parallel must be a positive integer".to_string());
+        }
+        if parallel > env_names.len() {
+            return Err("--parallel cannot exceed the number of selected environments".to_string());
+        }
+
+        Ok(UpgradeFleetOptions {
+            env_names,
+            runtime,
+            parallel,
+            failure_policy,
+            dry_run,
+            accept_fleet_outage,
+        })
+    }
+
+    fn create_upgrade_batch_checkpoint_locked(
+        &self,
+        env_name: &str,
+        label: &str,
+    ) -> Result<EnvSnapshotSummary, String> {
+        let prepared = self
+            .environment_service()
+            .prepare_snapshot_capture_locked(env_name)?;
+        let service_state = self
+            .service_service()
+            .quiesce_for_snapshot_locked(env_name)?;
+        let snapshot_result = self
+            .environment_service()
+            .create_snapshot_locked_from_preparation(
+                CreateEnvSnapshotOptions {
+                    env_name: env_name.to_string(),
+                    label: Some(label.to_string()),
+                },
+                service_state.map(|state| (state.enabled, state.running)),
+                prepared,
+            );
+        let service_result = self
+            .service_service()
+            .restore_after_snapshot_locked(env_name, service_state);
+        match (snapshot_result, service_result) {
+            (Ok(snapshot), Ok(())) => Ok(snapshot),
+            (Ok(snapshot), Err(service_error)) => Err(format!(
+                "snapshot {} was created, but the managed service could not be restored: {service_error}",
+                snapshot.id
+            )),
+            (Err(snapshot_error), Ok(())) => Err(snapshot_error),
+            (Err(snapshot_error), Err(service_error)) => Err(format!(
+                "{snapshot_error}; also failed to restore the managed service after snapshot capture: {service_error}"
+            )),
+        }
+    }
+
+    fn run_parallel_batch_work<T, F>(
+        &self,
+        env_names: &[String],
+        parallel: usize,
+        work: F,
+    ) -> Vec<(String, Result<T, String>)>
+    where
+        T: Send + 'static,
+        F: Fn(&Cli, &str) -> Result<T, String> + Send + Sync + 'static,
+    {
+        let queue = Arc::new(Mutex::new(VecDeque::from(env_names.to_vec())));
+        let work = Arc::new(work);
+        let (sender, receiver) = mpsc::channel();
+        let mut workers = Vec::with_capacity(parallel);
+
+        for _ in 0..parallel {
+            let queue = Arc::clone(&queue);
+            let work = Arc::clone(&work);
+            let sender = sender.clone();
+            let env = self.env.clone();
+            let cwd = self.cwd.clone();
+            workers.push(thread::spawn(move || {
+                loop {
+                    let env_name = match queue.lock() {
+                        Ok(mut queue) => queue.pop_front(),
+                        Err(_) => None,
+                    };
+                    let Some(env_name) = env_name else {
+                        break;
+                    };
+                    let cli = Cli {
+                        env: env.clone(),
+                        cwd: cwd.clone(),
+                    };
+                    let result = work(&cli, &env_name);
+                    let _ = sender.send((env_name, result));
+                }
+            }));
+        }
+        drop(sender);
+        for worker in workers {
+            let _ = worker.join();
+        }
+        receiver.into_iter().collect()
+    }
+
+    fn upgrade_batch_journal_path(&self, batch_id: &str) -> Result<PathBuf, String> {
+        let dir = ensure_store(&self.env, &self.cwd)?
+            .home
+            .join("upgrade-batches");
+        fs::create_dir_all(&dir).map_err(|error| error.to_string())?;
+        Ok(dir.join(format!("{batch_id}.json")))
+    }
+
+    fn save_upgrade_batch_journal(
+        &self,
+        path: &Path,
+        summary: &UpgradeFleetBatchSummary,
+    ) -> Result<(), String> {
+        write_json(path, summary)
+    }
+
+    fn finish_upgrade_batch(
+        &self,
+        summary: UpgradeFleetBatchSummary,
+        json_flag: bool,
+        profile: render::RenderProfile,
+    ) -> Result<i32, String> {
+        let failed = matches!(summary.outcome.as_str(), "partial" | "snapshot-failed");
+        if json_flag {
+            self.print_json(&summary)?;
+        } else {
+            self.stdout_lines(render::upgrade::upgrade_fleet_batch(&summary, profile));
+        }
+        Ok(if failed { 1 } else { 0 })
+    }
+
     fn handle_upgrade_rollback(
         &self,
         args: Vec<String>,
@@ -524,6 +964,7 @@ impl Cli {
         };
         Self::assert_no_extra_args(&args[1..])?;
 
+        let _batch_lock = lock_upgrade_participant(&self.env, &self.cwd)?;
         let summary =
             self.rollback_completed_upgrade(env_name, transaction_id.as_deref(), dry_run)?;
         let failed = matches!(summary.outcome.as_str(), "failed" | "rollback-failed");
@@ -1728,6 +2169,16 @@ impl Cli {
     }
 
     fn upgrade_env(
+        &self,
+        name: &str,
+        target: &UpgradeTarget,
+        options: UpgradeOptions,
+    ) -> Result<UpgradeEnvSummary, String> {
+        let _batch_lock = lock_upgrade_participant(&self.env, &self.cwd)?;
+        self.upgrade_env_in_batch(name, target, options)
+    }
+
+    fn upgrade_env_in_batch(
         &self,
         name: &str,
         target: &UpgradeTarget,
@@ -4743,6 +5194,29 @@ fn service_action_for_dry_run(
     } else {
         Some("would-start".to_string())
     }
+}
+
+fn new_upgrade_batch_id() -> String {
+    let now = time::OffsetDateTime::now_utc();
+    format!("{}-{:09}", now.unix_timestamp(), now.nanosecond())
+}
+
+fn sort_batch_checkpoints(checkpoints: &mut [UpgradeFleetCheckpoint], env_names: &[String]) {
+    checkpoints.sort_by_key(|checkpoint| {
+        env_names
+            .iter()
+            .position(|env_name| env_name == &checkpoint.env_name)
+            .unwrap_or(usize::MAX)
+    });
+}
+
+fn sort_batch_results(results: &mut [UpgradeEnvSummary], env_names: &[String]) {
+    results.sort_by_key(|result| {
+        env_names
+            .iter()
+            .position(|env_name| env_name == &result.env_name)
+            .unwrap_or(usize::MAX)
+    });
 }
 
 fn is_changed_upgrade_outcome(outcome: &str) -> bool {

--- a/src/store/common.rs
+++ b/src/store/common.rs
@@ -34,6 +34,16 @@ impl Drop for ExclusiveFileLock {
     }
 }
 
+pub(crate) struct SharedFileLock {
+    file: File,
+}
+
+impl Drop for SharedFileLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
 pub(crate) fn lock_file(path: &Path, label: &str) -> Result<ExclusiveFileLock, String> {
     if let Some(parent) = path.parent() {
         ensure_dir(parent)?;
@@ -52,6 +62,26 @@ pub(crate) fn lock_file(path: &Path, label: &str) -> Result<ExclusiveFileLock, S
         )
     })?;
     Ok(ExclusiveFileLock { file })
+}
+
+pub(crate) fn lock_file_shared(path: &Path, label: &str) -> Result<SharedFileLock, String> {
+    if let Some(parent) = path.parent() {
+        ensure_dir(parent)?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| format!("failed to open {label} lock at {}: {error}", path.display()))?;
+    FileExt::lock_shared(&file).map_err(|error| {
+        format!(
+            "failed to acquire shared {label} lock at {}: {error}",
+            path.display()
+        )
+    })?;
+    Ok(SharedFileLock { file })
 }
 
 pub(crate) fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), String> {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -96,8 +96,9 @@ pub use upgrade_history::{
     get_upgrade_history_record, list_upgrade_history, save_upgrade_history_record,
 };
 pub(crate) use upgrade_history::{
-    UpgradeRuntimeRecovery, get_upgrade_runtime_recovery, lock_upgrade_transaction,
-    remove_upgrade_recovery, remove_upgrade_recovery_for_snapshot,
+    UpgradeRuntimeRecovery, get_upgrade_runtime_recovery, lock_upgrade_batch,
+    lock_upgrade_participant, lock_upgrade_transaction, remove_upgrade_recovery,
+    remove_upgrade_recovery_for_snapshot,
 };
 
 pub fn now_utc() -> OffsetDateTime {

--- a/src/store/upgrade_history.rs
+++ b/src/store/upgrade_history.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use super::common::{
-    ExclusiveFileLock, load_json_files, lock_file, path_exists, read_json, write_json,
+    ExclusiveFileLock, SharedFileLock, load_json_files, lock_file, lock_file_shared, path_exists,
+    read_json, write_json,
 };
 use super::layout::{
     display_path, runtime_install_root, upgrade_history_env_dir, upgrade_history_meta_path,
@@ -173,6 +174,28 @@ pub(crate) fn lock_upgrade_transaction(
         .join("upgrades")
         .join(format!("{env_name}.lock"));
     lock_file(&path, "upgrade transaction")
+}
+
+fn upgrade_batch_lock_path(env: &BTreeMap<String, String>, cwd: &Path) -> Result<PathBuf, String> {
+    Ok(super::ensure_store(env, cwd)?
+        .home
+        .join("locks")
+        .join("upgrades")
+        .join("batch.lock"))
+}
+
+pub(crate) fn lock_upgrade_batch(
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<ExclusiveFileLock, String> {
+    lock_file(&upgrade_batch_lock_path(env, cwd)?, "upgrade batch")
+}
+
+pub(crate) fn lock_upgrade_participant(
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<SharedFileLock, String> {
+    lock_file_shared(&upgrade_batch_lock_path(env, cwd)?, "upgrade batch")
 }
 
 pub(crate) fn get_upgrade_runtime_recovery(
@@ -383,8 +406,8 @@ mod tests {
         RuntimeMeta, RuntimeSourceKind, UpgradeHistoryBinding, UpgradeHistoryPhaseTiming,
         UpgradeHistoryRecord, UpgradeHistoryRuntimeRecovery, UpgradeHistoryServiceState,
         UpgradeHistoryStage, get_upgrade_history_record, get_upgrade_runtime_recovery,
-        list_upgrade_history, lock_upgrade_transaction, runtime_install_root,
-        save_upgrade_history_record, write_json,
+        list_upgrade_history, lock_upgrade_batch, lock_upgrade_participant,
+        lock_upgrade_transaction, runtime_install_root, save_upgrade_history_record, write_json,
     };
     use crate::store::layout::upgrade_history_runtime_recovery_dir;
 
@@ -703,6 +726,31 @@ mod tests {
                 .is_err()
         );
         drop(first);
+        acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        waiter.join().unwrap();
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn upgrade_batch_lock_blocks_regular_upgrade_participants() {
+        let (root, env) = test_env("batch-lock");
+        let cwd = root.as_path();
+        let batch = lock_upgrade_batch(&env, cwd).unwrap();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let thread_env = env.clone();
+        let thread_cwd = root.clone();
+        let waiter = thread::spawn(move || {
+            let _participant = lock_upgrade_participant(&thread_env, thread_cwd.as_path()).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        assert!(
+            acquired_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err()
+        );
+        drop(batch);
         acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap();
         waiter.join().unwrap();
 

--- a/tests/cli_validation_tests.rs
+++ b/tests/cli_validation_tests.rs
@@ -335,6 +335,71 @@ fn env_snapshot_prune_validates_scope_and_numeric_values() {
 }
 
 #[test]
+fn upgrade_batch_requires_explicit_scope_runtime_and_outage_acknowledgement() {
+    let root = TestDir::new("cli-upgrade-batch-validation");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+
+    let missing_envs = run_ocm(&cwd, &env, &["upgrade", "batch", "--runtime", "target"]);
+    assert_eq!(missing_envs.status.code(), Some(1));
+    assert!(stderr(&missing_envs).contains("upgrade batch requires --envs"));
+
+    let missing_runtime = run_ocm(&cwd, &env, &["upgrade", "batch", "--envs", "alpha,beta"]);
+    assert_eq!(missing_runtime.status.code(), Some(1));
+    assert!(stderr(&missing_runtime).contains("upgrade batch requires --runtime"));
+
+    let one_env = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "batch",
+            "--runtime",
+            "target",
+            "--envs",
+            "alpha",
+            "--accept-fleet-outage",
+        ],
+    );
+    assert_eq!(one_env.status.code(), Some(1));
+    assert!(stderr(&one_env).contains("at least two unique environments"));
+
+    let zero_parallel = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "batch",
+            "--runtime",
+            "target",
+            "--envs",
+            "alpha,beta",
+            "--parallel",
+            "0",
+            "--accept-fleet-outage",
+        ],
+    );
+    assert_eq!(zero_parallel.status.code(), Some(1));
+    assert!(stderr(&zero_parallel).contains("--parallel must be a positive integer"));
+
+    let missing_ack = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "batch",
+            "--runtime",
+            "target",
+            "--envs",
+            "alpha,beta",
+        ],
+    );
+    assert_eq!(missing_ack.status.code(), Some(1));
+    assert!(stderr(&missing_ack).contains("--accept-fleet-outage"));
+}
+
+#[test]
 fn env_doctor_requires_a_name() {
     let root = TestDir::new("cli-env-doctor-validation");
     let cwd = root.child("workspace");

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -276,6 +276,9 @@ fn upgrade_help_is_available_from_help_and_flag() {
     assert!(output.contains("--dry-run"));
     assert!(output.contains("--no-rollback"));
     assert!(output.contains("ocm upgrade --all"));
+    assert!(output.contains("ocm upgrade batch --runtime <runtime> --envs <env,env,...>"));
+    assert!(output.contains("--accept-fleet-outage"));
+    assert!(output.contains("cold checkpoint for every selected environment"));
     assert!(output.contains("Simulations clone the source env"));
     assert!(output.contains("Channel-tracked runtimes move forward automatically."));
     assert!(output.contains("older targets are rejected before snapshot creation"));

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -282,6 +282,34 @@ case "$1" in
         echo "forced update finalize failure" >&2
         exit 23
       fi
+      if [ -n "${{OCM_TEST_FAIL_UPDATE_FINALIZE_ENV:-}}" ] &&
+         [ "$OCM_TEST_FAIL_UPDATE_FINALIZE_ENV" = "${{OCM_ACTIVE_ENV:-}}" ]; then
+        echo "forced update finalize failure for $OCM_ACTIVE_ENV" >&2
+        exit 23
+      fi
+      if [ -n "${{OCM_TEST_REQUIRE_BATCH_SNAPSHOT_ENVS:-}}" ]; then
+        for batch_env in $(printf '%s' "$OCM_TEST_REQUIRE_BATCH_SNAPSHOT_ENVS" | tr ',' ' '); do
+          snapshot_dir="${{OCM_HOME:?}}/snapshots/$batch_env"
+          if ! grep -R -q '"label": "fast-batch-' "$snapshot_dir" 2>/dev/null; then
+            echo "batch snapshot barrier missing for $batch_env" >&2
+            exit 25
+          fi
+        done
+      fi
+      if [ -n "${{OCM_TEST_BATCH_FINALIZE_BARRIER_DIR:-}}" ]; then
+        mkdir -p "$OCM_TEST_BATCH_FINALIZE_BARRIER_DIR"
+        : > "$OCM_TEST_BATCH_FINALIZE_BARRIER_DIR/${{OCM_ACTIVE_ENV:?}}"
+        expected="${{OCM_TEST_BATCH_FINALIZE_BARRIER_COUNT:-1}}"
+        attempts=0
+        while [ "$(find "$OCM_TEST_BATCH_FINALIZE_BARRIER_DIR" -type f | wc -l | tr -d ' ')" -lt "$expected" ]; do
+          attempts=$((attempts + 1))
+          if [ "$attempts" -ge 100 ]; then
+            echo "parallel finalize barrier timed out" >&2
+            exit 26
+          fi
+          sleep 0.05
+        done
+      fi
       has_arg "--json" "$@" && has_arg "--yes" "$@" && has_arg "--no-restart" "$@" || {{
         echo "missing update finalize flags" >&2
         exit 1
@@ -5128,6 +5156,266 @@ fn upgrade_keeps_a_stopped_installed_service_stopped() {
     assert!(output.contains("from=launcher:hacking.local"), "{output}");
     assert!(output.contains("to=runtime:stable"), "{output}");
     assert!(!output.contains("service="), "{output}");
+}
+
+#[test]
+fn upgrade_batch_dry_run_creates_no_journal_snapshot_or_runtime_change() {
+    let root = TestDir::new("upgrade-fast-batch-dry-run");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("2026.8.1"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("2026.8.2"));
+
+    let env = ocm_env(&root);
+    for (name, runtime) in [("old", &old_runtime), ("new", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &["runtime", "add", name, "--path", &path_string(runtime)],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+    for env_name in ["alpha", "beta"] {
+        let start = run_ocm(
+            &cwd,
+            &env,
+            &["start", env_name, "--runtime", "old", "--no-service"],
+        );
+        assert!(start.status.success(), "{}", stderr(&start));
+    }
+
+    let batch = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "batch",
+            "--runtime",
+            "new",
+            "--envs",
+            "alpha,beta",
+            "--dry-run",
+            "--json",
+        ],
+    );
+    assert!(batch.status.success(), "{}", stderr(&batch));
+    let summary: Value = serde_json::from_str(&stdout(&batch)).unwrap();
+    assert_eq!(summary["outcome"], "dry-run");
+    assert!(summary["journalPath"].is_null());
+    assert!(!root.child("ocm-home/upgrade-batches").exists());
+
+    let snapshots = run_ocm(&cwd, &env, &["env", "snapshot", "list", "--all", "--json"]);
+    assert!(snapshots.status.success(), "{}", stderr(&snapshots));
+    assert!(
+        serde_json::from_str::<Value>(&stdout(&snapshots))
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    for env_name in ["alpha", "beta"] {
+        let shown = run_ocm(&cwd, &env, &["env", "show", env_name, "--json"]);
+        assert_eq!(
+            serde_json::from_str::<Value>(&stdout(&shown)).unwrap()["defaultRuntime"],
+            "old"
+        );
+    }
+}
+
+#[test]
+fn upgrade_batch_snapshots_every_selected_env_before_parallel_runtime_switches() {
+    let root = TestDir::new("upgrade-fast-batch");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("2026.8.1"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("2026.8.2"));
+
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_TEST_REQUIRE_BATCH_SNAPSHOT_ENVS".to_string(),
+        "alpha,beta".to_string(),
+    );
+    env.insert(
+        "OCM_TEST_BATCH_FINALIZE_BARRIER_DIR".to_string(),
+        path_string(&root.child("batch-finalize-barrier")),
+    );
+    env.insert(
+        "OCM_TEST_BATCH_FINALIZE_BARRIER_COUNT".to_string(),
+        "2".to_string(),
+    );
+    for (name, runtime) in [("old", &old_runtime), ("new", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &["runtime", "add", name, "--path", &path_string(runtime)],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+    for env_name in ["alpha", "beta", "rescue"] {
+        let start = run_ocm(
+            &cwd,
+            &env,
+            &["start", env_name, "--runtime", "old", "--no-service"],
+        );
+        assert!(start.status.success(), "{}", stderr(&start));
+    }
+
+    let batch = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "batch",
+            "--runtime",
+            "new",
+            "--envs",
+            "alpha,beta",
+            "--parallel",
+            "2",
+            "--failure-policy",
+            "continue",
+            "--accept-fleet-outage",
+            "--json",
+        ],
+    );
+    assert!(
+        batch.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&batch),
+        stderr(&batch)
+    );
+    let summary: Value = serde_json::from_str(&stdout(&batch)).unwrap();
+    assert_eq!(summary["outcome"], "completed");
+    assert_eq!(summary["parallel"], 2);
+    assert_eq!(summary["checkpoints"].as_array().unwrap().len(), 2);
+    assert_eq!(summary["results"].as_array().unwrap().len(), 2);
+    let journal = PathBuf::from(summary["journalPath"].as_str().unwrap());
+    assert!(journal.exists());
+    let journal: Value = serde_json::from_slice(&fs::read(journal).unwrap()).unwrap();
+    assert_eq!(journal["outcome"], "completed");
+
+    for env_name in ["alpha", "beta", "rescue"] {
+        let shown = run_ocm(&cwd, &env, &["env", "show", env_name, "--json"]);
+        assert!(shown.status.success(), "{}", stderr(&shown));
+        let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+        let expected = if env_name == "rescue" { "old" } else { "new" };
+        assert_eq!(shown["defaultRuntime"], expected);
+    }
+
+    let all_snapshots = run_ocm(&cwd, &env, &["env", "snapshot", "list", "--all", "--json"]);
+    assert!(all_snapshots.status.success(), "{}", stderr(&all_snapshots));
+    let all_snapshots: Value = serde_json::from_str(&stdout(&all_snapshots)).unwrap();
+    assert!(all_snapshots.as_array().unwrap().iter().any(|snapshot| {
+        snapshot["envName"] == "alpha"
+            && snapshot["label"]
+                .as_str()
+                .is_some_and(|label| label.starts_with("fast-batch-"))
+    }));
+    assert!(all_snapshots.as_array().unwrap().iter().any(|snapshot| {
+        snapshot["envName"] == "beta"
+            && snapshot["label"]
+                .as_str()
+                .is_some_and(|label| label.starts_with("fast-batch-"))
+    }));
+    assert!(
+        !all_snapshots
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|snapshot| snapshot["envName"] == "rescue")
+    );
+}
+
+#[test]
+fn upgrade_batch_continue_finishes_other_envs_and_leaves_failure_for_external_recovery() {
+    let root = TestDir::new("upgrade-fast-batch-continue");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("2026.8.1"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("2026.8.2"));
+
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_TEST_FAIL_UPDATE_FINALIZE_ENV".to_string(),
+        "alpha".to_string(),
+    );
+    for (name, runtime) in [("old", &old_runtime), ("new", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &["runtime", "add", name, "--path", &path_string(runtime)],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+    for env_name in ["alpha", "beta"] {
+        let start = run_ocm(
+            &cwd,
+            &env,
+            &["start", env_name, "--runtime", "old", "--no-service"],
+        );
+        assert!(start.status.success(), "{}", stderr(&start));
+    }
+
+    let batch = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "batch",
+            "--runtime",
+            "new",
+            "--envs",
+            "alpha,beta",
+            "--parallel",
+            "2",
+            "--failure-policy",
+            "continue",
+            "--accept-fleet-outage",
+            "--json",
+        ],
+    );
+    assert_eq!(batch.status.code(), Some(1));
+    let summary: Value = serde_json::from_str(&stdout(&batch)).unwrap();
+    assert_eq!(summary["outcome"], "partial");
+    assert_eq!(summary["checkpoints"].as_array().unwrap().len(), 2);
+    let results = summary["results"].as_array().unwrap();
+    let alpha = results
+        .iter()
+        .find(|result| result["envName"] == "alpha")
+        .unwrap();
+    let beta = results
+        .iter()
+        .find(|result| result["envName"] == "beta")
+        .unwrap();
+    assert_eq!(alpha["outcome"], "failed");
+    assert_eq!(alpha["rollback"], "disabled");
+    assert!(
+        alpha["note"]
+            .as_str()
+            .unwrap()
+            .contains("left the gateway stopped for external recovery")
+    );
+    assert_eq!(beta["outcome"], "switched");
+
+    let alpha_env = run_ocm(&cwd, &env, &["env", "show", "alpha", "--json"]);
+    let beta_env = run_ocm(&cwd, &env, &["env", "show", "beta", "--json"]);
+    assert_eq!(
+        serde_json::from_str::<Value>(&stdout(&alpha_env)).unwrap()["defaultRuntime"],
+        "old"
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(&stdout(&beta_env)).unwrap()["defaultRuntime"],
+        "new"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What Problem This Solves

Operators updating several OpenClaw gateways must currently run complete upgrades serially, even when every environment will use the same already-installed runtime. The repeated snapshot, finalization, restart, and verification windows make fleet rollouts unnecessarily long.

## Why This Change Was Made

Adds an explicit `ocm upgrade batch` mode that coordinates selected environments under one exclusive batch lock. It creates a cold checkpoint for every selected environment before any transition, then performs bounded parallel per-environment upgrades while preserving existing upgrade history and rollback behavior.

This is deliberately opt-in and requires `--accept-fleet-outage`. Environments are always selected explicitly, so a recovery gateway can remain outside the batch.

## User Impact

Operators can update a selected gateway fleet concurrently:

```bash
ocm upgrade batch \
  --runtime origin-main-local \
  --envs clawpatrol,personal,openclaw,main \
  --parallel 4 \
  --failure-policy continue \
  --accept-fleet-outage
```

The normal single-environment and serial `--all` workflows are unchanged.

## Evidence

- 323 library tests passed.
- 33 CLI validation tests passed.
- 32 help tests passed.
- 51 upgrade tests passed, including:
  - dry-run creates no state
  - every selected checkpoint exists before finalizers proceed
  - finalizers overlap at the configured concurrency
  - excluded environments remain unchanged
  - `continue` completes healthy environments and leaves failures stopped
- 33 daemon isolation tests passed.
- Release build passed.
- `cargo clippy --lib --bins -- -D warnings -A clippy::too_many_arguments` passed.
- One existing service fixture race and one availability timing test failed only during full-suite load; both passed in isolation.
