### PR TITLE
Restore services after interrupted upgrades

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2,7 +2,11 @@ use std::collections::{BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{
+    Arc, Mutex, OnceLock,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    mpsc,
+};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -37,6 +41,50 @@ use crate::store::{
     runtime_integrity_issue, runtime_meta_path, save_environment, save_upgrade_history_record,
     upgrade_history_recovery_dir, upgrade_history_runtime_recovery_dir, write_json,
 };
+
+static UPGRADE_INTERRUPT_REQUESTED: AtomicBool = AtomicBool::new(false);
+static UPGRADE_CRITICAL_DEPTH: AtomicUsize = AtomicUsize::new(0);
+static UPGRADE_SIGNAL_HANDLER: OnceLock<Result<(), String>> = OnceLock::new();
+
+fn install_upgrade_interrupt_handler() -> Result<(), String> {
+    UPGRADE_SIGNAL_HANDLER
+        .get_or_init(|| {
+            UPGRADE_INTERRUPT_REQUESTED.store(false, Ordering::SeqCst);
+            ctrlc::set_handler(|| {
+                if UPGRADE_CRITICAL_DEPTH.load(Ordering::SeqCst) > 0 {
+                    UPGRADE_INTERRUPT_REQUESTED.store(true, Ordering::SeqCst);
+                } else {
+                    std::process::exit(130);
+                }
+            })
+            .map_err(|error| format!("failed to install upgrade signal handler: {error}"))
+        })
+        .clone()
+}
+
+#[derive(Debug)]
+struct UpgradeInterruptFence;
+
+impl UpgradeInterruptFence {
+    fn enter() -> Result<Self, String> {
+        install_upgrade_interrupt_handler()?;
+        UPGRADE_CRITICAL_DEPTH.fetch_add(1, Ordering::SeqCst);
+        Ok(Self)
+    }
+
+    fn requested(&self) -> bool {
+        UPGRADE_INTERRUPT_REQUESTED.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for UpgradeInterruptFence {
+    fn drop(&mut self) {
+        UPGRADE_CRITICAL_DEPTH.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+const UPGRADE_INTERRUPTED_ERROR: &str =
+    "upgrade interrupted by SIGINT or SIGTERM; restoring the pre-upgrade state";
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -851,6 +899,7 @@ impl Cli {
         env_name: &str,
         label: &str,
     ) -> Result<EnvSnapshotSummary, String> {
+        let interrupt_fence = UpgradeInterruptFence::enter()?;
         let prepared = self
             .environment_service()
             .prepare_snapshot_capture_locked(env_name)?;
@@ -870,6 +919,9 @@ impl Cli {
         let service_result = self
             .service_service()
             .restore_after_snapshot_locked(env_name, service_state);
+        if interrupt_fence.requested() && service_result.is_ok() {
+            return Err(UPGRADE_INTERRUPTED_ERROR.to_string());
+        }
         match (snapshot_result, service_result) {
             (Ok(snapshot), Ok(())) => Ok(snapshot),
             (Ok(snapshot), Err(service_error)) => Err(format!(
@@ -1260,6 +1312,14 @@ impl Cli {
             Some(plan.record.id.clone()),
             UpgradeTimingRecorder::new(),
         )?;
+        if transaction.interrupted() {
+            return Ok(self.fail_upgrade_rollback_locked(
+                env_name,
+                &plan,
+                transaction,
+                UPGRADE_INTERRUPTED_ERROR.to_string(),
+            ));
+        }
         let rollback_transaction_id = transaction.id.clone();
         let safety_snapshot_id = transaction.snapshot_id.clone();
 
@@ -2314,6 +2374,19 @@ impl Cli {
                 None,
                 timings,
             )?;
+            if transaction.interrupted() {
+                return self.rollback_failed_upgrade(
+                    env_name,
+                    "runtime",
+                    previous_binding_name,
+                    "runtime",
+                    target_runtime_name,
+                    target_version,
+                    target.release_channel_hint(),
+                    transaction,
+                    UPGRADE_INTERRUPTED_ERROR.to_string(),
+                );
+            }
             if target_changed {
                 transaction.mark_runtime_mutated(&prepared.name);
             }
@@ -2616,6 +2689,19 @@ impl Cli {
                 None,
                 timings,
             )?;
+            if transaction.interrupted() {
+                return self.rollback_failed_upgrade(
+                    env_name,
+                    "runtime",
+                    previous_binding_name,
+                    "runtime",
+                    target_runtime_name,
+                    target_version,
+                    target.release_channel_hint(),
+                    transaction,
+                    UPGRADE_INTERRUPTED_ERROR.to_string(),
+                );
+            }
             if changed {
                 transaction.mark_runtime_mutated(&prepared.name);
             }
@@ -2885,6 +2971,19 @@ impl Cli {
             None,
             timings,
         )?;
+        if transaction.interrupted() {
+            return self.rollback_failed_upgrade(
+                env_name,
+                "runtime",
+                previous_binding_name,
+                "runtime",
+                current.name,
+                current.release_version,
+                current.release_channel,
+                transaction,
+                UPGRADE_INTERRUPTED_ERROR.to_string(),
+            );
+        }
         transaction.mark_runtime_mutated(&current.name);
         let updated = match prepared.commit() {
             Ok(updated) => updated,
@@ -3169,6 +3268,19 @@ impl Cli {
             None,
             timings,
         )?;
+        if transaction.interrupted() {
+            return self.rollback_failed_upgrade(
+                env_name,
+                "launcher",
+                launcher_name.to_string(),
+                "runtime",
+                target_runtime_name,
+                target_version,
+                target.release_channel_hint(),
+                transaction,
+                UPGRADE_INTERRUPTED_ERROR.to_string(),
+            );
+        }
         if target_changed {
             transaction.mark_runtime_mutated(&prepared.name);
         }
@@ -4124,6 +4236,7 @@ impl Cli {
         rollback_of: Option<String>,
         mut timings: UpgradeTimingRecorder,
     ) -> Result<UpgradeTransaction, String> {
+        let interrupt_fence = UpgradeInterruptFence::enter()?;
         let snapshot_preparation_started = timings.start();
         let env_meta = self.environment_service().get(env_name)?;
         let prepared = self
@@ -4177,6 +4290,12 @@ impl Cli {
             snapshot_preparation_started,
             "completed",
         );
+        if interrupt_fence.requested() {
+            for backup in runtime_backups {
+                backup.cleanup();
+            }
+            return Err(UPGRADE_INTERRUPTED_ERROR.to_string());
+        }
         let quiescence_started = timings.start();
         let service_state = match self.service_service().quiesce_for_snapshot_locked(env_name) {
             Ok(service_state) => service_state,
@@ -4258,6 +4377,7 @@ impl Cli {
             service_quiesced,
             mutated_runtime_names: BTreeSet::new(),
             rollback_of,
+            interrupt_fence,
         })
     }
 
@@ -4266,6 +4386,19 @@ impl Cli {
         summary: UpgradeEnvSummary,
         mut transaction: UpgradeTransaction,
     ) -> Result<UpgradeEnvSummary, String> {
+        if transaction.interrupted() {
+            return self.rollback_failed_upgrade(
+                &summary.env_name,
+                &summary.previous_binding_kind,
+                summary.previous_binding_name.clone(),
+                &summary.binding_kind,
+                summary.binding_name.clone(),
+                summary.runtime_release_version.clone(),
+                summary.runtime_release_channel.clone(),
+                transaction,
+                UPGRADE_INTERRUPTED_ERROR.to_string(),
+            );
+        }
         if let Err(error) =
             self.retain_required_runtime_recovery(&summary.env_name, &mut transaction)
         {
@@ -4292,6 +4425,19 @@ impl Cli {
                 summary.runtime_release_channel.clone(),
                 transaction,
                 format!("failed to record upgrade history: {error}"),
+            );
+        }
+        if transaction.interrupted() {
+            return self.rollback_failed_upgrade(
+                &summary.env_name,
+                &summary.previous_binding_kind,
+                summary.previous_binding_name.clone(),
+                &summary.binding_kind,
+                summary.binding_name.clone(),
+                summary.runtime_release_version.clone(),
+                summary.runtime_release_channel.clone(),
+                transaction,
+                UPGRADE_INTERRUPTED_ERROR.to_string(),
             );
         }
         transaction.commit();
@@ -4871,9 +5017,14 @@ struct UpgradeTransaction {
     service_quiesced: bool,
     mutated_runtime_names: BTreeSet<String>,
     rollback_of: Option<String>,
+    interrupt_fence: UpgradeInterruptFence,
 }
 
 impl UpgradeTransaction {
+    fn interrupted(&self) -> bool {
+        self.interrupt_fence.requested()
+    }
+
     fn mark_runtime_mutated(&mut self, runtime_name: &str) {
         self.mutated_runtime_names.insert(runtime_name.to_string());
     }

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -4044,6 +4044,199 @@ fn upgrade_holds_the_environment_operation_lock_until_completion() {
     assert_eq!(env_json["defaultRuntime"], "old-local");
 }
 
+#[cfg(unix)]
+fn assert_interrupted_upgrade_restores_service(start_running: bool) {
+    let root = TestDir::new(if start_running {
+        "upgrade-interrupt-running"
+    } else {
+        "upgrade-interrupt-stopped"
+    });
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let old_runtime = root.child("old-openclaw");
+    let new_runtime = root.child("new-openclaw");
+    write_executable_script(&old_runtime, &recording_openclaw_script("2026.8.1"));
+    write_executable_script(&new_runtime, &recording_openclaw_script("2026.8.2"));
+
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    for (name, runtime) in [("old", &old_runtime), ("new", &new_runtime)] {
+        let add = run_ocm(
+            &cwd,
+            &env,
+            &["runtime", "add", name, "--path", &path_string(runtime)],
+        );
+        assert!(add.status.success(), "{}", stderr(&add));
+    }
+
+    let (health_port, _requests, health_stop, health_handle) = spawn_converging_health_server();
+    let setup = if start_running {
+        run_ocm(
+            &cwd,
+            &env,
+            &[
+                "start",
+                "demo",
+                "--runtime",
+                "old",
+                "--port",
+                &health_port.to_string(),
+            ],
+        )
+    } else {
+        run_ocm(
+            &cwd,
+            &env,
+            &[
+                "env",
+                "create",
+                "demo",
+                "--runtime",
+                "old",
+                "--port",
+                &health_port.to_string(),
+            ],
+        )
+    };
+    assert!(setup.status.success(), "{}", stderr(&setup));
+
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    fs::create_dir_all(runtime_path.parent().unwrap()).unwrap();
+    let ocm_home = env.get("OCM_HOME").unwrap().clone();
+    if start_running {
+        write_running_supervisor_runtime(&runtime_path, &ocm_home, "old", 4242, health_port);
+    } else {
+        write_empty_supervisor_runtime(&runtime_path, &ocm_home);
+    }
+
+    let observer_done = Arc::new(AtomicBool::new(false));
+    let observer_done_thread = Arc::clone(&observer_done);
+    let registry_path = env_registry_path(&env, &cwd).unwrap();
+    let observer_runtime_path = runtime_path.clone();
+    let observer_ocm_home = ocm_home.clone();
+    let observer = thread::spawn(move || {
+        let mut last_running = start_running;
+        let mut last_binding = "old".to_string();
+        let mut next_pid = 4243;
+        while !observer_done_thread.load(Ordering::Relaxed) {
+            let registry = fs::read(&registry_path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .unwrap_or(Value::Null);
+            let meta = registry["envs"]
+                .as_array()
+                .and_then(|envs| envs.iter().find(|entry| entry["name"] == "demo"));
+            let running = meta
+                .and_then(|entry| entry["serviceRunning"].as_bool())
+                .unwrap_or(last_running);
+            let binding = meta
+                .and_then(|entry| entry["defaultRuntime"].as_str())
+                .unwrap_or(&last_binding)
+                .to_string();
+            if running != last_running || (running && binding != last_binding) {
+                if running {
+                    write_running_supervisor_runtime(
+                        &observer_runtime_path,
+                        &observer_ocm_home,
+                        &binding,
+                        next_pid,
+                        health_port,
+                    );
+                    next_pid += 1;
+                } else {
+                    write_empty_supervisor_runtime(&observer_runtime_path, &observer_ocm_home);
+                }
+                last_running = running;
+                last_binding = binding;
+            }
+            sleep(Duration::from_millis(5));
+        }
+    });
+
+    let finalize_started = root.child("upgrade-finalize-started");
+    let finalize_release = root.child("upgrade-finalize-release");
+    env.insert(
+        "OCM_TEST_UPDATE_FINALIZE_STARTED".to_string(),
+        path_string(&finalize_started),
+    );
+    env.insert(
+        "OCM_TEST_UPDATE_FINALIZE_RELEASE".to_string(),
+        path_string(&finalize_release),
+    );
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ocm"));
+    command
+        .current_dir(&cwd)
+        .args(["upgrade", "demo", "--runtime", "new", "--json"])
+        .env_clear()
+        .envs(&env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let upgrade = command.spawn().unwrap();
+
+    for _ in 0..400 {
+        if finalize_started.exists() {
+            break;
+        }
+        sleep(Duration::from_millis(25));
+    }
+    if !finalize_started.exists() {
+        fs::write(&finalize_release, "").unwrap();
+        let output = upgrade.wait_with_output().unwrap();
+        observer_done.store(true, Ordering::Relaxed);
+        observer.join().unwrap();
+        stop_converging_health_server(health_port, &health_stop, health_handle);
+        panic!(
+            "upgrade did not reach finalization: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let signal_result = unsafe { libc::kill(upgrade.id() as i32, libc::SIGTERM) };
+    assert_eq!(signal_result, 0, "failed to signal upgrade process");
+    fs::write(&finalize_release, "").unwrap();
+    let output = upgrade.wait_with_output().unwrap();
+    observer_done.store(true, Ordering::Relaxed);
+    observer.join().unwrap();
+    stop_converging_health_server(health_port, &health_stop, health_handle);
+
+    assert!(!output.status.success(), "{}", stdout(&output));
+    let receipt: Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(receipt["outcome"], "rolled-back");
+    assert_eq!(receipt["rollback"], "restored");
+    assert!(
+        receipt["note"]
+            .as_str()
+            .is_some_and(|note| note.contains("interrupted by SIGINT or SIGTERM")),
+        "{}",
+        stdout(&output)
+    );
+
+    let shown = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["defaultRuntime"], "old");
+    assert_eq!(shown["serviceRunning"], start_running);
+}
+
+#[cfg(unix)]
+#[test]
+fn interrupted_upgrade_restores_a_running_service() {
+    assert_interrupted_upgrade_restores_service(true);
+}
+
+#[cfg(unix)]
+#[test]
+fn interrupted_upgrade_keeps_a_stopped_service_stopped() {
+    assert_interrupted_upgrade_restores_service(false);
+}
+
 #[test]
 fn upgrade_reuses_the_bound_named_runtime_without_retaining_recovery_bytes() {
     let root = TestDir::new("upgrade-reuse-bound-runtime");


### PR DESCRIPTION
## Summary

- defer SIGINT and SIGTERM while an upgrade has rollback-backed state in flight
- route an observed interruption through the existing rollback path
- restore the source binding and original managed-service state before exiting
- cover both initially running and initially stopped services

## Root cause

OCM persisted `service_running=false` while quiescing a gateway for its safety snapshot, but retained the prior running state only inside the upgrade process. A SIGTERM during that interval terminated the process before rollback or restoration ran. The supervisor then obeyed the persisted stopped state, leaving the gateway offline.

The signal fence is limited to the rollback-backed critical section. Signals outside it retain normal termination behavior. SIGKILL remains inherently uncatchable.

## Tests

- red/base and green/head reproduction with the same disposable launchd-managed environment and exact SIGTERM timing
- `interrupted_upgrade_restores_a_running_service`
- `interrupted_upgrade_keeps_a_stopped_service_stopped`
- all project tests pass with three unrelated baseline failures excluded; all three reproduce on untouched canonical main
- `cargo fmt --check`
- `cargo check`
- touched-scope Clippy with warnings denied
- source-blind CLI behavior validation, including persistence and invalid-target probes
- autoreview: scoped clean

## Evidence

The proof comment contains public red/green videos, raw transcripts, contact sheets, behavior-validator results, and a manifest with exact base/head SHAs and SHA-256 checksums.
