### PR TITLE
fix: complete self-updates across daemon and gateway restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to OCM are documented here.
 
 ### Added
 
+- Make `ocm self update` a recoverable local transaction that retains the previous executable, survives caller disconnection, refreshes a running daemon, checks gateway recovery, and records a durable result. Add `--status` and `--recover` for interrupted updates.
 - Let `runtime build-local` assemble repeatable, commit-matched official companion plugins through OpenClaw's release packaging contract, stage them as trusted runtime-owned bundled plugins with isolated dependencies, and record artifact and entrypoint hashes for verification.
 
 ### Changed

--- a/docs/SELF_UPDATE.md
+++ b/docs/SELF_UPDATE.md
@@ -1,0 +1,80 @@
+# Recoverable local self-update
+
+`ocm self update` checks the release archive digest and executable version before
+changing the install. It retains the previous executable beside the installed
+binary, then starts that retained OCM as a local helper. The helper atomically
+replaces the CLI, refreshes a running daemon, and checks the daemon version and
+HTTP readiness of previously running managed gateways. It leaves the persisted
+desired service state intact. An absent or stopped daemon stays stopped.
+
+The refresh briefly interrupts gateways, including a gateway hosting the caller.
+The helper runs in a separate session with detached standard streams, so it does
+not need the caller to remain connected. On Linux, a helper inside the OCM
+systemd service first moves into a transient `systemd-run --user --scope` scope.
+If that handoff fails, OCM does not replace the installed executable.
+
+## Result and recovery
+
+After reconnecting, use the same `HOME` and `OCM_HOME`:
+
+```sh
+ocm self update --status
+```
+
+The JSON receipt reports the transaction ID, phase, versions, affected gateways,
+original error, and any rollback error. It contains no saved process environment.
+The receipt and retained executable live in `.<binary-name>.self-update` beside
+the executable. For an executable named `ocm`, that directory is
+`.ocm.self-update`. The command prints its recovery executable path before waiting.
+
+If activation or health checks fail, the helper restores the previous CLI and
+refreshes the daemon back to that version. `rolledBack` means recovery succeeded,
+not that the update succeeded. `rollbackFailed` retains the original error and
+the recovery error. Both produce a nonzero update exit status.
+
+If the helper crashes or the host reboots during the update:
+
+```sh
+ocm self update --recover
+```
+
+Recovery rolls back, rather than guessing whether to finish an interrupted
+publication. A repeated recovery of a terminal receipt makes no service changes.
+If the candidate CLI cannot execute, invoke the printed retained executable:
+
+```sh
+/path/to/bin/.ocm.self-update/previous self update --recover
+```
+
+Only one update or recovery can own an executable at a time, even across OCM
+homes. An unfinished receipt blocks a fresh update. A surviving service-manager
+subcommand retains the update lock after a helper crash; recovery is refused
+until that command exits. OCM never kills an unknown PID to reclaim a lock.
+
+## Boundaries
+
+- `--check` and unchanged releases do not restart services.
+- Recovery is local and explicit after a helper crash or reboot. This is not a
+  boot-time recovery service or a zero-downtime update.
+- The previous executable and latest receipt remain until the next admitted
+  update. This is not a release history or a manual downgrade facility.
+- OCM refuses unknown or already-skewed running daemon versions, another store's
+  daemon, and service definitions bound to another executable. Resolve that
+  existing state before updating. Customized service definitions can require a
+  separate service refresh before admission.
+- The helper preserves current gateway desired state. It does not change
+  runtime bindings, gateway configuration, snapshots, or OpenClaw versions.
+- Supported release targets remain macOS x86_64/arm64 and Linux x86_64.
+  Windows and Linux arm64 self-update are explicitly unsupported; ordinary OCM
+  behavior on those platforms is unchanged.
+- Linux gateway-hosted updates require a working user systemd manager and
+  `systemd-run`. Logout, machine failure, storage corruption, and third-party
+  process containment are not transparent-survival guarantees. Recovery files
+  remain available after interruption.
+- Service-manager calls use the existing lifecycle implementation. If the
+  service manager hangs, the receipt remains nonterminal and the lock remains
+  held; OCM does not report success or start a competing update.
+
+Embedded macOS signatures are copied unchanged. Release digests, archive entry
+checks, and exact candidate version checks remain required. No new dependency,
+remote host, credential flow, or generic lifecycle transaction framework is used.

