### PR TITLE
fix: validate notarized macOS CLI without an app bundle

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Release prerequisites
 
-The canonical `.github/workflows/release.yml` workflow publishes OCM releases from signed tags on `main`. Linux packaging needs no repository credentials. Each macOS matrix job imports one Developer ID Application certificate, signs `ocm` with the identifier `com.openclaw.ocm`, submits a temporary ZIP to Apple's notary service, checks Gatekeeper acceptance, and verifies the executable again after extracting the final tarball.
+The canonical `.github/workflows/release.yml` workflow publishes OCM releases from signed tags on `main`. Linux packaging needs no repository credentials. Each macOS matrix job imports one Developer ID Application certificate, signs `ocm` with the identifier `com.openclaw.ocm`, submits a temporary ZIP to Apple's notary service, checks the executable's notarization ticket, and verifies the executable again after extracting the final tarball.
 
 Configure these GitHub Actions repository secrets:
 
@@ -14,10 +14,11 @@ Configure `MACOS_TEAM_ID` as a GitHub Actions repository variable. It must conta
 
 Use the same Apple Developer team and `com.openclaw.ocm` identifier for every release. Certificate renewal within that team preserves the stable designated requirement macOS uses to identify OCM across updates. Changing the team or identifier causes macOS to treat the executable as different code.
 
-OCM keeps the existing `.tar.gz` install and self-update format. Apple cannot staple tickets to a standalone command-line executable or tar archive. The workflow therefore notarizes a ZIP containing the signed executable and verifies the ticket through Gatekeeper before packaging. The Mach-O code signature is embedded in the executable, and `package-release.sh` verifies it after a tar create-and-extract round trip. `install.sh` and `ocm self update` continue to verify the published tarball against `SHA256SUMS` before installing it.
+OCM keeps the existing `.tar.gz` install and self-update format. Apple cannot staple tickets to a standalone command-line executable or tar archive. The workflow therefore notarizes a ZIP containing the signed executable and verifies the ticket with `codesign --verify --strict --check-notarization --test-requirement '=notarized'` before packaging. `--check-notarization` forces an online ticket check, and the explicit `notarized` requirement makes a missing ticket fail validation. Unlike `spctl --assess --type execute`, this checks standalone command-line tools without requiring an app bundle. The Mach-O code signature is embedded in the executable, and `package-release.sh` verifies it after a tar create-and-extract round trip. `install.sh` and `ocm self update` continue to verify the published tarball against `SHA256SUMS` before installing it.
 
 References:
 
+- Apple's `man codesign`: `--check-notarization` and `--test-requirement`.
 - [Apple: Notarizing macOS software before distribution](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
 - [Apple: Customizing the notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)
 - [Apple: Packaging Mac software for distribution](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution)

--- a/scripts/verify-macos-release.sh
+++ b/scripts/verify-macos-release.sh
@@ -93,23 +93,15 @@ grep -Eq '^Timestamp=' <<<"$metadata" || {
 }
 
 if [[ "$require_notarization" == "1" ]]; then
-  command -v spctl >/dev/null 2>&1 || {
-    echo "error: required command not found: spctl" >&2
-    exit 1
-  }
-  if ! assessment="$(spctl --assess --type execute --verbose=4 "$binary" 2>&1)"; then
+  if ! assessment="$(codesign --verify --strict --verbose=2 \
+    --check-notarization --test-requirement '=notarized' "$binary" 2>&1)"; then
     printf '%s\n' "$assessment" >&2
-    echo "error: Gatekeeper rejected the macOS release binary" >&2
+    echo "error: macOS release binary does not satisfy Apple's notarization requirement" >&2
     exit 1
   fi
-  grep -Fq 'source=Notarized Developer ID' <<<"$assessment" || {
-    printf '%s\n' "$assessment" >&2
-    echo "error: Gatekeeper did not report a notarized Developer ID signature" >&2
-    exit 1
-  }
 fi
 
 echo "Verified macOS release signature: ${identifier} (${team_id})"
 if [[ "$require_notarization" == "1" ]]; then
-  echo "Verified macOS notarization with Gatekeeper"
+  echo "Verified macOS notarization with codesign"
 fi

--- a/tests/release_asset_tests.rs
+++ b/tests/release_asset_tests.rs
@@ -243,6 +243,9 @@ fn fake_macos_verification_tools(root: &TestDir) -> PathBuf {
         &fake_bin.join("codesign"),
         r#"#!/usr/bin/env bash
 set -euo pipefail
+if [[ -n "${TEST_MACOS_CODESIGN_LOG:-}" ]]; then
+  printf '%s\n' "$*" >>"$TEST_MACOS_CODESIGN_LOG"
+fi
 if [[ "${1:-}" == "-d" ]]; then
   if [[ "${TEST_MACOS_SIGNATURE:-valid}" == "adhoc" ]]; then
     cat >&2 <<'EOF'
@@ -260,6 +263,17 @@ TeamIdentifier=ABCDE12345
 Timestamp=Sep 3, 2026 at 12:00:00
 EOF
   fi
+elif [[ "$*" == *"--check-notarization"* ]]; then
+  [[ "$#" == "7" && "$1" == "--verify" && "$2" == "--strict" &&
+    "$3" == "--verbose=2" && "$4" == "--check-notarization" &&
+    "$5" == "--test-requirement" && "$6" == "=notarized" ]] || exit 99
+  if [[ "${TEST_MACOS_NOTARIZATION:-accepted}" != "accepted" ]]; then
+    printf '%s\n' 'ocm: code failed to satisfy specified code requirement(s)' >&2
+    exit 3
+  fi
+elif [[ "${TEST_MACOS_SIGNATURE:-valid}" == "unsigned" ]]; then
+  printf '%s\n' 'ocm: code object is not signed at all' >&2
+  exit 1
 fi
 "#,
     );
@@ -267,11 +281,7 @@ fi
         &fake_bin.join("spctl"),
         r#"#!/usr/bin/env bash
 set -euo pipefail
-if [[ "${TEST_MACOS_NOTARIZATION:-accepted}" == "accepted" ]]; then
-  printf '%s\n' 'ocm: accepted' 'source=Notarized Developer ID' >&2
-  exit 0
-fi
-printf '%s\n' 'ocm: rejected' >&2
+printf '%s\n' 'ocm: rejected (the code is valid but does not seem to be an app)' >&2
 exit 3
 "#,
     );
