### PR TITLE
fix(snapshot): creation no longer returns while gateway is pending

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -204,8 +204,24 @@ impl<'a> ServiceService<'a> {
                 return Ok(());
             }
             self.start_locked(name)?;
+            self.wait_for_snapshot_running_state_locked(name)?;
         }
         Ok(())
+    }
+
+    fn wait_for_snapshot_running_state_locked(&self, name: &str) -> Result<(), String> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if self.status(name)?.running {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "supervisor did not restore the running service state for env \"{name}\" after snapshot maintenance"
+                ));
+            }
+            sleep(Duration::from_millis(25));
+        }
     }
 
     pub fn restart(&self, name: &str) -> Result<ServiceActionSummary, String> {

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -13,8 +13,8 @@ use ocm::supervisor::{SupervisorService, sync_supervisor_binding_if_present};
 use serde_json::{Value, to_value};
 
 use crate::support::{
-    TestDir, install_fake_launchctl, install_fake_systemd_tools, ocm_env, path_string, run_ocm,
-    stderr, stdout, write_executable_script,
+    TestDir, install_fake_launchctl, install_fake_systemd_tools, ocm_env, ocm_test_binary_path,
+    path_string, run_ocm, stderr, stdout, write_executable_script,
 };
 
 static DAEMON_RUNTIME_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -26,7 +26,7 @@ fn daemon_runtime_test_lock() -> MutexGuard<'static, ()> {
 }
 
 fn spawn_daemon_process(cwd: &Path, env: &BTreeMap<String, String>) -> Child {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    let mut command = Command::new(ocm_test_binary_path());
     command.current_dir(cwd);
     command.args(["__daemon", "run"]);
     command.env_clear();
@@ -670,6 +670,294 @@ fn snapshot_restore_preserves_running_sibling_despite_unrelated_drift() {
         1,
         "target snapshot restore restarted the sibling"
     );
+
+    stop_process(&mut daemon);
+}
+
+#[test]
+fn snapshot_create_preserves_all_running_siblings_and_restores_target() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("snapshot-create-preserves-supervisor-siblings");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+    let env_names = ["target", "sibling-a", "sibling-b", "sibling-c", "sibling-d"];
+
+    for env_name in env_names {
+        let runtime_name = format!("{env_name}-runtime");
+        let runtime = root.child(format!("bin/{runtime_name}"));
+        let started = root.child(format!("{env_name}-started"));
+        let stopped = root.child(format!("{env_name}-stopped"));
+        write_upgrade_aware_gateway_script(&runtime, "2026.8.1", &started, &stopped, false);
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                &runtime_name,
+                "--path",
+                &path_string(&runtime),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+        let create = run_ocm(
+            &cwd,
+            &env,
+            &["env", "create", env_name, "--runtime", &runtime_name],
+        );
+        assert!(create.status.success(), "{}", stderr(&create));
+        set_service_enabled(&cwd, &env, env_name, true);
+    }
+
+    service.sync().unwrap();
+    service.install_daemon().unwrap();
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let initial_runtime =
+        wait_for_runtime_children(&runtime_path, env_names.len(), None, Duration::from_secs(5))
+            .expect("daemon runtime state did not report the complete fixture");
+    for env_name in env_names {
+        assert!(
+            wait_for_file(
+                &root.child(format!("{env_name}-started")),
+                Duration::from_secs(5)
+            ),
+            "{env_name} did not enter its gateway loop"
+        );
+    }
+    let initial_target_pid = runtime_child_pid(&initial_runtime, "target").unwrap();
+    let initial_siblings = env_names[1..]
+        .iter()
+        .map(|name| {
+            (
+                *name,
+                persisted_child(&state_path, name),
+                runtime_child(&initial_runtime, name),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for env_name in &env_names[1..] {
+        let runtime_meta_path = root.child(format!("ocm-home/runtimes/{env_name}-runtime.json"));
+        let mut runtime_meta = read_persisted_service_state(&runtime_meta_path);
+        runtime_meta["releaseVersion"] = Value::String(format!("latent-{env_name}-drift"));
+        write_persisted_service_state(&runtime_meta_path, &runtime_meta);
+    }
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "snapshot",
+            "create",
+            "target",
+            "--label",
+            "sibling-preservation",
+            "--json",
+        ],
+    );
+    assert!(
+        snapshot.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&snapshot),
+        stderr(&snapshot)
+    );
+    let snapshot: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    assert_eq!(snapshot["serviceEnabled"], true);
+    assert_eq!(snapshot["serviceRunning"], true);
+
+    let final_runtime = read_persisted_service_state(&runtime_path);
+    assert_eq!(
+        final_runtime["children"].as_array().map(Vec::len),
+        Some(env_names.len()),
+        "snapshot creation returned before the complete fleet was running"
+    );
+
+    let target = run_ocm(&cwd, &env, &["env", "show", "target", "--json"]);
+    assert!(target.status.success(), "{}", stderr(&target));
+    let target: Value = serde_json::from_str(&stdout(&target)).unwrap();
+    assert_eq!(target["serviceEnabled"], true);
+    assert_eq!(target["serviceRunning"], true);
+    assert_ne!(
+        runtime_child_pid(&final_runtime, "target"),
+        Some(initial_target_pid),
+        "snapshot target PID did not change across cold capture"
+    );
+    assert_eq!(
+        fs::read_to_string(root.child("target-started"))
+            .unwrap()
+            .lines()
+            .count(),
+        2,
+        "snapshot target was not restarted exactly once"
+    );
+    assert_eq!(
+        fs::read_to_string(root.child("target-stopped"))
+            .unwrap()
+            .lines()
+            .count(),
+        1,
+        "snapshot target was not stopped exactly once"
+    );
+
+    for (env_name, initial_state, initial_child) in initial_siblings {
+        assert_eq!(
+            persisted_child(&state_path, env_name),
+            initial_state,
+            "snapshot creation changed the persisted spec for {env_name}"
+        );
+        assert_eq!(
+            runtime_child(&final_runtime, env_name),
+            initial_child,
+            "snapshot creation changed the PID, binding, or restart state for {env_name}"
+        );
+        assert!(
+            !root.child(format!("{env_name}-stopped")).exists(),
+            "snapshot creation stopped {env_name}"
+        );
+        assert_eq!(
+            fs::read_to_string(root.child(format!("{env_name}-started")))
+                .unwrap()
+                .lines()
+                .count(),
+            1,
+            "snapshot creation restarted {env_name}"
+        );
+    }
+
+    stop_process(&mut daemon);
+}
+
+#[test]
+fn snapshot_create_preserves_stopped_target_and_running_siblings() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("snapshot-create-preserves-stopped-target");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let service = SupervisorService::new(&env, &cwd);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+
+    for env_name in ["target", "sibling-a", "sibling-b"] {
+        let runtime_name = format!("{env_name}-runtime");
+        let runtime = root.child(format!("bin/{runtime_name}"));
+        let started = root.child(format!("{env_name}-started"));
+        let stopped = root.child(format!("{env_name}-stopped"));
+        write_upgrade_aware_gateway_script(&runtime, "2026.8.1", &started, &stopped, false);
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "runtime",
+                "add",
+                &runtime_name,
+                "--path",
+                &path_string(&runtime),
+            ],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+        let create = run_ocm(
+            &cwd,
+            &env,
+            &["env", "create", env_name, "--runtime", &runtime_name],
+        );
+        assert!(create.status.success(), "{}", stderr(&create));
+    }
+    EnvironmentService::new(&env, &cwd)
+        .set_service_policy("target", Some(true), Some(false))
+        .unwrap();
+    for env_name in ["sibling-a", "sibling-b"] {
+        set_service_enabled(&cwd, &env, env_name, true);
+    }
+
+    service.sync().unwrap();
+    service.install_daemon().unwrap();
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let initial_runtime =
+        wait_for_runtime_children(&runtime_path, 2, Some("sibling-a"), Duration::from_secs(5))
+            .expect("daemon runtime state did not report both running siblings");
+    for env_name in ["sibling-a", "sibling-b"] {
+        assert!(wait_for_file(
+            &root.child(format!("{env_name}-started")),
+            Duration::from_secs(5)
+        ));
+    }
+    let initial_siblings = ["sibling-a", "sibling-b"].map(|name| {
+        (
+            name,
+            persisted_child(&state_path, name),
+            runtime_child(&initial_runtime, name),
+        )
+    });
+
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "snapshot",
+            "create",
+            "target",
+            "--label",
+            "stopped-target",
+            "--json",
+        ],
+    );
+    assert!(
+        snapshot.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        stdout(&snapshot),
+        stderr(&snapshot)
+    );
+    let snapshot: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    assert_eq!(snapshot["serviceEnabled"], true);
+    assert_eq!(snapshot["serviceRunning"], false);
+
+    let target = run_ocm(&cwd, &env, &["env", "show", "target", "--json"]);
+    assert!(target.status.success(), "{}", stderr(&target));
+    let target: Value = serde_json::from_str(&stdout(&target)).unwrap();
+    assert_eq!(target["serviceEnabled"], true);
+    assert_eq!(target["serviceRunning"], false);
+    assert!(runtime_child_pid(&read_persisted_service_state(&runtime_path), "target").is_none());
+    assert!(!root.child("target-started").exists());
+    assert!(!root.child("target-stopped").exists());
+
+    let final_runtime = read_persisted_service_state(&runtime_path);
+    for (env_name, initial_state, initial_child) in initial_siblings {
+        assert_eq!(
+            persisted_child(&state_path, env_name),
+            initial_state,
+            "snapshot creation changed the persisted spec for {env_name}"
+        );
+        assert_eq!(
+            runtime_child(&final_runtime, env_name),
+            initial_child,
+            "snapshot creation changed the PID, binding, or restart state for {env_name}"
+        );
+        assert!(!root.child(format!("{env_name}-stopped")).exists());
+        assert_eq!(
+            fs::read_to_string(root.child(format!("{env_name}-started")))
+                .unwrap()
+                .lines()
+                .count(),
+            1
+        );
+    }
 
     stop_process(&mut daemon);
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -727,8 +727,14 @@ pub fn sha512_integrity(body: &[u8]) -> String {
     )
 }
 
