### PR TITLE
fix: bound git worktree helper subprocesses

### DIFF
--- a/src/infra/process.rs
+++ b/src/infra/process.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 pub fn run_direct(
     command: &str,
@@ -27,4 +29,100 @@ pub fn run_shell(command: &str, env: &BTreeMap<String, String>, cwd: &Path) -> R
     } else {
         run_direct("sh", &["-lc".to_string(), command.to_string()], env, cwd)
     }
+}
+
+/// Run a command, capture output, and kill the child if it exceeds `timeout`.
+pub(crate) fn command_output(
+    mut command: Command,
+    timeout: Duration,
+    label: &str,
+) -> Result<Output, String> {
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to run {label}: {error}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| format!("{label} stdout was not captured"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| format!("{label} stderr was not captured"))?;
+
+    let stdout_reader = thread::spawn(move || read_pipe(stdout));
+    let stderr_reader = thread::spawn(move || read_pipe(stderr));
+
+    let status = wait_for_child(&mut child, timeout, label);
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| format!("{label} stdout reader panicked"))?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| format!("{label} stderr reader panicked"))?;
+    Ok(Output {
+        status: status?,
+        stdout,
+        stderr,
+    })
+}
+
+fn read_pipe(mut reader: impl std::io::Read) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let _ = reader.read_to_end(&mut buf);
+    buf
+}
+
+pub(crate) fn wait_for_child(
+    child: &mut Child,
+    timeout: Duration,
+    label: &str,
+) -> Result<ExitStatus, String> {
+    let started_at = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) if started_at.elapsed() < timeout => {
+                thread::sleep(Duration::from_millis(25));
+            }
+            Ok(None) => {
+                terminate_child(child);
+                return Err(format!("{label} timed out after {timeout:?}"));
+            }
+            Err(error) => {
+                terminate_child(child);
+                return Err(format!("failed waiting for {label}: {error}"));
+            }
+        }
+    }
+}
+
+fn terminate_child(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        let process_group = format!("-{}", child.id());
+        let _ = Command::new("kill")
+            .args(["-TERM", "--", &process_group])
+            .status();
+        for _ in 0..20 {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(25)),
+                Err(_) => break,
+            }
+        }
+        let _ = Command::new("kill")
+            .args(["-KILL", "--", &process_group])
+            .status();
+    }
+    let _ = child.kill();
+    let _ = child.wait();
 }

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -1,15 +1,17 @@
 use std::collections::BTreeMap;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
 
 use serde_json::Value;
 
+use crate::infra::process::command_output;
 use crate::store::{clean_path, dev_sources::path_identity, display_path};
 
 const SOURCE_DEPENDENCY_PROBE: &str = r#"import fs from "node:fs";
@@ -64,6 +66,17 @@ for (const [name, specifier] of requirements) {
   }
 }
 process.stdout.write(JSON.stringify(issues));"#;
+
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
+
+fn git_output(
+    cwd: &Path,
+    args: impl IntoIterator<Item = impl AsRef<OsStr>>,
+) -> Result<Output, String> {
+    let mut command = git_command();
+    command.arg("-C").arg(cwd).args(args);
+    command_output(command, GIT_COMMAND_TIMEOUT, "git")
+}
 
 pub(crate) fn detect_openclaw_checkout(path: &Path) -> Option<PathBuf> {
     let package_json = path.join("package.json");
@@ -483,13 +496,16 @@ pub(crate) fn ensure_openclaw_worktree(
     let worktree_argument = worktree_root
         .strip_prefix(&repo_root)
         .map_err(|_| "OCM-owned worktree destination is outside its repository".to_string())?;
-    let output = git_command()
-        .arg("-C")
-        .arg(&repo_root)
-        .args(["worktree", "add", "--detach"])
-        .arg(worktree_argument)
-        .output()
-        .map_err(|error| format!("failed to run git worktree add: {error}"))?;
+    let output = git_output(
+        &repo_root,
+        [
+            OsStr::new("worktree"),
+            OsStr::new("add"),
+            OsStr::new("--detach"),
+            worktree_argument.as_os_str(),
+        ],
+    )
+    .map_err(|error| format!("failed to run git worktree add: {error}"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -579,10 +595,9 @@ fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), Strin
         return Ok(());
     }
 
-    let output = git_command()
-        .arg("-C")
-        .arg(worktree_root)
-        .args([
+    let output = git_output(
+        worktree_root,
+        [
             "clean",
             "-ffdX",
             "--",
@@ -596,9 +611,9 @@ fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), Strin
             "extensions/diffs-language-pack/assets",
             "extensions/diffs/assets",
             "extensions/discord/assets",
-        ])
-        .output()
-        .map_err(|error| format!("failed to remove generated simulation output: {error}"))?;
+        ],
+    )
+    .map_err(|error| format!("failed to remove generated simulation output: {error}"))?;
     if output.status.success() {
         return Ok(());
     }
@@ -614,13 +629,16 @@ fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), Strin
 fn remove_registered_worktree(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
     ensure_worktree_clean(worktree_root)?;
 
-    let output = git_command()
-        .arg("-C")
-        .arg(repo_root)
-        .args(["worktree", "remove", "--force"])
-        .arg(worktree_root)
-        .output()
-        .map_err(|error| format!("failed to run git worktree remove: {error}"))?;
+    let output = git_output(
+        repo_root,
+        [
+            OsStr::new("worktree"),
+            OsStr::new("remove"),
+            OsStr::new("--force"),
+            worktree_root.as_os_str(),
+        ],
+    )
+    .map_err(|error| format!("failed to run git worktree remove: {error}"))?;
     if output.status.success() {
         return Ok(());
     }
@@ -636,18 +654,18 @@ fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
         return Ok(());
     }
 
