### PR TITLE
fix: preserve simulation result when cleanup fails

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -460,14 +460,14 @@ impl Cli {
         }
         if matches!(args.first().map(String::as_str), Some("simulate")) {
             let summaries = self.upgrade_simulate(args[1..].to_vec())?;
-            let failed = summaries.iter().any(|summary| summary.outcome == "failed");
+            let requires_attention = summaries.iter().any(simulation_requires_attention);
             if json_flag {
                 if summaries.len() == 1 {
                     self.print_json(&summaries[0])?;
                 } else {
                     self.print_json(&build_simulation_batch_summary(summaries))?;
                 }
-                return Ok(if failed { 1 } else { 0 });
+                return Ok(if requires_attention { 1 } else { 0 });
             }
             if summaries.len() == 1 {
                 self.stdout_lines(render::upgrade::upgrade_simulation(
@@ -482,7 +482,7 @@ impl Cli {
                     &self.command_example(),
                 ));
             }
-            return Ok(if failed { 1 } else { 0 });
+            return Ok(if requires_attention { 1 } else { 0 });
         }
 
         let (args, dry_run) = Self::consume_flag(args, "--dry-run");
@@ -2135,12 +2135,7 @@ impl Cli {
                 summary.cleanup = "cleaned".to_string();
             }
             Err(error) => {
-                summary.cleanup = "failed".to_string();
-                summary.checks.push(UpgradeSimulationCheck::failed(
-                    "cleanup simulation env",
-                    error,
-                ));
-                summary.outcome = "failed".to_string();
+                record_simulation_cleanup_failure(&mut summary, "cleanup simulation env", error);
             }
         }
         Ok(summary)
@@ -2166,12 +2161,11 @@ impl Cli {
                     .iter_mut()
                     .filter(|summary| summary.to_binding_name == prepared_runtime.name)
                 {
-                    summary.cleanup = "failed".to_string();
-                    summary.checks.push(UpgradeSimulationCheck::failed(
+                    record_simulation_cleanup_failure(
+                        summary,
                         "cleanup simulation runtime",
                         error.clone(),
-                    ));
-                    summary.outcome = "failed".to_string();
+                    );
                 }
                 Ok(())
             }
@@ -5048,6 +5042,21 @@ fn build_simulation_batch_summary(
     }
 }
 