--- a/src/cli/internal.rs
+++ b/src/cli/internal.rs
@@ -34,6 +34,7 @@ impl Cli {
         match action {
             "identity" => self.handle_daemon_identity(rest),
             "run" => self.handle_daemon_run(rest),
+            "self-update" => self.run_self_update_worker(rest),
             _ => Err(format!("unknown internal command: {action}")),
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ mod release;
 pub(crate) mod render;
 mod runtime;
 mod self_cmd;
+mod self_update_transaction;
 mod service;
 mod setup;
 mod start;

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -901,7 +901,7 @@ pub fn self_command_help(cmd: &str, action: &str) -> Option<String> {
     match action {
         "update" => Some(render_leaf(
             "Update ocm",
-            "Check for or install a newer ocm release in place.",
+            "Check for or install an ocm release with local recovery.",
             vec![format!(
                 "{cmd} self update [--version <version>] [--check] [--raw] [--json]"
             )],
@@ -911,6 +911,11 @@ pub fn self_command_help(cmd: &str, action: &str) -> Option<String> {
                     "Install one exact ocm release tag or version",
                 ),
                 ("--check", "Only report whether an update is available"),
+                ("--status", "Read the durable transaction receipt as JSON"),
+                (
+                    "--recover",
+                    "Roll back an interrupted transaction using retained OCM",
+                ),
                 ("--raw", "Use plain text instead of pretty TTY cards"),
                 ("--json", "Print the update summary as JSON"),
             ],
@@ -921,6 +926,10 @@ pub fn self_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "The current binary is replaced in place on supported macOS and Linux installs.",
+                "A running daemon and its gateways are briefly interrupted and health-checked.",
+                "The local helper survives caller disconnection. Inspect --status after reconnecting.",
+                "Use --recover with the original HOME and OCM_HOME after an interrupted helper.",
+                "If the installed CLI cannot run, use the printed .ocm.self-update/previous recovery executable.",
                 "Exact versions accept either `1.2.3` or `v1.2.3`.",
             ],
         )),

--- a/src/cli/render/self_update.rs
+++ b/src/cli/render/self_update.rs
@@ -45,6 +45,9 @@ pub fn self_update(summary: &SelfUpdateSummary, profile: RenderProfile, cmd: &st
     );
 
     let mut next = Vec::new();
+    if let Some(path) = &summary.receipt_path {
+        next.push(KeyValueRow::plain("Receipt", path.clone()));
+    }
     if matches!(summary.status, SelfUpdateStatus::UpdateAvailable) {
         next.push(KeyValueRow::accent(
             "Install",
@@ -90,6 +93,9 @@ fn self_update_raw(summary: &SelfUpdateSummary) -> Vec<String> {
     );
     if let Some(note) = summary.daemon_refresh_note.as_ref() {
         lines.insert("daemonRefreshNote".to_string(), note.clone());
+    }
+    if let Some(path) = &summary.receipt_path {
+        lines.insert("receiptPath".to_string(), path.clone());
     }
     format_key_value_lines(lines)
 }

--- a/src/cli/self_cmd.rs
+++ b/src/cli/self_cmd.rs
@@ -1,15 +1,16 @@
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
-use std::io;
+use std::io::{self, Read, Seek};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use semver::Version;
 use serde::Serialize;
 
+use super::self_update_transaction::{Phase, Transaction};
 use crate::infra::archive::extract_tar_gz;
 use crate::infra::download::{download_to_file, http_agent, verify_file_sha256};
-use crate::store::resolve_ocm_home;
 
 use super::{Cli, render};
 
@@ -61,6 +62,8 @@ pub(crate) struct SelfUpdateSummary {
     pub asset_name: String,
     pub daemon_refresh_required: bool,
     pub daemon_refresh_note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipt_path: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -121,12 +124,12 @@ impl Drop for SelfUpdateTempDir {
     }
 }
 
-struct StagedBinary {
+pub(super) struct StagedBinary {
     path: PathBuf,
 }
 
 impl StagedBinary {
-    fn copy_from(source: &Path, parent: &Path) -> Result<Self, String> {
+    pub(super) fn copy_from(source: &Path, parent: &Path) -> Result<Self, String> {
         let metadata = fs::symlink_metadata(source)
             .map_err(|error| format!("failed to inspect release archive binary: {error}"))?;
         if !metadata.file_type().is_file() {
@@ -193,7 +196,7 @@ impl StagedBinary {
         ))
     }
 
-    fn path(&self) -> &Path {
+    pub(super) fn path(&self) -> &Path {
         &self.path
     }
 }
@@ -208,9 +211,29 @@ impl Cli {
     pub(super) fn handle_self_update(&self, args: Vec<String>) -> Result<i32, String> {
         let (args, json_flag, profile) = self.consume_human_output_flags(args, "self update")?;
         let (args, check) = Self::consume_flag(args, "--check");
+        let (args, status) = Self::consume_flag(args, "--status");
+        let (args, recover) = Self::consume_flag(args, "--recover");
         let (args, version) = Self::consume_option(args, "--version")?;
         let version = Self::require_option_value(version, "--version")?;
         Self::assert_no_extra_args(&args)?;
+
+        if status || recover {
+            if check || version.is_some() || (status && recover) {
+                return Err("--status and --recover must be used alone".into());
+            }
+            let receipt = self.self_update_receipt(recover)?;
+            self.print_json(&receipt)?;
+            return Ok(
+                if matches!(
+                    receipt.phase,
+                    Phase::RolledBack | Phase::RollbackFailed | Phase::Failed
+                ) {
+                    1
+                } else {
+                    0
+                },
+            );
+        }
 
         let target_display = version.clone().unwrap_or_else(|| "latest".to_string());
         let summary = if check {
@@ -270,6 +293,7 @@ impl Cli {
             asset_name,
             daemon_refresh_required: false,
             daemon_refresh_note: None,
+            receipt_path: None,
         })
     }
 
@@ -277,6 +301,8 @@ impl Cli {
         let current_version = env!("CARGO_PKG_VERSION").to_string();
         let binary_path = self.current_binary_path()?;
         let asset_name = self.current_release_asset_name()?;
+        let transaction = Transaction::open(&binary_path, false)?;
+        transaction.admit()?;
         let release = self.fetch_self_release(version)?;
         let target_version = display_version_from_tag(&release.tag_name)?;
 
@@ -290,6 +316,7 @@ impl Cli {
                 asset_name,
                 daemon_refresh_required: false,
                 daemon_refresh_note: None,
+                receipt_path: None,
             });
         }
 
@@ -324,16 +351,26 @@ impl Cli {
         let extracted_binary = extract_dir.join("ocm");
         let staged_binary = StagedBinary::copy_from(&extracted_binary, parent)?;
         validate_staged_binary(staged_binary.path(), &target_version)?;
-
-        fs::rename(staged_binary.path(), &binary_path).map_err(|error| {
-            format!(
-                "failed to replace {}: {error}. If this path is managed elsewhere, reinstall ocm or use your package manager instead.",
-                binary_path.display()
-            )
-        })?;
-
-        let (daemon_refresh_required, daemon_refresh_note) =
-            self.daemon_refresh_notice_after_update(&target_version);
+        // Downloads and extraction no longer belong to the interruptible caller
+        // once the durable helper takes over.
+        drop(temp_root);
+        let receipt = transaction.launch(
+            self,
+            &binary_path,
+            staged_binary,
+            &current_version,
+            &target_version,
+        )?;
+        if receipt.phase != Phase::Updated {
+            return Err(format!(
+                "self-update {:?}: {}; inspect `ocm self update --status`",
+                receipt.phase,
+                receipt
+                    .error
+                    .as_deref()
+                    .unwrap_or("update did not complete")
+            ));
+        }
 
         Ok(SelfUpdateSummary {
             mode: SelfUpdateMode::Update,
@@ -342,40 +379,14 @@ impl Cli {
             target_version,
             binary_path: binary_path.to_string_lossy().into_owned(),
             asset_name,
-            daemon_refresh_required,
-            daemon_refresh_note,
+            daemon_refresh_required: false,
+            daemon_refresh_note: None,
+            receipt_path: Some(
+                super::self_update_transaction::receipt_path(&binary_path)?
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
         })
-    }
-
-    fn daemon_refresh_notice_after_update(&self, target_version: &str) -> (bool, Option<String>) {
-        let Ok(ocm_home) = resolve_ocm_home(&self.env, &self.cwd) else {
-            return (
-                false,
-                Some(
-                    "CLI updated, but OCM could not resolve the active store; run `ocm service status` to check the background service"
-                        .to_string(),
-                ),
-            );
-        };
-        if !ocm_home.exists() {
-            return (false, None);
-        }
-
-        match self.supervisor_service().daemon_status() {
-            Ok(daemon) if daemon.running => (
-                true,
-                Some(format!(
-                    "CLI {target_version} is installed, but the running OCM background service still uses its previously mapped executable; during a maintenance window run `ocm service refresh-daemon --acknowledge-gateway-restarts`"
-                )),
-            ),
-            Ok(_) => (false, None),
-            Err(error) => (
-                false,
-                Some(format!(
-                    "CLI updated, but OCM could not inspect the background service ({error}); run `ocm service status`"
-                )),
-            ),
-        }
     }
 
     fn current_binary_path(&self) -> Result<PathBuf, String> {
@@ -468,25 +479,47 @@ fn github_asset_sha256(asset: &GitHubReleaseAsset) -> Result<&str, String> {
     Ok(value)
 }
 
-fn validate_staged_binary(path: &Path, target_version: &str) -> Result<(), String> {
+pub(super) fn validate_staged_binary(path: &Path, target_version: &str) -> Result<(), String> {
     let metadata = fs::symlink_metadata(path)
         .map_err(|error| format!("failed to inspect staged ocm binary: {error}"))?;
     if !metadata.file_type().is_file() {
         return Err("staged ocm binary is not a regular file".to_string());
     }
 
-    let output = Command::new(path)
+    let mut capture = tempfile::tempfile().map_err(|e| e.to_string())?;
+    let mut child = Command::new(path)
         .arg("--version")
         .env_clear()
-        .output()
+        .stdin(Stdio::null())
+        .stdout(capture.try_clone().map_err(|e| e.to_string())?)
+        .stderr(Stdio::null())
+        .spawn()
         .map_err(|error| format!("failed to execute staged ocm binary: {error}"))?;
-    if !output.status.success() {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(10)),
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(
+                    "staged ocm binary version check did not finish within 5 seconds".into(),
+                );
+            }
+        }
+    };
+    if !status.success() {
         return Err(format!(
             "staged ocm binary failed its version check with status {}",
-            output.status
+            status
         ));
     }
-    let stdout = String::from_utf8(output.stdout)
+    capture.rewind().map_err(|e| e.to_string())?;
+    let mut stdout = String::new();
+    capture
+        .take(1024)
+        .read_to_string(&mut stdout)
         .map_err(|_| "staged ocm binary returned a non-UTF-8 version".to_string())?;
     let reported = stdout.strip_suffix('\n').unwrap_or(&stdout);
     let reported = reported.strip_suffix('\r').unwrap_or(reported);

--- a/src/cli/self_update_transaction.rs
+++ b/src/cli/self_update_transaction.rs
@@ -1,0 +1,560 @@
+//! Single-executable update journal. The retained, initiating OCM binary owns
+//! both forward progress and recovery; candidate code never owns rollback.
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+
+use super::Cli;
+use super::self_cmd::{StagedBinary, validate_staged_binary};
+use crate::infra::download::file_sha256;
+use crate::service::wait_for_gateway_readiness;
+use crate::store::{resolve_ocm_home, resolve_user_home};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) enum Phase {
+    Prepared,
+    Applying,
+    RollingBack,
+    Updated,
+    RolledBack,
+    RollbackFailed,
+    Failed,
+}
+
+impl Phase {
+    fn terminal(self) -> bool {
+        matches!(self, Self::Updated | Self::RolledBack | Self::Failed)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct Receipt {
+    schema: u32,
+    pub id: String,
+    pub phase: Phase,
+    pub binary_path: PathBuf,
+    ocm_home: PathBuf,
+    user_home: PathBuf,
+    pub current_version: String,
+    pub target_version: String,
+    previous_sha256: String,
+    candidate_sha256: String,
+    pub daemon_was_running: bool,
+    pub gateways: Vec<String>,
+    pub error: Option<String>,
+    pub rollback_error: Option<String>,
+}
+
+pub(super) struct Transaction {
+    root: PathBuf,
+    // Dropping the descriptor, rather than explicitly unlocking it, also works
+    // if a process dies. The helper opens its own descriptor after admission.
+    _lock: File,
+}
+
+fn transaction_root(binary: &Path) -> Result<PathBuf, String> {
+    let name = binary.file_name().ok_or("executable has no filename")?;
+    let mut directory = std::ffi::OsString::from(".");
+    directory.push(name);
+    directory.push(".self-update");
+    Ok(binary
+        .parent()
+        .ok_or("executable has no parent")?
+        .join(directory))
+}
+
+pub(super) fn receipt_path(binary: &Path) -> Result<PathBuf, String> {
+    Ok(transaction_root(binary)?.join("receipt.json"))
+}
+
+fn sync_dir(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    File::open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| format!("failed to sync {}: {error}", path.display()))?;
+    Ok(())
+}
+
+impl Transaction {
+    pub(super) fn open(binary: &Path, wait: bool) -> Result<Self, String> {
+        let root = transaction_root(binary)?;
+        let mut builder = fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        match builder.create(&root) {
+            Ok(()) => sync_dir(root.parent().unwrap())?,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(format!("cannot create update journal: {error}")),
+        }
+        let metadata = fs::symlink_metadata(&root).map_err(|e| e.to_string())?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Err("self-update journal must be a private directory, not a symlink".into());
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+            // SAFETY: geteuid has no preconditions.
+            if metadata.mode() & 0o077 != 0 || metadata.uid() != unsafe { libc::geteuid() } {
+                return Err("self-update journal must be owned by this user with mode 0700".into());
+            }
+            let mut options = OpenOptions::new();
+            options.custom_flags(libc::O_NOFOLLOW).mode(0o600);
+            return Self::lock(root, options, wait);
+        }
+        #[cfg(not(unix))]
+        Self::lock(root, OpenOptions::new(), wait)
+    }
+
+    fn lock(root: PathBuf, mut options: OpenOptions, wait: bool) -> Result<Self, String> {
+        let file = options
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(root.join("lock"))
+            .map_err(|e| e.to_string())?;
+        if wait {
+            FileExt::lock_exclusive(&file)
+        } else {
+            FileExt::try_lock_exclusive(&file)
+        }
+        .map_err(|error| {
+            format!("self-update is busy; inspect `ocm self update --status`: {error}")
+        })?;
+        Ok(Self { root, _lock: file })
+    }
+
+    fn read(&self) -> Result<Receipt, String> {
+        read_receipt(&self.root)
+    }
+
+    #[cfg(unix)]
+    fn retain_lock_in_subcommands(&self) -> Result<(), String> {
+        use std::os::fd::AsRawFd;
+        // After a worker crash, admission must remain locked while an already
+        // started service-manager command can still change the daemon.
+        let fd = self._lock.as_raw_fd();
+        // SAFETY: fd is owned by self and remains open throughout both calls.
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFD);
+            if flags == -1 || libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1 {
+                return Err(std::io::Error::last_os_error().to_string());
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn admit(&self) -> Result<(), String> {
+        if self.root.join("receipt.json").exists() && !self.read()?.phase.terminal() {
+            return Err(format!(
+                "unfinished self-update at {}; inspect --status, then use --recover",
+                self.root.display()
+            ));
+        }
+        Ok(())
+    }
+
+    fn save(&self, receipt: &Receipt) -> Result<(), String> {
+        let mut file = tempfile::NamedTempFile::new_in(&self.root).map_err(|e| e.to_string())?;
+        serde_json::to_writer_pretty(&mut file, receipt).map_err(|e| e.to_string())?;
+        file.write_all(b"\n").map_err(|e| e.to_string())?;
+        file.as_file().sync_all().map_err(|e| e.to_string())?;
+        file.persist(self.root.join("receipt.json"))
+            .map_err(|e| e.to_string())?;
+        sync_dir(&self.root)
+    }
+
+    pub(super) fn launch(
+        self,
+        cli: &Cli,
+        binary: &Path,
+        candidate: StagedBinary,
+        current_version: &str,
+        target_version: &str,
+    ) -> Result<Receipt, String> {
+        self.admit()?;
+        // All fallible staging happens before publishing the nonterminal journal.
+        // Keep the previous executable intact even when it is the running helper.
+        let previous = StagedBinary::copy_from(binary, &self.root)?;
+        validate_staged_binary(previous.path(), current_version)?;
+        let receipt = Receipt {
+            schema: 1,
+            id: format!(
+                "{}-{}",
+                std::process::id(),
+                time::OffsetDateTime::now_utc().unix_timestamp_nanos()
+            ),
+            phase: Phase::Prepared,
+            binary_path: binary.to_path_buf(),
+            ocm_home: resolve_ocm_home(&cli.env, &cli.cwd)?,
+            user_home: resolve_user_home(&cli.env),
+            current_version: current_version.into(),
+            target_version: target_version.into(),
+            previous_sha256: file_sha256(previous.path())?,
+            candidate_sha256: file_sha256(candidate.path())?,
+            daemon_was_running: false,
+            gateways: Vec::new(),
+            error: None,
+            rollback_error: None,
+        };
+        fs::rename(previous.path(), self.root.join("previous")).map_err(|e| e.to_string())?;
+        fs::rename(candidate.path(), self.root.join("candidate")).map_err(|e| e.to_string())?;
+        sync_dir(&self.root)?;
+        self.save(&receipt)?;
+        self.start_and_wait(cli, receipt)
+    }
+
+    fn start_and_wait(self, cli: &Cli, receipt: Receipt) -> Result<Receipt, String> {
+        let mut child = spawn_worker(cli, &self.root.join("previous"), &receipt)?;
+        let root = self.root.clone();
+        let id = receipt.id.clone();
+        cli.stderr_line(format!(
+            "Self-update {id}; reconnect with `ocm self update --status`. Recovery executable: {}",
+            root.join("previous").display()
+        ));
+        // Prepared state prevents another updater from entering this handoff gap.
+        drop(self);
+        let status = child.wait().map_err(|e| e.to_string())?;
+        let result = read_receipt(&root)?;
+        if result.id != id {
+            return Err("self-update receipt changed while waiting".into());
+        }
+        if !status.success() || !result.phase.terminal() {
+            return Err(format!(
+                "self-update did not finish; inspect {} and run --recover. {:?}: {}",
+                root.join("receipt.json").display(),
+                result.phase,
+                result
+                    .rollback_error
+                    .as_deref()
+                    .or(result.error.as_deref())
+                    .unwrap_or("helper exited")
+            ));
+        }
+        Ok(result)
+    }
+}
+
+fn read_receipt(root: &Path) -> Result<Receipt, String> {
+    let data = fs::read(root.join("receipt.json"))
+        .map_err(|error| format!("cannot read self-update receipt: {error}"))?;
+    let receipt: Receipt =
+        serde_json::from_slice(&data).map_err(|e| format!("invalid self-update receipt: {e}"))?;
+    if receipt.schema != 1 || transaction_root(&receipt.binary_path)? != root {
+        return Err("unsupported or misplaced self-update receipt".into());
+    }
+    Ok(receipt)
+}
+
+fn spawn_worker(cli: &Cli, previous: &Path, receipt: &Receipt) -> Result<Child, String> {
+    #[cfg(not(unix))]
+    {
+        let _ = (cli, previous, receipt);
+        Err("recoverable self-update is unsupported on this platform".into())
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let mut command = worker_command(previous, receipt)?;
+        command
+            .env_clear()
+            .envs(&cli.env)
+            .env_remove("OCM_ACTIVE_ENV")
+            .env_remove("OPENCLAW_SERVICE_KIND")
+            .env("OCM_SERVICE_EXECUTABLE", &receipt.binary_path)
+            .current_dir(&cli.cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        // SAFETY: only async-signal-safe syscalls in the post-fork child. A new
+        // session also releases the controlling terminal and source process group.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                libc::signal(libc::SIGHUP, libc::SIG_IGN);
+                Ok(())
+            });
+        }
+        command.spawn().map_err(|e| {
+            format!("cannot detach self-update helper; no executable was replaced: {e}")
+        })
+    }
+}
+
+#[cfg(unix)]
+fn worker_command(previous: &Path, receipt: &Receipt) -> Result<Command, String> {
+    #[cfg(target_os = "linux")]
+    let in_service = fs::read_to_string("/proc/self/cgroup")
+        .map_err(|e| format!("cannot inspect helper containment: {e}"))?
+        .split('/')
+        .any(|component| component.trim_end() == "ai.openclaw.ocm.service");
+    #[cfg(not(target_os = "linux"))]
+    let in_service = false;
+
+    let mut command = if in_service {
+        // setsid cannot escape systemd KillMode=control-group. A transient user
+        // scope moves the helper out before exec, preserving its environment.
+        let mut scope = Command::new("systemd-run");
+        scope
+            .args(["--user", "--scope", "--quiet", "--collect"])
+            .arg(format!("--unit=ocm-self-update-{}", receipt.id))
+            .arg("--")
+            .arg(previous);
+        scope
+    } else {
+        Command::new(previous)
+    };
+    command
+        .arg("__daemon")
+        .arg("self-update")
+        .arg(&receipt.binary_path)
+        .arg(&receipt.id);
+    Ok(command)
+}
+
+impl Cli {
+    pub(super) fn self_update_receipt(&self, recover: bool) -> Result<Receipt, String> {
+        let binary = std::env::current_exe().map_err(|e| e.to_string())?;
+        // The retained helper remains usable even when the candidate cannot run.
+        let root = if binary.file_name().is_some_and(|name| name == "previous") {
+            binary
+                .parent()
+                .ok_or("recovery executable has no parent")?
+                .to_path_buf()
+        } else {
+            transaction_root(&binary)?
+        };
+        let mut receipt = read_receipt(&root)?;
+        self.validate_receipt_home(&receipt)?;
+        if !recover || receipt.phase.terminal() {
+            return Ok(receipt);
+        }
+        let transaction = Transaction::open(&receipt.binary_path, false)?;
+        receipt = transaction.read()?;
+        if receipt.phase.terminal() {
+            return Ok(receipt);
+        }
+        receipt.phase = Phase::RollingBack;
+        receipt
+            .error
+            .get_or_insert("recovery requested after interrupted self-update".into());
+        transaction.save(&receipt)?;
+        transaction.start_and_wait(self, receipt)
+    }
+
+    fn validate_receipt_home(&self, receipt: &Receipt) -> Result<(), String> {
+        if resolve_ocm_home(&self.env, &self.cwd)? != receipt.ocm_home
+            || resolve_user_home(&self.env) != receipt.user_home
+        {
+            return Err(
+                "self-update belongs to a different HOME or OCM_HOME; use the original store"
+                    .into(),
+            );
+        }
+        Ok(())
+    }
+
+    pub(super) fn run_self_update_worker(&self, args: Vec<String>) -> Result<i32, String> {
+        let [binary, id] = args.as_slice() else {
+            return Err("internal self-update requires binary and transaction id".into());
+        };
+        let transaction = Transaction::open(Path::new(binary), true)?;
+        #[cfg(unix)]
+        transaction.retain_lock_in_subcommands()?;
+        let mut receipt = transaction.read()?;
+        self.validate_receipt_home(&receipt)?;
+        if &receipt.id != id {
+            return Err("stale self-update helper".into());
+        }
+        if receipt.phase.terminal() {
+            return Ok(0);
+        }
+        let mut env = self.env.clone();
+        env.remove("OCM_ACTIVE_ENV");
+        env.remove("OPENCLAW_SERVICE_KIND");
+        env.insert("OCM_SERVICE_EXECUTABLE".into(), binary.clone());
+        let worker = Cli {
+            env,
+            cwd: receipt.ocm_home.clone(),
+        };
+        let result = worker.perform_update(&transaction, &mut receipt);
+        if let Err(error) = result {
+            receipt.error.get_or_insert(error);
+            if receipt.phase == Phase::Prepared {
+                receipt.phase = Phase::Failed;
+            } else {
+                receipt.phase = Phase::RollingBack;
+                transaction.save(&receipt)?;
+                match worker.rollback_update(&transaction, &receipt) {
+                    Ok(()) => {
+                        receipt.phase = Phase::RolledBack;
+                        receipt.rollback_error = None;
+                    }
+                    Err(error) => {
+                        receipt.phase = Phase::RollbackFailed;
+                        receipt.rollback_error = Some(error);
+                    }
+                }
+            }
+        }
+        transaction.save(&receipt)?;
+        Ok(if receipt.phase == Phase::RollbackFailed {
+            1
+        } else {
+            0
+        })
+    }
+
+    fn perform_update(
+        &self,
+        transaction: &Transaction,
+        receipt: &mut Receipt,
+    ) -> Result<(), String> {
+        // Keep lifecycle admission through convergence AND rollback. Acquiring
+        // outside this function would recursively lock the ordinary refresh API.
+        let service = self.supervisor_service();
+        let _lifecycle = service.lock_daemon_lifecycle()?;
+        service.validate_self_update_daemon_locked()?;
+        if receipt.phase != Phase::Prepared {
+            return Err("interrupted update requires rollback".into());
+        }
+        if file_sha256(&receipt.binary_path)? != receipt.previous_sha256 {
+            return Err("installed executable changed after staging; refusing replacement".into());
+        }
+        let candidate = transaction.root.join("candidate");
+        if file_sha256(&candidate)? != receipt.candidate_sha256 {
+            return Err("staged candidate changed after verification".into());
+        }
+        validate_staged_binary(&candidate, &receipt.target_version)?;
+        let before = service.daemon_status()?;
+        receipt.daemon_was_running = before.running;
+        if before.running {
+            let runtime = service.runtime()?;
+            if !runtime.present
+                || runtime.daemon_version.as_deref() != Some(&receipt.current_version)
+            {
+                return Err("running daemon version is unknown or already skewed; refresh it before self-update".into());
+            }
+            receipt.gateways = runtime
+                .children
+                .into_iter()
+                .map(|child| child.env_name)
+                .collect();
+        }
+        receipt.phase = Phase::Applying;
+        transaction.save(receipt)?;
+        let result = (|| {
+            fs::rename(&candidate, &receipt.binary_path)
+                .map_err(|e| format!("cannot publish candidate: {e}"))?;
+            sync_dir(receipt.binary_path.parent().unwrap())?;
+            sync_dir(&transaction.root)?;
+            validate_staged_binary(&receipt.binary_path, &receipt.target_version)?;
+            if receipt.daemon_was_running {
+                self.refresh_and_verify(receipt, &receipt.target_version)?;
+            }
+            receipt.phase = Phase::Updated;
+            transaction.save(receipt)
+        })();
+        if let Err(error) = result {
+            receipt.error = Some(error);
+            receipt.phase = Phase::RollingBack;
+            transaction.save(receipt)?;
+            // Do not release lifecycle ownership between forward failure and undo.
+            match self.rollback_update_locked(transaction, receipt) {
+                Ok(()) => receipt.phase = Phase::RolledBack,
+                Err(error) => {
+                    receipt.phase = Phase::RollbackFailed;
+                    receipt.rollback_error = Some(error);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn rollback_update(&self, transaction: &Transaction, receipt: &Receipt) -> Result<(), String> {
+        let service = self.supervisor_service();
+        let _lifecycle = service.lock_daemon_lifecycle()?;
+        service.validate_self_update_daemon_locked()?;
+        self.rollback_update_locked(transaction, receipt)
+    }
+
+    fn rollback_update_locked(
+        &self,
+        transaction: &Transaction,
+        receipt: &Receipt,
+    ) -> Result<(), String> {
+        let previous = transaction.root.join("previous");
+        if file_sha256(&previous)? != receipt.previous_sha256 {
+            return Err("retained previous executable changed; refusing rollback".into());
+        }
+        let installed = file_sha256(&receipt.binary_path)?;
+        if installed != receipt.previous_sha256 && installed != receipt.candidate_sha256 {
+            return Err("installed executable has unrelated bytes; refusing rollback".into());
+        }
+        let restore = StagedBinary::copy_from(&previous, &transaction.root)?;
+        fs::rename(restore.path(), &receipt.binary_path).map_err(|e| e.to_string())?;
+        sync_dir(receipt.binary_path.parent().unwrap())?;
+        sync_dir(&transaction.root)?;
+        validate_staged_binary(&receipt.binary_path, &receipt.current_version)?;
+        if receipt.daemon_was_running {
+            self.refresh_and_verify(receipt, &receipt.current_version)?;
+        }
+        Ok(())
+    }
+
+    fn refresh_and_verify(&self, receipt: &Receipt, version: &str) -> Result<(), String> {
+        let service = self.supervisor_service();
+        let old_pid = service.daemon_status()?.pid;
+        let started = time::OffsetDateTime::now_utc();
+        // Same activation primitive as explicit refresh, without rebuilding desired
+        // state or moving this already-detached helper back into the caller group.
+        service.activate_daemon("self-update")?;
+        let timeout = self
+            .env
+            .get("OCM_INTERNAL_SELF_UPDATE_TIMEOUT_MS")
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(Duration::from_millis)
+            .unwrap_or(Duration::from_secs(30));
+        let deadline = Instant::now() + timeout;
+        loop {
+            let daemon = service.daemon_status()?;
+            let runtime = service.runtime()?;
+            if daemon.running
+                && daemon.pid.is_some()
+                && daemon.pid != old_pid
+                && runtime.present
+                && runtime.updated_at >= started
+                && runtime.daemon_version.as_deref() == Some(version)
+            {
+                break;
+            }
+            if Instant::now() >= deadline {
+                return Err(format!("daemon did not converge to OCM {version}"));
+            }
+            sleep(Duration::from_millis(100));
+        }
+        for name in &receipt.gateways {
+            let ready = wait_for_gateway_readiness(name, &self.env, &self.cwd)?;
+            if !ready.ready {
+                return Err(format!(
+                    "gateway {name} did not recover: {}",
+                    ready.issue.unwrap_or_default()
+                ));
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/service/platform.rs
+++ b/src/service/platform.rs
@@ -307,6 +307,31 @@ pub(crate) fn validate_managed_service_owner(
     ))
 }
 
+pub(crate) fn validate_managed_service_executable(
+    definition: &ManagedServiceDefinition,
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    if !definition.definition_path.exists() {
+        return Ok(());
+    }
+    let raw = fs::read_to_string(&definition.definition_path).map_err(|e| e.to_string())?;
+    let marker = match service_manager_kind(env) {
+        ServiceManagerKind::Launchd => format!(
+            "<key>ProgramArguments</key>\n    <array>\n      <string>{}</string>",
+            plist_escape(&definition.program_arguments[0])
+        ),
+        ServiceManagerKind::SystemdUser => format!(
+            "\nExecStart={} __daemon run\n",
+            systemd_quote(&definition.program_arguments[0])
+        ),
+        ServiceManagerKind::Unsupported => return Err(unsupported_service_manager_message().into()),
+    };
+    if !raw.contains(&marker) {
+        return Err("managed daemon uses a different executable or a nonstandard service definition; refusing self-update".into());
+    }
+    Ok(())
+}
+
 pub(crate) fn deactivate_managed_service(
     definition: &ManagedServiceDefinition,
     env: &BTreeMap<String, String>,

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -497,6 +497,12 @@ impl<'a> SupervisorService<'a> {
         validate_managed_service_owner(&definition, self.env)
     }
 
+    pub(crate) fn validate_self_update_daemon_locked(&self) -> Result<(), String> {
+        let definition = self.supervisor_daemon_definition()?;
+        validate_managed_service_owner(&definition, self.env)?;
+        crate::service::platform::validate_managed_service_executable(&definition, self.env)
+    }
+
     pub(crate) fn restore_daemon_state_locked(
         &self,
         before: &SupervisorDaemonSummary,
@@ -708,7 +714,7 @@ impl<'a> SupervisorService<'a> {
         self.activate_daemon(action)
     }
 
-    fn activate_daemon(&self, action: &str) -> Result<SupervisorDaemonSummary, String> {
+    pub(crate) fn activate_daemon(&self, action: &str) -> Result<SupervisorDaemonSummary, String> {
         let definition = self.supervisor_daemon_definition()?;
         write_managed_service_definition(&definition, self.env)?;
         activate_managed_service(&definition.label, &definition.definition_path, self.env)?;

--- a/tests/self_command_tests.rs
+++ b/tests/self_command_tests.rs
@@ -213,14 +213,57 @@ fn self_update_replaces_a_copied_binary_in_place() {
         .unwrap();
     assert!(updated.status.success());
     assert_eq!(String::from_utf8(updated.stdout).unwrap(), "9.9.9\n");
+    let journal = copied_binary.parent().unwrap().join(".ocm.self-update");
+    let receipt: serde_json::Value =
+        serde_json::from_slice(&fs::read(journal.join("receipt.json")).unwrap()).unwrap();
+    assert_eq!(receipt["phase"], "updated");
+    assert_eq!(receipt["daemonWasRunning"], false);
+    assert_eq!(
+        file_sha256(&journal.join("previous")).unwrap(),
+        file_sha256(Path::new(env!("CARGO_BIN_EXE_ocm"))).unwrap()
+    );
+    assert!(
+        !root
+            .child("home/Library/LaunchAgents/ai.openclaw.ocm.plist")
+            .exists()
+    );
+    assert!(
+        !root
+            .child("home/.config/systemd/user/ai.openclaw.ocm.service")
+            .exists()
+    );
 }
 
 #[test]
-fn self_update_reports_running_daemon_skew_without_restarting_it() {
+fn self_update_unchanged_and_check_do_not_create_a_receipt() {
+    let root = TestDir::new("self-update-unchanged");
+    let copied = copied_ocm(&root);
+    let metadata = format!(
+        "{{\"tag_name\":\"v{}\",\"assets\":[]}}",
+        env!("CARGO_PKG_VERSION")
+    );
+    let release =
+        TestHttpServer::serve_bytes_times("/release", "application/json", metadata.as_bytes(), 2);
+    let env = release_env(&root, &release.url());
+    for args in [
+        vec!["self", "update", "--check", "--json"],
+        vec!["self", "update", "--json"],
+    ] {
+        let output = run_ocm_binary(&copied, root.path(), &env, &args);
+        assert!(output.status.success(), "{}", stderr(&output));
+        let summary: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(summary["status"], "upToDate");
+        assert!(!root.child("bin/.ocm.self-update/receipt.json").exists());
+    }
+}
+
+#[test]
+fn self_update_refuses_an_unknown_daemon_version_before_replacement() {
     let root = TestDir::new("self-update-running-daemon-skew");
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let copied_binary = copied_ocm(&root);
+    let original = fs::read(&copied_binary).unwrap();
     let mut env = ocm_env(&root);
     env.insert(
         "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
@@ -271,10 +314,9 @@ fn self_update_reports_running_daemon_skew_without_restarting_it() {
         &env,
         &["self", "update", "--version", target_version, "--raw"],
     );
-    assert!(output.status.success(), "{}", stderr(&output));
-    let text = stdout(&output);
-    assert!(text.contains("daemonRefreshRequired: true"));
-    assert!(text.contains("service refresh-daemon --acknowledge-gateway-restarts"));
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("running daemon version is unknown"));
+    assert_eq!(fs::read(&copied_binary).unwrap(), original);
 
     let calls = fs::read_to_string(&launchctl_log).unwrap();
     assert!(calls.contains("print"));

--- a/tests/self_update_transaction_tests.rs
+++ b/tests/self_update_transaction_tests.rs
@@ -1,0 +1,455 @@
+#![cfg(unix)]
+mod support;
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use flate2::{Compression, write::GzEncoder};
+use ocm::infra::download::file_sha256;
+use serde_json::{Value, json};
+use support::{TestDir, TestHttpServer, ocm_env, run_ocm_binary, stderr, write_executable_script};
+
+fn wait_for(mut predicate: impl FnMut() -> bool, detail: &str) {
+    let deadline = Instant::now() + Duration::from_secs(25);
+    while Instant::now() < deadline {
+        if predicate() {
+            return;
+        }
+        sleep(Duration::from_millis(50));
+    }
+    panic!("timed out: {detail}");
+}
+
+fn read_json(path: &Path) -> Value {
+    fs::read(path)
+        .ok()
+        .and_then(|data| serde_json::from_slice(&data).ok())
+        .unwrap_or(Value::Null)
+}
+
+// Compile the same source as a different release. No patched version strings,
+// fake runtime-version records, shared target directory, or external downloads.
+fn build_candidate(root: &TestDir) -> PathBuf {
+    let source = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let package = root.child("candidate-package");
+    fs::create_dir_all(&package).unwrap();
+    let manifest = fs::read_to_string(source.join("Cargo.toml"))
+        .unwrap()
+        .replacen(
+            &format!("version = \"{}\"", env!("CARGO_PKG_VERSION")),
+            "version = \"9.9.9\"",
+            1,
+        );
+    fs::write(
+        package.join("Cargo.toml"),
+        format!(
+            "{manifest}\n[lib]\npath = {:?}\n[[bin]]\nname = \"ocm\"\npath = {:?}\n",
+            source.join("src/lib.rs"),
+            source.join("src/main.rs")
+        ),
+    )
+    .unwrap();
+    let lock = fs::read_to_string(source.join("Cargo.lock"))
+        .unwrap()
+        .replace(
+            &format!(
+                "name = \"ocm\"\nversion = \"{}\"",
+                env!("CARGO_PKG_VERSION")
+            ),
+            "name = \"ocm\"\nversion = \"9.9.9\"",
+        );
+    fs::write(package.join("Cargo.lock"), lock).unwrap();
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "--locked", "--offline", "--bin", "ocm"])
+        .current_dir(&package)
+        .env("CARGO_TARGET_DIR", package.join("target"))
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "candidate build: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    package.join("target/debug/ocm")
+}
+
+struct Fixture {
+    root: TestDir,
+    env: BTreeMap<String, String>,
+    binary: PathBuf,
+    _release: TestHttpServer,
+    _asset: TestHttpServer,
+}
+
+impl Fixture {
+    fn new(candidate: &Path, label: &str) -> Self {
+        let root = TestDir::new(label);
+        let mut env = ocm_env(&root);
+        env.remove("OCM_INTERNAL_SKIP_SERVICE_READINESS");
+        env.insert("OCM_INTERNAL_SELF_UPDATE_TIMEOUT_MS".into(), "2000".into());
+        env.insert(
+            "OCM_INTERNAL_GATEWAY_READINESS_TIMEOUT_MS".into(),
+            "3000".into(),
+        );
+        let binary = root.child("bin/ocm");
+        fs::create_dir_all(binary.parent().unwrap()).unwrap();
+        fs::copy(env!("CARGO_BIN_EXE_ocm"), &binary).unwrap();
+        let archive = root.child("candidate.tar.gz");
+        let file = fs::File::create(&archive).unwrap();
+        let mut tar = tar::Builder::new(GzEncoder::new(file, Compression::fast()));
+        tar.append_path_with_name(candidate, "ocm").unwrap();
+        tar.into_inner().unwrap().finish().unwrap();
+        let asset = TestHttpServer::serve_bytes_times(
+            "/candidate",
+            "application/gzip",
+            &fs::read(&archive).unwrap(),
+            4,
+        );
+        let target = if cfg!(target_os = "macos") {
+            "apple-darwin"
+        } else {
+            "unknown-linux-gnu"
+        };
+        let metadata = json!({"tag_name":"v9.9.9", "assets":[{
+            "name":format!("ocm-{}-{target}.tar.gz", std::env::consts::ARCH),
+            "browser_download_url":asset.url(),
+            "digest":format!("sha256:{}", file_sha256(&archive).unwrap())
+        }]});
+        let release = TestHttpServer::serve_bytes_times(
+            "/release",
+            "application/json",
+            &serde_json::to_vec(&metadata).unwrap(),
+            8,
+        );
+        env.insert("OCM_INTERNAL_SELF_UPDATE_RELEASE_URL".into(), release.url());
+        env.insert("OCM_INTERNAL_SERVICE_MANAGER".into(), "launchd".into());
+        let manager = root.child("manager");
+        env.insert(
+            "OCM_INTERNAL_LAUNCHCTL_BIN".into(),
+            manager.to_string_lossy().into_owned(),
+        );
+        // This is a process-launching stand-in, not a mock of daemon/runtime data.
+        // It never invokes the host service manager. Each PID comes from spawn.
+        let script = format!(
+            r##"#!/usr/bin/env node
+const fs = require('node:fs');
+const cp = require('node:child_process');
+const root = {root};
+const binary = {binary};
+const pidFile = root + '/daemon.pid';
+const args = process.argv.slice(2);
+const sleep = ms => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+const alive = pid => {{ try {{ process.kill(pid, 0); return true; }} catch {{ return false; }} }};
+fs.appendFileSync(root + '/manager.log', args.join(' ') + '\n');
+if (args[0] === 'managername') {{ console.log('Aqua'); process.exit(0); }}
+if (args[0] === 'print-disabled' || args[0] === 'enable') process.exit(0);
+if (args[0] === 'print') {{
+  if (/^(gui|user)\/[0-9]+$/.test(args[1])) process.exit(0);
+  const pid = fs.existsSync(pidFile) ? Number(fs.readFileSync(pidFile, 'utf8')) : 0;
+  if (pid && alive(pid)) {{ console.log('state = running\npid = ' + pid); process.exit(0); }}
+  console.error('Could not find service'); process.exit(1);
+}}
+if (args[0] === 'bootout' || args[0] === 'unload') {{
+  if (fs.existsSync(pidFile)) {{
+    const pid = Number(fs.readFileSync(pidFile, 'utf8'));
+    if (alive(pid)) process.kill(pid, 'SIGTERM');
+    for (let i = 0; i < 150 && alive(pid); i++) sleep(20);
+    fs.unlinkSync(pidFile);
+  }}
+  process.exit(0);
+}}
+if (args[0] === 'bootstrap') {{
+  if (fs.existsSync(root + '/pause')) {{
+    fs.writeFileSync(root + '/worker.pid', String(process.ppid));
+    fs.writeFileSync(root + '/manager.pid', String(process.pid));
+    while (fs.existsSync(root + '/pause')) sleep(20);
+  }}
+  const version = cp.execFileSync(binary, ['--version'], {{encoding:'utf8'}}).trim();
+  if (version === '9.9.9' && fs.existsSync(root + '/fail-candidate')) {{
+    console.error('injected candidate activation failure'); process.exit(1);
+  }}
+  if (fs.existsSync(root + '/fail-all')) {{ console.error('injected persistent failure'); process.exit(1); }}
+  const log = fs.openSync(root + '/daemon.log', 'a');
+  const child = cp.spawn(binary, ['__daemon', 'run'], {{env: {env}, detached:true, stdio:['ignore',log,log]}});
+  fs.writeFileSync(pidFile, String(child.pid)); child.unref(); process.exit(0);
+}}
+process.exit(0);
+"##,
+            root = json!(root.path()),
+            binary = json!(binary),
+            env = json!(env)
+        );
+        write_executable_script(&manager, &script);
+        let probe = Command::new(&manager)
+            .arg("managername")
+            .env_clear()
+            .envs(&env)
+            .output()
+            .unwrap();
+        assert!(
+            probe.status.success(),
+            "fixture manager: {}",
+            String::from_utf8_lossy(&probe.stderr)
+        );
+        Self {
+            root,
+            env,
+            binary,
+            _release: release,
+            _asset: asset,
+        }
+    }
+
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        run_ocm_binary(&self.binary, self.root.path(), &self.env, args)
+    }
+
+    fn receipt(&self) -> Value {
+        read_json(&self.root.child("bin/.ocm.self-update/receipt.json"))
+    }
+
+    fn setup_gateway(&self) {
+        let gateway = self.root.child("gateway");
+        write_executable_script(
+            &gateway,
+            &format!(
+                r##"#!/usr/bin/env node
+const fs = require('node:fs');
+const cp = require('node:child_process');
+const http = require('node:http');
+const args = process.argv.slice(2);
+const root = {root};
+if (args[0] === '--version') {{ console.log('2026.8.1'); process.exit(0); }}
+if (args[1] === 'restart-handoff') process.exit(64);
+if (args[1] === 'status') {{ console.log('{{"rpc":{{"ok":true}}}}'); process.exit(0); }}
+if (args[0] !== 'gateway' || !args.includes('--port')) process.exit(0);
+fs.appendFileSync(root + '/gateway-starts', process.pid + '\n');
+const port = Number(args[args.indexOf('--port') + 1]);
+http.createServer((req,res) => {{ res.writeHead(200); res.end('ok'); }}).listen(port, '127.0.0.1');
+setInterval(() => {{
+  if (fs.existsSync(root + '/invoke') && !fs.existsSync(root + '/invoked')) {{
+    fs.writeFileSync(root + '/invoked', 'yes');
+    const log = fs.openSync(root + '/update.log', 'a');
+    const child = cp.spawn({binary}, ['self','update','--version','9.9.9','--json'], {{env:{env},stdio:['ignore',log,log]}});
+    fs.writeFileSync(root + '/caller.pid', String(child.pid));
+  }}
+}}, 50);
+"##,
+                root = json!(self.root.path()),
+                binary = json!(self.binary),
+                env = json!(self.env)
+            ),
+        );
+        for args in [
+            vec![
+                "runtime",
+                "add",
+                "fixture",
+                "--path",
+                gateway.to_str().unwrap(),
+            ],
+            vec!["env", "create", "running", "--runtime", "fixture"],
+            vec!["env", "create", "stopped", "--runtime", "fixture"],
+            vec!["service", "start", "running"],
+        ] {
+            let result = self.run(&args);
+            assert!(result.status.success(), "{args:?}: {}", stderr(&result));
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        // Exact owned PID, from this fixture's manager. Graceful daemon shutdown
+        // also reaps its gateway group; no host service or unrelated process.
+        if let Ok(pid) = fs::read_to_string(self.root.child("daemon.pid")) {
+            let _ = Command::new("kill").args(["-TERM", pid.trim()]).status();
+            sleep(Duration::from_millis(400));
+        }
+    }
+}
+
+#[test]
+fn local_transaction_survives_gateway_teardown_and_recovers_failures() {
+    let candidate_root = TestDir::new("self-update-build");
+    let candidate = build_candidate(&candidate_root);
+
+    // The source gateway launches the update in its own group. Refresh kills
+    // that group, including the CLI. Only the detached retained helper survives.
+    let success = Fixture::new(&candidate, "transaction-success");
+    success.setup_gateway();
+    let before = success.run(&["service", "status", "running", "--json"]);
+    let before: Value = serde_json::from_slice(&before.stdout).unwrap();
+    let gateway_pid = before["childPid"].as_u64().unwrap() as i32;
+    fs::write(success.root.child("invoke"), "go").unwrap();
+    wait_for(
+        || success.receipt()["phase"] == "updated",
+        "gateway-owned update receipt",
+    );
+    let receipt = success.receipt();
+    assert_eq!(receipt["daemonWasRunning"], true);
+    assert_eq!(receipt["gateways"], json!(["running"]));
+    assert_eq!(
+        String::from_utf8(success.run(&["--version"]).stdout)
+            .unwrap()
+            .trim(),
+        "9.9.9"
+    );
+    let status = success.run(&["service", "status", "running", "--json"]);
+    let status: Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(status["ocmServiceVersion"], "9.9.9");
+    assert_eq!(status["running"], true);
+    assert_ne!(status["childPid"], gateway_pid);
+    // SAFETY: signal 0 observes only the fixture's original process group.
+    assert_eq!(
+        unsafe { libc::kill(-gateway_pid, 0) },
+        -1,
+        "source process group survived"
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(
+            &success
+                .run(&["service", "status", "stopped", "--json"])
+                .stdout
+        )
+        .unwrap()["desiredRunning"],
+        false
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&success.run(&["self", "update", "--status"]).stdout)
+            .unwrap(),
+        receipt
+    );
+    let manager_before = fs::read(success.root.child("manager.log")).unwrap();
+    assert!(
+        success
+            .run(&["self", "update", "--version", "9.9.9", "--json"])
+            .status
+            .success()
+    );
+    assert_eq!(
+        fs::read(success.root.child("manager.log")).unwrap(),
+        manager_before,
+        "unchanged release touched service manager"
+    );
+    drop(success);
+
+    let rollback = Fixture::new(&candidate, "transaction-rollback");
+    rollback.setup_gateway();
+    let original = file_sha256(&rollback.binary).unwrap();
+    fs::write(rollback.root.child("fail-candidate"), "yes").unwrap();
+    let result = rollback.run(&["self", "update", "--version", "9.9.9", "--json"]);
+    assert!(
+        !result.status.success(),
+        "failed activation was reported as successful"
+    );
+    assert_eq!(
+        rollback.receipt()["phase"],
+        "rolledBack",
+        "{}",
+        stderr(&result)
+    );
+    assert_eq!(file_sha256(&rollback.binary).unwrap(), original);
+    assert!(
+        rollback.receipt()["error"]
+            .as_str()
+            .unwrap()
+            .contains("injected candidate activation failure")
+    );
+    let status: Value = serde_json::from_slice(
+        &rollback
+            .run(&["service", "status", "running", "--json"])
+            .stdout,
+    )
+    .unwrap();
+    assert_eq!(status["ocmServiceVersion"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(status["running"], true);
+    drop(rollback);
+
+    let crash = Fixture::new(&candidate, "transaction-crash");
+    crash.setup_gateway();
+    let original = file_sha256(&crash.binary).unwrap();
+    fs::write(crash.root.child("pause"), "yes").unwrap();
+    let mut caller = Command::new(&crash.binary)
+        .args(["self", "update", "--version", "9.9.9", "--json"])
+        .env_clear()
+        .envs(&crash.env)
+        .current_dir(crash.root.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_for(
+        || crash.root.child("worker.pid").exists(),
+        "worker reached post-publication pause",
+    );
+    assert_eq!(crash.receipt()["phase"], "applying");
+    let id = crash.receipt()["id"].clone();
+    let concurrent = crash.run(&["self", "update", "--version", "9.9.9"]);
+    assert!(!concurrent.status.success());
+    assert!(stderr(&concurrent).contains("self-update is busy"));
+    let recover_busy = crash.run(&["self", "update", "--recover"]);
+    assert!(!recover_busy.status.success());
+    let worker_pid = fs::read_to_string(crash.root.child("worker.pid")).unwrap();
+    assert!(
+        Command::new("kill")
+            .args(["-KILL", worker_pid.trim()])
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(!caller.wait().unwrap().success());
+    // A still-running activation command retains the update lock after its
+    // worker dies. Releasing the fixture pause lets that command finish.
+    let orphan_busy = crash.run(&["self", "update", "--recover"]);
+    assert!(!orphan_busy.status.success());
+    assert!(stderr(&orphan_busy).contains("self-update is busy"));
+    fs::remove_file(crash.root.child("pause")).unwrap();
+    wait_for(
+        || crash.root.child("daemon.pid").exists(),
+        "orphan activation completed",
+    );
+    sleep(Duration::from_millis(200));
+    let retry = crash.run(&["self", "update", "--version", "9.9.9"]);
+    assert!(!retry.status.success());
+    assert!(stderr(&retry).contains("unfinished self-update"));
+    let recovered = crash.run(&["self", "update", "--recover"]);
+    assert_eq!(
+        crash.receipt()["phase"],
+        "rolledBack",
+        "{}",
+        stderr(&recovered)
+    );
+    assert_eq!(crash.receipt()["id"], id);
+    assert_eq!(file_sha256(&crash.binary).unwrap(), original);
+    let before_retry = fs::read(crash.root.child("manager.log")).unwrap();
+    let _ = crash.run(&["self", "update", "--recover"]);
+    assert_eq!(
+        fs::read(crash.root.child("manager.log")).unwrap(),
+        before_retry,
+        "recovery replay changed services"
+    );
+    drop(crash);
+
+    let failed_rollback = Fixture::new(&candidate, "transaction-rollback-failed");
+    failed_rollback.setup_gateway();
+    fs::write(failed_rollback.root.child("fail-all"), "yes").unwrap();
+    let failure = failed_rollback.run(&["self", "update", "--version", "9.9.9"]);
+    assert!(!failure.status.success());
+    assert_eq!(failed_rollback.receipt()["phase"], "rollbackFailed");
+    assert!(failed_rollback.receipt()["rollbackError"].is_string());
+    assert!(
+        failed_rollback
+            .root
+            .child("bin/.ocm.self-update/previous")
+            .is_file()
+    );
+    fs::remove_file(failed_rollback.root.child("fail-all")).unwrap();
+    let _ = failed_rollback.run(&["self", "update", "--recover"]);
+    assert_eq!(failed_rollback.receipt()["phase"], "rolledBack");
+    assert_eq!(failed_rollback.receipt()["rollbackError"], Value::Null);
+}


### PR DESCRIPTION
Related: #134. This PR does not change or close the target-hosted snapshot lifecycle issue.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled. The coordinator will commission independent review before merging. Do not merge as part of this task.

</details>

## What Problem This Solves

Resolves a problem where `ocm self update` replaces the CLI but leaves a running daemon on its previously mapped executable. Manually refreshing from an agent hosted by a managed gateway can also lose the caller during teardown, leaving no durable result.

## Why This Change Was Made

A retained copy of the initiating OCM executable now runs the update transaction in a detached local helper. No new dependency or outside machine is required.

- Keep release digest, regular-file and exact-version checks before publication; bound version probes. Preserve embedded executable signatures.
- Retain previous bytes and a private, fsynced journal beside the installed executable; atomically rename the candidate into place.
- Hold per-executable admission and the existing daemon lifecycle lock through convergence or rollback. Service-manager subcommands retain admission after helper death, preventing recovery from racing an orphaned activation.
- Start the helper in a separate session with detached standard streams. Within the Linux OCM systemd cgroup, use a transient local user scope because a new process group alone cannot escape cgroup teardown.
- Reuse daemon activation and gateway health checks without rebuilding desired service state. Observe a new daemon PID, fresh runtime state, target version, and readiness of the previously running gateways.
- On failure, restore the previous executable and daemon. Preserve the original error and any rollback error. An interrupted transaction blocks a new update until explicit recovery.

Scope stays in self-update. No snapshot, runtime-binding, OpenClaw upgrade, or general lifecycle rewrite. Refuse another store's daemon, a different executable binding, an unknown/skewed daemon version, and unsupported handoffs before publication.

## User Impact

`ocm self update` now includes a brief managed-gateway interruption when a daemon is running. Its helper completes after caller disconnection.

`ocm self update --status` reads the durable result. `--recover` rolls back an interrupted transaction. If the installed candidate cannot execute, the printed `.ocm.self-update/previous` executable remains usable for recovery. No daemon is installed or started when none was running. Check and unchanged paths do not restart services.

Recovery after helper death or reboot is explicit, not an automatic boot service. The latest receipt and previous binary remain until the next admitted update.

## Evidence

Base: `c5e7126c9b6cf7fb9b6f7903f59393f95e4c6ef1` (`0.2.38`).
Head: `10941b3d81b6784e1812a30c645cef60698454ce`.

The same isolated CLI fixture runs against both refs. It compiles an actual second OCM version, uses actual OCM daemon processes and a local HTTP gateway, and substitutes only the service-manager launcher. The detached baseline checkout has no product modifications; only the reproduction test is added.

- [Baseline red recording](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260904-063504-110850000/red.mp4?X-Amz-Expires=604800&X-Amz-Date=20260904T063504Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260904%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=745c1e905b3f0d17505d21f1c63f7c06698c903e1690c272f27cea9cd3720fb7): CLI becomes `9.9.9`, daemon stays `0.2.38`, and no transaction receipt appears. Contract test exits 101.
- [Exact-head green recording](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260904-063504-110850000/green.mp4?X-Amz-Expires=604800&X-Amz-Date=20260904T063504Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260904%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=0def9f919250d599bf5fd7ad74bb423fa74c2405ce1e86c6d68a5ce4d9f410d0): source process group dies; CLI and daemon converge to `9.9.9`; gateway health and receipt checks pass. Injected activation failure restores the previous CLI/daemon. SIGKILL recovery, concurrent update rejection, orphan-command locking, repeated recovery, and failed-rollback recovery pass. Test exits 0.
- [Artifact manifest and checksums](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260904-063504-110850000/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260904T063515Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260904%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=8dcf910fe875b24e121bb70cb9a18796315e7b758686daab9bda3e6e48e90509), [contract](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260904-063504-110850000/contract.md?X-Amz-Expires=604800&X-Amz-Date=20260904T063504Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260904%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=685f0020e0954ecb384869c63e2441fd6f45736ba8c25766400a45a6c1177c97), [exact commands and limitations](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260904-063504-110850000/checks.md?X-Amz-Expires=604800&X-Amz-Date=20260904T063504Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260904%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=5831d1bf7e42c19442ebe5f807c8366754e6aa8bd693de76454657f1bc4c726a), [proof summary](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260904-063504-110850000/summary.md?X-Amz-Expires=604800&X-Amz-Date=20260904T063504Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260904%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f1ef44e600c0040e2d8decba6f5aafc161dc8f8a9ead42751782a7690c9ea169).

The bundle includes canonical terminal casts. MP4s are deterministic 1x terminal renders, validated by full decode and frame extraction. Image-view capability was unavailable, so visual inspection is not claimed. A zero-gateway count after a terminal receipt is deliberate fixture cleanup. Download links expire after seven days.

| Check on head | Result |
| --- | --- |
| `cargo test --locked --test self_command_tests --test self_update_transaction_tests` | 10 command tests and 1 multi-scenario transaction test passed |
| `cargo fmt --check` | Passed |
| Rust 1.88 `cargo check --workspace --all-targets --locked` | Passed; two existing deprecation warnings |
| `cargo install --locked --path . --root <isolated-temp>`, then `ocm --version` | Passed, `0.2.38` |
| `cargo test --locked --no-fail-fast` | 1,020 passed; six environment/baseline failures, detailed below |
| Service-command suite rebuilt under an isolated path containing `target` | 38/38 passed |
| Required autoreview, one pass, default P0 scope | No P0 findings |

All six full-suite failures reproduced on unchanged base with the same environment:

1. `bin_wrapper_runs_with_an_overridden_home`: the Homebrew rustup shim handles `cargo run --quiet` as `rustup run` and rejects `--quiet`.
2. Three service executable-discovery tests expect a literal `target` path component; the initial isolated build used `target-head`. All 38 service tests pass with the expected isolated path shape.
3. `upgrade_can_switch_a_local_launcher_env_to_a_published_runtime` and `upgrade_keeps_a_stopped_installed_service_stopped`: launcher fixtures observe host Node `v24.20.0` as the OpenClaw version.

No test was skipped or weakened to bypass these failures. The legacy gateway-owned daemon-refresh test independently failed on the valid baseline run and passed in the head full run; it is timing-sensitive and is not used to claim a fix to every ordinary refresh path. Initial attempts that omitted Node from PATH were discarded as invalid product evidence.

### Remaining verification boundaries

- Local proof is macOS arm64. Native Linux systemd-cgroup survival and Windows runtime execution were not exercised here. Existing CI provides Linux tests/MSRV and Windows compilation.
- Windows and Linux arm64 self-update retain their explicit unsupported behavior.
- No live installation, live service definition, external test machine, or credentials were used.
- The source-aware implementation agent does not claim independent source-blind behavior-validator proof. That validation and the coordinator's independent review remain outstanding before merge.
- Service-manager hangs retain a nonterminal receipt and lock. Reboot/storage-fault injection is not covered.
