### PR TITLE
chore(release): bump version to 0.2.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.37"
+version = "0.2.38"
 edition = "2024"
 rust-version = "1.88"
 description = "OpenClaw Manager: the local control plane for isolated OpenClaw environments, launchers, runtimes, and services."


### PR DESCRIPTION
Prepare v0.2.38 using `scripts/release.sh 0.2.38 --skip-checks`.

Depends on https://github.com/openclaw/ocm/pull/144. Merge the validator fix first. This PR changes only the package version in Cargo.toml and Cargo.lock. The failed signed v0.2.37 tag will remain untouched.

All 48 release-focused tests and all-target Rust checks passed for the validator fix. This version-only preparation skips another local full-suite run; required hosted CI and exact-SHA protected-main CI still gate the release.

After squash merge and exact-main CI, create and verify the signed v0.2.38 tag with the canonical release tooling, then publish and verify both macOS signing/notarization builds.