+fn simulation_requires_attention(summary: &UpgradeSimulationSummary) -> bool {
+    summary.outcome == "failed" || summary.cleanup == "failed"
+}
+
+fn record_simulation_cleanup_failure(
+    summary: &mut UpgradeSimulationSummary,
+    check_name: &str,
+    error: String,
+) {
+    summary.cleanup = "failed".to_string();
+    summary
+        .checks
+        .push(UpgradeSimulationCheck::failed(check_name, error));
+}
+
 fn missing_simulation_version_error(version: &str, releases: &[OpenClawRelease]) -> String {
     let prefix = format!("{version}-");
     let nearby = releases
@@ -5452,11 +5461,65 @@ fn gateway_auth_failure_proves_reachable(error: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        candidate_codex_preflight_is_unsupported, command_output_reports_unsupported_command,
-        parse_openclaw_finalize_phases, release_version_from_output,
-        summarize_command_failure_text, verify_gateway_status_readiness,
-        version_output_matches_expected,
+        UpgradeSimulationSummary, candidate_codex_preflight_is_unsupported,
+        command_output_reports_unsupported_command, parse_openclaw_finalize_phases,
+        record_simulation_cleanup_failure, release_version_from_output,
+        simulation_requires_attention, summarize_command_failure_text,
+        verify_gateway_status_readiness, version_output_matches_expected,
     };
+
+    fn simulation_summary(outcome: &str, cleanup: &str) -> UpgradeSimulationSummary {
+        UpgradeSimulationSummary {
+            scenario: "current".to_string(),
+            source_env: "source".to_string(),
+            simulation_env: "simulation".to_string(),
+            from_binding_kind: "runtime".to_string(),
+            from_binding_name: "from".to_string(),
+            to_binding_kind: "runtime".to_string(),
+            to_binding_name: "to".to_string(),
+            to: "target".to_string(),
+            outcome: outcome.to_string(),
+            checks: Vec::new(),
+            cleanup_command: "ocm env destroy simulation --yes".to_string(),
+            cleanup: cleanup.to_string(),
+            note: None,
+        }
+    }
+
+    #[test]
+    fn simulation_exit_status_requires_attention_for_validation_or_cleanup_failure() {
+        assert!(!simulation_requires_attention(&simulation_summary(
+            "passed", "cleaned"
+        )));
+        assert!(simulation_requires_attention(&simulation_summary(
+            "failed", "cleaned"
+        )));
+        assert!(simulation_requires_attention(&simulation_summary(
+            "passed", "failed"
+        )));
+    }
+
+    #[test]
+    fn simulation_cleanup_failure_preserves_functional_outcome() {
+        let mut summary = simulation_summary("passed", "pending");
+
+        record_simulation_cleanup_failure(
+            &mut summary,
+            "cleanup simulation env",
+            "generated output remains".to_string(),
+        );
+
+        assert_eq!(summary.outcome, "passed");
+        assert_eq!(summary.cleanup, "failed");
+        assert!(simulation_requires_attention(&summary));
+        assert_eq!(summary.checks.len(), 1);
+        assert_eq!(summary.checks[0].name, "cleanup simulation env");
+        assert_eq!(summary.checks[0].status, "failed");
+        assert_eq!(
+            summary.checks[0].note.as_deref(),
+            Some("generated output remains")
+        );
+    }
 
     #[test]
     fn command_summary_prefers_structured_cli_error_message() {

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -725,6 +725,7 @@ fn init_openclaw_repo(root: &TestDir) -> PathBuf {
         r#"{"name":"openclaw","version":"2026.4.20-local"}"#,
     )
     .unwrap();
+    fs::write(repo.join(".gitignore"), "dist/\nnode_modules/\n").unwrap();
     fs::write(repo.join("scripts/run-node.mjs"), "console.log('run');\n").unwrap();
     fs::write(
         repo.join("scripts/watch-node.mjs"),
@@ -733,7 +734,7 @@ fn init_openclaw_repo(root: &TestDir) -> PathBuf {
     .unwrap();
     fs::write(
         repo.join(".gitignore"),
-        "node_modules/\n.artifacts/\ndist/\ndist-runtime/\npackages/*/dist/\n",
+        "node_modules/\n.artifacts/\ndist/\ndist-runtime/\npackages/*/dist/\n.env\n",
     )
     .unwrap();
 
@@ -821,6 +822,9 @@ case "$1" in
   build)
     mkdir -p .artifacts dist dist-runtime packages/demo/dist
     touch .artifacts/build.json dist/index.js dist-runtime/index.js packages/demo/dist/index.js
+    if [ "${OCM_TEST_SIMULATION_PRESERVED_IGNORED_FILE:-}" = "1" ]; then
+      touch .env
+    fi
     echo "$1 ok"
     exit 0
     ;;
@@ -836,6 +840,10 @@ case "$1" in
         exit 0
         ;;
       doctor)
+        if [ "${OCM_TEST_SIMULATION_DOCTOR_OK:-}" = "1" ]; then
+          echo '{"status":"ok"}'
+          exit 0
+        fi
         echo "Error: Cannot find module 'grammy'" >&2
         exit 1
         ;;
@@ -3216,6 +3224,70 @@ fn upgrade_simulate_reports_local_repo_doctor_failures() {
     let source_json: Value = serde_json::from_str(&stdout(&source)).unwrap();
     assert_eq!(source_json["defaultRuntime"], "stable");
     assert!(source_json["devRepoRoot"].is_null());
+}
+
+#[cfg(unix)]
+#[test]
+fn upgrade_simulate_preserves_passed_outcome_when_cleanup_fails() {
+    let root = TestDir::new("upgrade-simulate-cleanup-outcome");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let repo = init_openclaw_repo(&root);
+
+    let mut env = ocm_env(&root);
+    install_fake_node_and_npm(&root, &mut env, "22.22.3");
+    install_fake_simulation_pnpm(&root, &mut env);
+
+    let start = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "start",
+            "demo",
+            "--command",
+            "pnpm openclaw",
+            "--cwd",
+            &path_string(&repo),
+            "--no-service",
+        ],
+    );
+    assert!(start.status.success(), "{}", stderr(&start));
+
+    env.insert("OCM_TEST_SIMULATION_DOCTOR_OK".to_string(), "1".to_string());
+    env.insert(
+        "OCM_TEST_SIMULATION_PRESERVED_IGNORED_FILE".to_string(),
+        "1".to_string(),
+    );
+    let simulate = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "simulate",
+            "demo",
+            "--to",
+            &path_string(&repo),
+            "--json",
+        ],
+    );
+
+    assert_eq!(simulate.status.code(), Some(1), "{}", stderr(&simulate));
+    let json: Value = serde_json::from_str(&stdout(&simulate)).unwrap();
+    assert_eq!(json["outcome"], "passed", "{json:#}");
+    assert_eq!(json["cleanup"], "failed");
+    assert!(
+        json["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| check["name"] == "cleanup simulation env"
+                && check["status"] == "failed"
+                && check["note"]
+                    .as_str()
+                    .unwrap()
+                    .contains("contains ignored local files")),
+        "{json:#}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #120

## What Problem This Solves

Fixes an issue where users running `ocm upgrade simulate` would see a successful candidate validation reported as failed when only removal of the disposable simulation environment or runtime failed.

## Why This Change Was Made

The existing `outcome` field reports candidate validation, while the existing `cleanup` field reports cleanup independently. Cleanup failures still produce a failed check and a non-zero process exit, so automation does not silently accept incomplete cleanup.

Batch `passed` and `failed` counts remain scoped to candidate validation. This is intentionally separate from #119, which fixes one concrete cause of cleanup failure.

## User Impact

Users and release tooling can distinguish `outcome: passed, cleanup: failed` from a candidate failure without weakening fail-closed cleanup behavior. Automation must continue to treat either a non-zero process exit or `cleanup: failed` as requiring attention.

## Evidence

Exact public head: `e372b57fc23626fc9420ae267efaaf538f9885d3`

Fresh local checks:

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo test --locked simulation_cleanup_failure_preserves_functional_outcome`
- `cargo test --locked simulation_exit_status_requires_attention_for_validation_or_cleanup_failure`
- `git diff --check`

The focused tests pass on Windows and cover candidate failure, cleanup failure, and clean success.

### Real supported-path CLI proof

Fresh on macOS arm64 on 2026-08-31:

- Built this exact public head with Rust 1.88.0 using `cargo build --locked --release`.
- Used an empty, isolated `OCM_HOME` and an OCM-managed disposable source environment with no service.
- Targeted an exact clean public OpenClaw checkout at `a87f12a5ec5de34a4f81580be6431e65df59d10a`.
- Ran the built production CLI through `ocm upgrade simulate <disposable-env> --to <exact-local-checkout> --json`.
- Used no test-only environment hooks or fixture launcher.

Observed process exit status: `1`.

Observed redacted result:

```json
{
  "outcome": "passed",
  "cleanup": "failed",
  "failedCheck": {
    "name": "cleanup simulation env",
    "status": "failed",
    "note": "git worktree remove failed: <owned-simulation-worktree> contains ignored local files"
  }
}
```

Candidate validation itself passed all exercised checks: environment clone, scenario seed, target preparation, `pnpm build`, `pnpm ui:build`, `openclaw --version`, `openclaw doctor`, plugin-update dry-run, and Gateway status. The only failed check was cleanup of the disposable simulation environment.

This is the real failure mode reported in #120: candidate validation succeeds, generated ignored outputs prevent Git worktree removal, the functional result remains `passed`, cleanup is reported separately as `failed`, and the process remains fail-closed with exit status `1`.

The integration suite also drives the same public CLI contract on Unix and asserts the retained fields, cleanup failure, and exit status.
