### PR TITLE
fix: allow a separate supervisor bootstrap log directory

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -338,6 +338,33 @@ ocm service status mira
 
 Use `service install` when you want a background service for an environment that was created with `--no-service`, or when you want to bring an older env under background management later.
 
+### Supervisor bootstrap logs on a separate filesystem
+
+By default, the supervisor's own stdout/stderr logs live under
+`$OCM_HOME/supervisor/logs`. If the OS service manager cannot open logs there
+(for example, on an affected macOS external volume), select a dedicated,
+absolute directory on an accessible filesystem before installing the service:
+
+```bash
+export OCM_DAEMON_LOG_DIR="$HOME/Library/Logs/OCM"
+ocm service install mira
+```
+
+Only `daemon.stdout.log` and `daemon.stderr.log` use this directory. Environment
+data, runtimes, workspaces, gateway logs and the supervisor working directory
+stay under their existing paths. OCM creates the log directory using its normal
+private-directory permissions; choose a dedicated directory, not a shared one.
+
+Keep the same variable set for subsequent OCM lifecycle/inspection commands.
+It is also included in the generated supervisor environment so daemon-initiated
+operations retain the selection. Unsetting it selects the default again; this
+is not a persistent per-store configuration setting. Changing the variable
+alone does not reload an already-running OS service. Apply changes through the
+normal OCM service refresh workflow in a maintenance window.
+
+This does not grant macOS privacy permissions or make an unmounted store
+available. The store and executable must still be accessible at startup.
+
 ### Read logs
 
 ```bash

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -60,6 +60,7 @@ const SUPERVISED_CHILD_BASE_ENV_KEYS: [&str; 5] = ["HOME", "PATH", "OCM_HOME", "
 const SUPERVISED_CHILD_RUNTIME_ENV_KEYS: [&str; 4] =
     ["NODE_OPTIONS", "NODE_ENV", "NODE_PATH", "PNPM_HOME"];
 const SERVICE_EXECUTABLE_OVERRIDE: &str = "OCM_SERVICE_EXECUTABLE";
+const DAEMON_LOG_DIR_OVERRIDE: &str = "OCM_DAEMON_LOG_DIR";
 pub(crate) const SERVICE_EXECUTABLE_IDENTITY: &str = "ocm-service-supervisor";
 const SERVICE_EXECUTABLE_IDENTITY_TIMEOUT_MS: u64 = 1_000;
 const SERVICE_EXECUTABLE_IDENTITY_BUSY_ATTEMPTS: usize = 5;
@@ -739,7 +740,7 @@ impl<'a> SupervisorService<'a> {
         let ocm_home = resolve_ocm_home(self.env, self.cwd)?;
         let state_path = supervisor_state_path(self.env, self.cwd)?;
         let identity = managed_service_identity(self.env, self.cwd)?;
-        let logs_dir = supervisor_logs_dir(self.env, self.cwd)?;
+        let logs_dir = self.daemon_logs_dir()?;
         let stdout_path = logs_dir.join("daemon.stdout.log");
         let stderr_path = logs_dir.join("daemon.stderr.log");
         let status = inspect_job(&identity.label, &identity.definition_path, self.env);
@@ -772,7 +773,7 @@ impl<'a> SupervisorService<'a> {
     fn supervisor_daemon_definition(&self) -> Result<ManagedServiceDefinition, String> {
         let ocm_home = resolve_ocm_home(self.env, self.cwd)?;
         let identity = managed_service_identity(self.env, self.cwd)?;
-        let logs_dir = supervisor_logs_dir(self.env, self.cwd)?;
+        let logs_dir = self.daemon_logs_dir()?;
         let executable_path = self.supervisor_executable_path()?;
 
         Ok(ManagedServiceDefinition {
@@ -792,6 +793,21 @@ impl<'a> SupervisorService<'a> {
             stderr_path: logs_dir.join("daemon.stderr.log"),
             environment: supervisor_service_environment(self.env, &ocm_home, &executable_path),
         })
+    }
+
+    fn daemon_logs_dir(&self) -> Result<PathBuf, String> {
+        match self.env.get(DAEMON_LOG_DIR_OVERRIDE) {
+            Some(value) => {
+                let path = PathBuf::from(value);
+                if !path.is_absolute() {
+                    return Err(format!(
+                        "{DAEMON_LOG_DIR_OVERRIDE} must be an absolute directory path"
+                    ));
+                }
+                Ok(path)
+            }
+            None => supervisor_logs_dir(self.env, self.cwd),
+        }
     }
 
     fn supervisor_executable_path(&self) -> Result<PathBuf, String> {
@@ -2124,6 +2140,9 @@ fn supervisor_service_environment(
     }
     service_env.insert("OCM_HOME".to_string(), display_path(ocm_home));
     service_env.insert("OCM_SELF".to_string(), display_path(executable_path));
+    if let Some(value) = process_env.get(DAEMON_LOG_DIR_OVERRIDE) {
+        service_env.insert(DAEMON_LOG_DIR_OVERRIDE.to_string(), value.clone());
+    }
     service_env
 }
 
@@ -2714,6 +2733,62 @@ mod tests {
             let mut permissions = fs::metadata(path).unwrap().permissions();
             permissions.set_mode(0o755);
             fs::set_permissions(path, permissions).unwrap();
+        }
+    }
+
+    #[test]
+    fn daemon_bootstrap_log_override_preserves_store_logs() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let store = root.path().join("external-store");
+        let logs = root.path().join("internal-logs");
+        let mut env = BTreeMap::from([
+            ("HOME".to_string(), display_path(&home)),
+            ("OCM_HOME".to_string(), display_path(&store)),
+            ("OCM_DAEMON_LOG_DIR".to_string(), display_path(&logs)),
+            (
+                "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+                "launchd".to_string(),
+            ),
+        ]);
+        let service = super::SupervisorService::new(&env, root.path());
+        let definition = service.supervisor_daemon_definition().unwrap();
+        assert_eq!(definition.stdout_path, logs.join("daemon.stdout.log"));
+        assert_eq!(definition.stderr_path, logs.join("daemon.stderr.log"));
+        assert_eq!(definition.working_directory, store);
+        assert_eq!(
+            super::supervisor_logs_dir(&env, root.path()).unwrap(),
+            store.join("supervisor/logs")
+        );
+        assert_eq!(
+            definition.environment.get("OCM_DAEMON_LOG_DIR"),
+            env.get("OCM_DAEMON_LOG_DIR")
+        );
+        let summary = service.daemon_status().unwrap();
+        assert_eq!(summary.stdout_path, display_path(&definition.stdout_path));
+        assert_eq!(summary.stderr_path, display_path(&definition.stderr_path));
+        super::write_managed_service_definition(&definition, &env).unwrap();
+        assert!(logs.is_dir());
+        let again = service.supervisor_daemon_definition().unwrap();
+        super::write_managed_service_definition(&again, &env).unwrap();
+        assert_eq!(again.stdout_path, definition.stdout_path);
+
+        env.remove("OCM_DAEMON_LOG_DIR");
+        let default = super::SupervisorService::new(&env, root.path())
+            .supervisor_daemon_definition()
+            .unwrap();
+        assert_eq!(
+            default.stdout_path,
+            store.join("supervisor/logs/daemon.stdout.log")
+        );
+        for invalid in ["", "relative/logs"] {
+            env.insert("OCM_DAEMON_LOG_DIR".to_string(), invalid.to_string());
+            assert!(
+                super::SupervisorService::new(&env, root.path())
+                    .supervisor_daemon_definition()
+                    .unwrap_err()
+                    .contains("absolute")
+            );
         }
     }
 


### PR DESCRIPTION
Related: #148

## What Problem This Solves

Resolves a problem where operators keeping an OCM store on an affected external filesystem have no supported way to relocate just the supervisor's bootstrap logs. The observed workaround requires hand-editing a generated service definition, which OCM can overwrite later. This draft proposes a recovery control; it does not establish that the affected-host startup failure is fixed.

## Why This Change Was Made

Proposes an opt-in `OCM_DAEMON_LOG_DIR` for only the supervisor's `daemon.stdout.log` and `daemon.stderr.log`. Without it, paths are unchanged. With it, the generated definition and daemon summary use the same absolute directory, created through the existing private-directory writer. Empty and relative paths fail explicitly.

The value is included in the supervisor environment so daemon-initiated operations retain it. Operators must keep it set for later CLI lifecycle/inspection commands; this is deliberately not a new persistent per-store setting. The usage guide explains that boundary and the maintenance-window requirement for applying a changed location to an existing service.

## User Impact

Operators can keep state, runtimes, workspaces, working directory and gateway logs in their existing locations while putting just bootstrap logs on an accessible filesystem. No new dependencies, automatic relocation, permission grants or service-ownership changes.

This is independent of #149's plist ownership parser fix. **Maintainer decision:** is a caller-supplied override sufficient, or must the selection persist per store and survive later CLI invocations without the variable? This candidate implements only the former. It preserves the selection during regeneration when the variable is supplied, including by the generated daemon environment; it does not meet an unconditional durable-setting requirement. An automatic platform-specific default would be a separate compatibility choice.

## Evidence

Base: `c5e7126c9b6cf7fb9b6f7903f59393f95e4c6ef1` (0.2.38). Candidate: `36eda83882adfc7bfc1e7ec5c4c4678ad8ba62c0`.

- The new test first failed on unchanged production code because the requested bootstrap destination was ignored. It passes with this patch.
- It checks both stream paths, unchanged store-log resolution and working directory, supervisor-environment propagation, matching summary paths, directory creation, repeat definition generation, default compatibility, and empty/relative path rejection.
- Windows `cargo test --locked supervisor::tests --lib`: 27 passed, 0 failed. `cargo check --workspace --all-targets --locked`, formatting and diff checks passed.
- Historical native observation on macOS 26.6.2: changing only the two bootstrap plist paths from an affected external volume to internal storage changed supervisor startup from exit 78 to running, followed by gateway health/catalog success. No privacy permission was changed.

All five [CI jobs at this head](https://github.com/openclaw/ocm/actions/runs/33994786451) passed: formatting, Rust 1.88 minimum, Windows compilation, Ubuntu tests and macOS tests. Run the focused regression with `cargo test --locked daemon_bootstrap_log_override_preserves_store_logs --lib`.

**Before merge:** settle the configuration/persistence contract, then exercise a patched native binary on the affected external-volume host. Tests prove path selection and regeneration with the option present, not launchd access policy, reboot recovery or boot-time volume availability. This PR uses `Related`, not an automatic issue-closing keyword, until native acceptance and the interface decision are settled. No live OCM service or installed executable was changed during this patch work.
