### PR TITLE
fix: macOS permissions persist across OCM updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 run-name: Release ${{ inputs.tag }}
 
+# macOS signing and notarization prerequisites: docs/RELEASING.md
+
 on:
   workflow_dispatch:
     inputs:
@@ -63,10 +65,13 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            macos: false
           - os: macos-15-intel
             target: x86_64-apple-darwin
+            macos: true
           - os: macos-14
             target: aarch64-apple-darwin
+            macos: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -78,7 +83,34 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Build release binary
         run: cargo build --locked --release --target "${{ matrix.target }}"
-      - name: Package release archive
+      - name: Import Developer ID certificate
+        if: ${{ matrix.macos }}
+        uses: Apple-Actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.APPSTORE_CERTIFICATES_FILE_BASE64 }}
+          p12-password: ${{ secrets.APPSTORE_CERTIFICATES_PASSWORD }}
+      - name: Sign and notarize macOS executable
+        if: ${{ matrix.macos }}
+        env:
+          OCM_MACOS_TEAM_ID: ${{ vars.MACOS_TEAM_ID }}
+          OCM_NOTARY_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+          OCM_NOTARY_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          OCM_NOTARY_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+        run: |
+          ./scripts/sign-notarize-macos.sh \
+            --binary "./target/${{ matrix.target }}/release/ocm"
+      - name: Package macOS release archive
+        if: ${{ matrix.macos }}
+        env:
+          OCM_MACOS_TEAM_ID: ${{ vars.MACOS_TEAM_ID }}
+        run: |
+          ./scripts/package-release.sh \
+            --target "${{ matrix.target }}" \
+            --binary "./target/${{ matrix.target }}/release/ocm" \
+            --macos-team-id "$OCM_MACOS_TEAM_ID" \
+            --output-dir ./dist
+      - name: Package Linux release archive
+        if: ${{ !matrix.macos }}
         run: |
           ./scripts/package-release.sh \
             --target "${{ matrix.target }}" \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,25 @@
