### PR TITLE
fix: verify captured service log prefixes in APFS checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,13 @@ New snapshots preserve the complete environment root, including credentials,
 browser profiles, plugin payloads, unknown future directories, modes, symlinks,
 and SQLite sidecars. OCM verifies tree contents and SQLite integrity before
 publishing the checkpoint. APFS uses copy-on-write clones when available;
-other filesystems use a metadata-preserving full copy. Restore discards only
+other filesystems use a metadata-preserving full copy. For standard OpenClaw
+node/gateway stdout and stderr logs under `.openclaw[-profile]/logs`, APFS
+verification accepts the captured bytes only when they exactly match a prefix
+of a stable clone of the same live file. Post-capture appends need not stop an
+independently managed node. Logs are retained, not excluded; rewrites, unsafe
+rotation, mode changes, SQLite (even at a log path), and all other state still
+require strict verification. Full-copy checkpoints remain exact. Restore discards only
 explicit process residue such as locks, sockets, PIDs, and temporary runtime
 directories. Legacy tar snapshots remain readable.
 

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -380,15 +380,27 @@ fn verify_prepared_path(
             .and_then(|entry| entry.fingerprint)
             .is_some_and(|fingerprint| fingerprint == current);
         let destination_path = destination.join(relative);
-        preserve_special_mode(&destination_path, &metadata)?;
         if !unchanged {
-            verify_changed_checkpoint_path(path, &destination_path)?;
+            if !is_service_output_log(relative)
+                || prior.is_some_and(|entry| entry.sqlite)
+                || !verify_captured_log_prefix(
+                    path,
+                    &destination_path,
+                    current,
+                    destination.parent().ok_or("checkpoint has no parent")?,
+                )?
+            {
+                preserve_special_mode(&destination_path, &metadata)?;
+                verify_changed_checkpoint_path(path, &destination_path)?;
+            }
             if prior.is_some_and(|entry| entry.sqlite) || has_sqlite_magic(path)? {
                 sqlite_candidates.insert(destination_path);
             }
             if let Some(primary) = sqlite_primary_for_sidecar(relative) {
                 sqlite_candidates.insert(destination.join(primary));
             }
+        } else {
+            preserve_special_mode(&destination_path, &metadata)?;
         }
         return Ok(());
     }
@@ -404,6 +416,116 @@ fn verify_prepared_path(
         }
     }
     Ok(())
