### PR TITLE
fix(download): cap fetch_json decoded bytes

### DIFF
--- a/src/infra/download.rs
+++ b/src/infra/download.rs
@@ -11,6 +11,9 @@ use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256, Sha512};
 
 const MAX_DOWNLOAD_BYTES: u64 = 512 * 1024 * 1024;
+// JSON is parsed in memory. 64 MiB is above today's official npm packument
+// (~16 MiB) and well below the 512 MiB artifact cap.
+pub const MAX_JSON_BYTES: u64 = 64 * 1024 * 1024;
 const HTTP_PHASE_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ureq carries a recv-response deadline into body reads. Bound the header wait from the
@@ -104,10 +107,13 @@ pub fn fetch_json_with_accept<T: DeserializeOwned>(url: &str, accept: &str) -> R
 }
 
 fn parse_json_reader<T: DeserializeOwned>(
-    reader: Box<dyn io::Read>,
+    mut reader: Box<dyn io::Read>,
     url: &str,
 ) -> Result<T, String> {
-    serde_json::from_reader(reader)
+    let mut body = Vec::new();
+    copy_capped(&mut reader, &mut body, MAX_JSON_BYTES)
+        .map_err(|error| format!("failed to download runtime URL \"{}\": {error}", url.trim()))?;
+    serde_json::from_slice(&body)
         .map_err(|error| format!("failed to parse runtime URL \"{}\": {error}", url.trim()))
 }
 

--- a/tests/download_tests.rs
+++ b/tests/download_tests.rs
@@ -5,8 +5,8 @@ use std::io::Write;
 
 use flate2::{Compression, write::GzEncoder};
 use ocm::infra::download::{
-    artifact_file_name_from_url, download_to_file, fetch_json, fetch_json_with_accept, file_sha256,
-    normalize_sha256, verify_file_sha256,
+    MAX_JSON_BYTES, artifact_file_name_from_url, download_to_file, fetch_json,
+    fetch_json_with_accept, file_sha256, normalize_sha256, verify_file_sha256,
 };
 use serde_json::Value;
 
@@ -154,6 +154,27 @@ fn fetch_json_requests_and_decodes_gzip_responses() {
             .to_ascii_lowercase()
             .contains("accept-encoding: gzip")
     );
+}
+
+#[test]
+fn fetch_json_rejects_a_gzip_decoded_body_past_the_byte_cap() {
+    // One byte past the decoded JSON cap. Compressed on the wire this is a few KB.
+    let mut json = Vec::from(&b"{\"pad\":\""[..]);
+    json.extend(std::iter::repeat(b'x').take(MAX_JSON_BYTES as usize + 1));
+    json.extend_from_slice(b"\"}");
+    let encoded = gzip_bytes(&json);
+    let server = TestHttpServer::serve_bytes_with_headers(
+        "/manifests/releases.json",
+        "application/json",
+        &encoded,
+        &[("Content-Encoding", "gzip")],
+    );
+
+    let error = match fetch_json::<Value>(&server.url()) {
+        Err(error) => error,
+        Ok(_) => panic!("gzip-decoded JSON past the byte cap must be rejected"),
+    };
+    assert!(error.contains("exceeded"), "unexpected error: {error}");
 }
 
 #[test]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `ocm runtime releases`, `ocm runtime install --manifest-url`, or an official npm packument fetch would hang or run the process out of memory when the URL returned a huge, streaming, or gzip-expanded JSON body.

`download_to_file` already rejects bodies over 512 MiB ([#92](https://github.com/openclaw/ocm/pull/92)). `fetch_json` and `fetch_json_with_accept` still request gzip and parse the decoded stream with `serde_json::from_reader` and no decoded-byte cap. A 65 KB gzip payload in this session expanded to 64 MiB plus 11 bytes of JSON.

## Why This Change Was Made

Copy the decoded JSON through the existing `copy_capped` helper into a bounded buffer, then parse that buffer. JSON is kept in memory, so the cap is 64 MiB, which is above today's official `openclaw` npm packument (about 16 MiB) and far below the 512 MiB artifact cap.

## User Impact

A runtime manifest or npm packument that expands past 64 MiB now fails with `download exceeded 67108864 bytes` instead of growing without bound. Official `ocm runtime releases` still lists published OpenClaw versions.

## Evidence

terminal output from the patched `ocm` binary against a local gzip-expanded JSON URL, then against registry.npmjs.org:

A 65,265-byte gzip body decoded to 67,108,875 bytes (11 bytes past the 64 MiB cap). The CLI rejected it:

```console
$ ./target/debug/ocm runtime releases --manifest-url http://127.0.0.1:18765/manifest.json
ocm: failed to download runtime URL "http://127.0.0.1:18765/manifest.json": download exceeded 67108864 bytes
```

The same binary still loaded the official catalog (248 releases) and the stable channel (`2026.7.1-2`).

```console
$ ./target/debug/ocm runtime releases --json
count 248
sample ['2026.9.1-beta.1', '2026.8.1-beta.3', '2026.8.1-beta.2']

$ ./target/debug/ocm runtime releases --channel stable --json
count 1
first 2026.7.1-2
```

## Real behavior proof

- **Behavior or issue addressed:** `fetch_json` accepted unbounded decoded JSON (including gzip-expanded bodies) on `ocm runtime releases` and `--manifest-url` installs. Those commands now reject a body past 64 MiB decoded bytes.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, rustc 1.98.0, ocm 0.2.33 built from this branch at `/tmp/oc-pr-ocm-F003`. Isolated `OCM_HOME` under `/tmp/ocm-f003-proof-ocm`.
- **Exact steps or command run after this patch:**

  Built `./target/debug/ocm`. Served a gzip JSON body of 67,108,875 decoded bytes (65,265 bytes on the wire) from `127.0.0.1:18765`. Then ran `ocm runtime releases --manifest-url http://127.0.0.1:18765/manifest.json`, then `ocm runtime releases --json` and `ocm runtime releases --channel stable --json` against registry.npmjs.org.

- **Evidence after fix:** terminal output from the patched CLI:

  ```console
  $ ./target/debug/ocm runtime releases --manifest-url http://127.0.0.1:18765/manifest.json
  ocm: failed to download runtime URL "http://127.0.0.1:18765/manifest.json": download exceeded 67108864 bytes

  $ ./target/debug/ocm runtime releases --json
  count 248
  sample ['2026.9.1-beta.1', '2026.8.1-beta.3', '2026.8.1-beta.2']
  ```

- **Observed result after fix:** The gzip-expanded manifest URL exits 1 with the decoded-byte cap. The official npm catalog still returns 248 releases.
- **What was not tested:** A live attacker-controlled HTTPS host on the public internet. `ocm self update` GitHub release JSON (that path does not use `fetch_json`).

Related: [#92](https://github.com/openclaw/ocm/pull/92) added ureq timeouts and the `download_to_file` size cap. Gzip request wrapping landed in [`f0b7f2d`](https://github.com/openclaw/ocm/commit/f0b7f2d). `fetch_json` itself dates to [`768baf1`](https://github.com/openclaw/ocm/commit/768baf1). Same class of bound as [rust-lang/cargo#11151](https://github.com/rust-lang/cargo/pull/11151) (unpacked crate size).