+# Release prerequisites
+
+The canonical `.github/workflows/release.yml` workflow publishes OCM releases from signed tags on `main`. Linux packaging needs no repository credentials. Each macOS matrix job imports one Developer ID Application certificate, signs `ocm` with the identifier `com.openclaw.ocm`, submits a temporary ZIP to Apple's notary service, checks Gatekeeper acceptance, and verifies the executable again after extracting the final tarball.
+
+Configure these GitHub Actions repository secrets:
+
+- `APPSTORE_CERTIFICATES_FILE_BASE64`: a base64-encoded PKCS#12 file containing the Developer ID Application certificate and private key.
+- `APPSTORE_CERTIFICATES_PASSWORD`: the PKCS#12 export password.
+- `APPSTORE_API_PRIVATE_KEY`: the App Store Connect team API private key in P8 format.
+- `APPSTORE_API_KEY_ID`: the matching App Store Connect API key ID.
+- `APPSTORE_ISSUER_ID`: the matching App Store Connect issuer ID.
+
+Configure `MACOS_TEAM_ID` as a GitHub Actions repository variable. It must contain the 10-character Apple Developer Team ID for the certificate. The release fails if the signature has another identifier or team, is ad-hoc, lacks the hardened runtime or secure timestamp, or does not pass Apple's notarization checks.
+
+Use the same Apple Developer team and `com.openclaw.ocm` identifier for every release. Certificate renewal within that team preserves the stable designated requirement macOS uses to identify OCM across updates. Changing the team or identifier causes macOS to treat the executable as different code.
+
+OCM keeps the existing `.tar.gz` install and self-update format. Apple cannot staple tickets to a standalone command-line executable or tar archive. The workflow therefore notarizes a ZIP containing the signed executable and verifies the ticket through Gatekeeper before packaging. The Mach-O code signature is embedded in the executable, and `package-release.sh` verifies it after a tar create-and-extract round trip. `install.sh` and `ocm self update` continue to verify the published tarball against `SHA256SUMS` before installing it.
+
+References:
+
+- [Apple: Notarizing macOS software before distribution](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
+- [Apple: Customizing the notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)
+- [Apple: Packaging Mac software for distribution](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution)
+- [Apple: Code Signing Tasks](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html)
+- [GitHub: Installing an Apple certificate on macOS runners](https://docs.github.com/actions/how-tos/deploy/deploy-to-third-party-platforms/sign-xcode-applications)

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -7,12 +7,14 @@ Package a compiled ocm binary into a GitHub release archive.
 
 Usage:
   scripts/package-release.sh --target <triple> --binary <path> [--output-dir <dir>]
+    [--macos-team-id <id>]
 EOF
 }
 
 target=""
 binary=""
 output_dir="dist"
+macos_team_id=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -30,6 +32,11 @@ while [[ $# -gt 0 ]]; do
       shift
       [[ $# -gt 0 ]] || { echo "error: --output-dir requires a value" >&2; exit 1; }
       output_dir="$1"
+      ;;
+    --macos-team-id)
+      shift
+      [[ $# -gt 0 ]] || { echo "error: --macos-team-id requires a value" >&2; exit 1; }
+      macos_team_id="$1"
       ;;
     --help|-h)
       usage
@@ -54,6 +61,20 @@ case "$target" in
     ;;
 esac
 [[ -f "$binary" ]] || { echo "error: binary not found: $binary" >&2; exit 1; }
+case "$target" in
+  *-apple-darwin)
+    [[ -n "$macos_team_id" ]] || {
+      echo "error: --macos-team-id is required for macOS release archives" >&2
+      exit 1
+    }
+    ;;
+  *)
+    [[ -z "$macos_team_id" ]] || {
+      echo "error: --macos-team-id is only valid for macOS release archives" >&2
+      exit 1
+    }
+    ;;
+esac
 
 mkdir -p "$output_dir"
 tmp_dir="$(mktemp -d)"
@@ -75,6 +96,16 @@ cleanup_archive() {
 trap 'cleanup_archive; cleanup' EXIT
 
 tar -czf "$tmp_archive" -C "$tmp_dir" ocm LICENSE README.md
+if [[ "$target" == *-apple-darwin ]]; then
+  verify_dir="${tmp_dir}/verify"
+  mkdir -p "$verify_dir"
+  tar -xzf "$tmp_archive" -C "$verify_dir"
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  "${script_dir}/verify-macos-release.sh" \
+    --binary "${verify_dir}/ocm" \
+    --team-id "$macos_team_id" \
+    --require-notarization
+fi
 mv -f "$tmp_archive" "$archive_path"
 
 echo "$archive_path"

--- a/scripts/sign-notarize-macos.sh
+++ b/scripts/sign-notarize-macos.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Sign and notarize a macOS ocm executable in the release workflow.
+
+Usage:
+  scripts/sign-notarize-macos.sh --binary <path>
+
+Required environment:
+  OCM_MACOS_TEAM_ID
+  OCM_NOTARY_API_PRIVATE_KEY
+  OCM_NOTARY_API_KEY_ID
+  OCM_NOTARY_ISSUER_ID
+EOF
+}
+
+binary=""
+identifier="com.openclaw.ocm"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --binary)
+      shift
+      [[ $# -gt 0 ]] || { echo "error: --binary requires a value" >&2; exit 1; }
+      binary="$1"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+[[ -n "$binary" ]] || { echo "error: --binary is required" >&2; exit 1; }
+[[ -f "$binary" && ! -L "$binary" ]] || {
+  echo "error: macOS release binary is missing or invalid: $binary" >&2
+  exit 1
+}
+
+required_environment=(
+  OCM_MACOS_TEAM_ID
+  OCM_NOTARY_API_PRIVATE_KEY
+  OCM_NOTARY_API_KEY_ID
+  OCM_NOTARY_ISSUER_ID
+)
+for name in "${required_environment[@]}"; do
+  [[ -n "${!name:-}" ]] || {
+    echo "error: required environment variable is empty: $name" >&2
+    exit 1
+  }
+done
+[[ "$OCM_MACOS_TEAM_ID" =~ ^[A-Z0-9]{10}$ ]] || {
+  echo "error: OCM_MACOS_TEAM_ID must be a 10-character Apple Developer Team ID" >&2
+  exit 1
+}
+
+for tool in codesign ditto plutil security xcrun; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "error: required command not found: $tool" >&2
+    exit 1
+  }
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+identities="$(
+  security find-identity -v -p codesigning |
+    awk -v team="(${OCM_MACOS_TEAM_ID})" '
+      /Developer ID Application:/ && index($0, team) { print $2 }
+    '
+)"
+identity_count="$(grep -c . <<<"$identities" || true)"
+if [[ "$identity_count" != "1" ]]; then
+  echo "error: expected exactly one Developer ID Application identity for team ${OCM_MACOS_TEAM_ID}, found ${identity_count}" >&2
+  exit 1
+fi
+identity="$identities"
+
+codesign \
+  --force \
+  --identifier "$identifier" \
+  --options runtime \
+  --sign "$identity" \
+  --timestamp \
+  "$binary"
+
+"${script_dir}/verify-macos-release.sh" \
+  --binary "$binary" \
+  --team-id "$OCM_MACOS_TEAM_ID"
+
+tmp_dir="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/ocm-notarize.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+chmod 700 "$tmp_dir"
+
+notary_key="${tmp_dir}/AuthKey.p8"
+submission_archive="${tmp_dir}/ocm.zip"
+submission_result="${tmp_dir}/submission.json"
+umask 077
+printf '%s\n' "$OCM_NOTARY_API_PRIVATE_KEY" >"$notary_key"
+ditto -c -k --keepParent "$binary" "$submission_archive"
+
+if ! xcrun notarytool submit "$submission_archive" \
+  --key "$notary_key" \
+  --key-id "$OCM_NOTARY_API_KEY_ID" \
+  --issuer "$OCM_NOTARY_ISSUER_ID" \
+  --wait \
+  --output-format json >"$submission_result"; then
+  echo "error: Apple notarization submission failed" >&2
+  exit 1
+fi
+
+submission_status="$(plutil -extract status raw -o - "$submission_result")"
+submission_id="$(plutil -extract id raw -o - "$submission_result")"
+if [[ "$submission_status" != "Accepted" ]]; then
+  echo "error: Apple notarization ${submission_id:-unknown} finished with status ${submission_status:-unknown}" >&2
+  exit 1
+fi
+echo "Apple notarization accepted submission ${submission_id}"
+
+"${script_dir}/verify-macos-release.sh" \
+  --binary "$binary" \
+  --team-id "$OCM_MACOS_TEAM_ID" \
+  --require-notarization

--- a/scripts/verify-macos-release.sh
+++ b/scripts/verify-macos-release.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Verify the Developer ID signature on a shipped macOS ocm executable.
+
+Usage:
+  scripts/verify-macos-release.sh --binary <path> --team-id <id> [--require-notarization]
+EOF
+}
+
+binary=""
+team_id=""
+require_notarization=0
+identifier="com.openclaw.ocm"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --binary)
+      shift
+      [[ $# -gt 0 ]] || { echo "error: --binary requires a value" >&2; exit 1; }
+      binary="$1"
+      ;;
+    --team-id)
+      shift
+      [[ $# -gt 0 ]] || { echo "error: --team-id requires a value" >&2; exit 1; }
+      team_id="$1"
+      ;;
+    --require-notarization)
+      require_notarization=1
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+[[ -n "$binary" ]] || { echo "error: --binary is required" >&2; exit 1; }
+[[ -f "$binary" && ! -L "$binary" ]] || {
+  echo "error: macOS release binary is missing or invalid: $binary" >&2
+  exit 1
+}
+[[ "$team_id" =~ ^[A-Z0-9]{10}$ ]] || {
+  echo "error: --team-id must be a 10-character Apple Developer Team ID" >&2
+  exit 1
+}
+
+for tool in codesign grep; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "error: required command not found: $tool" >&2
+    exit 1
+  }
+done
+
+if ! verification="$(codesign --verify --strict --verbose=2 "$binary" 2>&1)"; then
+  printf '%s\n' "$verification" >&2
+  echo "error: macOS release binary has an invalid code signature" >&2
+  exit 1
+fi
+
+metadata="$(codesign -d --verbose=4 "$binary" 2>&1)"
+if grep -Fxq "Signature=adhoc" <<<"$metadata"; then
+  echo "error: macOS release binary has an ad-hoc signature" >&2
+  exit 1
+fi
+grep -Fxq "Identifier=${identifier}" <<<"$metadata" || {
+  echo "error: macOS release binary does not use identifier ${identifier}" >&2
+  exit 1
+}
+grep -Fxq "TeamIdentifier=${team_id}" <<<"$metadata" || {
+  echo "error: macOS release binary is not signed by Apple Developer Team ${team_id}" >&2
+  exit 1
+}
+grep -Eq '^Authority=Developer ID Application:' <<<"$metadata" || {
+  echo "error: macOS release binary is not signed with a Developer ID Application certificate" >&2
+  exit 1
+}
+grep -Eq 'flags=.*\(runtime\)' <<<"$metadata" || {
+  echo "error: macOS release binary does not enable the hardened runtime" >&2
+  exit 1
+}
+grep -Eq '^Timestamp=' <<<"$metadata" || {
+  echo "error: macOS release binary does not have a secure signing timestamp" >&2
+  exit 1
+}
+
+if [[ "$require_notarization" == "1" ]]; then
+  command -v spctl >/dev/null 2>&1 || {
+    echo "error: required command not found: spctl" >&2
+    exit 1
+  }
+  if ! assessment="$(spctl --assess --type execute --verbose=4 "$binary" 2>&1)"; then
+    printf '%s\n' "$assessment" >&2
+    echo "error: Gatekeeper rejected the macOS release binary" >&2
+    exit 1
+  fi
+  grep -Fq 'source=Notarized Developer ID' <<<"$assessment" || {
+    printf '%s\n' "$assessment" >&2
+    echo "error: Gatekeeper did not report a notarized Developer ID signature" >&2
+    exit 1
+  }
+fi
+
+echo "Verified macOS release signature: ${identifier} (${team_id})"
+if [[ "$require_notarization" == "1" ]]; then
+  echo "Verified macOS notarization with Gatekeeper"
+fi

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -30,6 +30,8 @@ const RELEASE_ASSETS: [&str; 5] = [
     "ocm-x86_64-unknown-linux-gnu.tar.gz",
 ];
 
+const TEST_MACOS_TEAM_ID: &str = "ABCDE12345";
+
 fn script(name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("scripts")
@@ -234,6 +236,48 @@ fn assert_exact_regular_archive(path: &Path) {
     assert!(verbose.lines().all(|line| line.starts_with('-')));
 }
 
+fn fake_macos_verification_tools(root: &TestDir) -> PathBuf {
+    let fake_bin = root.child("macos-verification-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    write_executable_script(
+        &fake_bin.join("codesign"),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-d" ]]; then
+  if [[ "${TEST_MACOS_SIGNATURE:-valid}" == "adhoc" ]]; then
+    cat >&2 <<'EOF'
+Identifier=ocm-changing-hash
+CodeDirectory v=20400 flags=0x20002(adhoc,linker-signed)
+Signature=adhoc
+TeamIdentifier=not set
+EOF
+  else
+    cat >&2 <<'EOF'
+Identifier=com.openclaw.ocm
+CodeDirectory v=20500 flags=0x10000(runtime)
+Authority=Developer ID Application: OpenClaw Test (ABCDE12345)
+TeamIdentifier=ABCDE12345
+Timestamp=Sep 3, 2026 at 12:00:00
+EOF
+  fi
+fi
+"#,
+    );
+    write_executable_script(
+        &fake_bin.join("spctl"),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${TEST_MACOS_NOTARIZATION:-accepted}" == "accepted" ]]; then
+  printf '%s\n' 'ocm: accepted' 'source=Notarized Developer ID' >&2
+  exit 0
+fi
+printf '%s\n' 'ocm: rejected' >&2
+exit 3
+"#,
+    );
+    fake_bin
+}
+
 fn populate_release_archives(asset_dir: &Path, root: &TestDir) {
     fs::create_dir_all(asset_dir).unwrap();
     fs::write(asset_dir.join("install.sh"), "#!/usr/bin/env bash\n").unwrap();
@@ -269,6 +313,7 @@ fn package_release_preserves_existing_archive_when_tar_fails() {
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .args(["--target", "x86_64-apple-darwin", "--binary"])
         .arg(&binary)
+        .args(["--macos-team-id", TEST_MACOS_TEAM_ID])
         .arg("--output-dir")
         .arg(&output_dir)
         .env("PATH", path)
@@ -292,18 +337,43 @@ fn package_release_accepts_only_the_supported_matrix_and_emits_exact_bundles() {
     let output_dir = root.child("dist");
     let binary = root.child("ocm");
     fs::write(&binary, "binary").unwrap();
+    let fake_bin = fake_macos_verification_tools(&root);
+    let path = format!(
+        "{}:{}",
+        path_string(&fake_bin),
+        std::env::var("PATH").unwrap()
+    );
 
     for target in SUPPORTED_TARGETS {
-        let output = Command::new(script("package-release.sh"))
+        let mut command = Command::new(script("package-release.sh"));
+        command
             .current_dir(env!("CARGO_MANIFEST_DIR"))
             .args(["--target", target, "--binary"])
-            .arg(&binary)
+            .arg(&binary);
+        if target.ends_with("-apple-darwin") {
+            command.args(["--macos-team-id", TEST_MACOS_TEAM_ID]);
+        }
+        let output = command
             .arg("--output-dir")
             .arg(&output_dir)
+            .env("PATH", &path)
             .output()
             .unwrap();
         assert!(output.status.success(), "{}", stderr(&output));
-        assert_exact_regular_archive(&output_dir.join(format!("ocm-{target}.tar.gz")));
+        let archive = output_dir.join(format!("ocm-{target}.tar.gz"));
+        assert_exact_regular_archive(&archive);
+
+        let extract_dir = root.child(format!("extract-{target}"));
+        fs::create_dir_all(&extract_dir).unwrap();
+        let extracted = Command::new("tar")
+            .arg("-xzf")
+            .arg(&archive)
+            .arg("-C")
+            .arg(&extract_dir)
+            .output()
+            .unwrap();
+        assert!(extracted.status.success(), "{}", stderr(&extracted));
+        assert_eq!(fs::read(extract_dir.join("ocm")).unwrap(), b"binary");
     }
 
     fs::write(output_dir.join("install.sh"), "#!/usr/bin/env bash\n").unwrap();
@@ -327,6 +397,50 @@ fn package_release_accepts_only_the_supported_matrix_and_emits_exact_bundles() {
         assert!(stderr(&output).contains("unsupported release target"));
         assert!(!rejected_dir.join(format!("ocm-{target}.tar.gz")).exists());
     }
+}
+
+#[test]
+fn macos_release_verifier_rejects_ad_hoc_and_unnotarized_code() {
+    let root = TestDir::new("verify-macos-release");
+    let binary = root.child("ocm");
+    fs::write(&binary, "binary").unwrap();
+    let fake_bin = fake_macos_verification_tools(&root);
+    let path = format!(
+        "{}:{}",
+        path_string(&fake_bin),
+        std::env::var("PATH").unwrap()
+    );
+
+    let ad_hoc = Command::new(script("verify-macos-release.sh"))
+        .arg("--binary")
+        .arg(&binary)
+        .args(["--team-id", TEST_MACOS_TEAM_ID])
+        .env("PATH", &path)
+        .env("TEST_MACOS_SIGNATURE", "adhoc")
+        .output()
+        .unwrap();
+    assert_eq!(ad_hoc.status.code(), Some(1));
+    assert!(stderr(&ad_hoc).contains("ad-hoc signature"));
+
+    let unnotarized = Command::new(script("verify-macos-release.sh"))
+        .arg("--binary")
+        .arg(&binary)
+        .args(["--team-id", TEST_MACOS_TEAM_ID, "--require-notarization"])
+        .env("PATH", &path)
+        .env("TEST_MACOS_NOTARIZATION", "rejected")
+        .output()
+        .unwrap();
+    assert_eq!(unnotarized.status.code(), Some(1));
+    assert!(stderr(&unnotarized).contains("Gatekeeper rejected"));
+
+    let accepted = Command::new(script("verify-macos-release.sh"))
+        .arg("--binary")
+        .arg(&binary)
+        .args(["--team-id", TEST_MACOS_TEAM_ID, "--require-notarization"])
+        .env("PATH", path)
+        .output()
+        .unwrap();
+    assert!(accepted.status.success(), "{}", stderr(&accepted));
 }
 
 #[test]
@@ -1111,6 +1225,19 @@ fn workflows_pin_actions_lock_dependencies_and_gate_the_msrv() {
     assert!(ci.contains("cargo test --locked"));
     assert!(ci.contains("cargo install --locked"));
     assert!(release.contains("cargo build --locked --release"));
+    assert!(
+        release.contains(
+            "Apple-Actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466"
+        )
+    );
+    assert!(release.contains("secrets.APPSTORE_CERTIFICATES_FILE_BASE64"));
+    assert!(release.contains("secrets.APPSTORE_CERTIFICATES_PASSWORD"));
+    assert!(release.contains("secrets.APPSTORE_API_PRIVATE_KEY"));
+    assert!(release.contains("secrets.APPSTORE_API_KEY_ID"));
+    assert!(release.contains("secrets.APPSTORE_ISSUER_ID"));
+    assert!(release.contains("vars.MACOS_TEAM_ID"));
+    assert!(release.contains("scripts/sign-notarize-macos.sh"));
+    assert!(release.contains("--macos-team-id \"$OCM_MACOS_TEAM_ID\""));
     assert!(release.contains("scripts/verify-release-tag.sh"));
     assert!(release.contains("scripts/verify-release-ci.sh"));
     assert!(release.contains("scripts/publish-release.sh"));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users have to grant OCM file-access permissions again after each update. Published OCM binaries currently have linker-generated ad-hoc signatures, so their designated requirement is only the changing CDHash.

## Why This Change Was Made

The canonical release workflow now signs both macOS architectures with one Developer ID Application identity and the stable identifier `com.openclaw.ocm`. It enables the hardened runtime and secure timestamp, submits a temporary ZIP to Apple's notary service, checks Gatekeeper acceptance, and validates the executable again after the final tar archive is extracted.

Linux packaging and the existing tarball installer format are unchanged.

## Security and release setup

The certificate import action is pinned to an exact commit. Signing remains limited to the existing protected-main, signed-tag release workflow.

Maintainers must configure these repository secrets:

- `APPSTORE_CERTIFICATES_FILE_BASE64`
- `APPSTORE_CERTIFICATES_PASSWORD`
- `APPSTORE_API_PRIVATE_KEY`
- `APPSTORE_API_KEY_ID`
- `APPSTORE_ISSUER_ID`

They must also configure the repository variable `MACOS_TEAM_ID`. `docs/RELEASING.md` documents the certificate and App Store Connect API key requirements.

Apple cannot staple a ticket to a standalone command-line executable or `.tar.gz` archive. The workflow notarizes the signed executable in a ZIP submission, then uses `spctl` to verify Apple's ticket before packaging. The embedded Mach-O signature survives the tar create-and-extract round trip, which the packaging script now checks.

## User Impact

Future macOS releases have a stable code identity across updates, so TCC can retain OCM's file-access approval when the binary changes. Releases fail closed if signing, notarization, or post-extraction verification fails.

## Evidence

Current `v0.2.36` arm64 release before this change:

```text
Signature=adhoc
TeamIdentifier=not set
# designated => cdhash H"7af90e4a15e3785ea048ad03a09f395c5700cb95"
spctl: rejected
```

Local checks:

- `cargo test --locked --test release_asset_tests`: 17 passed
- `cargo check --workspace --all-targets --locked`: passed
- `cargo fmt --all -- --check`: passed
- `bash -n` for all changed release scripts: passed
- ShellCheck 0.11.0 for all changed release scripts: passed
- actionlint 1.7.12 for `.github/workflows/release.yml`: passed
- The new validator rejects the published ad-hoc `v0.2.36` binary and mocked unnotarized code.
- [GitHub CI run 33827450741](https://github.com/openclaw/ocm/actions/runs/33827450741): all required jobs passed on macOS, Ubuntu, and Windows.

The broad `cargo test --locked` run passed the 334 library tests and the release-related integration targets, but the unrelated macOS daemon test `gateway_owned_daemon_refresh_survives_its_source_process_group` failed again when rerun alone. This PR does not change Rust service or daemon code.

Live Developer ID signing and Apple notarization could not be exercised locally without the repository's Apple credentials. The release workflow will provide the final end-to-end proof once maintainers configure the documented secrets and variable.

## Worked on by

- @fuller-stack-dev