+pub fn ocm_test_binary_path() -> PathBuf {
+    std::env::var_os("OCM_TEST_BINARY")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_BIN_EXE_ocm")))
+}
+
 pub fn run_ocm(cwd: &Path, env: &BTreeMap<String, String>, args: &[&str]) -> Output {
-    run_ocm_binary(Path::new(env!("CARGO_BIN_EXE_ocm")), cwd, env, args)
+    run_ocm_binary(&ocm_test_binary_path(), cwd, env, args)
 }
 
 pub fn run_ocm_binary(
@@ -751,7 +757,7 @@ pub fn run_ocm_with_stdin(
     args: &[&str],
     input: &str,
 ) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    let mut command = Command::new(ocm_test_binary_path());
     command.current_dir(cwd);
     command.args(args);
     command.env_clear();

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -4530,6 +4530,11 @@ fn upgrade_rollback_restarts_and_verifies_a_managed_service() {
         ],
     );
     assert!(start.status.success(), "{}", stderr(&start));
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    write_running_supervisor_runtime(&runtime_path, &ocm_home, "old", 4241, health_port);
+    let state_path = supervisor_state_path(&env, &cwd).unwrap();
     let env_show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
     assert!(env_show.status.success(), "{}", stderr(&env_show));
     let env_json: Value = serde_json::from_str(&stdout(&env_show)).unwrap();