+}
+
+// Only OpenClaw's standard service streams have a diagnostic prefix contract.
+// Other files under logs/, sessions, SQLite, and arbitrary *.log files remain exact.
+#[cfg(target_os = "macos")]
+fn is_service_output_log(relative: &Path) -> bool {
+    let parts = relative.iter().collect::<Vec<_>>();
+    parts.len() == 3
+        && parts[0].to_str().is_some_and(|name| {
+            name == ".openclaw"
+                || name
+                    .strip_prefix(".openclaw-")
+                    .is_some_and(|profile| !profile.is_empty())
+        })
+        && parts[1] == "logs"
+        && matches!(
+            parts[2].to_str(),
+            Some(
+                "node.log"
+                    | "node.err.log"
+                    | "node.error.log"
+                    | "gateway.log"
+                    | "gateway.err.log"
+                    | "gateway.error.log"
+            )
+        )
+}
+
+#[cfg(target_os = "macos")]
+fn verify_captured_log_prefix(
+    source: &Path,
+    destination: &Path,
+    observed: FileFingerprint,
+    scratch_parent: &Path,
+) -> Result<bool, String> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    let captured_metadata = fs::symlink_metadata(destination).map_err(|e| e.to_string())?;
+    if !captured_metadata.is_file() || has_sqlite_magic(destination)? {
+        return Ok(false);
+    }
+    // Pin the source inode, not a pathname that rotation can replace. O_NOFOLLOW
+    // also prevents a replaced stream from turning this into a symlink exemption.
+    let live = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(source)
+        .map_err(|e| e.to_string())?;
+    let same_file = |metadata: &fs::Metadata| {
+        metadata.is_file()
+            && metadata.dev() == observed.device
+            && metadata.ino() == observed.inode
+            && metadata.mode() == observed.mode
+    };
+    if !same_file(&live.metadata().map_err(|e| e.to_string())?)
+        || captured_metadata.mode() != observed.mode
+    {
+        return Ok(false);
+    }
+    // Keep verification scratch outside the captured tree (including read-only
+    // log directories), so it can never become restored environment state.
+    let reference_dir = tempfile::tempdir_in(scratch_parent).map_err(|e| e.to_string())?;
+    let reference = reference_dir.path().join("stream");
+    let reference_c = CString::new(reference.as_os_str().as_bytes()).map_err(|e| e.to_string())?;
+    // A second COW clone is a stable comparison source; never hash to the moving
+    // live EOF or retry until an independently managed writer becomes idle.
+    const CLONE_ACL: u32 = 1 << 2;
+    if unsafe {
+        fclonefileat(
+            live.as_raw_fd(),
+            libc::AT_FDCWD,
+            reference_c.as_ptr(),
+            CLONE_ACL,
+        )
+    } != 0
+    {
+        return Err(format!(
+            "failed to clone checkpoint log reference: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if !same_file(&fs::symlink_metadata(source).map_err(|e| e.to_string())?)
+        || has_sqlite_magic(&reference)?
+    {
+        return Ok(false);
+    }
+    let mut reference_file = fs::File::open(&reference).map_err(|e| e.to_string())?;
+    if reference_file.metadata().map_err(|e| e.to_string())?.len() < captured_metadata.len() {
+        return Ok(false);
+    }
+    let mut captured = fs::File::open(destination).map_err(|e| e.to_string())?;
+    let mut remaining = captured_metadata.len();
+    let mut captured_buffer = [0_u8; 64 * 1024];
+    let mut reference_buffer = [0_u8; 64 * 1024];
+    while remaining > 0 {
+        let count = remaining.min(captured_buffer.len() as u64) as usize;
+        captured
+            .read_exact(&mut captured_buffer[..count])
+            .map_err(|e| e.to_string())?;
+        reference_file
+            .read_exact(&mut reference_buffer[..count])
+            .map_err(|e| e.to_string())?;
+        if captured_buffer[..count] != reference_buffer[..count] {
+            return Ok(false);
+        }
+        remaining -= count as u64;
+    }
+    Ok(true)
 }
 
 #[cfg(target_os = "macos")]
@@ -583,6 +705,12 @@ unsafe extern "C" {
         state: CopyfileState,
         flag: u32,
         value: *const libc::c_void,
+    ) -> libc::c_int;
+    fn fclonefileat(
+        source_fd: libc::c_int,
+        destination_dir_fd: libc::c_int,
+        destination: *const libc::c_char,
+        flags: u32,
     ) -> libc::c_int;
     fn clonefile(
         source: *const libc::c_char,
@@ -810,6 +938,132 @@ mod tests {
                 .mode()
                 & 0o7777,
             0o4755
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn apfs_checkpoint_accepts_captured_service_log_prefix() {
+        use std::io::Write;
+        for relative in [
+            ".openclaw/logs/node.log",
+            ".openclaw-rosita-node/logs/node.error.log",
+            ".openclaw/logs/gateway.log",
+            ".openclaw/logs/gateway.err.log",
+        ] {
+            let source = tempfile::tempdir().unwrap();
+            let log = source.path().join(relative);
+            fs::create_dir_all(log.parent().unwrap()).unwrap();
+            fs::write(&log, "captured diagnostics\n").unwrap();
+            fs::write(source.path().join("durable.json"), "durable state").unwrap();
+            let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+            let parent = tempfile::tempdir().unwrap();
+            let destination = parent.path().join("checkpoint");
+            super::clone_tree_checkpoint(source.path(), &destination).unwrap();
+            // The independent node can write after native capture, even while
+            // the environment's managed Gateway is quiescent.
+            fs::OpenOptions::new()
+                .append(true)
+                .open(&log)
+                .unwrap()
+                .write_all(b"written after capture\n")
+                .unwrap();
+            super::verify_prepared_clone(source.path(), &destination, prepared.regular_files)
+                .unwrap();
+            assert_eq!(
+                fs::read(destination.join(relative)).unwrap(),
+                b"captured diagnostics\n"
+            );
+            assert_eq!(
+                fs::read(destination.join("durable.json")).unwrap(),
+                b"durable state"
+            );
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn apfs_checkpoint_refuses_non_log_appends_and_unsafe_log_changes() {
+        use std::io::Write;
+        use std::os::unix::fs::{PermissionsExt, symlink};
+        for (relative, change) in [
+            ("state.jsonl", "append"),
+            (".openclaw/logs/audit.jsonl", "append"),
+            ("workspace/.openclaw/logs/node.log", "append"),
+            (".openclaw/logs/node.log-wal", "append"),
+            (".openclaw/logs/node.log", "rewrite"),
+            (".openclaw/logs/node.log", "truncate"),
+            (".openclaw/logs/node.log", "rotate"),
+            (".openclaw/logs/node.log", "mode"),
+            (".openclaw/logs/node.log", "setuid"),
+            (".openclaw/logs/node.log", "setgid"),
+            (".openclaw/logs/node.log", "corrupt-capture"),
+            (".openclaw/logs/node.log", "symlink-capture"),
+        ] {
+            let source = tempfile::tempdir().unwrap();
+            let file = source.path().join(relative);
+            fs::create_dir_all(file.parent().unwrap()).unwrap();
+            fs::write(&file, "captured diagnostics\n").unwrap();
+            fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).unwrap();
+            let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+            let parent = tempfile::tempdir().unwrap();
+            let destination = parent.path().join("checkpoint");
+            super::clone_tree_checkpoint(source.path(), &destination).unwrap();
+            fs::OpenOptions::new()
+                .append(true)
+                .open(&file)
+                .unwrap()
+                .write_all(b"written after capture\n")
+                .unwrap();
+            match change {
+                "rewrite" => fs::write(&file, "rewritten diagnostics\nmore\n").unwrap(),
+                "truncate" => fs::write(&file, "short\n").unwrap(),
+                "rotate" => {
+                    fs::rename(&file, file.with_extension("log.1")).unwrap();
+                    fs::write(&file, "new generation diagnostics\n").unwrap();
+                }
+                "mode" => fs::set_permissions(&file, fs::Permissions::from_mode(0o600)).unwrap(),
+                "setuid" => fs::set_permissions(&file, fs::Permissions::from_mode(0o4755)).unwrap(),
+                "setgid" => fs::set_permissions(&file, fs::Permissions::from_mode(0o2755)).unwrap(),
+                "corrupt-capture" => {
+                    fs::write(destination.join(relative), "corrupt diagnostics\n").unwrap()
+                }
+                "symlink-capture" => {
+                    fs::remove_file(destination.join(relative)).unwrap();
+                    symlink(&file, destination.join(relative)).unwrap();
+                }
+                _ => {}
+            }
+            let result =
+                super::verify_prepared_clone(source.path(), &destination, prepared.regular_files);
+            assert!(result.is_err(), "accepted {relative}: {change}");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn apfs_checkpoint_never_treats_sqlite_as_service_output() {
+        use std::io::Write;
+        let source = tempfile::tempdir().unwrap();
+        let database_path = source.path().join(".openclaw/logs/node.log");
+        fs::create_dir_all(database_path.parent().unwrap()).unwrap();
+        let db = rusqlite::Connection::open(&database_path).unwrap();
+        db.execute_batch("CREATE TABLE state(value); INSERT INTO state VALUES ('preserve');")
+            .unwrap();
+        drop(db);
+        let prepared = prepare_tree_checkpoint(source.path()).unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let destination = parent.path().join("checkpoint");
+        super::clone_tree_checkpoint(source.path(), &destination).unwrap();
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&database_path)
+            .unwrap()
+            .write_all(b"post-capture bytes")
+            .unwrap();
+        assert!(
+            super::verify_prepared_clone(source.path(), &destination, prepared.regular_files)
+                .is_err()
         );
     }
 

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -393,6 +393,11 @@ fn env_snapshot_restores_the_complete_durable_root_with_metadata_and_sqlite() {
     assert!(database_wal.exists());
     assert!(database_shm.exists());
     let expected_wal = fs::read(&database_wal).unwrap();
+    #[cfg(target_os = "macos")]
+    let log_relative = ".openclaw-rosita-node/logs/node.error.log";
+    #[cfg(target_os = "macos")]
+    let log_writer =
+        support::active_service_log::ActiveServiceLog::start(&env_root.join(log_relative));
 
     let snapshot = run_ocm(
         &cwd,
@@ -402,6 +407,16 @@ fn env_snapshot_restores_the_complete_durable_root_with_metadata_and_sqlite() {
     assert!(snapshot.status.success(), "{}", stderr(&snapshot));
     let snapshot_json: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
     let snapshot_id = snapshot_json["id"].as_str().unwrap();
+    #[cfg(target_os = "macos")]
+    let captured_log = {
+        let final_log = log_writer.finish();
+        let checkpoint = Path::new(snapshot_json["archivePath"].as_str().unwrap());
+        let captured = fs::read(checkpoint.join(log_relative)).unwrap();
+        assert!(!captured.is_empty());
+        assert!(final_log.starts_with(&captured));
+        fs::write(env_root.join(log_relative), b"changed after snapshot\n").unwrap();
+        captured
+    };
     drop(database);
 
     write_text(&dotenv, "OPENCLAW_SENTINEL=after\n");
@@ -460,6 +475,8 @@ fn env_snapshot_restores_the_complete_durable_root_with_metadata_and_sqlite() {
     );
     assert_eq!(fs::read_link(&future_link).unwrap(), Path::new("state.txt"));
     assert_eq!(fs::read(&database_wal).unwrap(), expected_wal);
+    #[cfg(target_os = "macos")]
+    assert_eq!(fs::read(env_root.join(log_relative)).unwrap(), captured_log);
     assert!(fs::metadata(&database_shm).unwrap().len() > 0);
 
     let restored = Connection::open_with_flags(

--- a/tests/support/active_service_log.rs
+++ b/tests/support/active_service_log.rs
@@ -1,0 +1,62 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+    mpsc,
+};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+/// A separate service stream that deliberately ignores Gateway quiescence.
+pub struct ActiveServiceLog {
+    path: PathBuf,
+    stop: Arc<AtomicBool>,
+    writer: Option<JoinHandle<()>>,
+}
+
+impl ActiveServiceLog {
+    pub fn start(path: &Path) -> Self {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .append(true)
+            .open(path)
+            .unwrap();
+        file.write_all(b"diagnostic stream starts\n").unwrap();
+        let stop = Arc::new(AtomicBool::new(false));
+        let writer_stop = Arc::clone(&stop);
+        let (ready_tx, ready_rx) = mpsc::sync_channel(0);
+        let writer = thread::spawn(move || {
+            file.write_all(b"independent service is running\n").unwrap();
+            ready_tx.send(()).unwrap();
+            while !writer_stop.load(Ordering::Relaxed) {
+                file.write_all(b"independent node diagnostics continue during checkpoint\n")
+                    .unwrap();
+                thread::sleep(Duration::from_micros(100));
+            }
+        });
+        ready_rx.recv().unwrap();
+        Self {
+            path: path.to_path_buf(),
+            stop,
+            writer: Some(writer),
+        }
+    }
+
+    pub fn finish(mut self) -> Vec<u8> {
+        self.stop.store(true, Ordering::Relaxed);
+        self.writer.take().unwrap().join().unwrap();
+        fs::read(&self.path).unwrap()
+    }
+}
+
+impl Drop for ActiveServiceLog {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(writer) = self.writer.take() {
+            let _ = writer.join();
+        }
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+#[cfg(target_os = "macos")]
+pub mod active_service_log;
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::{Read, Write};

--- a/tests/upgrade_availability_tests.rs
+++ b/tests/upgrade_availability_tests.rs
@@ -572,9 +572,17 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
         finalize_timeline.mark("publication_released");
     });
 
+    #[cfg(target_os = "macos")]
+    let log_relative = ".openclaw-rosita-node/logs/node.error.log";
+    #[cfg(target_os = "macos")]
+    let log_writer = support::active_service_log::ActiveServiceLog::start(
+        &Path::new(env_json["root"].as_str().unwrap()).join(log_relative),
+    );
     timeline.mark("command_started");
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo"]);
     timeline.mark("command_finished");
+    #[cfg(target_os = "macos")]
+    let final_log = log_writer.finish();
 
     finalize_releaser.join().unwrap();
     delayed_server.join().unwrap();
@@ -644,6 +652,22 @@ fn upgrade_prepares_target_before_cutover_and_bounds_stop_to_ready() {
     let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
     assert!(history.status.success(), "{}", stderr(&history));
     let history_json: Value = serde_json::from_slice(&history.stdout).unwrap();
+    #[cfg(target_os = "macos")]
+    {
+        let snapshot_id = history_json[0]["snapshotId"].as_str().unwrap();
+        let snapshot = run_ocm(
+            &cwd,
+            &env,
+            &["env", "snapshot", "show", "demo", snapshot_id, "--json"],
+        );
+        assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+        let snapshot_json: Value = serde_json::from_slice(&snapshot.stdout).unwrap();
+        let captured =
+            fs::read(Path::new(snapshot_json["archivePath"].as_str().unwrap()).join(log_relative))
+                .unwrap();
+        assert!(!captured.is_empty());
+        assert!(final_log.starts_with(&captured));
+    }
     let phases = history_json[0]["phases"]
         .as_array()
         .expect("upgrade receipt must include structured phase timings");


### PR DESCRIPTION
## Summary

Fix APFS checkpoint failures when an independently managed OpenClaw node keeps appending its service log during a Gateway upgrade. Preserve the captured log and all durable environment state.

## Root cause

Pausing the managed Gateway does not pause a separately managed node. After a successful native clone, checkpoint validation compared the captured node stderr against the still-moving live source and rejected it with `does not exactly match changed source`. This is reproducible on current main / v0.2.38 through both snapshot and upgrade CLI paths.

## Change

- Limit append-prefix validation to canonical node/gateway stdout and stderr filenames directly under `.openclaw[-profile]/logs`.
- Pin the live source descriptor with no symlink following, verify identity/mode around a second native COW clone, and compare the complete captured bytes against that stable reference. No live-EOF hashing, sleeps, or retry loop.
- Keep all captured log bytes. Arbitrary files, session JSONL, sidecars, SQLite even at an eligible log pathname, mode changes, corrupted prefixes, and unsafe rotation retain strict refusal. Full-copy verification is unchanged.
- Keep comparison scratch outside the checkpoint tree. No snapshot format change, log exclusion, automation workaround, or live service change.

## Verification

Baseline: `c5e7126c9b6cf7fb9b6f7903f59393f95e4c6ef1` (`v0.2.38`), native macOS/APFS.

| Native fixture | Baseline | Candidate |
| --- | --- | --- |
| Clone, append node log, verify | Changed-source refusal | Captured bytes preserved |
| Snapshot CLI with active node stderr | Same observed failure | Snapshot and complete-state restore pass |
| Managed upgrade CLI; independent writer, 2,000 dependency files, SQLite sentinel | Exit 1; old binding retained | Exit 0; new binding; all 2,000 files and SQLite sentinel retained |

The successful upgrade checkpoint contains a 39,619-byte exact log prefix; the live log reached 61,108 bytes. These are synthetic isolated fixtures, not a production upgrade. The checked-in restore test additionally verifies SQLite WAL/SHM, credential-shaped sentinels, browser/plugin state, future directories, modes, symlinks, and the captured log. Negative controls cover state/JSONL/sidecar appends, SQLite disguised as a log, rewrites, truncation, rotation, permission changes, and corrupted/symlink captures.

Candidate: `1c6c9ff5949940adcea5af0a00dbb2ee21f17041`.

- Final checkpoint unit cases, all 36 snapshot integration tests, and the managed-upgrade test pass.
- Rust 1.88 all-target compile and native Rust formatting pass.
- Independent P0–P2 review found one special-mode ordering issue. Reproduced it red, fixed it, and verified setuid/setgid refusal plus existing special-mode preservation. Final independent review and evidence-based adjudication are **scoped-clean through P2**. A secondary metadata-only claim was disproven by an executed baseline probe and the unchanged inventory contract; captured metadata remains retained. The [hosted exact-head review](https://github.com/openclaw/ocm/pull/152#issuecomment-5556487741) also found no actionable defect.
- Broader local run: 1,003 passed; 23 failures exactly match untouched main (21 release-script cases and 2 local-launcher version probes). The separately run shell-wrapper test also fails identically on main. The two upgrade failures reject a fixture version `v24.20.0` before checkpoint capture. These files are unchanged; no exemptions were added to product checks. Exact-head hosted CI remains the cross-platform gate.

Final review is complete. All five [exact-head CI jobs](https://github.com/openclaw/ocm/actions/runs/34007652318) passed: Format, Rust 1.88, Windows compile, Linux tests/install smoke, and macOS tests/install smoke. Landing uses a head-pinned squash merge.

## Scope and release note

Fix: native APFS snapshots/upgrades no longer fail solely because standard service logs receive post-capture appends. Unsafe or non-prefix changes can still refuse a snapshot; this is deliberate. No global idle gate or weakening of SQLite/rollback checks.

Coordinated shared-file ownership with the owner of #151. This PR is independently based on main and does not include #151's online checkpoint preparation or its separate directory-roundtrip finding. Its owner will reconcile the shared verifier after landing.

A new OCM release is required for installations on 0.2.38 to receive this fix. This PR does not release, install, restart, or deploy OCM.
