### PR TITLE
chore(release): bump version to 0.2.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.33"
+version = "0.2.34"
 edition = "2024"
 rust-version = "1.88"
 description = "OpenClaw Manager: the local control plane for isolated OpenClaw environments, launchers, runtimes, and services."


### PR DESCRIPTION
Prepare v0.2.34.

This pull request changes only `Cargo.toml` and `Cargo.lock`. After squash merge and successful exact-SHA `main` CI, create the signed `v0.2.34` tag and dispatch the protected-main release workflow.