### PR TITLE
fix: local checkout simulations fail during cleanup

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2119,7 +2119,7 @@ impl Cli {
 
         match self
             .environment_service()
-            .remove(&summary.simulation_env, true)
+            .remove_simulation(&summary.simulation_env)
         {
             Ok(_) => {
                 summary.cleanup = "cleaned".to_string();

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -1,8 +1,11 @@
+use std::path::Path;
+
 use serde::{Deserialize, Serialize};
 use time::Duration;
 use time::OffsetDateTime;
 
 use super::EnvironmentService;
+use crate::openclaw_repo::remove_openclaw_simulation_worktree;
 use crate::runtime::RuntimeService;
 use crate::store::{
     EnvironmentOperationLock, clone_environment, clone_environment_for_simulation,
@@ -364,6 +367,19 @@ impl<'a> EnvironmentService<'a> {
         let meta = remove_environment(name, force, self.env, self.cwd)?;
         sync_supervisor_env_if_present(self.env, self.cwd, name)?;
         Ok(meta)
+    }
+
+    pub(crate) fn remove_simulation(&self, name: &str) -> Result<EnvMeta, String> {
+        let _lock = self.lock_operation(name)?;
+        let meta = get_environment(name, self.env, self.cwd)?;
+        if let Some(dev) = meta.dev.as_ref() {
+            remove_openclaw_simulation_worktree(
+                Path::new(&dev.repo_root),
+                Path::new(&dev.worktree_root),
+                &meta.name,
+            )?;
+        }
+        self.remove_locked(name, true)
     }
 
     pub fn prune_candidates(&self, older_than_days: i64) -> Result<Vec<EnvMeta>, String> {

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -5,7 +5,7 @@ use time::Duration;
 use time::OffsetDateTime;
 
 use super::EnvironmentService;
-use crate::openclaw_repo::remove_openclaw_simulation_worktree;
+use crate::openclaw_repo::prepare_openclaw_simulation_worktree_cleanup;
 use crate::runtime::RuntimeService;
 use crate::store::{
     EnvironmentOperationLock, clone_environment, clone_environment_for_simulation,
@@ -373,7 +373,7 @@ impl<'a> EnvironmentService<'a> {
         let _lock = self.lock_operation(name)?;
         let meta = get_environment(name, self.env, self.cwd)?;
         if let Some(dev) = meta.dev.as_ref() {
-            remove_openclaw_simulation_worktree(
+            prepare_openclaw_simulation_worktree_cleanup(
                 Path::new(&dev.repo_root),
                 Path::new(&dev.worktree_root),
                 &meta.name,

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -173,17 +173,19 @@ pub(crate) fn prepare_openclaw_simulation_worktree_cleanup(
 }
 
 fn remove_openclaw_worktree_checked(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
-    ensure_registered_worktree_identity(repo_root, worktree_root)?;
+    if !ensure_registered_worktree_identity(repo_root, worktree_root)? {
+        return Ok(());
+    }
     remove_registered_worktree(repo_root, worktree_root)
 }
 
 fn ensure_registered_worktree_identity(
     repo_root: &Path,
     worktree_root: &Path,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let registered = match registered_worktree_paths(repo_root) {
         Ok(registered) => registered,
-        Err(_) if !worktree_root.exists() => return Ok(()),
+        Err(_) if !worktree_root.exists() => return Ok(false),
         Err(error) => return Err(error),
     };
     if !contains_worktree_path(&registered, worktree_root) {
@@ -193,7 +195,7 @@ fn ensure_registered_worktree_identity(
                 display_path(worktree_root)
             ));
         }
-        return Ok(());
+        return Ok(false);
     }
 
     if worktree_root.exists() && !has_expected_worktree_identity(repo_root, worktree_root) {
@@ -203,7 +205,7 @@ fn ensure_registered_worktree_identity(
         ));
     }
 
-    Ok(())
+    Ok(true)
 }
 
 fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), String> {

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -98,7 +98,11 @@ pub(crate) fn ensure_openclaw_worktree(
 
     if worktree_registered {
         if !worktree_root.exists() {
-            remove_registered_worktree(&repo_root, &worktree_root)?;
+            remove_registered_worktree(
+                &repo_root,
+                &worktree_root,
+                WorktreeCleanupPolicy::PreserveIgnoredLocalFiles,
+            )?;
         } else if is_existing_openclaw_worktree(&repo_root, &worktree_root) {
             return Ok(worktree_root);
         } else {
@@ -151,6 +155,45 @@ pub(crate) fn remove_openclaw_worktree(
     repo_root: &Path,
     worktree_root: &Path,
 ) -> Result<(), String> {
+    remove_openclaw_worktree_with_policy(
+        repo_root,
+        worktree_root,
+        WorktreeCleanupPolicy::PreserveIgnoredLocalFiles,
+    )
+}
+
+pub(crate) fn remove_openclaw_simulation_worktree(
+    repo_root: &Path,
+    worktree_root: &Path,
+    simulation_name: &str,
+) -> Result<(), String> {
+    let expected = default_worktree_root(repo_root, simulation_name);
+    if normalize_worktree_path(worktree_root) != normalize_worktree_path(&expected) {
+        return Err(format!(
+            "refusing simulation cleanup outside its OCM-owned worktree: expected {}, found {}",
+            display_path(&expected),
+            display_path(worktree_root)
+        ));
+    }
+
+    remove_openclaw_worktree_with_policy(
+        repo_root,
+        worktree_root,
+        WorktreeCleanupPolicy::DiscardIgnoredLocalFiles,
+    )
+}
+
+#[derive(Clone, Copy)]
+enum WorktreeCleanupPolicy {
+    PreserveIgnoredLocalFiles,
+    DiscardIgnoredLocalFiles,
+}
+
+fn remove_openclaw_worktree_with_policy(
+    repo_root: &Path,
+    worktree_root: &Path,
+    cleanup_policy: WorktreeCleanupPolicy,
+) -> Result<(), String> {
     let registered = match registered_worktree_paths(repo_root) {
         Ok(registered) => registered,
         Err(_) if !worktree_root.exists() => return Ok(()),
@@ -173,11 +216,15 @@ pub(crate) fn remove_openclaw_worktree(
         ));
     }
 
-    remove_registered_worktree(repo_root, worktree_root)
+    remove_registered_worktree(repo_root, worktree_root, cleanup_policy)
 }
 
-fn remove_registered_worktree(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
-    ensure_worktree_clean(worktree_root)?;
+fn remove_registered_worktree(
+    repo_root: &Path,
+    worktree_root: &Path,
+    cleanup_policy: WorktreeCleanupPolicy,
+) -> Result<(), String> {
+    ensure_worktree_clean(worktree_root, cleanup_policy)?;
 
     let output = Command::new("git")
         .arg("-C")
@@ -196,7 +243,10 @@ fn remove_registered_worktree(repo_root: &Path, worktree_root: &Path) -> Result<
     Err(format!("git worktree remove failed: {detail}"))
 }
 
-fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
+fn ensure_worktree_clean(
+    worktree_root: &Path,
+    cleanup_policy: WorktreeCleanupPolicy,
+) -> Result<(), String> {
     if !worktree_root.exists() {
         return Ok(());
     }
@@ -226,7 +276,12 @@ fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
         ));
     }
 
-    ensure_no_ignored_local_files(worktree_root)?;
+    if matches!(
+        cleanup_policy,
+        WorktreeCleanupPolicy::PreserveIgnoredLocalFiles
+    ) {
+        ensure_no_ignored_local_files(worktree_root)?;
+    }
     Ok(())
 }
 
@@ -493,13 +548,108 @@ fn git_path_from_bytes(path: &[u8]) -> Result<OsString, String> {
         .map_err(|_| "git returned a non-UTF-8 path".to_string())
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::process::Command;
+
+    #[cfg(unix)]
     use std::os::unix::ffi::OsStrExt;
     use std::path::PathBuf;
 
-    use super::{parse_legacy_registered_worktree_paths, parse_registered_worktree_paths};
+    use tempfile::TempDir;
 
+    #[cfg(unix)]
+    use super::parse_registered_worktree_paths;
+    use super::{
+        ensure_openclaw_worktree, parse_legacy_registered_worktree_paths,
+        remove_openclaw_simulation_worktree, remove_openclaw_worktree,
+    };
+
+    fn run_git(repo: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_openclaw_repo() -> (TempDir, PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("openclaw");
+        fs::create_dir_all(repo.join("scripts")).unwrap();
+        fs::write(
+            repo.join("package.json"),
+            r#"{"name":"openclaw","version":"test"}"#,
+        )
+        .unwrap();
+        fs::write(repo.join("scripts/run-node.mjs"), "console.log('test');\n").unwrap();
+        fs::write(
+            repo.join(".gitignore"),
+            "node_modules/\n.artifacts/\ndist/\ndist-runtime/\npackages/*/dist/\n.env\n",
+        )
+        .unwrap();
+
+        let init = Command::new("git").arg("init").arg(&repo).output().unwrap();
+        assert!(init.status.success());
+        run_git(&repo, &["config", "user.email", "tests@example.com"]);
+        run_git(&repo, &["config", "user.name", "OCM Tests"]);
+        run_git(&repo, &["add", "."]);
+        run_git(&repo, &["commit", "-m", "init"]);
+        (temp, repo)
+    }
+
+    #[test]
+    fn simulation_cleanup_discards_ignored_outputs_only_for_owned_worktree() {
+        let (_temp, repo) = init_openclaw_repo();
+        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
+        for relative in [
+            "node_modules/pkg/index.js",
+            ".artifacts/build.json",
+            "dist/index.js",
+            "dist-runtime/index.js",
+            "packages/demo/dist/index.js",
+        ] {
+            let path = worktree.join(relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, "generated\n").unwrap();
+        }
+
+        let ordinary_error = remove_openclaw_worktree(&repo, &worktree).unwrap_err();
+        assert!(ordinary_error.contains("contains ignored local files"));
+        assert!(worktree.exists());
+
+        let ownership_error =
+            remove_openclaw_simulation_worktree(&repo, &worktree, "other-sim").unwrap_err();
+        assert!(ownership_error.contains("outside its OCM-owned worktree"));
+        assert!(worktree.exists());
+
+        remove_openclaw_simulation_worktree(&repo, &worktree, "demo-sim").unwrap();
+        assert!(!worktree.exists());
+    }
+
+    #[test]
+    fn simulation_cleanup_preserves_untracked_files() {
+        let (_temp, repo) = init_openclaw_repo();
+        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
+        fs::write(worktree.join("operator-notes.txt"), "preserve\n").unwrap();
+
+        let error = remove_openclaw_simulation_worktree(&repo, &worktree, "demo-sim").unwrap_err();
+        assert!(error.contains("contains modified or untracked files"));
+        assert_eq!(
+            fs::read_to_string(worktree.join("operator-notes.txt")).unwrap(),
+            "preserve\n"
+        );
+    }
+
+    #[cfg(unix)]
     #[test]
     fn worktree_porcelain_parser_preserves_non_utf8_paths() {
         let paths = parse_registered_worktree_paths(

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -168,11 +168,20 @@ pub(crate) fn remove_openclaw_simulation_worktree(
         ));
     }
 
+    ensure_registered_worktree_identity(repo_root, worktree_root)?;
     remove_generated_simulation_outputs(worktree_root)?;
     remove_openclaw_worktree_checked(repo_root, worktree_root)
 }
 
 fn remove_openclaw_worktree_checked(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
+    ensure_registered_worktree_identity(repo_root, worktree_root)?;
+    remove_registered_worktree(repo_root, worktree_root)
+}
+
+fn ensure_registered_worktree_identity(
+    repo_root: &Path,
+    worktree_root: &Path,
+) -> Result<(), String> {
     let registered = match registered_worktree_paths(repo_root) {
         Ok(registered) => registered,
         Err(_) if !worktree_root.exists() => return Ok(()),
@@ -195,10 +204,14 @@ fn remove_openclaw_worktree_checked(repo_root: &Path, worktree_root: &Path) -> R
         ));
     }
 
-    remove_registered_worktree(repo_root, worktree_root)
+    Ok(())
 }
 
 fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), String> {
+    if !worktree_root.exists() {
+        return Ok(());
+    }
+
     let output = Command::new("git")
         .arg("-C")
         .arg(worktree_root)
@@ -661,6 +674,39 @@ mod tests {
         );
         assert!(!generated.exists());
         assert!(worktree.exists());
+    }
+
+    #[test]
+    fn simulation_cleanup_does_not_touch_replaced_unregistered_checkout() {
+        let (_temp, repo) = init_openclaw_repo();
+        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                "--",
+                worktree.to_str().unwrap(),
+            ],
+        );
+
+        fs::create_dir_all(worktree.join("dist")).unwrap();
+        fs::write(worktree.join(".gitignore"), "dist/\n").unwrap();
+        fs::write(worktree.join("dist/operator-output.txt"), "preserve\n").unwrap();
+        let init = Command::new("git")
+            .arg("init")
+            .arg(&worktree)
+            .output()
+            .unwrap();
+        assert!(init.status.success());
+
+        let error = remove_openclaw_simulation_worktree(&repo, &worktree, "demo-sim").unwrap_err();
+        assert!(error.contains("not registered"));
+        assert_eq!(
+            fs::read_to_string(worktree.join("dist/operator-output.txt")).unwrap(),
+            "preserve\n"
+        );
     }
 
     #[cfg(unix)]

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -154,7 +154,7 @@ pub(crate) fn remove_openclaw_worktree(
     remove_openclaw_worktree_checked(repo_root, worktree_root)
 }
 
-pub(crate) fn remove_openclaw_simulation_worktree(
+pub(crate) fn prepare_openclaw_simulation_worktree_cleanup(
     repo_root: &Path,
     worktree_root: &Path,
     simulation_name: &str,
@@ -169,8 +169,7 @@ pub(crate) fn remove_openclaw_simulation_worktree(
     }
 
     ensure_registered_worktree_identity(repo_root, worktree_root)?;
-    remove_generated_simulation_outputs(worktree_root)?;
-    remove_openclaw_worktree_checked(repo_root, worktree_root)
+    remove_generated_simulation_outputs(worktree_root)
 }
 
 fn remove_openclaw_worktree_checked(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
@@ -576,7 +575,7 @@ mod tests {
     use super::parse_registered_worktree_paths;
     use super::{
         ensure_openclaw_worktree, parse_legacy_registered_worktree_paths,
-        remove_openclaw_simulation_worktree, remove_openclaw_worktree,
+        prepare_openclaw_simulation_worktree_cleanup, remove_openclaw_worktree,
     };
 
     fn run_git(repo: &std::path::Path, args: &[&str]) {
@@ -645,11 +644,14 @@ mod tests {
         assert!(worktree.exists());
 
         let ownership_error =
-            remove_openclaw_simulation_worktree(&repo, &worktree, "other-sim").unwrap_err();
+            prepare_openclaw_simulation_worktree_cleanup(&repo, &worktree, "other-sim")
+                .unwrap_err();
         assert!(ownership_error.contains("outside its OCM-owned worktree"));
         assert!(worktree.exists());
 
-        remove_openclaw_simulation_worktree(&repo, &worktree, "demo-sim").unwrap();
+        prepare_openclaw_simulation_worktree_cleanup(&repo, &worktree, "demo-sim").unwrap();
+        assert!(worktree.exists());
+        remove_openclaw_worktree(&repo, &worktree).unwrap();
         assert!(!worktree.exists());
     }
 
@@ -659,7 +661,8 @@ mod tests {
         let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
         fs::write(worktree.join("operator-notes.txt"), "preserve\n").unwrap();
 
-        let error = remove_openclaw_simulation_worktree(&repo, &worktree, "demo-sim").unwrap_err();
+        prepare_openclaw_simulation_worktree_cleanup(&repo, &worktree, "demo-sim").unwrap();
+        let error = remove_openclaw_worktree(&repo, &worktree).unwrap_err();
         assert!(error.contains("contains modified or untracked files"));
         assert_eq!(
             fs::read_to_string(worktree.join("operator-notes.txt")).unwrap(),
@@ -676,7 +679,8 @@ mod tests {
         fs::create_dir_all(generated.parent().unwrap()).unwrap();
         fs::write(&generated, "generated\n").unwrap();
 
-        let error = remove_openclaw_simulation_worktree(&repo, &worktree, "demo-sim").unwrap_err();
+        prepare_openclaw_simulation_worktree_cleanup(&repo, &worktree, "demo-sim").unwrap();
+        let error = remove_openclaw_worktree(&repo, &worktree).unwrap_err();
         assert!(error.contains("contains ignored local files"));
         assert_eq!(
             fs::read_to_string(worktree.join(".env")).unwrap(),
@@ -711,7 +715,8 @@ mod tests {
             .unwrap();
         assert!(init.status.success());
 
-        let error = remove_openclaw_simulation_worktree(&repo, &worktree, "demo-sim").unwrap_err();
+        let error =
+            prepare_openclaw_simulation_worktree_cleanup(&repo, &worktree, "demo-sim").unwrap_err();
         assert!(error.contains("not registered"));
         assert_eq!(
             fs::read_to_string(worktree.join("dist/operator-output.txt")).unwrap(),

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -98,11 +98,7 @@ pub(crate) fn ensure_openclaw_worktree(
 
     if worktree_registered {
         if !worktree_root.exists() {
-            remove_registered_worktree(
-                &repo_root,
-                &worktree_root,
-                WorktreeCleanupPolicy::PreserveIgnoredLocalFiles,
-            )?;
+            remove_registered_worktree(&repo_root, &worktree_root)?;
         } else if is_existing_openclaw_worktree(&repo_root, &worktree_root) {
             return Ok(worktree_root);
         } else {
@@ -155,11 +151,7 @@ pub(crate) fn remove_openclaw_worktree(
     repo_root: &Path,
     worktree_root: &Path,
 ) -> Result<(), String> {
-    remove_openclaw_worktree_with_policy(
-        repo_root,
-        worktree_root,
-        WorktreeCleanupPolicy::PreserveIgnoredLocalFiles,
-    )
+    remove_openclaw_worktree_checked(repo_root, worktree_root)
 }
 
 pub(crate) fn remove_openclaw_simulation_worktree(
@@ -176,24 +168,11 @@ pub(crate) fn remove_openclaw_simulation_worktree(
         ));
     }
 
-    remove_openclaw_worktree_with_policy(
-        repo_root,
-        worktree_root,
-        WorktreeCleanupPolicy::DiscardIgnoredLocalFiles,
-    )
+    remove_generated_simulation_outputs(worktree_root)?;
+    remove_openclaw_worktree_checked(repo_root, worktree_root)
 }
 
-#[derive(Clone, Copy)]
-enum WorktreeCleanupPolicy {
-    PreserveIgnoredLocalFiles,
-    DiscardIgnoredLocalFiles,
-}
-
-fn remove_openclaw_worktree_with_policy(
-    repo_root: &Path,
-    worktree_root: &Path,
-    cleanup_policy: WorktreeCleanupPolicy,
-) -> Result<(), String> {
+fn remove_openclaw_worktree_checked(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
     let registered = match registered_worktree_paths(repo_root) {
         Ok(registered) => registered,
         Err(_) if !worktree_root.exists() => return Ok(()),
@@ -216,15 +195,39 @@ fn remove_openclaw_worktree_with_policy(
         ));
     }
 
-    remove_registered_worktree(repo_root, worktree_root, cleanup_policy)
+    remove_registered_worktree(repo_root, worktree_root)
 }
 
-fn remove_registered_worktree(
-    repo_root: &Path,
-    worktree_root: &Path,
-    cleanup_policy: WorktreeCleanupPolicy,
-) -> Result<(), String> {
-    ensure_worktree_clean(worktree_root, cleanup_policy)?;
+fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(worktree_root)
+        .args([
+            "clean",
+            "-ffdX",
+            "--",
+            "node_modules",
+            ".artifacts",
+            "dist",
+            "dist-runtime",
+            ":(glob)packages/*/dist",
+        ])
+        .output()
+        .map_err(|error| format!("failed to remove generated simulation output: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+    Err(format!(
+        "failed to remove generated simulation output: {detail}"
+    ))
+}
+
+fn remove_registered_worktree(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
+    ensure_worktree_clean(worktree_root)?;
 
     let output = Command::new("git")
         .arg("-C")
@@ -243,10 +246,7 @@ fn remove_registered_worktree(
     Err(format!("git worktree remove failed: {detail}"))
 }
 
-fn ensure_worktree_clean(
-    worktree_root: &Path,
-    cleanup_policy: WorktreeCleanupPolicy,
-) -> Result<(), String> {
+fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
     if !worktree_root.exists() {
         return Ok(());
     }
@@ -276,12 +276,7 @@ fn ensure_worktree_clean(
         ));
     }
 
-    if matches!(
-        cleanup_policy,
-        WorktreeCleanupPolicy::PreserveIgnoredLocalFiles
-    ) {
-        ensure_no_ignored_local_files(worktree_root)?;
-    }
+    ensure_no_ignored_local_files(worktree_root)?;
     Ok(())
 }
 
@@ -647,6 +642,25 @@ mod tests {
             fs::read_to_string(worktree.join("operator-notes.txt")).unwrap(),
             "preserve\n"
         );
+    }
+
+    #[test]
+    fn simulation_cleanup_preserves_non_build_ignored_files() {
+        let (_temp, repo) = init_openclaw_repo();
+        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
+        fs::write(worktree.join(".env"), "PRIVATE_VALUE=preserve\n").unwrap();
+        let generated = worktree.join("dist/index.js");
+        fs::create_dir_all(generated.parent().unwrap()).unwrap();
+        fs::write(&generated, "generated\n").unwrap();
+
+        let error = remove_openclaw_simulation_worktree(&repo, &worktree, "demo-sim").unwrap_err();
+        assert!(error.contains("contains ignored local files"));
+        assert_eq!(
+            fs::read_to_string(worktree.join(".env")).unwrap(),
+            "PRIVATE_VALUE=preserve\n"
+        );
+        assert!(!generated.exists());
+        assert!(worktree.exists());
     }
 
     #[cfg(unix)]

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -220,10 +220,15 @@ fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), Strin
             "-ffdX",
             "--",
             "node_modules",
+            ":(glob)**/node_modules",
             ".artifacts",
             "dist",
             "dist-runtime",
             ":(glob)packages/*/dist",
+            "extensions/canvas/src/host/a2ui",
+            "extensions/diffs-language-pack/assets",
+            "extensions/diffs/assets",
+            "extensions/discord/assets",
         ])
         .output()
         .map_err(|error| format!("failed to remove generated simulation output: {error}"))?;
@@ -601,7 +606,7 @@ mod tests {
         fs::write(repo.join("scripts/run-node.mjs"), "console.log('test');\n").unwrap();
         fs::write(
             repo.join(".gitignore"),
-            "node_modules/\n.artifacts/\ndist/\ndist-runtime/\npackages/*/dist/\n.env\n",
+            "node_modules/\n.artifacts/\ndist/\ndist-runtime/\npackages/*/dist/\nextensions/canvas/src/host/a2ui/\nextensions/diffs-language-pack/assets/\nextensions/diffs/assets/\nextensions/discord/assets/\n.env\n",
         )
         .unwrap();
 
@@ -620,10 +625,15 @@ mod tests {
         let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
         for relative in [
             "node_modules/pkg/index.js",
+            "extensions/demo/node_modules/pkg/index.js",
             ".artifacts/build.json",
             "dist/index.js",
             "dist-runtime/index.js",
             "packages/demo/dist/index.js",
+            "extensions/canvas/src/host/a2ui/index.html",
+            "extensions/diffs-language-pack/assets/viewer-runtime.js",
+            "extensions/diffs/assets/viewer-runtime.js",
+            "extensions/discord/assets/activity.js",
         ] {
             let path = worktree.join(relative);
             fs::create_dir_all(path.parent().unwrap()).unwrap();

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -694,6 +694,11 @@ fn init_openclaw_repo(root: &TestDir) -> PathBuf {
         "console.log('watch');\n",
     )
     .unwrap();
+    fs::write(
+        repo.join(".gitignore"),
+        "node_modules/\n.artifacts/\ndist/\ndist-runtime/\npackages/*/dist/\n",
+    )
+    .unwrap();
 
     let init = Command::new("git").arg("init").arg(&repo).output().unwrap();
     assert!(
@@ -776,7 +781,13 @@ case "$1" in
     touch node_modules/.bin/tsx
     exit 0
     ;;
-  build|ui:build)
+  build)
+    mkdir -p .artifacts dist dist-runtime packages/demo/dist
+    touch .artifacts/build.json dist/index.js dist-runtime/index.js packages/demo/dist/index.js
+    echo "$1 ok"
+    exit 0
+    ;;
+  ui:build)
     echo "$1 ok"
     exit 0
     ;;
@@ -3064,6 +3075,7 @@ fn upgrade_simulate_reports_local_repo_doctor_failures() {
     assert!(!simulate.status.success(), "{}", stdout(&simulate));
     let output = stdout(&simulate);
     assert!(output.contains("outcome=failed"), "{output}");
+    assert!(output.contains("cleanup=cleaned"), "{output}");
     assert!(output.contains("check=openclaw doctor"), "{output}");
     assert!(output.contains("Cannot find module 'grammy'"), "{output}");
 


### PR DESCRIPTION
Closes #118

## What Problem This Solves

Fixes an issue where users validating an exact local OpenClaw checkout with `upgrade simulate` would see a functionally successful candidate reported as failed when generated ignored build outputs prevented cleanup of the simulation worktree.

## Why This Change Was Made

Simulation cleanup first proves the worktree is the canonical `.worktrees/<simulation-name>` path registered to the selected repository with the expected checkout identity. It then removes only OpenClaw's known generated output paths: root and nested `node_modules`, `.artifacts`, `dist`, `dist-runtime`, `packages/*/dist`, and the four generated extension asset directories observed on current OpenClaw main. The existing environment-removal path remains the sole worktree remover and repeats the registration/identity and fail-closed cleanliness checks. Other ignored files, including `.env`, still block cleanup and remain on disk.

The `status --json` ownership presentation noted in #118 is intentionally not changed here; it is separate from the cleanup failure.

## User Impact

Local-checkout simulations can build Core/UI and clean up their generated output without turning a successful validation into a cleanup failure. Developer-owned worktrees retain the existing preservation behavior.

## Evidence

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo test --locked --lib openclaw_repo::tests -- --nocapture` — 6 passed
- Added coverage that:
  - removes representative ignored build outputs from the proven simulation-owned worktree;
  - rejects a mismatched worktree/name ownership claim;
  - preserves modified and untracked files;
  - preserves an ignored non-build `.env` while removing generated `dist` output;
  - leaves a replacement unregistered checkout and its ignored build output untouched;
  - keeps ordinary worktree cleanup fail-closed;
  - requires the local-repo simulation fixture to report `cleanup=cleaned` after generating `.artifacts`, `dist`, `dist-runtime`, package `dist`, and `node_modules` output.

### Real CLI boundary proof

Both runs used the public PR head `dbee8182660fefb73f73966af9274f94c9a9ce64` in an ephemeral Crabbox local container pinned to `rust:1.88-bookworm@sha256:8aa70d1416cf5b1cff4b95ec6c57f1c5e4e649a3b53d616a26695cda6fbb46bc`. No personal runtime, configuration, or credentials were mounted.

**Allowed cleanup — run `run_4782048080f3`:** the production CLI targeted a real current OpenClaw checkout at `f46f9b5aa39feaec7eda5d9d480972566b6aabf5`. OpenClaw's own build checks stopped on their documented low-memory guard, but OCM still removed the generated outputs and its owned simulation worktree exactly as intended:

```json
{
  "command": "ocm upgrade simulate proof-source --to <exact-local-openclaw-checkout> --scenario current --json",
  "cleanup": "cleaned",
  "simulation_worktrees_remaining": []
}
```

This proves cleanup behavior, not a successful OpenClaw build; the candidate outcome remained failed because the container exposed less than OpenClaw's required 4352 MB build heap.

**Nearest non-owned rejection — run `run_54860981ff04`:** a disposable local OpenClaw-shaped fixture replaced the OCM-created worktree at the canonical path with a new unregistered checkout immediately before finalization. The production CLI rejected it before generated-output cleanup, left the replacement present, and preserved the sentinel byte-for-byte:

```json
{
  "cleanup": "failed",
  "cleanup_rejection": "refusing to remove worktree path not registered to this OpenClaw checkout: <redacted-canonical-simulation-path>",
  "replacement_exists_after_cleanup": true,
  "replacement_registered_to_source": false,
  "sentinel_sha256": "bd875fb2a0244493aa0b8facb09fa3d9fec61dc89b639fd45a45e58c79affedb",
  "sentinel_preserved": true
}
```

The two Crabbox artefact bundles were retained with SHA-256 `A1E1CCB0580E3DF44A3A3A36A8CA9D30DEF905CEF7A841EC0BC1E7FC85AB538C` and `EC91D86C95C7639936FE3A693FDD3953E7842D1EE80F1AB03DA7947BA3312D3E` respectively.

## Risk

Low and bounded to automatic cleanup of OCM-created local-repo simulation worktrees. The path, Git registration, and checkout identity checks run first; only the explicit generated-output path allowlist is cleaned, and every remaining modified, untracked, or ignored file blocks removal.

## Agent involvement

Implemented and tested with Codex under operator direction; the operator reviewed and authorized the issue and PR workflow.