@@ -400,7 +410,7 @@ fn package_release_accepts_only_the_supported_matrix_and_emits_exact_bundles() {
 }
 
 #[test]
-fn macos_release_verifier_rejects_ad_hoc_and_unnotarized_code() {
+fn macos_release_verifier_rejects_unsigned_ad_hoc_and_unnotarized_code() {
     let root = TestDir::new("verify-macos-release");
     let binary = root.child("ocm");
     fs::write(&binary, "binary").unwrap();
@@ -410,6 +420,17 @@ fn macos_release_verifier_rejects_ad_hoc_and_unnotarized_code() {
         path_string(&fake_bin),
         std::env::var("PATH").unwrap()
     );
+
+    let unsigned = Command::new(script("verify-macos-release.sh"))
+        .arg("--binary")
+        .arg(&binary)
+        .args(["--team-id", TEST_MACOS_TEAM_ID, "--require-notarization"])
+        .env("PATH", &path)
+        .env("TEST_MACOS_SIGNATURE", "unsigned")
+        .output()
+        .unwrap();
+    assert_eq!(unsigned.status.code(), Some(1));
+    assert!(stderr(&unsigned).contains("invalid code signature"));
 
     let ad_hoc = Command::new(script("verify-macos-release.sh"))
         .arg("--binary")
@@ -431,16 +452,22 @@ fn macos_release_verifier_rejects_ad_hoc_and_unnotarized_code() {
         .output()
         .unwrap();
     assert_eq!(unnotarized.status.code(), Some(1));
-    assert!(stderr(&unnotarized).contains("Gatekeeper rejected"));
+    assert!(stderr(&unnotarized).contains("does not satisfy Apple's notarization requirement"));
+
+    let codesign_log = root.child("codesign.log");
 
     let accepted = Command::new(script("verify-macos-release.sh"))
         .arg("--binary")
         .arg(&binary)
         .args(["--team-id", TEST_MACOS_TEAM_ID, "--require-notarization"])
         .env("PATH", path)
+        .env("TEST_MACOS_CODESIGN_LOG", &codesign_log)
         .output()
         .unwrap();
     assert!(accepted.status.success(), "{}", stderr(&accepted));
+    assert!(fs::read_to_string(&codesign_log).unwrap().contains(
+        "--verify --strict --verbose=2 --check-notarization --test-requirement =notarized"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix the release-blocking validation error after Apple accepts OCM notarization. Release attempt https://github.com/openclaw/ocm/actions/runs/33830651180 failed on both macOS architectures because `spctl --assess --type execute` rejects standalone Mach-O tools as “the code is valid but does not seem to be an app”.

Use `codesign --verify --strict --verbose=2 --check-notarization --test-requirement '=notarized'` instead. Apple's `codesign` manual documents the online notarization check and explicit requirement test. The leading `=` makes the requirement an inline expression rather than a filename.

Keep Developer ID, Team ID, stable identifier, hardened runtime, timestamp, signature integrity, successful notary submission, and post-tar-extraction checks mandatory. No unsigned fallback, credential changes, archive changes, or Linux/Windows behavior changes.

## Verification

- Reproduced the old packaging test failure with a realistic `spctl` stub that rejects standalone tools.
- Updated mocks require the exact online check and explicit notarization requirement; tests reject unsigned, ad-hoc, and unnotarized inputs.
- `cargo test --locked --test release_asset_tests`: 17 passed on Rust 1.88.
- `cargo fmt --check`, `bash -n`, ShellCheck, `git diff --check`, and release-workflow YAML parsing passed.
- Native macOS proof using installed 1Password CLI: `spctl` rejects it as not an app; the replacement `codesign` command succeeds, including the explicit requirement.
- Native temporary Mach-O proof: validator rejects both ad-hoc and unsigned binaries; the explicit notarization requirement rejects the unnotarized binary.
- All 48 release-focused tests passed across `release_asset_tests`, `release_script_tests`, `release_manifest_tests`, and `release_command_tests`. `cargo check --workspace --all-targets --locked` passed. Hosted CI gates landing.

## Release follow-up

The signed `v0.2.37` tag will not be moved. After landing, prepare the next release using the canonical version-only PR and signed-tag process, then verify both macOS notarization jobs before updating the installed OCM.