-    let output = git_command()
-        .args(["-c", "status.showUntrackedFiles=all"])
-        .arg("-C")
-        .arg(worktree_root)
-        .args([
+    let output = git_output(
+        worktree_root,
+        [
+            "-c",
+            "status.showUntrackedFiles=all",
             "status",
             "--porcelain=v1",
             "--untracked-files=all",
             "--ignore-submodules=none",
-        ])
-        .output()
-        .map_err(|error| format!("failed to inspect git worktree status: {error}"))?;
+        ],
+    )
+    .map_err(|error| format!("failed to inspect git worktree status: {error}"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -666,18 +684,17 @@ fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
 }
 
 fn ensure_no_ignored_local_files(worktree_root: &Path) -> Result<(), String> {
-    let worktree_output = git_command()
-        .arg("-C")
-        .arg(worktree_root)
-        .args([
+    let worktree_output = git_output(
+        worktree_root,
+        [
             "ls-files",
             "--others",
             "--ignored",
             "--exclude-standard",
             "-z",
-        ])
-        .output()
-        .map_err(|error| format!("failed to inspect ignored worktree files: {error}"))?;
+        ],
+    )
+    .map_err(|error| format!("failed to inspect ignored worktree files: {error}"))?;
     if !worktree_output.status.success() {
         let stderr = String::from_utf8_lossy(&worktree_output.stderr)
             .trim()
@@ -689,18 +706,17 @@ fn ensure_no_ignored_local_files(worktree_root: &Path) -> Result<(), String> {
         return Err(format!("git ignored-file inspection failed: {detail}"));
     }
 
-    let submodule_output = git_command()
-        .arg("-C")
-        .arg(worktree_root)
-        .args([
+    let submodule_output = git_output(
+        worktree_root,
+        [
             "submodule",
             "foreach",
             "--quiet",
             "--recursive",
             "git ls-files --others --ignored --exclude-standard -z",
-        ])
-        .output()
-        .map_err(|error| format!("failed to inspect ignored submodule files: {error}"))?;
+        ],
+    )
+    .map_err(|error| format!("failed to inspect ignored submodule files: {error}"))?;
     if !submodule_output.status.success() {
         let stderr = String::from_utf8_lossy(&submodule_output.stderr)
             .trim()
@@ -739,28 +755,23 @@ fn is_disposable_ignored_path(path: &Path) -> bool {
 }
 
 fn registered_worktree_paths(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
-    let output = git_command()
-        .arg("-C")
-        .arg(repo_root)
-        .args(["worktree", "list", "--porcelain", "-z"])
-        .output()
+    let output = git_output(repo_root, ["worktree", "list", "--porcelain", "-z"])
         .map_err(|error| format!("failed to run git worktree list: {error}"))?;
     if output.status.success() {
         return parse_registered_worktree_paths(&output.stdout);
     }
 
-    let fallback = git_command()
-        .arg("-C")
-        .arg(repo_root)
-        .args([
+    let fallback = git_output(
+        repo_root,
+        [
             "-c",
             "core.quotePath=false",
             "worktree",
             "list",
             "--porcelain",
-        ])
-        .output()
-        .map_err(|error| format!("failed to run compatible git worktree list: {error}"))?;
+        ],
+    )
+    .map_err(|error| format!("failed to run compatible git worktree list: {error}"))?;
     if fallback.status.success() {
         return parse_legacy_registered_worktree_paths(&fallback.stdout);
     }
@@ -1021,12 +1032,7 @@ fn git_command() -> Command {
 }
 
 fn git_rev_parse_path(path: &Path, selector: &str) -> Option<PathBuf> {
-    let output = git_command()
-        .arg("-C")
-        .arg(path)
-        .args(["rev-parse", selector])
-        .output()
-        .ok()?;
+    let output = git_output(path, ["rev-parse", selector]).ok()?;
     if !output.status.success() {
         return None;
     }
@@ -1083,10 +1089,33 @@ mod tests {
 
     #[cfg(unix)]
     use super::parse_registered_worktree_paths;
+    use crate::infra::process::command_output;
+
     use super::{
         ensure_openclaw_worktree, parse_legacy_registered_worktree_paths,
         prepare_openclaw_simulation_worktree_cleanup, remove_openclaw_worktree,
     };
+
+    #[cfg(unix)]
+    #[test]
+    fn git_timeout_kills_sleep_after_deadline() {
+        use std::time::{Duration, Instant};
+
+        let started = Instant::now();
+        let mut command = Command::new("/bin/sleep");
+        command.arg("30");
+        let error = command_output(command, Duration::from_millis(200), "sleep")
+            .expect_err("sleep should be killed at the deadline");
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "timed runner should return within 1s, took {elapsed:?}"
+        );
+        assert!(
+            error.contains("timed out"),
+            "expected timeout error, got {error}"
+        );
+    }
 
     fn run_git(repo: &std::path::Path, args: &[&str]) {
         let output = Command::new("git")

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -1108,8 +1108,8 @@ mod tests {
             .expect_err("sleep should be killed at the deadline");
         let elapsed = started.elapsed();
         assert!(
-            elapsed < Duration::from_secs(1),
-            "timed runner should return within 1s, took {elapsed:?}"
+            elapsed < Duration::from_secs(5),
+            "timed runner should return well before the 30s sleep, took {elapsed:?}"
         );
         assert!(
             error.contains("timed out"),

--- a/src/supervisor/openclaw_handoff.rs
+++ b/src/supervisor/openclaw_handoff.rs
@@ -2,9 +2,9 @@ use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::Path;
-use std::process::{Child, Command, ExitStatus, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use serde::Deserialize;
 
@@ -240,7 +240,11 @@ fn run_openclaw_machine_command(
     let stdout_reader = thread::spawn(move || read_bounded(stdout));
     let stderr_reader = thread::spawn(move || read_bounded(stderr));
 
-    let status = wait_for_child(&mut child, COMMAND_TIMEOUT);
+    let status = crate::infra::process::wait_for_child(
+        &mut child,
+        COMMAND_TIMEOUT,
+        "restart-handoff command",
+    );
     let stdout = stdout_reader
         .join()
         .map_err(|_| "restart-handoff stdout reader panicked".to_string())?
@@ -338,53 +342,6 @@ fn read_bounded<R: Read>(mut reader: R) -> std::io::Result<Vec<u8>> {
         kept.extend_from_slice(&chunk[..read.min(remaining)]);
     }
     Ok(kept)
-}
-
-fn wait_for_child(child: &mut Child, timeout: Duration) -> Result<ExitStatus, String> {
-    let started_at = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return Ok(status),
-            Ok(None) if started_at.elapsed() < timeout => {
-                thread::sleep(Duration::from_millis(25));
-            }
-            Ok(None) => {
-                terminate_child(child);
-                return Err(format!(
-                    "restart-handoff command timed out after {} seconds",
-                    timeout.as_secs()
-                ));
-            }
-            Err(error) => {
-                terminate_child(child);
-                return Err(format!(
-                    "failed waiting for restart-handoff command: {error}"
-                ));
-            }
-        }
-    }
-}
-
-fn terminate_child(child: &mut Child) {
-    #[cfg(unix)]
-    {
-        let process_group = format!("-{}", child.id());
-        let _ = Command::new("kill")
-            .args(["-TERM", "--", &process_group])
-            .status();
-        for _ in 0..20 {
-            match child.try_wait() {
-                Ok(Some(_)) => return,
-                Ok(None) => thread::sleep(Duration::from_millis(25)),
-                Err(_) => break,
-            }
-        }
-        let _ = Command::new("kill")
-            .args(["-KILL", "--", &process_group])
-            .status();
-    }
-    let _ = child.kill();
-    let _ = child.wait();
 }
 
 fn command_failure_detail(status: ExitStatus) -> String {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `ocm` dev, setup, and upgrade would hang forever when a git worktree helper (`worktree add` / `remove` / `status` / `ls-files` / `submodule foreach`) blocked on a lock or a stuck child. Those helpers called `Command::output()` with no kill deadline.

The first timeout patch waited only on the direct child, then joined stdout/stderr readers with no deadline. A descendant that still held those inherited pipes could block the caller after the child had already exited. The drain path then called terminate on that already-exited child; `try_wait()` returned `Some` and skipped process-group KILL, so a TERM-resistant descendant stayed alive.

On origin/main the hang is here:

https://github.com/openclaw/ocm/blob/e04c10166d6b58932213bf8422ccfc201cf6ac37/src/openclaw_repo.rs#L123-L129

https://github.com/openclaw/ocm/commit/e04c10166d6b58932213bf8422ccfc201cf6ac37

## Why This Change Was Made

Production worktree helpers now go through a shared timed runner. The child is polled, then terminated (process group TERM, then KILL) when the deadline expires. The same deadline stays active while the captured pipes drain. Cleanup waits for the process group, not only the direct child, so a descendant that ignores TERM still gets KILL. Fixture git used only to build temp repos stays unbounded. The 15s default is unchanged.

## User Impact

A wedged git during worktree setup or cleanup fails after 15s instead of blocking the CLI. A helper whose direct child already exited no longer hangs on leftover pipe holders, and TERM-resistant leftovers are killed with the group. Successful worktree add/remove/status behavior is unchanged.

## Evidence

Live analog of the remaining descendant leak. The grandchild ignores SIGTERM and holds a pipe. TERM alone leaves it alive. KILL removes it:

```console
$ python3 /tmp/proof-ocm136-p2-live.py
descendant_pid=37239
alive_after_term_only=True
gone_after_kill=True
DONE analog
```

The patched `command_output` runs that same shape (parent exits, TERM-resistant descendant holds stdout) with an 800ms deadline. It returns in 1.50s and the descendant is gone. A real `ensure_openclaw_worktree` add/reuse/remove on a temp OpenClaw fixture returns in 1.02s through the same `git_output` path. The 15s production default is unchanged.

```console
$ cargo test --offline --lib git_timeout_kills_term_resistant -- --nocapture
test openclaw_repo::tests::git_timeout_kills_term_resistant_descendant ... ok
finished in 1.50s

$ cargo test --offline --lib owned_worktree_uses_canonical -- --nocapture
test openclaw_repo::tests::owned_worktree_uses_canonical_repository_paths ... ok
finished in 1.02s
```

Earlier live analog of the unbounded drain hang, plus rustc `/bin/sleep 30` vs the 200ms deadline, remains in the prior evidence.

## Real behavior proof

- **Behavior or issue addressed:** Git worktree helpers no longer block `ocm` forever. After the direct child exits, inherited stdout/stderr drains stay under the same deadline. A TERM-resistant descendant that still holds those pipes is killed with the process group.
- **Real environment tested:** macOS (Darwin 25.6.0 arm64), rustc 1.98.0, perl 5, ocm checkout `/private/tmp/ocm136-p1` on `fix/git-worktree-timeout`.
- **Exact steps or command run after this patch:** Ran `python3 /tmp/proof-ocm136-p2-live.py` to show TERM-only leaves the descendant alive. Then ran the patched `command_output` against `perl` that forks, ignores SIGTERM, writes its pid, and sleeps 30s. Then ran production `ensure_openclaw_worktree` add/reuse/remove on a temp OpenClaw git repo.
- **Evidence after fix:** terminal output above. `alive_after_term_only=True`, `gone_after_kill=True`. The patched runner returned in 1.50s with the descendant gone. `ensure_openclaw_worktree` completed add/reuse/remove in 1.02s. `GIT_COMMAND_TIMEOUT` is still 15 seconds.
- **Observed result after fix:** The helper returns while a 30s descendant would still be holding stdout. Group KILL removes a SIG_IGN leftover. A normal worktree add through `git_output` still succeeds. The 15s default is unchanged.
- **What was not tested:** A live `index.lock` hang inside a full OpenClaw checkout during `ocm setup`, the Windows job-object kill path, and lengthening the 15s default for valid slow worktree operations. That last item is an owner decision.

## Summary

Shared timed runner for git worktree helpers. Deadline covers the direct child wait and the inherited pipe drain. Process-group cleanup escalates to KILL even when the direct child has already exited. 15s default unchanged.
