### PR TITLE
fix: prepare checkpoints online and restore service before cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ other filesystems use a metadata-preserving full copy. Restore discards only
 explicit process residue such as locks, sockets, PIDs, and temporary runtime
 directories. Legacy tar snapshots remain readable.
 
+On APFS, snapshot preparation clones the bulk tree while the gateway is running.
+The final service pause reconciles changed or removed entries and checks changed
+SQLite state before publishing the checkpoint. Failed or displaced preparation
+trees are cleaned up after service restoration or upgrade completion, not before
+restart. Other filesystems retain the fully verified copy path.
+
 Checkpoints contain secrets and share the source filesystem. Keep `OCM_HOME`
 private, allow enough space for checkpoint divergence plus a restore candidate,
 and retain an off-disk backup for disaster recovery.

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -811,6 +811,7 @@ impl Cli {
             let prepared = self
                 .environment_service()
                 .prepare_snapshot_capture_locked(name)?;
+            let _checkpoint_cleanup = prepared.cleanup_guard();
             let service_state = self
                 .service_service()
                 .quiesce_for_snapshot_locked(name)?;

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -957,6 +957,7 @@ impl Cli {
         let prepared = self
             .environment_service()
             .prepare_snapshot_capture_locked(env_name)?;
+        let _checkpoint_cleanup = prepared.cleanup_guard();
         let service_state = self
             .service_service()
             .quiesce_for_snapshot_locked(env_name)?;
@@ -4305,6 +4306,7 @@ impl Cli {
             .environment_service()
             .prepare_snapshot_capture_locked(env_name)?;
         let mut seen = BTreeSet::new();
+        let checkpoint_cleanup = prepared.cleanup_guard();
         let mut runtime_backups: Vec<RuntimeRollbackBackup> = Vec::new();
         let mut created_runtime_names = Vec::new();
 
@@ -4387,16 +4389,16 @@ impl Cli {
         let snapshot = match snapshot_result {
             Ok(snapshot) => snapshot,
             Err(error) => {
+                let restore_result = self
+                    .service_service()
+                    .restore_after_snapshot_locked(env_name, service_state);
                 for backup in runtime_backups {
                     backup.cleanup();
                 }
                 let snapshot_error = format!(
                     "failed to create {snapshot_label} snapshot for env \"{env_name}\": {error}"
                 );
-                return match self
-                    .service_service()
-                    .restore_after_snapshot_locked(env_name, service_state)
-                {
+                return match restore_result {
                     Ok(()) => Err(snapshot_error),
                     Err(service_error) => Err(format!(
                         "{snapshot_error}; also failed to restore the managed service after snapshot capture: {service_error}"
@@ -4416,6 +4418,7 @@ impl Cli {
 
         Ok(UpgradeTransaction {
             id,
+            _checkpoint_cleanup: checkpoint_cleanup,
             snapshot_id: snapshot.id,
             runtime_backups,
             created_runtime_names,
@@ -5065,6 +5068,8 @@ impl UpgradeSimulationScenario {
 #[derive(Debug)]
 struct UpgradeTransaction {
     id: String,
+    // Retain failed/displaced preparation trees through restart or rollback.
+    _checkpoint_cleanup: crate::store::CheckpointCleanup,
     snapshot_id: String,
     runtime_backups: Vec<RuntimeRollbackBackup>,
     created_runtime_names: Vec<String>,

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -5,6 +5,10 @@ use std::io::Read;
 #[cfg(target_os = "macos")]
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 #[cfg(not(target_os = "macos"))]
 use filetime::{FileTime, set_file_times, set_symlink_file_times};
@@ -23,8 +27,74 @@ pub(crate) const STORAGE_TAR_ARCHIVE: &str = "tar-archive-v1";
 #[derive(Debug)]
 pub(crate) struct PreparedTreeCheckpoint {
     source: PathBuf,
+    cleanup: CheckpointCleanup,
     #[cfg(target_os = "macos")]
-    regular_files: HashMap<Box<[u8]>, PreparedRegularFile>,
+    cloned: bool,
+    #[cfg(target_os = "macos")]
+    entries: HashMap<Box<[u8]>, PreparedEntry>,
+}
+
+/// Service owners retain this guard until restart/rollback has finished. Neither a
+/// failed capture nor replacing a large staged directory may delete it while offline.
+#[derive(Clone, Debug)]
+pub(crate) struct CheckpointCleanup(Arc<CheckpointWorkspace>);
+
+#[derive(Debug)]
+struct CheckpointWorkspace {
+    root: PathBuf,
+    next_retired: AtomicU64,
+}
+
+impl CheckpointCleanup {
+    fn new(parent: &Path) -> Result<Self, String> {
+        ensure_dir(parent)?;
+        let root = tempfile::Builder::new()
+            .prefix(".checkpoint-preparation-")
+            .tempdir_in(parent)
+            .map_err(|error| error.to_string())?
+            .keep();
+        Ok(Self(Arc::new(CheckpointWorkspace {
+            root,
+            next_retired: AtomicU64::new(0),
+        })))
+    }
+
+    fn candidate(&self) -> PathBuf {
+        self.0.root.join("tree")
+    }
+
+    pub(crate) fn retire(&self, path: &Path) -> Result<(), String> {
+        if !path_exists(path) {
+            return Ok(());
+        }
+        let id = self.0.next_retired.fetch_add(1, Ordering::Relaxed);
+        fs::rename(path, self.0.root.join(format!("retired-{id}"))).map_err(|error| {
+            format!(
+                "failed to defer checkpoint cleanup; retained {}: {error}",
+                display_path(path)
+            )
+        })
+    }
+}
+
+impl Drop for CheckpointWorkspace {
+    fn drop(&mut self) {
+        if let Err(error) = remove_tree_if_present(&self.root) {
+            eprintln!(
+                "ocm: retained checkpoint preparation {}: {error}",
+                display_path(&self.root)
+            );
+        } else if let Some(parent) = self.root.parent() {
+            // Remove only an empty parent; never recursively clean a shared snapshot directory.
+            let _ = fs::remove_dir(parent);
+        }
+    }
+}
+
+impl PreparedTreeCheckpoint {
+    pub(crate) fn cleanup_guard(&self) -> CheckpointCleanup {
+        self.cleanup.clone()
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -42,7 +112,7 @@ struct FileFingerprint {
 
 #[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug)]
-struct PreparedRegularFile {
+struct PreparedEntry {
     fingerprint: Option<FileFingerprint>,
     sqlite: bool,
 }
@@ -59,11 +129,23 @@ pub(crate) fn default_snapshot_storage_kind() -> String {
 }
 
 pub(crate) fn create_tree_checkpoint(source: &Path, destination: &Path) -> Result<String, String> {
-    let prepared = prepare_tree_checkpoint(source)?;
+    let parent = destination
+        .parent()
+        .ok_or("checkpoint destination has no parent")?;
+    let prepared = prepare_tree_checkpoint_in(source, parent)?;
     create_tree_checkpoint_from_preparation(prepared, destination)
 }
 
-pub(crate) fn prepare_tree_checkpoint(source: &Path) -> Result<PreparedTreeCheckpoint, String> {
+#[cfg(test)]
+fn prepare_tree_checkpoint(source: &Path) -> Result<PreparedTreeCheckpoint, String> {
+    let parent = source.parent().ok_or("checkpoint source has no parent")?;
+    prepare_tree_checkpoint_in(source, parent)
+}
+
+pub(crate) fn prepare_tree_checkpoint_in(
+    source: &Path,
+    parent: &Path,
+) -> Result<PreparedTreeCheckpoint, String> {
     if !path_exists(source) {
         return Err(format!(
             "checkpoint source does not exist: {}",
@@ -72,14 +154,29 @@ pub(crate) fn prepare_tree_checkpoint(source: &Path) -> Result<PreparedTreeCheck
     }
 
     #[cfg(target_os = "macos")]
-    let regular_files = prepare_regular_files(source)?;
+    let entries = prepare_entries(source)?;
     #[cfg(not(target_os = "macos"))]
     preflight_sqlite_databases(source)?;
 
+    let cleanup = CheckpointCleanup::new(parent)?;
+    #[cfg(target_os = "macos")]
+    let cloned = {
+        // This live copy is only a seed. Fingerprints were recorded BEFORE cloning;
+        // capture must reconcile everything that changed before publishing it.
+        let cloned = clone_tree_checkpoint(source, &cleanup.candidate()).is_ok();
+        if !cloned {
+            cleanup.retire(&cleanup.candidate())?;
+        }
+        cloned
+    };
+
     Ok(PreparedTreeCheckpoint {
         source: source.to_path_buf(),
+        cleanup,
         #[cfg(target_os = "macos")]
-        regular_files,
+        cloned,
+        #[cfg(target_os = "macos")]
+        entries,
     })
 }
 
@@ -97,41 +194,29 @@ pub(crate) fn create_tree_checkpoint_from_preparation(
         ensure_dir(parent)?;
     }
 
+    let candidate = prepared.cleanup.candidate();
     #[cfg(target_os = "macos")]
-    {
-        match clone_tree_checkpoint(&prepared.source, destination) {
-            Ok(()) => {
-                if let Err(error) = (|| {
-                    verify_prepared_clone(&prepared.source, destination, prepared.regular_files)?;
-                    sync_tree_root(destination)
-                })() {
-                    let _ = remove_tree_if_present(destination);
-                    return Err(error);
-                }
-                return Ok(STORAGE_APFS_CLONE.to_string());
-            }
-            Err(clone_error) => {
-                remove_tree_if_present(destination)?;
-                copyfile_tree(&prepared.source, destination).map_err(|copy_error| {
-                    format!(
-                        "APFS clone was unavailable ({clone_error}); full checkpoint copy also failed: {copy_error}"
-                    )
-                })?;
-            }
-        }
+    if prepared.cloned {
+        capture_prepared_clone(
+            &prepared.source,
+            &candidate,
+            prepared.entries,
+            &prepared.cleanup,
+        )?;
+        sync_tree_root(&candidate)?;
+        fs::rename(&candidate, destination).map_err(|error| error.to_string())?;
+        return Ok(STORAGE_APFS_CLONE.to_string());
+    } else {
+        copyfile_tree(&prepared.source, &candidate)?;
     }
 
     #[cfg(not(target_os = "macos"))]
-    copy_tree_preserving_metadata(&prepared.source, destination)?;
+    copy_tree_preserving_metadata(&prepared.source, &candidate)?;
 
-    if let Err(error) = (|| {
-        verify_tree_checkpoint(&prepared.source, destination)?;
-        verify_sqlite_databases(destination)?;
-        sync_tree_root(destination)
-    })() {
-        let _ = remove_tree_if_present(destination);
-        return Err(error);
-    }
+    verify_tree_checkpoint(&prepared.source, &candidate)?;
+    verify_sqlite_databases(&candidate)?;
+    sync_tree_root(&candidate)?;
+    fs::rename(&candidate, destination).map_err(|error| error.to_string())?;
     Ok(STORAGE_FULL_COPY.to_string())
 }
 
@@ -226,17 +311,17 @@ fn sqlite_is_busy(error: &rusqlite::Error) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn prepare_regular_files(root: &Path) -> Result<HashMap<Box<[u8]>, PreparedRegularFile>, String> {
+fn prepare_entries(root: &Path) -> Result<HashMap<Box<[u8]>, PreparedEntry>, String> {
     let mut out = HashMap::new();
-    prepare_regular_path(root, root, &mut out)?;
+    prepare_entry_path(root, root, &mut out)?;
     Ok(out)
 }
 
 #[cfg(target_os = "macos")]
-fn prepare_regular_path(
+fn prepare_entry_path(
     root: &Path,
     path: &Path,
-    out: &mut HashMap<Box<[u8]>, PreparedRegularFile>,
+    out: &mut HashMap<Box<[u8]>, PreparedEntry>,
 ) -> Result<(), String> {
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
@@ -250,6 +335,14 @@ fn prepare_regular_path(
     };
     let file_type = metadata.file_type();
     if file_type.is_symlink() {
+        let relative = path.strip_prefix(root).map_err(|error| error.to_string())?;
+        out.insert(
+            relative.as_os_str().as_bytes().to_vec().into_boxed_slice(),
+            PreparedEntry {
+                fingerprint: Some(file_fingerprint(&metadata)),
+                sqlite: false,
+            },
+        );
         return Ok(());
     }
     if file_type.is_file() {
@@ -266,7 +359,7 @@ fn prepare_regular_path(
             Err(_) if !path_exists(path) => {
                 out.insert(
                     relative,
-                    PreparedRegularFile {
+                    PreparedEntry {
                         fingerprint: None,
                         sqlite: false,
                     },
@@ -283,7 +376,7 @@ fn prepare_regular_path(
         };
         out.insert(
             relative,
-            PreparedRegularFile {
+            PreparedEntry {
                 fingerprint: after.filter(|fingerprint| {
                     *fingerprint == before && sqlite_check != SqliteCheck::Deferred
                 }),
@@ -293,6 +386,14 @@ fn prepare_regular_path(
         return Ok(());
     }
     if file_type.is_dir() {
+        let relative = path.strip_prefix(root).map_err(|error| error.to_string())?;
+        out.insert(
+            relative.as_os_str().as_bytes().to_vec().into_boxed_slice(),
+            PreparedEntry {
+                fingerprint: Some(file_fingerprint(&metadata)),
+                sqlite: false,
+            },
+        );
         let entries = match fs::read_dir(path) {
             Ok(entries) => entries,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -300,7 +401,7 @@ fn prepare_regular_path(
         };
         for entry in entries {
             match entry {
-                Ok(entry) => prepare_regular_path(root, &entry.path(), out)?,
+                Ok(entry) => prepare_entry_path(root, &entry.path(), out)?,
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                 Err(error) => return Err(error.to_string()),
             }
@@ -326,17 +427,26 @@ fn file_fingerprint(metadata: &fs::Metadata) -> FileFingerprint {
 }
 
 #[cfg(target_os = "macos")]
-fn verify_prepared_clone(
+fn capture_prepared_clone(
     source: &Path,
     destination: &Path,
-    mut prepared: HashMap<Box<[u8]>, PreparedRegularFile>,
+    mut prepared: HashMap<Box<[u8]>, PreparedEntry>,
+    cleanup: &CheckpointCleanup,
 ) -> Result<(), String> {
     let mut candidates = HashSet::new();
-    verify_prepared_path(source, source, destination, &mut prepared, &mut candidates)?;
+    capture_prepared_path(
+        source,
+        source,
+        destination,
+        &mut prepared,
+        &mut candidates,
+        cleanup,
+    )?;
     for (relative, prior) in prepared {
         let relative = PathBuf::from(std::ffi::OsStr::from_bytes(&relative).to_os_string());
-        verify_changed_checkpoint_path(&source.join(&relative), &destination.join(&relative))?;
-        if prior.sqlite && path_exists(&destination.join(&relative)) {
+        // Remaining entries were deleted or changed type. Reconciliation already
+        // removed them; do not traverse an old path through a replacement symlink.
+        if prior.sqlite && checkpoint_regular_file(destination, &relative)? {
             candidates.insert(destination.join(&relative));
         }
         if let Some(primary) = sqlite_primary_for_sidecar(&relative) {
@@ -347,12 +457,11 @@ fn verify_prepared_clone(
     let mut candidates = candidates.into_iter().collect::<Vec<_>>();
     candidates.sort();
     for path in candidates {
-        let metadata = match fs::symlink_metadata(&path) {
-            Ok(metadata) => metadata,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(error) => return Err(error.to_string()),
-        };
-        if metadata.is_file() {
+        if checkpoint_regular_file(
+            destination,
+            path.strip_prefix(destination)
+                .map_err(|error| error.to_string())?,
+        )? {
             let _ = verify_sqlite_database(&path)?;
         }
     }
@@ -360,50 +469,125 @@ fn verify_prepared_clone(
 }
 
 #[cfg(target_os = "macos")]
-fn verify_prepared_path(
+fn checkpoint_regular_file(root: &Path, relative: &Path) -> Result<bool, String> {
+    if relative.as_os_str().is_empty() {
+        return fs::symlink_metadata(root)
+            .map(|metadata| metadata.is_file())
+            .map_err(|error| error.to_string());
+    }
+    let mut path = root.to_path_buf();
+    for component in relative.components() {
+        path.push(component);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => return Ok(false),
+            Ok(metadata) if path == root.join(relative) => return Ok(metadata.is_file()),
+            Ok(metadata) if !metadata.is_dir() => return Ok(false),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(target_os = "macos")]
+fn capture_prepared_path(
     root: &Path,
     path: &Path,
     destination: &Path,
-    prepared: &mut HashMap<Box<[u8]>, PreparedRegularFile>,
+    prepared: &mut HashMap<Box<[u8]>, PreparedEntry>,
     sqlite_candidates: &mut HashSet<PathBuf>,
-) -> Result<(), String> {
+    cleanup: &CheckpointCleanup,
+) -> Result<bool, String> {
+    use std::os::unix::fs::PermissionsExt;
+
     let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    let relative = path.strip_prefix(root).map_err(|error| error.to_string())?;
+    let destination_path = destination.join(relative);
+    let prior = prepared.remove(relative.as_os_str().as_bytes());
+    let unchanged = prior
+        .and_then(|entry| entry.fingerprint)
+        .is_some_and(|fingerprint| fingerprint == file_fingerprint(&metadata));
     if metadata.file_type().is_symlink() {
-        return Ok(());
+        if unchanged {
+            return Ok(false);
+        }
+        cleanup.retire(&destination_path)?;
+        copyfile_tree(path, &destination_path)?;
+        verify_changed_checkpoint_path(path, &destination_path)?;
+        return Ok(true);
     }
     if metadata.is_file() {
-        let relative = path.strip_prefix(root).map_err(|error| error.to_string())?;
-        let relative_bytes = relative.as_os_str().as_bytes();
-        let current = file_fingerprint(&metadata);
-        let prior = prepared.remove(relative_bytes);
-        let unchanged = prior
-            .and_then(|entry| entry.fingerprint)
-            .is_some_and(|fingerprint| fingerprint == current);
-        let destination_path = destination.join(relative);
-        preserve_special_mode(&destination_path, &metadata)?;
         if !unchanged {
+            // An unchanged source fingerprint spans the live clone. All other
+            // files need a fresh capture; never overwrite a staged link or tree.
+            cleanup.retire(&destination_path)?;
+            if clone_tree_checkpoint(path, &destination_path).is_err() {
+                cleanup.retire(&destination_path)?;
+                copyfile_tree(path, &destination_path)?;
+            }
+            preserve_special_mode(&destination_path, &metadata)?;
             verify_changed_checkpoint_path(path, &destination_path)?;
             if prior.is_some_and(|entry| entry.sqlite) || has_sqlite_magic(path)? {
-                sqlite_candidates.insert(destination_path);
+                sqlite_candidates.insert(destination_path.clone());
             }
             if let Some(primary) = sqlite_primary_for_sidecar(relative) {
                 sqlite_candidates.insert(destination.join(primary));
             }
         }
-        return Ok(());
+        if unchanged {
+            preserve_special_mode(&destination_path, &metadata)?;
+        }
+        return Ok(!unchanged);
     }
     if metadata.is_dir() {
+        let destination_metadata = match fs::symlink_metadata(&destination_path) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.to_string()),
+        };
+        let created = !destination_metadata.is_some_and(|metadata| metadata.is_dir());
+        if created {
+            cleanup.retire(&destination_path)?;
+            fs::create_dir(&destination_path).map_err(|error| error.to_string())?;
+        }
+        // Cloned directories can be read-only. Restore full metadata after children.
+        let made_writable = metadata.permissions().mode() & 0o700 != 0o700;
+        if made_writable || !unchanged {
+            fs::set_permissions(&destination_path, fs::Permissions::from_mode(0o700))
+                .map_err(|error| error.to_string())?;
+        }
+        let mut names = HashSet::new();
+        let mut children_changed = false;
         for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
-            verify_prepared_path(
+            let entry = entry.map_err(|error| error.to_string())?;
+            names.insert(entry.file_name());
+            children_changed |= capture_prepared_path(
                 root,
-                &entry.map_err(|error| error.to_string())?.path(),
+                &entry.path(),
                 destination,
                 prepared,
                 sqlite_candidates,
+                cleanup,
             )?;
         }
+        for entry in fs::read_dir(&destination_path).map_err(|error| error.to_string())? {
+            let entry = entry.map_err(|error| error.to_string())?;
+            if !names.contains(&entry.file_name()) {
+                // Bounded rename, even for a removed dependency tree.
+                cleanup.retire(&entry.path())?;
+                children_changed = true;
+            }
+        }
+        if !unchanged || made_writable || children_changed {
+            copyfile_metadata(path, &destination_path)?;
+        }
+        return Ok(created);
     }
-    Ok(())
+    Err(format!(
+        "unsupported special file in checkpoint: {}",
+        display_path(path)
+    ))
 }
 
 #[cfg(target_os = "macos")]
@@ -597,6 +781,7 @@ fn clone_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::MetadataExt;
 
+    const CLONE_NOFOLLOW: u32 = 1;
     const CLONE_ACL: u32 = 1 << 2;
     let destination_parent = destination
         .parent()
@@ -615,7 +800,13 @@ fn clone_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String
     let destination_c =
         CString::new(destination.as_os_str().as_bytes()).map_err(|error| error.to_string())?;
     // Directory clonefile is all-or-nothing and never falls back to byte copying.
-    let result = unsafe { clonefile(source_c.as_ptr(), destination_c.as_ptr(), CLONE_ACL) };
+    let result = unsafe {
+        clonefile(
+            source_c.as_ptr(),
+            destination_c.as_ptr(),
+            CLONE_ACL | CLONE_NOFOLLOW,
+        )
+    };
     if result != 0 {
         return Err(std::io::Error::last_os_error().to_string());
     }
@@ -624,12 +815,25 @@ fn clone_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String
 
 #[cfg(target_os = "macos")]
 fn copyfile_tree(source: &Path, destination: &Path) -> Result<(), String> {
+    const COPYFILE_ALL: u32 = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
+    const COPYFILE_RECURSIVE: u32 = 1 << 15;
+    copyfile_with_flags(source, destination, COPYFILE_ALL | COPYFILE_RECURSIVE)?;
+    preserve_special_modes(source, destination)
+}
+
+#[cfg(target_os = "macos")]
+fn copyfile_metadata(source: &Path, destination: &Path) -> Result<(), String> {
+    const COPYFILE_METADATA: u32 = (1 << 0) | (1 << 1) | (1 << 2);
+    copyfile_with_flags(source, destination, COPYFILE_METADATA)
+}
+
+#[cfg(target_os = "macos")]
+fn copyfile_with_flags(source: &Path, destination: &Path, flags: u32) -> Result<(), String> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
-    const COPYFILE_ALL: u32 = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
-    const COPYFILE_RECURSIVE: u32 = 1 << 15;
     const COPYFILE_NOFOLLOW_SRC: u32 = 1 << 18;
+    const COPYFILE_NOFOLLOW_DST: u32 = 1 << 19;
     const COPYFILE_STATE_PRESERVE_SUID: u32 = 16;
 
     let source_c =
@@ -659,7 +863,7 @@ fn copyfile_tree(source: &Path, destination: &Path) -> Result<(), String> {
             source_c.as_ptr(),
             destination_c.as_ptr(),
             state,
-            COPYFILE_ALL | COPYFILE_RECURSIVE | COPYFILE_NOFOLLOW_SRC,
+            flags | COPYFILE_NOFOLLOW_SRC | COPYFILE_NOFOLLOW_DST,
         )
     };
     unsafe {
@@ -668,7 +872,6 @@ fn copyfile_tree(source: &Path, destination: &Path) -> Result<(), String> {
     if result != 0 {
         return Err(std::io::Error::last_os_error().to_string());
     }
-    preserve_special_modes(source, destination)?;
     Ok(())
 }
 
@@ -868,6 +1071,157 @@ mod tests {
 
         assert_eq!(storage, STORAGE_APFS_CLONE);
         verify_tree_checkpoint(source.path(), &destination).unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn prepared_checkpoint_reconciles_live_changes_without_recopying_unchanged_files() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+
+        let source = tempfile::tempdir().unwrap();
+        let destination_parent = tempfile::tempdir().unwrap();
+        let destination = destination_parent.path().join("checkpoint");
+        fs::write(source.path().join("unchanged"), "bulk data").unwrap();
+        fs::write(source.path().join("changed"), "before").unwrap();
+        fs::write(source.path().join("file-to-dir"), "old").unwrap();
+        fs::create_dir_all(source.path().join("removed/node_modules/pkg")).unwrap();
+        fs::write(
+            source.path().join("removed/node_modules/pkg/data"),
+            "dependency",
+        )
+        .unwrap();
+        fs::create_dir(source.path().join("dir-to-link")).unwrap();
+        fs::write(source.path().join("dir-to-link/state.sqlite-wal"), "old").unwrap();
+        symlink("unchanged", source.path().join("link")).unwrap();
+        symlink("unchanged", source.path().join("unchanged-link")).unwrap();
+        xattr::set(source.path(), "user.ocm-removed", b"old").unwrap();
+
+        let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+        assert!(prepared.cloned);
+        let cleanup = prepared.cleanup_guard();
+        let unchanged_inode = fs::metadata(cleanup.candidate().join("unchanged"))
+            .unwrap()
+            .ino();
+        let unchanged_link_inode = fs::symlink_metadata(cleanup.candidate().join("unchanged-link"))
+            .unwrap()
+            .ino();
+        let modified = filetime::FileTime::from_last_modification_time(
+            &fs::metadata(source.path().join("changed")).unwrap(),
+        );
+        fs::write(source.path().join("changed"), "after!").unwrap();
+        filetime::set_file_mtime(source.path().join("changed"), modified).unwrap();
+        fs::remove_dir_all(source.path().join("removed")).unwrap();
+        fs::remove_file(source.path().join("file-to-dir")).unwrap();
+        fs::create_dir(source.path().join("file-to-dir")).unwrap();
+        fs::write(source.path().join("file-to-dir/new"), "new").unwrap();
+        fs::remove_dir_all(source.path().join("dir-to-link")).unwrap();
+        symlink(destination_parent.path(), source.path().join("dir-to-link")).unwrap();
+        fs::remove_file(source.path().join("link")).unwrap();
+        symlink("missing", source.path().join("link")).unwrap();
+        xattr::remove(source.path(), "user.ocm-removed").unwrap();
+        xattr::set(source.path(), "user.ocm-added", b"new").unwrap();
+        fs::set_permissions(source.path(), fs::Permissions::from_mode(0o750)).unwrap();
+
+        create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+
+        verify_tree_checkpoint(source.path(), &destination).unwrap();
+        assert_eq!(
+            fs::metadata(destination.join("unchanged")).unwrap().ino(),
+            unchanged_inode
+        );
+        assert_eq!(
+            fs::symlink_metadata(destination.join("unchanged-link"))
+                .unwrap()
+                .ino(),
+            unchanged_link_inode
+        );
+        assert_eq!(xattr::get(&destination, "user.ocm-removed").unwrap(), None);
+        assert_eq!(
+            xattr::get(&destination, "user.ocm-added").unwrap(),
+            Some(b"new".to_vec())
+        );
+        let retired = fs::read_dir(&cleanup.0.root).unwrap().count();
+        assert!(
+            retired >= 4,
+            "displaced trees must survive until the service owner releases cleanup"
+        );
+        let cleanup_root = cleanup.0.root.clone();
+        drop(cleanup);
+        assert!(!cleanup_root.exists());
+        assert!(destination.exists());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn failed_capture_defers_tree_cleanup_until_service_owner_releases_guard() {
+        for force_full_copy in [false, true] {
+            let source = tempfile::tempdir().unwrap();
+            fs::write(source.path().join("bulk"), "unchanged").unwrap();
+            let mut prepared = prepare_tree_checkpoint(source.path()).unwrap();
+            let cleanup = prepared.cleanup_guard();
+            if force_full_copy {
+                cleanup.retire(&cleanup.candidate()).unwrap();
+                prepared.cloned = false;
+            }
+            fs::write(
+                source.path().join("late.sqlite"),
+                b"SQLite format 3\0not a database",
+            )
+            .unwrap();
+            let destination_parent = tempfile::tempdir().unwrap();
+            let destination = destination_parent.path().join("checkpoint");
+
+            let error =
+                create_tree_checkpoint_from_preparation(prepared, &destination).unwrap_err();
+
+            assert!(error.contains("SQLite"), "{error}");
+            assert!(!destination.exists());
+            assert!(cleanup.candidate().join("bulk").exists());
+            let cleanup_root = cleanup.0.root.clone();
+            drop(cleanup);
+            assert!(!cleanup_root.exists());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn prepared_checkpoint_reconciles_wal_commits_and_sidecar_removal() {
+        let source = tempfile::tempdir().unwrap();
+        let database_path = source.path().join("state.sqlite");
+        let database = rusqlite::Connection::open(&database_path).unwrap();
+        database.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE state(value TEXT); INSERT INTO state VALUES ('before');").unwrap();
+        let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+        database
+            .execute_batch("INSERT INTO state VALUES ('after');")
+            .unwrap();
+        let destination_parent = tempfile::tempdir().unwrap();
+        let destination = destination_parent.path().join("checkpoint");
+        create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+        let captured = rusqlite::Connection::open(destination.join("state.sqlite")).unwrap();
+        let count: i64 = captured
+            .query_row("SELECT count(*) FROM state", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
+        drop(captured);
+
+        let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+        drop(database);
+        assert!(!source.path().join("state.sqlite-wal").exists());
+        let destination = destination_parent
+            .path()
+            .join("checkpoint-without-sidecars");
+        create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+        // SQLite's read-only verification may create fresh empty WAL/SHM files;
+        // it must not replay the stale sidecars from the live preparation.
+        assert_eq!(
+            fs::read(&database_path).unwrap(),
+            fs::read(destination.join("state.sqlite")).unwrap()
+        );
+        let captured = rusqlite::Connection::open(destination.join("state.sqlite")).unwrap();
+        let count: i64 = captured
+            .query_row("SELECT count(*) FROM state", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
     }
 
     #[cfg(target_os = "macos")]

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -64,8 +64,10 @@ impl CheckpointCleanup {
     }
 
     pub(crate) fn retire(&self, path: &Path) -> Result<(), String> {
-        if !path_exists(path) {
-            return Ok(());
+        match fs::symlink_metadata(path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error.to_string()),
         }
         let id = self.0.next_retired.fetch_add(1, Ordering::Relaxed);
         fs::rename(path, self.0.root.join(format!("retired-{id}"))).map_err(|error| {
@@ -616,6 +618,27 @@ fn preserve_special_mode(destination: &Path, source_metadata: &fs::Metadata) -> 
 fn preserve_special_modes(source: &Path, destination: &Path) -> Result<(), String> {
     let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
     if metadata.file_type().is_symlink() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // copyfile recreates symlinks with default permissions. chmod would
+        // follow the link and mutate its target, so restore the link mode itself.
+        let path = std::ffi::CString::new(destination.as_os_str().as_bytes())
+            .map_err(|error| error.to_string())?;
+        let result = unsafe {
+            libc::fchmodat(
+                libc::AT_FDCWD,
+                path.as_ptr(),
+                (metadata.permissions().mode() & 0o7777) as libc::mode_t,
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if result != 0 {
+            return Err(format!(
+                "failed to preserve checkpoint symlink mode for {}: {}",
+                display_path(destination),
+                std::io::Error::last_os_error()
+            ));
+        }
         return Ok(());
     }
     if metadata.is_file() {
@@ -632,8 +655,9 @@ fn preserve_special_modes(source: &Path, destination: &Path) -> Result<(), Strin
 
 #[cfg(target_os = "macos")]
 fn verify_changed_checkpoint_path(source: &Path, destination: &Path) -> Result<(), String> {
-    let source_exists = path_exists(source);
-    let destination_exists = path_exists(destination);
+    // A dangling symlink is still a captured entry, not an absent path.
+    let source_exists = fs::symlink_metadata(source).is_ok();
+    let destination_exists = fs::symlink_metadata(destination).is_ok();
     if !source_exists && !destination_exists {
         return Ok(());
     }
@@ -1282,5 +1306,51 @@ mod tests {
             0o4755
         );
         verify_tree_checkpoint(source.path(), &destination).unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn changed_symlink_preserves_restricted_permissions_without_touching_its_target() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::{MetadataExt, symlink};
+        let source = tempfile::tempdir().unwrap();
+        fs::write(source.path().join("target"), "unchanged target").unwrap();
+        symlink("missing", source.path().join("link")).unwrap();
+        let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+        fs::remove_file(source.path().join("link")).unwrap();
+        symlink("target", source.path().join("link")).unwrap();
+        let link =
+            std::ffi::CString::new(source.path().join("link").as_os_str().as_bytes()).unwrap();
+        assert_eq!(
+            unsafe {
+                libc::fchmodat(
+                    libc::AT_FDCWD,
+                    link.as_ptr(),
+                    0o750,
+                    libc::AT_SYMLINK_NOFOLLOW,
+                )
+            },
+            0
+        );
+        let target_mode = fs::metadata(source.path().join("target")).unwrap().mode();
+        let destination_parent = tempfile::tempdir().unwrap();
+        let destination = destination_parent.path().join("checkpoint");
+        create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+        verify_tree_checkpoint(source.path(), &destination).unwrap();
+        assert_eq!(
+            fs::symlink_metadata(destination.join("link"))
+                .unwrap()
+                .mode()
+                & 0o777,
+            0o750
+        );
+        assert_eq!(
+            fs::metadata(destination.join("target")).unwrap().mode(),
+            target_mode
+        );
+        assert_eq!(
+            fs::metadata(source.path().join("target")).unwrap().mode(),
+            target_mode
+        );
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -18,6 +18,7 @@ use time::OffsetDateTime;
 
 use crate::env::EnvMeta;
 use crate::env::EnvSummary;
+pub(crate) use checkpoints::CheckpointCleanup;
 pub(crate) use common::{
     ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, write_json,
 };

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -14,9 +14,9 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use super::checkpoints::{
-    PreparedTreeCheckpoint, STORAGE_TAR_ARCHIVE, copy_tree_checkpoint,
+    CheckpointCleanup, PreparedTreeCheckpoint, STORAGE_TAR_ARCHIVE, copy_tree_checkpoint,
     create_tree_checkpoint_from_preparation, default_snapshot_storage_kind,
-    prepare_tree_checkpoint, remove_tree_if_present,
+    prepare_tree_checkpoint_in, remove_tree_if_present,
 };
 use super::common::{
     copy_dir_recursive, copy_path_recursive, load_json_files, path_exists, read_json, write_json,
@@ -76,6 +76,12 @@ pub(crate) struct PreparedEnvSnapshotCapture {
     checkpoint: PreparedTreeCheckpoint,
 }
 
+impl PreparedEnvSnapshotCapture {
+    pub(crate) fn cleanup_guard(&self) -> CheckpointCleanup {
+        self.checkpoint.cleanup_guard()
+    }
+}
+
 #[derive(Debug)]
 struct RestoreOperationNamespace {
     root: PathBuf,
@@ -117,7 +123,8 @@ pub(crate) fn prepare_env_snapshot_capture(
             display_path(&env_paths.root)
         ));
     }
-    let checkpoint = prepare_tree_checkpoint(&env_paths.root)?;
+    let checkpoint =
+        prepare_tree_checkpoint_in(&env_paths.root, &snapshot_env_dir(&env_name, env, cwd)?)?;
     Ok(PreparedEnvSnapshotCapture {
         env_name,
         source_root: env_paths.root,
@@ -166,6 +173,7 @@ pub(crate) fn create_env_snapshot_from_preparation(
     let checkpoint_path = snapshot_checkpoint_path(&env_name, &snapshot_id, env, cwd)?;
     let meta_path = snapshot_meta_path(&env_name, &snapshot_id, env, cwd)?;
 
+    let cleanup = prepared.cleanup_guard();
     let result = (|| {
         let storage_kind =
             create_tree_checkpoint_from_preparation(prepared.checkpoint, &checkpoint_path)?;
@@ -190,12 +198,13 @@ pub(crate) fn create_env_snapshot_from_preparation(
         Ok(snapshot)
     })();
 
-    if result.is_err() {
-        let _ = remove_tree_if_present(&checkpoint_path);
+    if let Err(error) = result {
+        let cleanup_result = cleanup.retire(&checkpoint_path);
         let _ = fs::remove_file(&meta_path);
-        if let Some(snapshot_dir) = checkpoint_path.parent() {
-            let _ = fs::remove_dir(snapshot_dir);
-        }
+        return Err(match cleanup_result {
+            Ok(()) => error,
+            Err(cleanup_error) => format!("{error}; {cleanup_error}"),
+        });
     }
 
     result

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -1741,6 +1741,9 @@ fn env_snapshot_rechecks_sqlite_mutated_after_preflight_and_restores_service() {
     let ocm_home = env.get("OCM_HOME").unwrap().clone();
     let observer_done = Arc::new(AtomicBool::new(false));
     let observer_mutated = Arc::new(AtomicBool::new(false));
+    let cleanup_deferred = Arc::new(AtomicBool::new(false));
+    let cleanup_deferred_thread = Arc::clone(&cleanup_deferred);
+    let snapshot_dir = root.child("ocm-home/snapshots/source");
     let observer_done_thread = Arc::clone(&observer_done);
     let observer_mutated_thread = Arc::clone(&observer_mutated);
     let observer_database = database_path.clone();
@@ -1757,6 +1760,11 @@ fn env_snapshot_rechecks_sqlite_mutated_after_preflight_and_restores_service() {
                 .unwrap_or(last_running);
             if desired_running != last_running {
                 if desired_running {
+                    cleanup_deferred_thread.store(
+                        fs::read_dir(&snapshot_dir)
+                            .is_ok_and(|mut entries| entries.next().is_some()),
+                        Ordering::Relaxed,
+                    );
                     fs::write(&observer_runtime_path, &running_runtime).unwrap();
                 } else {
                     fs::write(
@@ -1778,6 +1786,10 @@ fn env_snapshot_rechecks_sqlite_mutated_after_preflight_and_restores_service() {
     observer.join().unwrap();
 
     assert!(observer_mutated.load(Ordering::Relaxed));
+    assert!(
+        cleanup_deferred.load(Ordering::Relaxed),
+        "failed backup must survive until service restoration, not be deleted during the outage"
+    );
     assert_eq!(snapshot.status.code(), Some(1));
     assert!(
         stderr(&snapshot).contains("SQLite"),


### PR DESCRIPTION
## Summary

Prepare APFS checkpoint data while the gateway is running, then reconcile changes during the final service pause. Keep failed/displaced backup cleanup outside the stopped interval.

## Problem

Checkpoint preparation previously recorded fingerprints but cloned the full environment only after quiescence. Capture errors recursively removed the failed tree before returning to the service owner, so a large workspace could keep the gateway offline while deleting its failed backup.

## Changes

- Stage the APFS clone online. At capture, reuse unchanged files, links, and directory metadata; capture additions and changes; remove deleted entries from the candidate by bounded rename.
- Preserve complete environment contents and existing SQLite validation, including WAL/SHM changes. Publish only a verified checkpoint. Non-APFS filesystems retain full-copy verification.
- Retain a private cleanup guard through standalone snapshot restoration, batch checkpoint restoration, and upgrade restart/rollback. Restore service before cleaning runtime backups on capture failure.
- Add regressions for cleanup ordering, unchanged-file reuse, same-size edits, deleted/type-changed entries, links, attributes, WAL commits, sidecar removal, and copy fallback.

## Verification

Canonical base: `c5e7126c9b6cf7fb9b6f7903f59393f95e4c6ef1`.
Proposed head: `9df24ab984395eeda42255f2a2434a8a9729aed8`.

Native macOS/APFS: 338 library tests, 36 snapshot integration tests, and the upgrade availability test passed (`cargo test --locked --lib --test env_snapshot_tests --test upgrade_availability_tests`). Formatting passed. Autoreview reported no actionable P0 findings in the main bundle and the follow-up symlink-mode patch. The external CLI fixture caught the symlink issue before publication; the final changed-state and dangling-link probes pass.

The source-blind CLI harness and receipt validator pass the online-preparation, capture completeness, restore-before-cleanup, timing, and negative-control checks. They do not inspect product source; this is black-box fixture validation, not an independent second-model behavior review.

A Linux AWS Crabbox attempt could not execute because the image lacked Cargo (exit 127). Its lease was released. The normal PR CI remains the cross-platform test gate.

## Evidence

All runs use 12,000 dependency-shaped files, valid SQLite state, pre-registered runtimes, and a synthetic supervisor on native APFS. Exact-head successful capture preserves all 12,000 files. Separate controls preserve changed/deleted/added files, updated SQLite state, and changed symlinks; cover standalone snapshot creation; keep an initially stopped service stopped; and leave bindings and snapshots untouched on preflight failure or dry run.

| Stopped interval | Base | Head |
| --- | ---: | ---: |
| Successful upgrade, median of five runs | 0.3082 s | 0.2060 s |
| Successful upgrade, observed range | 0.2824–0.3238 s | 0.1935–0.3489 s |
| Late SQLite failure, recorded run | 1.3055 s | 0.1601 s |

The failure recording shows the baseline completing cleanup while stopped. The head restores the gateway while the failed backup still exists, then finishes cleanup while running. Timing variation is included above; these measurements do not predict production OpenClaw startup latency or promise zero downtime.

[Red/base video](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260906-005241-047865000/red-base.mp4?X-Amz-Expires=604800&X-Amz-Date=20260906T005244Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260906%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=30ca5747f76a8df9e46db7db9528064d296b08121d2213323c259c1334075901) · [Green/head video](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260906-005241-047865000/green-head.mp4?X-Amz-Expires=604800&X-Amz-Date=20260906T005244Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260906%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=03a915200afcf3da032c688f6683d0a3b7b7828f99b21a088f7cc4bd3ab45a06)

[Raw base recording](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260906-005241-047865000/red-base.cast?X-Amz-Expires=604800&X-Amz-Date=20260906T005244Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260906%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=4d73052c98c83a523517552a2f901f5ea40a06f8f28bef066a1087c89ad7dd8a) · [Raw head recording](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260906-005241-047865000/green-head.cast?X-Amz-Expires=604800&X-Amz-Date=20260906T005244Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260906%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=b5895d03306000cb3c5deddac64d402675338fb165d507d6fac5bfbbc9630088) · [Contract](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260906-005241-047865000/contract.md?X-Amz-Expires=604800&X-Amz-Date=20260906T005244Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260906%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f1bd9040753fc43a1505802b4f19ddde6f3ba407754f9524b410863959124e74) · [Proof manifest and checksums](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260906-005241-047865000/proof-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260906T005244Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260906%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=fa875dffe92068abde42bd305aa1ff0a05c21a33c5323b8f52822932c8b38a2e) · [Behavior report and all timing samples](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/evidence/20260906-005241-047865000/behavior-report.json?X-Amz-Expires=604800&X-Amz-Date=20260906T005244Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260906%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=d1f78838a5811ef4a6fc9dacf1c16a14add3d615fdd2a22017d4eeeae8e9607b)

The MP4s are non-generative renders of redacted timed terminal captures. Personal path prefixes are replaced deterministically; timings and observations are unchanged. Originals remain local. No live fleet instance or conversation transcript is included. Signed artifact links expire September 13, 2026.