@@ -4538,15 +4543,56 @@ fn upgrade_rollback_restarts_and_verifies_a_managed_service() {
     fs::create_dir_all(marker.parent().unwrap()).unwrap();
     fs::write(&marker, "before-upgrade").unwrap();
 
+    let snapshot_observer_done = Arc::new(AtomicBool::new(false));
+    let snapshot_observer_done_thread = Arc::clone(&snapshot_observer_done);
+    let snapshot_runtime_path = runtime_path.clone();
+    let snapshot_ocm_home = ocm_home.clone();
+    let snapshot_state_path = state_path.clone();
+    let snapshot_observer = thread::spawn(move || {
+        let mut observed_running = true;
+        let mut saw_stop = false;
+        let mut saw_start = false;
+        while !snapshot_observer_done_thread.load(Ordering::Relaxed) {
+            let state = fs::read_to_string(&snapshot_state_path).unwrap_or_default();
+            let parsed: Value = serde_json::from_str(&state).unwrap_or(Value::Null);
+            let desired_running = parsed["children"]
+                .as_array()
+                .is_some_and(|children| children.iter().any(|child| child["envName"] == "demo"));
+            if desired_running != observed_running {
+                if desired_running {
+                    write_running_supervisor_runtime(
+                        &snapshot_runtime_path,
+                        &snapshot_ocm_home,
+                        "old",
+                        4242,
+                        health_port,
+                    );
+                    saw_start = true;
+                } else {
+                    write_empty_supervisor_runtime(&snapshot_runtime_path, &snapshot_ocm_home);
+                    saw_stop = true;
+                }
+                observed_running = desired_running;
+            }
+            sleep(Duration::from_millis(5));
+        }
+        (saw_stop, saw_start)
+    });
     let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "demo", "--json"]);
