### PR TITLE
chore(deps): refresh SHA-2 and stabilize validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,11 +22,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -85,10 +85,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -104,12 +110,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -144,11 +149,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -262,16 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +310,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -421,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -781,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1038,12 +1043,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 json5 = "1.3"
 serde_yaml = "0.9"
-sha2 = "0.10"
+sha2 = "0.11"
 semver = "1.0"
 base64 = "0.23"
 flate2 = "1.1"

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -1599,7 +1599,11 @@ fn env_destroy_state_token(
     };
     let encoded = serde_json::to_vec(&state)
         .map_err(|error| format!("failed to encode environment destroy state: {error}"))?;
-    Ok(format!("v1:{:x}", Sha256::digest(encoded)))
+    let digest: String = Sha256::digest(encoded)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    Ok(format!("v1:{digest}"))
 }
 
 #[cfg(unix)]

--- a/src/infra/download.rs
+++ b/src/infra/download.rs
@@ -156,7 +156,11 @@ pub fn file_sha256(path: &Path) -> Result<String, String> {
         hasher.update(&buffer[..read]);
     }
 
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
 }
 
 pub fn normalize_sha256(expected: &str) -> Result<String, String> {

--- a/src/infra/tree_digest.rs
+++ b/src/infra/tree_digest.rs
@@ -105,7 +105,11 @@ pub(crate) fn tree_sha256(root: &Path) -> Result<String, String> {
             hasher.update(sha256);
         }
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
 }
 
 fn hash_path(path: &Path, hasher: &mut Sha256) -> Result<(), String> {
@@ -147,6 +151,20 @@ fn metadata_mode(metadata: &fs::Metadata) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::tree_sha256;
+
+    #[cfg(unix)]
+    #[test]
+    fn tree_digest_preserves_v1_encoding() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert_eq!(
+            tree_sha256(root.path()).unwrap(),
+            "47d8bf62e61e92d5b7e76a8669b829db917ffdeaf8e1b6484ec4882c3d42d005"
+        );
+    }
 
     #[test]
     fn tree_digest_is_stable_and_covers_nested_files() {

--- a/tests/bin_wrapper_tests.rs
+++ b/tests/bin_wrapper_tests.rs
@@ -26,8 +26,10 @@ fn bin_wrapper_runs_with_an_overridden_home() {
     std::fs::create_dir_all(&ocm_home).unwrap();
     std::fs::create_dir_all(&shim_bin).unwrap();
 
-    let rustup = find_executable("rustup").expect("rustup must be available for wrapper tests");
-    std::os::unix::fs::symlink(rustup, shim_bin.join("cargo")).unwrap();
+    let cargo = find_executable("rustup")
+        .or_else(|| find_executable("cargo"))
+        .expect("cargo must be available for wrapper tests");
+    std::os::unix::fs::symlink(cargo, shim_bin.join("cargo")).unwrap();
     let path = std::env::join_paths(std::iter::once(shim_bin).chain(std::env::split_paths(
         &std::env::var_os("PATH").unwrap_or_default(),
     )))

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -88,6 +88,14 @@ fn wait_for_file_value(path: &Path, expected: &str, timeout: Duration) -> bool {
     false
 }
 
+fn wait_for_started_pid(path: &Path, pid: u64) {
+    assert!(
+        wait_for_file_value(path, &pid.to_string(), Duration::from_secs(5)),
+        "{} did not record startup for PID {pid}",
+        path.display()
+    );
+}
+
 fn wait_for_runtime_service_state(
     path: &Path,
     env_name: &str,
@@ -212,8 +220,8 @@ if [ "${{1:-}}" = "gateway" ] && [ "${{2:-}}" = "status" ]; then
   exit 0
 fi
 if [ "${{1:-}}" = "gateway" ]; then
-  printf '%s\n' "$$" >> '{started}'
   trap 'printf "%s\n" "$$" >> "{stopped}"; exit 0' TERM INT
+  printf '%s\n' "$$" >> '{started}'
   while :; do sleep 3600; done
 fi
 case "${{1:-}}" in
@@ -596,6 +604,14 @@ fn snapshot_restore_preserves_running_sibling_despite_unrelated_drift() {
         .expect("daemon runtime state did not report both children");
     let initial_sibling_runtime = runtime_child(&initial_runtime, "sibling");
     let initial_sibling_state = persisted_child(&state_path, "sibling");
+    wait_for_started_pid(
+        &target_started,
+        runtime_child_pid(&initial_runtime, "target").unwrap(),
+    );
+    wait_for_started_pid(
+        &sibling_started,
+        runtime_child_pid(&initial_runtime, "sibling").unwrap(),
+    );
     let initial_sibling = run_ocm(&cwd, &env, &["env", "show", "sibling", "--json"]);
     assert!(
         initial_sibling.status.success(),
@@ -725,12 +741,9 @@ fn snapshot_create_preserves_all_running_siblings_and_restores_target() {
         wait_for_runtime_children(&runtime_path, env_names.len(), None, Duration::from_secs(5))
             .expect("daemon runtime state did not report the complete fixture");
     for env_name in env_names {
-        assert!(
-            wait_for_file(
-                &root.child(format!("{env_name}-started")),
-                Duration::from_secs(5)
-            ),
-            "{env_name} did not enter its gateway loop"
+        wait_for_started_pid(
+            &root.child(format!("{env_name}-started")),
+            runtime_child_pid(&initial_runtime, env_name).unwrap(),
         );
     }
     let initial_target_pid = runtime_child_pid(&initial_runtime, "target").unwrap();
@@ -792,6 +805,14 @@ fn snapshot_create_preserves_all_running_siblings_and_restores_target() {
         Some(initial_target_pid),
         "snapshot target PID did not change across cold capture"
     );
+    assert!(wait_for_file_value(
+        &root.child("target-started"),
+        &format!(
+            "{initial_target_pid}\n{}",
+            runtime_child_pid(&final_runtime, "target").unwrap()
+        ),
+        Duration::from_secs(5)
+    ));
     assert_eq!(
         fs::read_to_string(root.child("target-started"))
             .unwrap()
@@ -892,10 +913,10 @@ fn snapshot_create_preserves_stopped_target_and_running_siblings() {
         wait_for_runtime_children(&runtime_path, 2, Some("sibling-a"), Duration::from_secs(5))
             .expect("daemon runtime state did not report both running siblings");
     for env_name in ["sibling-a", "sibling-b"] {
-        assert!(wait_for_file(
+        wait_for_started_pid(
             &root.child(format!("{env_name}-started")),
-            Duration::from_secs(5)
-        ));
+            runtime_child_pid(&initial_runtime, env_name).unwrap(),
+        );
     }
     let initial_siblings = ["sibling-a", "sibling-b"].map(|name| {
         (
@@ -1043,6 +1064,11 @@ fn failed_upgrade_rollback_preserves_running_sibling_despite_unrelated_drift() {
     let initial_target_pid = runtime_child_pid(&initial_runtime, "target").unwrap();
     let initial_sibling_runtime = runtime_child(&initial_runtime, "sibling");
     let initial_sibling_state = persisted_child(&state_path, "sibling");
+    wait_for_started_pid(&target_started, initial_target_pid);
+    wait_for_started_pid(
+        &sibling_started,
+        runtime_child_pid(&initial_runtime, "sibling").unwrap(),
+    );
     let initial_sibling = run_ocm(&cwd, &env, &["env", "show", "sibling", "--json"]);
     assert!(
         initial_sibling.status.success(),
@@ -1736,6 +1762,7 @@ fn publishing_an_unbound_runtime_preserves_unrelated_active_child_spec_and_pid()
         wait_for_runtime_children(&runtime_path, 1, Some("env-a"), Duration::from_secs(5))
             .expect("daemon runtime state did not report env-a");
     let initial_pid = runtime_child_pid(&initial_runtime, "env-a").unwrap();
+    wait_for_started_pid(&started, initial_pid);
 
     let mut latent_runtime_meta = read_persisted_service_state(&runtime_meta_path);
     latent_runtime_meta["releaseVersion"] = Value::String("latent-v2".to_string());
@@ -1850,6 +1877,8 @@ fn targeted_runtime_refresh_ignores_unrelated_drift_and_restarts_effective_chang
     let env_b_pid = runtime_child_pid(&initial_runtime, "env-b").unwrap();
 
     let mut runtime_a_meta = read_persisted_service_state(&runtime_a_meta_path);
+    wait_for_started_pid(&runtime_a_started, env_a_pid);
+    wait_for_started_pid(&runtime_b_started, env_b_pid);
     runtime_a_meta["releaseVersion"] = Value::String("latent-a-v2".to_string());
     write_persisted_service_state(&runtime_a_meta_path, &runtime_a_meta);
 
@@ -1891,9 +1920,15 @@ fn targeted_runtime_refresh_ignores_unrelated_drift_and_restarts_effective_chang
         Duration::from_secs(10),
     )
     .expect("effective runtime change did not replace only env-b");
-    sleep(Duration::from_millis(500));
     let final_a_pid = runtime_child_pid(&changed_runtime, "env-a").unwrap();
     let final_b_pid = runtime_child_pid(&changed_runtime, "env-b").unwrap();
+    // A published child PID can precede the fixture's startup record.
+    assert!(wait_for_file_value(
+        &runtime_b_started,
+        &format!("{env_b_pid}\n{final_b_pid}"),
+        Duration::from_secs(5)
+    ));
+    sleep(Duration::from_millis(500));
     let runtime_a_start_count = fs::read_to_string(&runtime_a_started)
         .unwrap()
         .lines()
@@ -1992,6 +2027,8 @@ fn service_uninstall_removes_only_target_child_despite_unrelated_drift() {
         .expect("daemon runtime state did not report both children");
     let target_pid = runtime_child_pid(&initial_runtime, "target").unwrap();
     let sibling_pid = runtime_child_pid(&initial_runtime, "sibling").unwrap();
+    wait_for_started_pid(&target_started, target_pid);
+    wait_for_started_pid(&sibling_started, sibling_pid);
 
     let sibling_meta_path = root.child("ocm-home/runtimes/sibling-runtime.json");
     let mut sibling_meta = read_persisted_service_state(&sibling_meta_path);
@@ -2780,10 +2817,15 @@ fn daemon_stops_the_full_dev_process_tree_after_service_stop() {
     write_legacy_openclaw_script(
         &script,
         &format!(
-            "#!/bin/sh\nsh -c 'echo $$ > \"{}\"; trap \"exit 0\" TERM INT; while :; do sleep 1; done' &\nprintf 'started\\n' >> '{}'\ntrap 'printf \"stopped\\n\" >> \"{}\"; exit 0' TERM INT\nwhile :; do sleep 1; done\n",
-            path_string(&child_pid_file),
-            path_string(&started),
-            path_string(&stopped),
+            r#"#!/bin/sh
+sh -c 'trap "exit 0" TERM INT; printf "%s\n" "$$" > "$1.tmp"; mv "$1.tmp" "$1"; while :; do sleep 1; done' sh '{child_pid_file}' &
+trap 'printf "stopped\n" >> "{stopped}"; exit 0' TERM INT
+printf 'started\n' >> '{started}'
+while :; do sleep 1; done
+"#,
+            child_pid_file = path_string(&child_pid_file),
+            started = path_string(&started),
+            stopped = path_string(&stopped),
         ),
     );
 
@@ -2847,7 +2889,7 @@ fn daemon_cleans_descendants_after_a_child_exits_before_restart() {
     write_legacy_openclaw_script(
         &script,
         &format!(
-            "#!/bin/sh\ncount=0\nif [ -f '{starts}' ]; then count=$(cat '{starts}'); fi\ncount=$((count + 1))\nprintf '%s\n' \"$count\" > '{starts}'\nif [ \"$count\" -eq 1 ]; then\n  trap '' HUP\n  sleep 60 &\n  printf '%s\n' \"$!\" > '{descendant_pid_file}'\n  sleep 1\n  exit 1\nfi\nsleep 10\n",
+            "#!/bin/sh\ncount=0\nif [ -f '{starts}' ]; then count=$(cat '{starts}'); fi\ncount=$((count + 1))\nprintf '%s\n' \"$count\" > '{starts}'\nif [ \"$count\" -eq 1 ]; then\n  trap '' HUP\n  sleep 60 &\n  printf '%s\n' \"$!\" > '{descendant_pid_file}.tmp'\n  mv '{descendant_pid_file}.tmp' '{descendant_pid_file}'\n  sleep 1\n  exit 1\nfi\nsleep 10\n",
             starts = path_string(&starts),
             descendant_pid_file = path_string(&descendant_pid_file),
         ),

--- a/tests/env_destroy_tests.rs
+++ b/tests/env_destroy_tests.rs
@@ -630,7 +630,7 @@ fn env_destroy_yes_terminates_live_listener_processes() {
     let second_listener_log = root.child("listener-2.log");
     fs::write(
         &server,
-        r#"import argparse, socket, time
+        r#"import argparse, os, socket, time
 parser = argparse.ArgumentParser()
 parser.add_argument("--ready", required=True)
 args = parser.parse_args()
@@ -638,9 +638,9 @@ s = socket.socket()
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.bind(("127.0.0.1", 0))
 s.listen(1)
-with open(args.ready, "w", encoding="utf-8") as ready:
+with open(args.ready + ".tmp", "w", encoding="utf-8") as ready:
     ready.write(str(s.getsockname()[1]))
-    ready.flush()
+os.replace(args.ready + ".tmp", args.ready)
 time.sleep(60)
 "#,
     )
@@ -926,9 +926,9 @@ def replace(_signum, _frame):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    with open(replacement_pid_path, "w", encoding="utf-8") as output:
+    with open(replacement_pid_path + ".tmp", "w", encoding="utf-8") as output:
         output.write(str(replacement.pid))
-        output.flush()
+    os.replace(replacement_pid_path + ".tmp", replacement_pid_path)
     raise SystemExit(0)
 signal.signal(signal.SIGTERM, replace)
 with open(ready_path, "w", encoding="utf-8") as output:

--- a/tests/env_status_tests.rs
+++ b/tests/env_status_tests.rs
@@ -6,8 +6,9 @@ use std::net::TcpListener;
 use serde_json::Value;
 
 use crate::support::{
-    TestDir, TestHttpServer, install_fake_node_and_npm, install_fake_service_manager, ocm_env,
-    openclaw_package_tarball, run_ocm, sha512_integrity, stderr, stdout, write_executable_script,
+    TestDir, TestHttpServer, install_fake_managed_node_archive, install_fake_node_and_npm,
+    install_fake_service_manager, ocm_env, openclaw_package_tarball, run_ocm, sha512_integrity,
+    stderr, stdout, write_executable_script,
 };
 
 fn allocate_free_port() -> u16 {
@@ -276,6 +277,7 @@ fn env_status_keeps_official_runtime_healthy_when_managed_fallback_is_available(
             .to_string_lossy()
             .to_string(),
     );
+    let _managed_node_server = install_fake_managed_node_archive(&root, &mut status_env, "24.15.0");
 
     let status = run_ocm(&cwd, &status_env, &["env", "status", "demo", "--json"]);
     assert!(status.status.success(), "{}", stderr(&status));

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -665,7 +665,10 @@ pub fn install_fake_managed_node_archive(
     let archive = fake_managed_node_archive(version);
     let archive_sha256 = {
         use sha2::{Digest, Sha256};
-        format!("{:x}", Sha256::digest(&archive))
+        Sha256::digest(&archive)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
     };
     let server = TestHttpServer::serve_bytes(
         "/managed-node-toolchain",


### PR DESCRIPTION
## What Problem This Solves

Finishes the SHA-2 dependency upgrade deferred by the previous refresh and updates the remaining compatible lockfile package. Default-branch build/test CI was green at the start.

## Why This Change Was Made

- Upgrade `sha2` 0.10.9 → 0.11.0, taking the breaking release after reviewing its [migration notes](https://github.com/RustCrypto/hashes/blob/sha2-v0.11.0/sha2/CHANGELOG.md). Its digest output no longer implements `LowerHex`; explicitly encode each byte as two lowercase hex digits in artifact checksums, runtime tree checksums, destroy-state tokens, and the managed-Node test fixture.
- Regenerate `Cargo.lock` with Cargo: `indexmap` 2.14.0 → 2.14.1; SHA-2 brings `digest` 0.11.3, `block-buffer` 0.12.1, `crypto-common` 0.2.2, and `cpufeatures` 0.3.1. Cargo replaces the obsolete `generic-array`/`version_check` transitive packages with `hybrid-array`/`const-oid`. No direct dependencies were added or removed.
- Preserve the v1 runtime-tree digest with an independently calculated fixed-value test, alongside the existing known SHA-256 vector and integrity-failure coverage.
- Fix daemon-fixture synchronization races exposed by local runs: publish descendant PID markers atomically, install signal traps before publishing readiness, and wait for initial/replacement process startup records across the related snapshot, rollback, uninstall, and runtime-refresh scenarios before checking preservation or exact restart counts. All process cleanup, sibling preservation, and count assertions remain.
- Publish the listener port and replacement PID fixture files atomically before the destroy tests parse them; listener readiness and process-termination assertions remain unchanged.
- Use the existing local managed-Node archive fixture in the fallback status test, preserving download, SHA-256 verification, extraction, and health assertions without reaching the public Node distribution server.
- Let the wrapper's isolated-home test use native Cargo when Rustup is unavailable. Rustup-equipped hosts still exercise the original Rustup route, and all existing success/help assertions remain.

Every direct Cargo dependency is at its latest published stable version. The checkout, rust-cache, rust-toolchain, upload-artifact, and download-artifact pins are already current. No breaking updates were skipped. `serde_yaml` remains on its latest published, deprecated version; replacing the dependency is outside this update.

## User Impact

No intended CLI, stored-checksum, state-token, or minimum-Rust behavior change. The package continues to require Rust 1.88; every refreshed package declares Rust 1.85 support. This is internal maintenance, so no changelog entry is needed.

## Evidence

- `cargo build --locked`, `cargo fmt --check`, and `git diff --check` pass locally on Rust 1.98.0.
- The final local `cargo test --locked --no-fail-fast -- --test-threads=1` attempt passed all 324 library tests and the early CLI targets, then failed `daemon_run_persists_live_runtime_children` at its existing five-second startup wait. The failed run was stopped later in the dev tests; **there is no clean full local-suite result**. The exact unchanged test passed on rerun with `cargo test --locked --test daemon_runtime_tests daemon_run_persists_live_runtime_children -- --exact` (`1 passed; 0 failed; 34 filtered out; finished in 51.34s`).
- Earlier diagnostics exposed the fixture races fixed here and source-watch startup timeouts under concurrent load. The complete destroy target passes all 14 tests after atomic publication. Existing assertions and startup deadlines are retained.
- Codex autoreview of the complete committed diff is scoped-clean with no accepted/actionable findings.
- **Draft / needs maintainer decision:** rerun the complete local suite on an idle host before marking ready. Hosted CI independently verifies the complete committed candidate, but does not replace the requested local gate.

The live check used the actually built binary and a fresh `OCM_HOME`, a loopback HTTP server, and synthetic runtime/workspace data. The expected SHA-256 was calculated independently with Python `hashlib`; altered installed bytes were rejected. Snapshot restore and export/import preserved the exact workspace text. The fixture and server were cleaned up afterward.

<details>
<summary>Exact live commands and output</summary>

```text
OCM_HOME=/Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home
$ /Users/steipete/Projects/ocm/target/debug/ocm --version
0.2.34
$ /Users/steipete/Projects/ocm/target/debug/ocm runtime install proof-runtime --manifest-url http://127.0.0.1:56736/releases.json --version 1.0.0 --raw
Installed runtime proof-runtime
  binary path: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/runtimes/proof-runtime/files/fixture-runtime
  install root: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/runtimes/proof-runtime
  use in env: ocm env create mira --runtime proof-runtime
$ /Users/steipete/Projects/ocm/target/debug/ocm runtime verify proof-runtime --json
{
  "name": "proof-runtime",
  "binaryPath": "/Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/runtimes/proof-runtime/files/fixture-runtime",
  "sourceKind": "installed",
  "sourcePath": null,
  "sourceUrl": "http://127.0.0.1:56736/fixture-runtime",
  "sourceManifestUrl": "http://127.0.0.1:56736/releases.json",
  "sourceSha256": "d5403cd5497904ddc5bea4d5bdb368a8356f2811ec7b7b10e2385b1bb5d55aaa",
  "sourceIntegrity": null,
  "runtimeSha256": null,
  "releaseVersion": "1.0.0",
  "releaseChannel": "stable",
  "releaseSelectorKind": "version",
  "releaseSelectorValue": "1.0.0",
  "installRoot": "/Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/runtimes/proof-runtime",
  "companions": [],
  "healthy": true,
  "issue": null
}
$ /Users/steipete/Projects/ocm/target/debug/ocm env create proof --runtime proof-runtime --raw
Created env proof
  root: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/envs/proof
  openclaw home: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/envs/proof
  workspace: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/envs/proof/.openclaw/workspace
  effective gateway port: 18801 (computed)
  runtime: proof-runtime
  open: ocm @proof -- tui
  onboard: ocm @proof -- onboard
  run: ocm @proof -- status
$ /Users/steipete/Projects/ocm/target/debug/ocm @proof -- dependency-refresh
live runtime input: dependency-refresh
$ /Users/steipete/Projects/ocm/target/debug/ocm env snapshot create proof --label deps-refresh --json
{
  "id": "1788156568-186031000",
  "envName": "proof",
  "label": "deps-refresh",
  "archivePath": "/Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/snapshots/proof/1788156568-186031000.checkpoint",
  "storageKind": "apfs-clone-v1",
  "sourceRoot": "/Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/envs/proof",
  "gatewayPort": 18801,
  "serviceEnabled": false,
  "serviceRunning": false,
  "defaultRuntime": "proof-runtime",
  "defaultLauncher": null,
  "protected": false,
  "createdAt": "2026-08-31T06:09:28.186031Z"
}
$ /Users/steipete/Projects/ocm/target/debug/ocm env export proof --output /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/proof.ocm-env.tar --raw
Exported env proof
  root: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/envs/proof
  archive: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/proof.ocm-env.tar
  runtime: proof-runtime
$ /Users/steipete/Projects/ocm/target/debug/ocm env import /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/proof.ocm-env.tar --name proof-copy --raw
Imported env proof-copy from proof
  root: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/envs/proof-copy
  archive: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/proof.ocm-env.tar
  runtime: proof-runtime
  open: ocm @proof-copy -- tui
  run: ocm @proof-copy -- status
export/import content verified: dependency refresh: snapshot and archive round-trip
$ /Users/steipete/Projects/ocm/target/debug/ocm env snapshot restore proof 1788156568-186031000 --raw
Restored env proof from snapshot 1788156568-186031000
  root: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/envs/proof
  checkpoint: /Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/snapshots/proof/1788156568-186031000.checkpoint
  storage: apfs-clone-v1
  label: deps-refresh
  runtime: proof-runtime
snapshot restore content verified: dependency refresh: snapshot and archive round-trip
$ /Users/steipete/Projects/ocm/target/debug/ocm runtime verify proof-runtime --json
{
  "name": "proof-runtime",
  "binaryPath": "/Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/runtimes/proof-runtime/files/fixture-runtime",
  "sourceKind": "installed",
  "sourcePath": null,
  "sourceUrl": "http://127.0.0.1:56736/fixture-runtime",
  "sourceManifestUrl": "http://127.0.0.1:56736/releases.json",
  "sourceSha256": "d5403cd5497904ddc5bea4d5bdb368a8356f2811ec7b7b10e2385b1bb5d55aaa",
  "sourceIntegrity": null,
  "runtimeSha256": null,
  "releaseVersion": "1.0.0",
  "releaseChannel": "stable",
  "releaseSelectorKind": "version",
  "releaseSelectorValue": "1.0.0",
  "installRoot": "/Users/steipete/Projects/ocm/target/deps-refresh-live-20260830/ocm-home/runtimes/proof-runtime",
  "companions": [],
  "healthy": false,
  "issue": "sha256 mismatch: expected d5403cd5497904ddc5bea4d5bdb368a8356f2811ec7b7b10e2385b1bb5d55aaa, got 6b85ac33c1bf6b81626590d063b2eb91012c95e0e51be81af7dcae01c7fb8b3f"
}
PASS: real HTTP install, SHA-256 verification, runtime execution, snapshot restore, archive round-trip, tamper rejection
```

</details>

### CI reasoning

The starting default-branch [CI run](https://github.com/openclaw/ocm/actions/runs/33353987874) passed formatting, Rust 1.88 compatibility, Windows compilation, and full Linux/macOS tests plus cargo-install smoke checks. No jobs or assertions were removed, skipped, or weakened. The separate manually dispatched Release workflow is publication infrastructure and was not run for this PR. Generated CodeQL push/scheduled scans are security analysis, separate from the repository's build/test CI.

[PR CI is green](https://github.com/openclaw/ocm/actions/runs/33366001290): formatting, Rust 1.88 minimum, Windows compilation, complete Linux/macOS suites, and cargo-install smoke checks all pass. [CodeQL is green](https://github.com/openclaw/ocm/actions/runs/33365999611) for Rust and Actions. No hosted CI reruns were needed. The PR remains draft solely because the full local gate has not passed.