+    snapshot_observer_done.store(true, Ordering::Relaxed);
+    let (snapshot_saw_stop, snapshot_saw_start) = snapshot_observer.join().unwrap();
     assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    assert!(
+        snapshot_saw_stop,
+        "snapshot did not stop the managed service"
+    );
+    assert!(
+        snapshot_saw_start,
+        "snapshot did not restore the managed service"
+    );
     let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
     let snapshot_id = snapshot_json["id"].as_str().unwrap();
-    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
-    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
-    let ocm_home = env.get("OCM_HOME").unwrap().clone();
     write_running_supervisor_runtime(&runtime_path, &ocm_home, "old", 4242, health_port);
-    let state_path = supervisor_state_path(&env, &cwd).unwrap();
     let bind_observer_done = Arc::new(AtomicBool::new(false));
     let bind_observer_done_thread = Arc::clone(&bind_observer_done);
     let bind_runtime_path = runtime_path.clone();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `ocm env snapshot create` could report success while the
target gateway was still pending after snapshot maintenance.

The August 28, 2026 incident created checkpoint
`1787940797-746445000` with the correct running service policy, but Main had
not returned to the supervisor runtime when the command completed.

## Why This Change Was Made

Snapshot service restoration now waits for the supervisor to report the target
gateway running before the operation succeeds. The existing targeted
supervisor reconciliation remains responsible for preserving unrelated
children.

Daemon-backed tests cover a running target with four running siblings,
including latent sibling binding metadata drift, and an intentionally stopped
target with running siblings.

## User Impact

Successful snapshot creation now means a previously running target has actually
returned to running. Sibling gateway PIDs, bindings, restart state, and
persisted service specifications remain unchanged.

## Evidence

- Installed OCM path reproduction:
  `OCM_TEST_BINARY=/Users/hrudolph/.local/bin/ocm cargo test --test daemon_runtime_tests snapshot_create_preserves_all_running_siblings_and_restores_target -- --nocapture`
  failed because snapshot creation returned with four of five runtime children.
- The release-shaped fixed binary passed both focused snapshot-create tests.
- `cargo test --lib`: 322 passed.
- `cargo test --test daemon_runtime_tests`: 35 passed.
- `cargo test --test env_snapshot_tests`: 36 passed.
- `cargo test --test service_command_tests`: 38 passed.
- Progress-output and focused CLI validation tests passed.
- `cargo build --release --locked`, `cargo fmt --check`, and
  `git diff --check` passed.

The historical OpenClaw sibling stop remains causally unresolved because
concurrent snapshot pruning was active and the exact supervisor-state writer
was not retained. The controlled installed-path reproduction preserved all
four sibling PIDs and bindings.

## Worked on by

- @hannesrudolph

OpenClaw-Publication: c9eaf7f5-379d-40a4-b4ce-9c96fed16471
