### PR TITLE
feat: automate checked OCM releases after main merges

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,67 @@
+name: Automatic release
+
+on:
+  workflow_run:
+    workflows: [CI, Release]
+    types: [completed]
+    branches: [main, 'release/**']
+  # Reconcile after missed events or an interrupted run. No release if unchanged.
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump (auto stops on declared breaking changes)
+        type: choice
+        default: auto
+        options: [auto, patch, minor, major]
+
+permissions:
+  contents: read
+
+# Serialize version allocation, branch writes, tag signing, and dispatch.
+# Replacing a queued event is safe: each run reconciles all unreleased changes.
+concurrency:
+  group: ocm-automatic-release
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    if: >-
+      github.repository == 'openclaw/ocm' &&
+      github.ref == 'refs/heads/main' &&
+      vars.OCM_AUTO_RELEASE_ENABLED == 'true' &&
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.head_repository.full_name == 'openclaw/ocm' &&
+        (github.event.workflow_run.event == 'push' ||
+         github.event.workflow_run.event == 'pull_request' ||
+         github.event.workflow_run.event == 'workflow_dispatch')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Never check out the triggering PR or download its artifacts with secrets.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: 1.88.0
+      - name: Import release identity
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
+        with:
+          gpg_private_key: ${{ secrets.OCM_RELEASE_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.OCM_RELEASE_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+      - name: Reconcile checked release
+        env:
+          # A dedicated account token, not GITHUB_TOKEN: its branch/PR/merge
+          # events must start CI. Keep its account's public signing key registered.
+          GH_TOKEN: ${{ secrets.OCM_RELEASE_TOKEN }}
+          OCM_RELEASE_BUMP: ${{ inputs.bump || 'auto' }}
+        run: |
+          gh auth setup-git
+          python3 scripts/auto-release.py --bump "$OCM_RELEASE_BUMP"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Check formatting
         run: cargo fmt --check
+      - name: Test automatic release policy
+        run: python3 -B -m unittest discover -s scripts/tests -p 'test_auto_release.py'
 
   msrv:
     name: Rust 1.88 minimum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Check formatting
         run: cargo fmt --check
-      - name: Test automatic release policy
-        run: python3 -B -m unittest discover -s scripts/tests -p 'test_auto_release.py'
+      - name: Test automatic release policy and production boundaries
+        run: python3 -B -m unittest discover -s scripts/tests -p 'test_auto_release*.py'
 
   msrv:
     name: Rust 1.88 minimum

--- a/docs/AUTOMATIC_RELEASES.md
+++ b/docs/AUTOMATIC_RELEASES.md
@@ -70,7 +70,11 @@ workflow and complete public assets have all been observed.
 - A manually owned release PR is never adopted, modified or merged. Finish it
   using `scripts/release.sh`, or close it before resuming automation.
 - To change a pending release's version increment, close its PR and dispatch
-  with the desired bump. Old branches are not deleted automatically.
+  with the desired different bump. Old branches are not deleted automatically.
+  A previously closed proposal is never recreated, even if its branch was
+  deleted. Reopen that proposal explicitly to resume the same version.
+- Merging a manually prepared version PR does not authorize automatic signing
+  or publication. Its owner must complete the existing manual release flow.
 - Existing signed tags are never moved. Existing public releases and their
   assets are never rewritten. An active build is not dispatched again.
 - A failed or cancelled release build stops reconciliation visibly. Inspect and
@@ -82,14 +86,24 @@ workflow and complete public assets have all been observed.
 
 ## Verification
 
-Run the policy, Git fixture and mocked GitHub lifecycle tests without network
+Run the policy, lifecycle and subprocess boundary tests without public network
 access or publishing:
 
 ```sh
-python3 -B -m unittest discover -s scripts/tests -p 'test_auto_release.py'
+python3 -B -m unittest discover -s scripts/tests -p 'test_auto_release*.py'
 ```
 
-These tests run in the existing CI Format job. Cargo, Perl, Git and Python 3
-are required because the tests use OCM's real version editors and validators.
+These tests run in the existing Linux CI Format job. Cargo, Perl, Git, Python 3,
+`gh` and `ssh-keygen` are required. The subprocess proof runs the production CLI
+and unchanged release verifiers, pushes real signed tags to an isolated bare
+Git repository, and uses real `gh` HTTP requests through its documented Unix
+socket transport. The local service verifies the real tag signature before
+reporting it verified. It checks successful dispatch and retry deduplication,
+plus zero writes for a merged manual release and a closed proposal (with or
+without its branch). Temporary keys and state are removed after each test.
+
+GitHub responses and build completion are still service fixtures, not a live
+GitHub release or a proof that the production signing account is configured.
+Activation therefore still requires the observed live sequence described above.
 The existing Rust release-script and release-asset suites remain authoritative
 for signed-tag verification and complete-asset publication.

--- a/docs/AUTOMATIC_RELEASES.md
+++ b/docs/AUTOMATIC_RELEASES.md
@@ -1,0 +1,95 @@
+# Automatic OCM releases
+
+`auto-release.yml` connects merged changes to the existing release pipeline.
+It does not update a running OCM daemon or OpenClaw environment. Consumers such
+as Odin's scheduled updater still install OCM first, then update OpenClaw.
+
+## Sequence
+
+1. CI completion triggers reconciliation. A scheduled hourly check recovers
+   missed events and interrupted runs. Only trusted `main` workflow code runs
+   with release credentials; triggering PR code and artifacts are never executed.
+2. Reconciliation checks current `main` CI, then examines all changes since the
+   current published version. Docs-only changes produce no release. Scripts,
+   skills, CI, installers, dependencies and other product changes do.
+3. The automation creates one `release/vX.Y.Z` PR changing only the OCM version
+   in `Cargo.toml` and `Cargo.lock`. The default increment is a patch. It refreshes
+   a stale automation-owned branch with an exact-head lease, then waits for CI.
+4. Once the release PR is current, all five CI jobs pass and GitHub reports normal
+   mergeability, it squash-merges that exact head without bypassing protection.
+   No tag is created until the resulting exact `main` commit passes CI too.
+5. The configured signer creates a signed annotated tag for that release commit.
+   The unchanged `verify-release-tag.sh` and `verify-release-ci.sh` must accept it.
+   The existing `release.yml` then builds all platforms, signs/notarizes macOS
+   binaries, verifies the complete asset set and publishes the draft release.
+
+Concurrent merges may share one release. Global reconciliation serialization
+prevents competing version allocation. Each run re-reads authoritative GitHub
+state instead of relying on the triggering event's possibly stale SHA.
+Version PR merges do not recursively create new versions. Reconciliation finishes
+the pending release before allocating another version.
+
+## One-time configuration
+
+Automatic releases are disabled until `OCM_AUTO_RELEASE_ENABLED` is `true` in
+repository Actions variables. Configure the release identity first through
+GitHub's protected repository settings, never through chat or logged commands:
+
+- `OCM_RELEASE_TOKEN`: a dedicated release account's fine-grained token scoped
+  only to `openclaw/ocm`, with Contents, Pull requests and Actions read/write.
+  The account must be allowed to push release branches, merge normally, and
+  dispatch workflows, without bypass privileges. Its GitHub-verified email must
+  match the signing identity. Repository rules must allow this account's
+  version-only PR to merge after the required checks and reviews.
+- `OCM_RELEASE_GPG_PRIVATE_KEY`: the release identity's signing-only GPG key,
+  whose public key is registered with that GitHub account. GitHub must mark
+  annotated tag signatures verified. Keep the key in Actions secrets.
+- `OCM_RELEASE_GPG_PASSPHRASE`: its passphrase if applicable.
+
+The workflow uses a SHA-pinned GPG import action that removes imported key
+material on exit. The ordinary `GITHUB_TOKEN` remains read-only. A dedicated
+account token is necessary because branch/PR/merge events created with
+`GITHUB_TOKEN` do not start the CI runs required by the release protocol.
+Do not replace the signer with unsigned tags or reuse Apple's code-signing key.
+Existing Apple signing secrets and `MACOS_TEAM_ID` remain unchanged.
+
+After configuration, enable the variable and dispatch **Automatic release**
+from `main` with `bump=auto`. It will include already-merged unreleased fixes.
+Do not mark setup complete until the release PR, signed tag, successful release
+workflow and complete public assets have all been observed.
+
+## Version choices and pauses
+
+- Default `auto` and explicit `patch` stop if any unreleased commit declares
+  `BREAKING CHANGE:`, `BREAKING-CHANGE:`, or uses a Conventional Commit `!` header.
+  Use a manual dispatch with `bump=minor` or `bump=major` after deciding the proper
+  compatibility boundary. Undeclared breaking changes cannot be detected; code
+  review must enforce release declarations.
+- Set a pending release PR to draft or add `release:hold` to pause its merge.
+  Set `OCM_AUTO_RELEASE_ENABLED=false` to stop all automatic release operations.
+- A manually owned release PR is never adopted, modified or merged. Finish it
+  using `scripts/release.sh`, or close it before resuming automation.
+- To change a pending release's version increment, close its PR and dispatch
+  with the desired bump. Old branches are not deleted automatically.
+- Existing signed tags are never moved. Existing public releases and their
+  assets are never rewritten. An active build is not dispatched again.
+- A failed or cancelled release build stops reconciliation visibly. Inspect and
+  rerun that existing workflow run after correcting the cause. The reconciler
+  does not create endless retries or mistake a draft/partial release for success.
+- A pushed automation branch whose PR creation was interrupted is recovered only
+  when its commit is signed by the release account and contains the exact
+  version-only change and automation marker.
+
+## Verification
+
+Run the policy, Git fixture and mocked GitHub lifecycle tests without network
+access or publishing:
+
+```sh
+python3 -B -m unittest discover -s scripts/tests -p 'test_auto_release.py'
+```
+
+These tests run in the existing CI Format job. Cargo, Perl, Git and Python 3
+are required because the tests use OCM's real version editors and validators.
+The existing Rust release-script and release-asset suites remain authoritative
+for signed-tag verification and complete-asset publication.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,5 +1,9 @@
 # Release prerequisites
 
+For automatic post-merge version PRs and signed release dispatch, see
+[Automatic OCM releases](AUTOMATIC_RELEASES.md). The same signing, CI and complete
+asset checks below apply to both automatic and manual releases.
+
 The canonical `.github/workflows/release.yml` workflow publishes OCM releases from signed tags on `main`. Linux packaging needs no repository credentials. Each macOS matrix job imports one Developer ID Application certificate, signs `ocm` with the identifier `com.openclaw.ocm`, submits a temporary ZIP to Apple's notary service, checks the executable's notarization ticket, and verifies the executable again after extracting the final tarball.
 
 Configure these GitHub Actions repository secrets:

--- a/scripts/auto-release.py
+++ b/scripts/auto-release.py
@@ -168,6 +168,8 @@ class Reconciler:
             raise ReleaseError("Unpublished version is not a canonical merged release PR")
         commit, number = candidates[0]
         pr = api(f"pulls/{number}")
+        if pr["user"]["login"] != self.actor or MARKER not in (pr["body"] or ""):
+            raise ReleaseError("Unpublished release is manually owned; leaving signing and dispatch to its owner")
         if not pr["merged"] or pr["base"]["ref"] != "main" or \
                 pr["head"]["ref"] != f"release/{tag}" or \
                 pr["merge_commit_sha"] != commit or pr["title"] != title or \
@@ -269,7 +271,7 @@ class Reconciler:
     def reconcile(self):
         if self.git("status", "--porcelain"):
             raise ReleaseError("Use a clean disposable checkout")
-        if self.git("remote", "get-url", "origin") not in {
+        if self.git("config", "--get", "remote.origin.url") not in {
                 f"https://github.com/{REPO}", f"https://github.com/{REPO}.git", f"git@github.com:{REPO}.git"}:
             raise ReleaseError("Origin must be the canonical OCM repository")
         self.actor = api("/user")["login"]
@@ -314,6 +316,9 @@ class Reconciler:
             return
         branch = f"release/v{target}"
         if not pr:
+            previous = pages(f"pulls?state=closed&base=main&head=openclaw:{branch}")
+            if previous:
+                raise ReleaseError("A prior release proposal was closed; reopen it explicitly or select another version")
             # Recover a push that succeeded before PR creation failed. Adopt only
             # our signed, canonical version-only commit, never a manual branch.
             refs = pages("git/matching-refs/heads/" + branch)

--- a/scripts/auto-release.py
+++ b/scripts/auto-release.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""One bounded, restartable reconciliation of OCM's existing release protocol.
+
+Run only from a disposable checkout with a configured Git signer and gh identity.
+Publication stays exclusively with release.yml and its existing verifiers.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = "openclaw/ocm"
+ROOT = Path(__file__).resolve().parent.parent
+VERSION = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\Z")
+SHA = re.compile(r"[0-9a-f]{40}\Z")
+MARKER = "<!-- ocm-auto-release:v1 -->"
+CI_JOBS = {"Format", "Rust 1.88 minimum", "Windows compile",
+           "Test (ubuntu-latest)", "Test (macos-latest)"}
+
+
+class ReleaseError(RuntimeError):
+    pass
+
+
+def run(*args, cwd=None, data=None, strip=True):
+    cwd = ROOT if cwd is None else cwd
+    result = subprocess.run(args, cwd=cwd, input=data, text=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=180)
+    if result.returncode:
+        # Do not echo argv or credential-bearing authentication diagnostics.
+        raise ReleaseError(f"{args[0]} {args[1] if len(args) > 1 else ''} failed ({result.returncode})")
+    return result.stdout.strip() if strip else result.stdout
+
+
+def api(endpoint, method="GET", payload=None):
+    args = ["gh", "api", f"repos/{REPO}/{endpoint}" if endpoint != "/user" else "user",
+            "--method", method]
+    if payload is not None:
+        args += ["--input", "-"]
+    result = run(*args, data=json.dumps(payload) if payload is not None else None)
+    return json.loads(result) if result else None
+
+
+def pages(endpoint):
+    result = []
+    for page in range(1, 101):
+        batch = api(f"{endpoint}{'&' if '?' in endpoint else '?'}per_page=100&page={page}")
+        if not isinstance(batch, list):
+            raise ReleaseError("Malformed paginated GitHub response")
+        result += batch
+        if len(batch) < 100:
+            return result
+    raise ReleaseError("GitHub pagination limit exceeded")
+
+
+def version_tuple(version):
+    if not VERSION.fullmatch(version):
+        raise ReleaseError(f"Automatic releases require a stable version: {version}")
+    return tuple(map(int, version.split(".")))
+
+
+def next_version(version, bump):
+    major, minor, patch = version_tuple(version)
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def docs_only(paths):
+    # Conservative allowlist. Skills, scripts, CI, installers and unknown files
+    # are releasable even when they look like documentation.
+    return bool(paths) and all(
+        p.startswith("docs/") or p in {"README.md", "CONTRIBUTING.md", "CHANGELOG.md"}
+        for p in paths)
+
+
+def needs_explicit_bump(messages):
+    return any(re.search(r"(?m)^BREAKING[ -]CHANGE:|^[^\n:]+!:", m) for m in messages)
+
+
+def checked_sha(value):
+    if not isinstance(value, str) or not SHA.fullmatch(value):
+        raise ReleaseError("Invalid commit identity")
+    return value
+
+
+class Reconciler:
+    def __init__(self, bump="auto"):
+        self.bump = bump
+        self.main = None
+        self.actor = None
+
+    def git(self, *args):
+        return run("git", *args, strip=args[0] != "show")
+
+    def script(self, name, *args):
+        return run(str(ROOT / "scripts" / name), *args)
+
+    def current_main(self):
+        return checked_sha(api("git/ref/heads/main")["object"]["sha"])
+
+    def version_at(self, commit):
+        with tempfile.TemporaryDirectory(prefix="ocm-auto-version-") as directory:
+            files = []
+            for name in ("Cargo.toml", "Cargo.lock"):
+                path = Path(directory) / name
+                path.write_text(self.git("show", f"{commit}:{name}"))
+                files.append(str(path))
+            return self.script("read-package-version.sh", *files)
+
+    def ci(self, commit, branch, event):
+        data = api(f"actions/workflows/ci.yml/runs?head_sha={commit}&event={event}&per_page=100")
+        runs = [r for r in data["workflow_runs"]
+                if r["head_sha"] == commit and r["head_branch"] == branch
+                and r["event"] == event and r["head_repository"]["full_name"] == REPO]
+        if len(runs) > 1:
+            raise ReleaseError("Ambiguous CI runs; rerun the existing run rather than creating another")
+        if not runs or runs[0]["status"] != "completed":
+            return False
+        ci_run = runs[0]
+        if ci_run["conclusion"] != "success":
+            raise ReleaseError(f"CI did not pass: {ci_run['html_url']}")
+        jobs = api(f"actions/runs/{ci_run['id']}/jobs?filter=latest&per_page=100")
+        actual = jobs["jobs"]
+        if jobs["total_count"] != len(actual) or len(actual) != len(CI_JOBS) or \
+                {j["name"] for j in actual} != CI_JOBS or \
+                any(j["conclusion"] != "success" for j in actual):
+            raise ReleaseError("CI did not complete every required release job successfully")
+        return True
+
+    def release_runs(self, tag):
+        # run-name in release.yml is exactly "Release <tag>". Inspect all pages:
+        # a prior dispatch must not disappear just because other releases ran.
+        runs = []
+        for page in range(1, 101):
+            response = api(f"actions/workflows/release.yml/runs?event=workflow_dispatch&per_page=100&page={page}")
+            batch = response["workflow_runs"]
+            runs += [r for r in batch if r["display_title"] == f"Release {tag}"
+                     and r["head_branch"] == "main"
+                     and r["head_repository"]["full_name"] == REPO]
+            if len(batch) < 100:
+                return runs
+        raise ReleaseError("Release run pagination limit exceeded")
+
+    def finish_release(self, version, releases):
+        tag = f"v{version}"
+        published = [r for r in releases if r["tag_name"] == tag and not r["draft"]
+                     and not r["prerelease"]]
+        if published:
+            return False
+        # Later dependency edits may also touch Cargo.toml. Find the canonical
+        # version-introducing release commit, not simply its last file edit.
+        title = f"chore(release): bump version to {version}"
+        candidates = []
+        for line in self.git("log", "--first-parent", "--format=%H%x00%s", self.main,
+                             "--", "Cargo.toml").splitlines():
+            sha, subject = line.split("\0", 1)
+            match = re.fullmatch(re.escape(title) + r" \(#([1-9]\d*)\)", subject)
+            if match:
+                candidates.append((checked_sha(sha), match[1]))
+        if len(candidates) != 1:
+            raise ReleaseError("Unpublished version is not a canonical merged release PR")
+        commit, number = candidates[0]
+        pr = api(f"pulls/{number}")
+        if not pr["merged"] or pr["base"]["ref"] != "main" or \
+                pr["head"]["ref"] != f"release/{tag}" or \
+                pr["merge_commit_sha"] != commit or pr["title"] != title or \
+                self.version_at(commit) != version:
+            raise ReleaseError("Release PR does not match the unpublished version")
+        self.verify_version_diff(commit, version)
+        if not self.ci(commit, "main", "push"):
+            print(f"Waiting for post-merge CI on {commit}")
+            return True
+        self.script("verify-release-ci.sh", "--repo", REPO, "--commit", commit)
+        refs = pages("git/matching-refs/tags/" + tag)
+        refs = [r for r in refs if r["ref"] == "refs/tags/" + tag]
+        if not refs:
+            # Never move/recreate an existing tag. Sign the checked release SHA,
+            # not HEAD or a moving branch. Authentication is gh's credential helper.
+            self.git("-c", "tag.gpgSign=true", "tag", "-s", tag, commit, "-m", tag)
+            self.git("verify-tag", tag)
+            self.git("push", "origin", "refs/tags/" + tag)
+        self.script("verify-release-tag.sh", "--repo", REPO, "--tag", tag, "--commit", commit)
+        runs = self.release_runs(tag)
+        if runs:
+            latest = runs[0]
+            if latest["status"] == "completed":
+                raise ReleaseError(f"Release has no published result; inspect or rerun {latest['html_url']}")
+            print(f"Release build already running for {tag}")
+        else:
+            run("gh", "workflow", "run", "release.yml", "--repo", REPO,
+                "--ref", "main", "-f", f"tag={tag}")
+            print(f"Dispatched existing signed-release workflow for {tag}")
+        return True
+
+    def verify_version_diff(self, commit, version):
+        parents = self.git("rev-list", "--parents", "-n", "1", commit).split()
+        if len(parents) != 2:
+            raise ReleaseError("Release commit must have exactly one parent")
+        parent = checked_sha(parents[1])
+        paths = self.git("diff", "--name-only", parent, commit).splitlines()
+        if set(paths) != {"Cargo.toml", "Cargo.lock"}:
+            raise ReleaseError("Release PR must change only the two version files")
+        old_version = self.version_at(parent)
+        if version_tuple(version) <= version_tuple(old_version):
+            raise ReleaseError("Release version must increase")
+        # Verify bytes, not just filenames: no dependency or package changes may
+        # be smuggled into a PR that this automation can merge.
+        for name in paths:
+            before = self.git("show", f"{parent}:{name}")
+            after = self.git("show", f"{commit}:{name}")
+            pattern = (r'(?m)^(version = ")[^"]+("\s*)$' if name == "Cargo.toml" else
+                       r'(\[\[package\]\]\nname = "ocm"\nversion = ")[^"]+(")')
+            expected, count = re.subn(pattern, lambda m: m[1] + version + m[2], before, count=1)
+            if count != 1 or after != expected:
+                raise ReleaseError("Release PR contains changes beyond the package version")
+        return parent
+
+    def pending(self):
+        prs = pages("pulls?state=open&base=main")
+        candidates = [p for p in prs if p["head"]["ref"].startswith("release/")]
+        if len(candidates) > 1:
+            raise ReleaseError("Multiple release PRs exist; resolve ownership before releasing")
+        if not candidates:
+            return None
+        pr = candidates[0]
+        if pr["user"]["login"] != self.actor or MARKER not in (pr["body"] or "") or \
+                pr["head"]["repo"]["full_name"] != REPO:
+            raise ReleaseError("A manually owned release PR exists; leaving it untouched")
+        return pr
+
+    def check_changes(self, last_commit, bump):
+        paths = self.git("diff", "--name-only", last_commit, self.main).splitlines()
+        if not paths or docs_only(paths):
+            return False
+        messages = self.git("log", "--format=%B%x00", f"{last_commit}..{self.main}").split("\0")
+        if needs_explicit_bump(messages) and bump not in {"minor", "major"}:
+            raise ReleaseError("Declared breaking change: dispatch with an explicit minor or major bump")
+        return True
+
+    def create_version_commit(self, version):
+        # Work in a private index/tree. Do not switch to or execute PR source.
+        with tempfile.TemporaryDirectory(prefix="ocm-auto-release-") as directory:
+            self.git("worktree", "add", "--detach", directory, self.main)
+            try:
+                # Run only the version editor from this trusted workflow checkout.
+                # Its repo-relative root requires a copy alongside the version files.
+                trusted_scripts = ROOT / "scripts"
+                for name in ("update-version.sh", "read-package-version.sh", "validate-version.sh"):
+                    target = Path(directory) / "scripts" / name
+                    target.write_bytes((trusted_scripts / name).read_bytes())
+                    target.chmod(0o755)
+                run(str(Path(directory) / "scripts/update-version.sh"), version, cwd=directory)
+                run("git", "add", "Cargo.toml", "Cargo.lock", cwd=directory)
+                run("git", "commit", "-m", f"chore(release): bump version to {version}",
+                    "-m", MARKER, cwd=directory)
+                commit = checked_sha(run("git", "rev-parse", "HEAD", cwd=directory))
+                self.verify_version_diff(commit, version)
+                return commit
+            finally:
+                self.git("worktree", "remove", "--force", directory)
+
+    def reconcile(self):
+        if self.git("status", "--porcelain"):
+            raise ReleaseError("Use a clean disposable checkout")
+        if self.git("remote", "get-url", "origin") not in {
+                f"https://github.com/{REPO}", f"https://github.com/{REPO}.git", f"git@github.com:{REPO}.git"}:
+            raise ReleaseError("Origin must be the canonical OCM repository")
+        self.actor = api("/user")["login"]
+        self.git("fetch", "origin", "main", "--tags")
+        self.main = self.current_main()
+        self.git("cat-file", "-e", self.main + "^{commit}")
+        version = self.version_at(self.main)
+        version_tuple(version)
+        releases = pages("releases")
+        if self.finish_release(version, releases):
+            return
+        release = next(r for r in releases if r["tag_name"] == f"v{version}" and not r["draft"] and not r["prerelease"])
+        tag = release["tag_name"]
+        last_commit = checked_sha(self.git("rev-parse", tag + "^{commit}"))
+        self.script("verify-release-tag.sh", "--repo", REPO, "--tag", tag, "--commit", last_commit)
+        if self.git("merge-base", last_commit, self.main) != last_commit:
+            raise ReleaseError("Last release is not an ancestor of main")
+        pr = self.pending()
+        bump = self.bump
+        if pr:
+            head = checked_sha(pr["head"]["sha"])
+            self.git("fetch", "origin", "refs/heads/" + pr["head"]["ref"])
+            target = self.version_at(head)
+            base = self.verify_version_diff(head, target)
+            inferred = next((b for b in ("patch", "minor", "major") if next_version(version, b) == target), None)
+            if not inferred or pr["head"]["ref"] != f"release/v{target}" or \
+                    pr["title"] != f"chore(release): bump version to {target}":
+                raise ReleaseError("Pending release PR has an unexpected version or identity")
+            if bump != "auto" and bump != inferred:
+                raise ReleaseError("Close the pending release PR before selecting a different bump")
+            bump = inferred
+        else:
+            target = next_version(version, bump)
+        if not self.check_changes(last_commit, bump):
+            print("No unreleased product changes")
+            return
+        if not self.ci(self.main, "main", "push"):
+            print("Waiting for current main CI")
+            return
+        if self.current_main() != self.main:
+            print("Main advanced; next reconciliation will include it")
+            return
+        branch = f"release/v{target}"
+        if not pr:
+            # Recover a push that succeeded before PR creation failed. Adopt only
+            # our signed, canonical version-only commit, never a manual branch.
+            refs = pages("git/matching-refs/heads/" + branch)
+            refs = [r for r in refs if r["ref"] == "refs/heads/" + branch]
+            if refs:
+                orphan = checked_sha(refs[0]["object"]["sha"])
+                self.git("fetch", "origin", "refs/heads/" + branch)
+                data = api(f"commits/{orphan}")
+                if (data.get("author") or {}).get("login") != self.actor or \
+                        not data["commit"]["verification"]["verified"] or \
+                        data["commit"]["message"].strip() != \
+                        f"chore(release): bump version to {target}\n\n{MARKER}":
+                    raise ReleaseError("Existing release branch is not owned by this automation")
+                self.verify_version_diff(orphan, target)
+                self.ensure_pr(branch, target)
+                return
+        if not pr or base != self.main:
+            commit = self.create_version_commit(target)
+            # Empty lease means branch must not exist. Never overwrite manual work.
+            expected = head if pr else ""
+            self.git("push", f"--force-with-lease=refs/heads/{branch}:{expected}",
+                     "origin", f"{commit}:refs/heads/{branch}")
+            if not pr:
+                pr = self.ensure_pr(branch, target)
+            print(f"Release PR ready for CI: {pr['html_url']}")
+            return
+        if not self.ci(head, branch, "pull_request"):
+            print(f"Waiting for release PR CI: {pr['html_url']}")
+            return
+        live = api(f"pulls/{pr['number']}")
+        if live["head"]["sha"] != head or live["state"] != "open" or live["draft"] or \
+                live["title"] != pr["title"] or MARKER not in (live["body"] or "") or \
+                live["base"]["ref"] != "main" or \
+                any(label["name"] == "release:hold" for label in live.get("labels", [])) or \
+                self.current_main() != self.main:
+            print("Release PR or main changed; leaving it for reconciliation")
+            return
+        if live["mergeable_state"] != "clean":
+            raise ReleaseError("Release PR is not mergeable under normal branch protection")
+        result = api(f"pulls/{pr['number']}/merge", "PUT", {
+            "sha": head, "merge_method": "squash",
+            "commit_title": f"{pr['title']} (#{pr['number']})"})
+        if not result["merged"]:
+            raise ReleaseError("GitHub did not confirm release PR merge")
+        print(f"Merged version PR at {checked_sha(result['sha'])}; waiting for exact main CI")
+
+    def ensure_pr(self, branch, version):
+        return api("pulls", "POST", {
+            "base": "main", "head": branch,
+            "title": f"chore(release): bump version to {version}",
+            "body": f"{MARKER}\n\nAutomatic version-only release. CI must pass before squash merge.\n"
+                    "The signed-tag and complete-artifact release checks remain required."})
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bump", choices=("auto", "patch", "minor", "major"), default="auto")
+    args = parser.parse_args()
+    try:
+        Reconciler(args.bump).reconcile()
+    except (ReleaseError, KeyError, ValueError, subprocess.TimeoutExpired) as error:
+        print(f"Automatic release stopped: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/auto-release.py
+++ b/scripts/auto-release.py
@@ -323,6 +323,7 @@ class Reconciler:
                 self.git("fetch", "origin", "refs/heads/" + branch)
                 data = api(f"commits/{orphan}")
                 if (data.get("author") or {}).get("login") != self.actor or \
+                        (data.get("committer") or {}).get("login") != self.actor or \
                         not data["commit"]["verification"]["verified"] or \
                         data["commit"]["message"].strip() != \
                         f"chore(release): bump version to {target}\n\n{MARKER}":

--- a/scripts/tests/test_auto_release.py
+++ b/scripts/tests/test_auto_release.py
@@ -168,7 +168,7 @@ class ReconciliationTests(unittest.TestCase):
 
     def setup_reconcile(self, pr=None, base=A, ready=True):
         self.r.git = Mock(side_effect=lambda *a: {
-            "status": "", "remote": f"https://github.com/{release.REPO}.git",
+            "status": "", "config": f"https://github.com/{release.REPO}.git",
             "rev-parse": C, "merge-base": C}.get(a[0], ""))
         self.r.current_main = Mock(return_value=A)
         self.r.version_at = Mock(side_effect=lambda sha: "0.2.39" if sha == B else "0.2.38")
@@ -191,7 +191,7 @@ class ReconciliationTests(unittest.TestCase):
                 return self.pr
             self.fail(endpoint)
         with patch.object(release, "api", side_effect=api), \
-                patch.object(release, "pages", side_effect=[self.published, []]):
+                patch.object(release, "pages", side_effect=[self.published, [], []]):
             self.r.reconcile()
         self.r.git.assert_any_call("push", "--force-with-lease=refs/heads/release/v0.2.39:",
                                   "origin", f"{B}:refs/heads/release/v0.2.39")
@@ -254,7 +254,7 @@ class ReconciliationTests(unittest.TestCase):
                 "verification": {"verified": verified},
                 "message": f"chore(release): bump version to 0.2.39\n\n{release.MARKER}"}}
             with patch.object(release, "api", side_effect=[{"login": "release-bot"}, data, self.pr]) as api, \
-                    patch.object(release, "pages", side_effect=[self.published, [{
+                    patch.object(release, "pages", side_effect=[self.published, [], [{
                         "ref": "refs/heads/release/v0.2.39", "object": {"sha": B}}]]):
                 if verified and committer == "release-bot":
                     self.r.reconcile()
@@ -264,6 +264,27 @@ class ReconciliationTests(unittest.TestCase):
                         self.r.reconcile()
                     self.assertEqual(api.call_count, 2)
             self.r.create_version_commit.assert_not_called()
+
+    def test_closed_proposal_is_not_recreated_even_when_its_branch_was_deleted(self):
+        self.setup_reconcile()
+        with patch.object(release, "api", return_value={"login": "release-bot"}) as api, \
+                patch.object(release, "pages", side_effect=[self.published, [dict(self.pr, state="closed")]]), \
+                self.assertRaisesRegex(release.ReleaseError, "closed"):
+            self.r.reconcile()
+        self.r.create_version_commit.assert_not_called()
+        self.assertEqual(api.call_count, 1)
+
+    def test_merged_manual_release_is_rejected_before_ci_signing_or_dispatch(self):
+        self.r.git = Mock(return_value=f"{C}\0chore(release): bump version to 0.2.39 (#10)")
+        self.r.ci = Mock()
+        self.r.script = Mock()
+        for manual in (dict(self.pr, body="manual release"), dict(self.pr, user={"login": "human"})):
+            with patch.object(release, "api", return_value=manual), patch.object(release, "run") as run, \
+                    self.assertRaisesRegex(release.ReleaseError, "manually owned"):
+                self.r.finish_release("0.2.39", self.published)
+            run.assert_not_called()
+        self.r.ci.assert_not_called()
+        self.r.script.assert_not_called()
 
     def test_release_signs_only_checked_merge_commit_and_dispatches_once(self):
         self.r.git = Mock(return_value=f"{A}\0fix: newer dependency edit\n{C}\0chore(release): bump version to 0.2.39 (#10)")

--- a/scripts/tests/test_auto_release.py
+++ b/scripts/tests/test_auto_release.py
@@ -248,15 +248,15 @@ class ReconciliationTests(unittest.TestCase):
             self.assertEqual(api.call_count, 2)
 
     def test_interrupted_branch_push_is_recovered_only_for_signed_automation_commit(self):
-        for verified in (True, False):
+        for verified, committer in ((True, "release-bot"), (False, "release-bot"), (True, "another-user")):
             self.setup_reconcile()
-            data = {"author": {"login": "release-bot"}, "commit": {
+            data = {"author": {"login": "release-bot"}, "committer": {"login": committer}, "commit": {
                 "verification": {"verified": verified},
                 "message": f"chore(release): bump version to 0.2.39\n\n{release.MARKER}"}}
             with patch.object(release, "api", side_effect=[{"login": "release-bot"}, data, self.pr]) as api, \
                     patch.object(release, "pages", side_effect=[self.published, [{
                         "ref": "refs/heads/release/v0.2.39", "object": {"sha": B}}]]):
-                if verified:
+                if verified and committer == "release-bot":
                     self.r.reconcile()
                     self.assertEqual(api.call_args.args[:2], ("pulls", "POST"))
                 else:

--- a/scripts/tests/test_auto_release.py
+++ b/scripts/tests/test_auto_release.py
@@ -1,0 +1,332 @@
+"""Release policy and Git/GitHub boundary tests. No network or real publishing."""
+
+import copy
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+SOURCE = Path(__file__).resolve().parents[1] / "auto-release.py"
+spec = importlib.util.spec_from_file_location("auto_release", SOURCE)
+release = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release)
+A, B, C = "a" * 40, "b" * 40, "c" * 40
+
+
+class PolicyTests(unittest.TestCase):
+    def test_versions(self):
+        self.assertEqual(release.next_version("0.2.38", "auto"), "0.2.39")
+        self.assertEqual(release.next_version("0.2.38", "minor"), "0.3.0")
+        self.assertEqual(release.next_version("0.2.38", "major"), "1.0.0")
+        for value in ["0.2.38-rc.1", "01.2.3", "v1.2.3", "1.2", "1.2.3\n", "1.2.3;exit"]:
+            with self.subTest(value=value), self.assertRaises(release.ReleaseError):
+                release.next_version(value, "auto")
+
+    def test_documentation_allowlist_does_not_hide_shipped_scripts_or_skills(self):
+        self.assertTrue(release.docs_only(["docs/RELEASING.md", "README.md"]))
+        for paths in [[], ["skills/foo/SKILL.md"], ["scripts/release.sh"],
+                      [".github/workflows/ci.yml"], ["README.md", "src/main.rs"]]:
+            self.assertFalse(release.docs_only(paths))
+
+    def test_breaking_changes_need_explicit_minor_or_major(self):
+        for message in ["feat!: new format", "fix(state)!: migrate", "fix: x\n\nBREAKING CHANGE: schema",
+                        "feat: x\nBREAKING-CHANGE: schema"]:
+            self.assertTrue(release.needs_explicit_bump([message]))
+        self.assertFalse(release.needs_explicit_bump(["fix: checkpoint logs", "docs: explain BREAKING CHANGE examples"]))
+
+
+class GitVersionTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.directory.name)
+        self.root_patch = patch.object(release, "ROOT", self.root)
+        self.root_patch.start()
+        # Do not inherit the operator's signer, git hooks, or credential config.
+        self.environment = patch.dict(os.environ, {
+            "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_AUTHOR_NAME": "Release test", "GIT_AUTHOR_EMAIL": "test@example.invalid",
+            "GIT_COMMITTER_NAME": "Release test", "GIT_COMMITTER_EMAIL": "test@example.invalid"})
+        self.environment.start()
+        self.r = release.Reconciler()
+        self.r.git("init", "-b", "main")
+        (self.root / "scripts").mkdir()
+        for name in ["read-package-version.sh", "update-version.sh", "validate-version.sh"]:
+            target = self.root / "scripts" / name
+            target.write_bytes((SOURCE.parent / name).read_bytes())
+            target.chmod(0o755)
+        (self.root / "Cargo.toml").write_text('[package]\nname = "ocm"\nversion = "0.2.38"\n')
+        (self.root / "Cargo.lock").write_text('version = 4\n\n[[package]]\nname = "ocm"\nversion = "0.2.38"\n')
+        self.r.git("add", ".")
+        self.r.git("commit", "-m", "initial")
+        self.base = self.r.git("rev-parse", "HEAD")
+        self.r.main = self.base
+
+    def tearDown(self):
+        self.environment.stop()
+        self.root_patch.stop()
+        self.directory.cleanup()
+
+    def commit_version(self):
+        self.r.script("update-version.sh", "0.2.39")
+        self.r.git("add", "Cargo.toml", "Cargo.lock")
+        self.r.git("commit", "-m", "version")
+        return self.r.git("rev-parse", "HEAD")
+
+    def test_real_version_commit_is_version_only_and_checkout_is_untouched(self):
+        commit = self.r.create_version_commit("0.2.39")
+        self.assertEqual(self.r.verify_version_diff(commit, "0.2.39"), self.base)
+        self.assertEqual(self.r.git("rev-parse", "HEAD"), self.base)
+        self.assertEqual(self.r.git("status", "--porcelain"), "")
+        self.assertEqual(self.r.version_at(commit), "0.2.39")
+
+    def test_rejects_dependency_changes_in_version_files(self):
+        self.commit_version()
+        with (self.root / "Cargo.toml").open("a") as stream:
+            stream.write('\n[dependencies]\nevil = "1"\n')
+        self.r.git("add", "Cargo.toml")
+        self.r.git("commit", "--amend", "--no-edit")
+        with self.assertRaisesRegex(release.ReleaseError, "beyond"):
+            self.r.verify_version_diff(self.r.git("rev-parse", "HEAD"), "0.2.39")
+
+    def test_rejects_non_version_file_and_trailing_whitespace_changes(self):
+        self.commit_version()
+        with (self.root / "Cargo.lock").open("a") as stream:
+            stream.write(" \n")
+        self.r.git("add", "Cargo.lock")
+        self.r.git("commit", "--amend", "--no-edit")
+        with self.assertRaises(release.ReleaseError):
+            self.r.verify_version_diff(self.r.git("rev-parse", "HEAD"), "0.2.39")
+        (self.root / "payload").write_text("code")
+        self.r.git("add", "payload")
+        self.r.git("commit", "--amend", "--no-edit")
+        with self.assertRaisesRegex(release.ReleaseError, "only the two"):
+            self.r.verify_version_diff(self.r.git("rev-parse", "HEAD"), "0.2.39")
+
+
+class CIGateTests(unittest.TestCase):
+    def setUp(self):
+        self.r = release.Reconciler()
+        self.ci = {"id": 42, "head_sha": A, "head_branch": "main", "event": "push",
+                   "head_repository": {"full_name": release.REPO}, "status": "completed",
+                   "conclusion": "success", "html_url": "https://github.com/openclaw/ocm/actions/runs/42"}
+        self.jobs = {"total_count": 5, "jobs": [{"name": n, "conclusion": "success"}
+                                                for n in release.CI_JOBS]}
+
+    def check(self, runs, jobs=None):
+        with patch.object(release, "api", side_effect=[{"workflow_runs": runs}, jobs or self.jobs]):
+            return self.r.ci(A, "main", "push")
+
+    def test_exact_main_ci_all_jobs_pass(self):
+        self.assertTrue(self.check([self.ci]))
+
+    def test_missing_running_wrong_sha_wrong_branch_and_fork_do_not_pass(self):
+        self.assertFalse(self.check([]))
+        for key, value in [("head_sha", B), ("head_branch", "feature"),
+                           ("event", "pull_request"), ("status", "in_progress"),
+                           ("head_repository", {"full_name": "attacker/ocm"})]:
+            run = dict(self.ci, **{key: value})
+            self.assertFalse(self.check([run]))
+
+    def test_failed_ambiguous_missing_and_skipped_jobs_stop_release(self):
+        with self.assertRaises(release.ReleaseError):
+            self.check([dict(self.ci, conclusion="failure")])
+        with self.assertRaises(release.ReleaseError):
+            self.check([self.ci, self.ci])
+        for outcome in ["skipped", "failure", None]:
+            jobs = copy.deepcopy(self.jobs)
+            jobs["jobs"][0]["conclusion"] = outcome
+            with self.assertRaises(release.ReleaseError):
+                self.check([self.ci], jobs)
+        with self.assertRaises(release.ReleaseError):
+            self.check([self.ci], {"total_count": 5, "jobs": self.jobs["jobs"][:-1]})
+
+
+class ReconciliationTests(unittest.TestCase):
+    def setUp(self):
+        self.r = release.Reconciler()
+        self.r.actor = "release-bot"
+        self.r.main = A
+        self.pr = {"number": 10, "head": {"ref": "release/v0.2.39", "sha": B,
+                   "repo": {"full_name": release.REPO}}, "base": {"ref": "main"},
+                   "user": {"login": "release-bot"}, "body": release.MARKER,
+                   "title": "chore(release): bump version to 0.2.39", "html_url": "pr/10"}
+        self.published = [{"tag_name": "v0.2.38", "draft": False, "prerelease": False}]
+
+    def test_manual_release_pr_and_multiple_releases_are_not_adopted(self):
+        for prs in [[dict(self.pr, body="manual")], [dict(self.pr, user={"login": "human"})],
+                    [self.pr, self.pr]]:
+            with patch.object(release, "pages", return_value=prs), self.assertRaises(release.ReleaseError):
+                self.r.pending()
+
+    def test_already_published_release_does_not_dispatch_or_tag(self):
+        with patch.object(release, "api") as api, patch.object(release, "run") as run:
+            self.assertFalse(self.r.finish_release("0.2.38", self.published))
+            api.assert_not_called()
+            run.assert_not_called()
+
+    def setup_reconcile(self, pr=None, base=A, ready=True):
+        self.r.git = Mock(side_effect=lambda *a: {
+            "status": "", "remote": f"https://github.com/{release.REPO}.git",
+            "rev-parse": C, "merge-base": C}.get(a[0], ""))
+        self.r.current_main = Mock(return_value=A)
+        self.r.version_at = Mock(side_effect=lambda sha: "0.2.39" if sha == B else "0.2.38")
+        self.r.script = Mock()
+        self.r.finish_release = Mock(return_value=False)
+        self.r.pending = Mock(return_value=pr)
+        self.r.verify_version_diff = Mock(return_value=base)
+        self.r.check_changes = Mock(return_value=True)
+        self.r.ci = Mock(return_value=ready)
+        self.r.create_version_commit = Mock(return_value=B)
+
+    def test_create_release_pr_once_with_empty_branch_lease(self):
+        self.setup_reconcile()
+        def api(endpoint, method="GET", payload=None):
+            if endpoint == "/user":
+                return {"login": "release-bot"}
+            if endpoint == "pulls":
+                self.assertEqual(method, "POST")
+                self.assertEqual(payload["head"], "release/v0.2.39")
+                return self.pr
+            self.fail(endpoint)
+        with patch.object(release, "api", side_effect=api), \
+                patch.object(release, "pages", side_effect=[self.published, []]):
+            self.r.reconcile()
+        self.r.git.assert_any_call("push", "--force-with-lease=refs/heads/release/v0.2.39:",
+                                  "origin", f"{B}:refs/heads/release/v0.2.39")
+
+    def test_refresh_stale_release_branch_only_with_exact_lease(self):
+        self.setup_reconcile(self.pr, base=C)
+        with patch.object(release, "api", return_value={"login": "release-bot"}), \
+                patch.object(release, "pages", return_value=self.published):
+            self.r.reconcile()
+        self.r.git.assert_any_call("push", f"--force-with-lease=refs/heads/release/v0.2.39:{B}",
+                                  "origin", f"{B}:refs/heads/release/v0.2.39")
+
+    def test_ready_pr_merges_once_by_exact_sha_then_waits_for_main_ci(self):
+        self.setup_reconcile(self.pr)
+        live = dict(self.pr, state="open", draft=False, mergeable_state="clean")
+        with patch.object(release, "api", side_effect=[{"login": "release-bot"}, live,
+                                                     {"merged": True, "sha": C}]) as api, \
+                patch.object(release, "pages", return_value=self.published):
+            self.r.reconcile()
+        self.assertEqual(api.call_args.args[:2], ("pulls/10/merge", "PUT"))
+        self.assertEqual(api.call_args.args[2]["sha"], B)
+        self.assertEqual(api.call_args.args[2]["merge_method"], "squash")
+        self.r.script.assert_called_once()  # only prior release verification, no new tag
+        self.r.create_version_commit.assert_not_called()
+
+    def test_pending_ci_docs_only_and_main_race_never_merge(self):
+        for case in ("ci", "docs", "race"):
+            self.setup_reconcile(self.pr)
+            if case == "ci":
+                self.r.ci.return_value = False
+            if case == "docs":
+                self.r.check_changes.return_value = False
+            if case == "race":
+                self.r.current_main.side_effect = [A, C]
+            with patch.object(release, "api", return_value={"login": "release-bot"}) as api, \
+                    patch.object(release, "pages", return_value=self.published):
+                self.r.reconcile()
+            self.assertEqual(api.call_count, 1)
+            self.r.create_version_commit.assert_not_called()
+
+    def test_protection_or_changed_head_prevents_merge(self):
+        for changes in ({"mergeable_state": "blocked"}, {"head": dict(self.pr["head"], sha=C)},
+                        {"labels": [{"name": "release:hold"}]}, {"draft": True}):
+            self.setup_reconcile(self.pr)
+            live = dict(self.pr, state="open", draft=False, mergeable_state="clean")
+            live.update(changes)
+            with patch.object(release, "api", side_effect=[{"login": "release-bot"}, live]) as api, \
+                    patch.object(release, "pages", return_value=self.published):
+                if "mergeable_state" in changes:
+                    with self.assertRaises(release.ReleaseError):
+                        self.r.reconcile()
+                else:
+                    self.r.reconcile()
+            self.assertEqual(api.call_count, 2)
+
+    def test_interrupted_branch_push_is_recovered_only_for_signed_automation_commit(self):
+        for verified in (True, False):
+            self.setup_reconcile()
+            data = {"author": {"login": "release-bot"}, "commit": {
+                "verification": {"verified": verified},
+                "message": f"chore(release): bump version to 0.2.39\n\n{release.MARKER}"}}
+            with patch.object(release, "api", side_effect=[{"login": "release-bot"}, data, self.pr]) as api, \
+                    patch.object(release, "pages", side_effect=[self.published, [{
+                        "ref": "refs/heads/release/v0.2.39", "object": {"sha": B}}]]):
+                if verified:
+                    self.r.reconcile()
+                    self.assertEqual(api.call_args.args[:2], ("pulls", "POST"))
+                else:
+                    with self.assertRaises(release.ReleaseError):
+                        self.r.reconcile()
+                    self.assertEqual(api.call_count, 2)
+            self.r.create_version_commit.assert_not_called()
+
+    def test_release_signs_only_checked_merge_commit_and_dispatches_once(self):
+        self.r.git = Mock(return_value=f"{A}\0fix: newer dependency edit\n{C}\0chore(release): bump version to 0.2.39 (#10)")
+        self.r.version_at = Mock(return_value="0.2.39")
+        self.r.verify_version_diff = Mock(return_value=A)
+        self.r.ci = Mock(return_value=True)
+        self.r.script = Mock(return_value=C)
+        self.r.release_runs = Mock(return_value=[])
+        pr = dict(self.pr, merged=True, merge_commit_sha=C)
+        with patch.object(release, "api", return_value=pr), \
+                patch.object(release, "pages", return_value=[]), patch.object(release, "run") as run:
+            self.assertTrue(self.r.finish_release("0.2.39", self.published))
+        self.r.git.assert_any_call("-c", "tag.gpgSign=true", "tag", "-s", "v0.2.39", C, "-m", "v0.2.39")
+        self.r.git.assert_any_call("verify-tag", "v0.2.39")
+        self.r.script.assert_any_call("verify-release-tag.sh", "--repo", release.REPO,
+                                      "--tag", "v0.2.39", "--commit", C)
+        run.assert_called_once_with("gh", "workflow", "run", "release.yml", "--repo", release.REPO,
+                                    "--ref", "main", "-f", "tag=v0.2.39")
+
+    def test_rejected_tag_signature_prevents_dispatch(self):
+        self.r.git = Mock(return_value=f"{C}\0chore(release): bump version to 0.2.39 (#10)")
+        self.r.version_at = Mock(return_value="0.2.39")
+        self.r.verify_version_diff = Mock(return_value=A)
+        self.r.ci = Mock(return_value=True)
+        self.r.script = Mock(side_effect=[None, release.ReleaseError("signature rejected")])
+        pr = dict(self.pr, merged=True, merge_commit_sha=C)
+        with patch.object(release, "api", return_value=pr), \
+                patch.object(release, "pages", return_value=[{"ref": "refs/tags/v0.2.39"}]), \
+                patch.object(release, "run") as run, self.assertRaises(release.ReleaseError):
+            self.r.finish_release("0.2.39", self.published)
+        run.assert_not_called()
+
+    def test_post_merge_pending_ci_cannot_sign(self):
+        self.r.git = Mock(return_value=f"{A}\0fix: update dependencies\n{C}\0chore(release): bump version to 0.2.39 (#10)")
+        self.r.version_at = Mock(return_value="0.2.39")
+        self.r.verify_version_diff = Mock(return_value=A)
+        self.r.ci = Mock(return_value=False)
+        pr = dict(self.pr, merged=True, merge_commit_sha=C)
+        with patch.object(release, "api", return_value=pr), patch.object(release, "run") as run:
+            self.assertTrue(self.r.finish_release("0.2.39", self.published))
+            run.assert_not_called()
+        self.assertFalse(any(call.args[0] == "push" for call in self.r.git.call_args_list))
+
+    def test_existing_signed_tag_active_and_failed_builds_never_redispatch(self):
+        for status in ("in_progress", "completed"):
+            self.r.git = Mock(return_value=f"{C}\0chore(release): bump version to 0.2.39 (#10)")
+            self.r.version_at = Mock(return_value="0.2.39")
+            self.r.verify_version_diff = Mock(return_value=A)
+            self.r.ci = Mock(return_value=True)
+            self.r.script = Mock(return_value=C)
+            self.r.release_runs = Mock(return_value=[{"status": status, "html_url": "run/42"}])
+            pr = dict(self.pr, merged=True, merge_commit_sha=C)
+            with patch.object(release, "api", return_value=pr), \
+                    patch.object(release, "pages", return_value=[{"ref": "refs/tags/v0.2.39"}]), \
+                    patch.object(release, "run") as run:
+                if status == "completed":
+                    with self.assertRaises(release.ReleaseError):
+                        self.r.finish_release("0.2.39", self.published)
+                else:
+                    self.r.finish_release("0.2.39", self.published)
+                run.assert_not_called()
+            self.assertFalse(any(call.args[0] == "push" for call in self.r.git.call_args_list))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_auto_release_boundary.py
+++ b/scripts/tests/test_auto_release_boundary.py
@@ -1,0 +1,281 @@
+"""Production CLI proof with real Git/signing/gh and a local GitHub service.
+
+No production credential, repository, release or service is touched. Only the
+GitHub API is a fixture; the CLI, existing verification scripts, Git transport,
+tag signature verification, gh JSON queries and dispatch HTTP request are real.
+"""
+
+import http.server
+import json
+import os
+from pathlib import Path
+import shutil
+import socketserver
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from urllib.parse import parse_qs, urlsplit
+
+ROOT = Path(__file__).resolve().parents[2]
+REPO = "openclaw/ocm"
+MARKER = "<!-- ocm-auto-release:v1 -->"
+JOBS = ("Format", "Rust 1.88 minimum", "Windows compile",
+        "Test (ubuntu-latest)", "Test (macos-latest)")
+
+
+class ReleaseBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        for tool in ("git", "gh", "ssh-keygen", "cargo", "perl"):
+            self.assertIsNotNone(shutil.which(tool), f"Boundary proof requires {tool}")
+        directory = tempfile.TemporaryDirectory(prefix="ocm-release-boundary-")
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+        self.repo = self.root / "checkout"
+        self.repo.mkdir()
+        self.remote = self.root / "remote.git"
+        # Deliberate environment allowlist: never inherit tokens or credentials.
+        self.env = {key: os.environ[key] for key in ("PATH", "HOME", "TMPDIR")
+                    if key in os.environ}
+        self.env.update(GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL=os.devnull,
+                        GH_CONFIG_DIR=str(self.root / "gh"), GH_PROMPT_DISABLED="1",
+                        GH_ENTERPRISE_TOKEN="inert-loopback-fixture",
+                        OCM_GH_BIN=shutil.which("gh"))
+        self.command("git", "init", "--bare", str(self.remote))
+        self.git("init", "-b", "main")
+        self.git("config", "user.name", "Release Fixture")
+        self.git("config", "user.email", "fixture@example.invalid")
+        key = self.root / "signer"
+        self.command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key))
+        allowed = self.root / "allowed-signers"
+        allowed.write_text("fixture@example.invalid " + key.with_suffix(".pub").read_text())
+        self.git("config", "gpg.format", "ssh")
+        self.git("config", "user.signingkey", str(key))
+        self.git("config", "gpg.ssh.allowedSignersFile", str(allowed))
+        self.git("remote", "add", "origin", f"https://github.com/{REPO}.git")
+        self.git("config", f"url.{self.remote.as_uri()}.insteadOf", f"https://github.com/{REPO}.git")
+        scripts = self.repo / "scripts"
+        scripts.mkdir()
+        for name in ("auto-release.py", "verify-release-tag.sh", "verify-release-ci.sh",
+                     "read-package-version.sh", "validate-version.sh", "update-version.sh"):
+            shutil.copy2(ROOT / "scripts" / name, scripts / name)
+        (self.repo / "src").mkdir()
+        (self.repo / "src/main.rs").write_text("fn main() {}\n")
+        self.version("0.2.37")
+        self.commit("fixture base")
+        self.version("0.2.38")
+        self.base = self.commit("chore(release): bump version to 0.2.38 (#1)")
+        self.git("tag", "-s", "v0.2.38", "-m", "v0.2.38")
+        (self.repo / "src/main.rs").write_text('fn main() { println!("fix"); }\n')
+        self.product = self.commit("fix: eligible product change")
+        self.prs = {1: self.release_pr(1, "0.2.38", self.base)}
+        self.closed = []
+        self.requests = []
+        self.effects = []
+        self.dispatched = False
+        self.api_errors = []
+        self.serve()
+
+    def command(self, *args, check=True):
+        result = subprocess.run(args, cwd=self.repo, env=self.env, text=True,
+                                capture_output=True, timeout=60)
+        if check:
+            self.assertEqual(result.returncode, 0, result.stderr)
+        return result
+
+    def git(self, *args):
+        return self.command("git", *args).stdout.strip()
+
+    def version(self, version):
+        (self.repo / "Cargo.toml").write_text(
+            f'[package]\nname = "ocm"\nversion = "{version}"\nedition = "2024"\n')
+        (self.repo / "Cargo.lock").write_text(
+            f'version = 4\n\n[[package]]\nname = "ocm"\nversion = "{version}"\n')
+
+    def commit(self, title):
+        self.git("add", ".")
+        self.git("commit", "-m", title)
+        return self.git("rev-parse", "HEAD")
+
+    def release_pr(self, number, version, sha, automated=True):
+        return {"number": number, "user": {"login": "release-bot" if automated else "maintainer"},
+                "body": MARKER if automated else "Manual release", "merged": True,
+                "state": "closed", "merged_at": "2026-01-01T00:00:00Z",
+                "base": {"ref": "main"}, "head": {"ref": f"release/v{version}",
+                "sha": sha, "repo": {"full_name": REPO}}, "merge_commit_sha": sha,
+                "title": f"chore(release): bump version to {version}"}
+
+    def serve(self):
+        fixture = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass  # Never log request headers (including inert authentication).
+
+            def respond(self):
+                path = urlsplit(self.path)
+                body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+                payload = json.loads(body) if body else None
+                fixture.requests.append((self.command, path.path))
+                if self.command != "GET":
+                    fixture.effects.append((self.command, path.path, payload))
+                try:
+                    result = fixture.route(path.path, parse_qs(path.query), self.command, payload)
+                    data = json.dumps(result).encode() if result is not None else b""
+                    self.send_response(200 if data else 204)
+                except Exception as error:
+                    fixture.api_errors.append(str(error))
+                    data = b'{"message":"unexpected fixture request"}'
+                    self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            do_GET = respond
+            do_POST = respond
+            do_PUT = respond
+
+        # gh's documented Unix-socket transport cannot connect to public GitHub.
+        # Keep the pathname short enough for macOS's sockaddr_un limit.
+        socket_dir = tempfile.TemporaryDirectory(prefix="ocm-gh-", dir="/tmp")
+        self.addCleanup(socket_dir.cleanup)
+        socket_path = str(Path(socket_dir.name) / "api.sock")
+        server = socketserver.ThreadingUnixStreamServer(socket_path, Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        self.env["GH_HOST"] = "release-fixture.invalid"
+        self.command("gh", "config", "set", "http_unix_socket", socket_path)
+
+    def route(self, path, query, method, payload):
+        prefix = f"/api/v3/repos/{REPO}"
+        if path == "/api/v3/user":
+            return {"login": "release-bot"}
+        if path == "/api/v3/meta":
+            return {"installed_version": "3.16.0"}
+        self.assertTrue(path.startswith(prefix), f"Unexpected API route: {path}")
+        endpoint = path[len(prefix):].strip("/")
+        if endpoint == "":
+            return {"default_branch": "main", "full_name": REPO}
+        if endpoint == "releases":
+            return [{"tag_name": "v0.2.38", "draft": False, "prerelease": False}]
+        if endpoint == "git/ref/heads/main":
+            return {"object": {"sha": self.head, "type": "commit"}}
+        if endpoint.startswith("git/ref/tags/"):
+            tag = endpoint.removeprefix("git/ref/tags/")
+            return {"object": {"type": "tag", "sha": self.git("--git-dir", str(self.remote),
+                                                               "rev-parse", f"refs/tags/{tag}")}}
+        if endpoint.startswith("git/tags/"):
+            obj = endpoint.removeprefix("git/tags/")
+            tag = next(line[4:] for line in self.git("cat-file", "-p", obj).splitlines()
+                       if line.startswith("tag "))
+            verified = self.command("git", "verify-tag", obj, check=False).returncode == 0
+            return {"tag": tag, "object": {"type": "commit", "sha": self.git("rev-parse", obj + "^{}")},
+                    "verification": {"verified": verified}}
+        if endpoint.startswith("git/matching-refs/"):
+            prefix_ref = "refs/" + endpoint.removeprefix("git/matching-refs/")
+            refs = self.git("--git-dir", str(self.remote), "for-each-ref", "--format=%(refname) %(objectname)")
+            return [{"ref": name, "object": {"sha": sha}} for name, sha in
+                    (line.split() for line in refs.splitlines()) if name.startswith(prefix_ref)]
+        if endpoint.startswith("compare/"):
+            base, head = endpoint.removeprefix("compare/").split("...")
+            self.git("merge-base", "--is-ancestor", base, head)
+            return {"status": "identical" if base == head else "ahead"}
+        if endpoint.startswith("commits/") and endpoint.endswith("/pulls"):
+            sha = endpoint.split("/")[1]
+            return [pr for pr in self.prs.values() if pr["merge_commit_sha"] == sha]
+        if endpoint == "pulls":
+            if method == "GET":
+                return self.closed if query.get("state") == ["closed"] else []
+            raise AssertionError("Unexpected PR creation")
+        if endpoint.startswith("pulls/"):
+            self.assertEqual(method, "GET", "Unexpected PR mutation")
+            return self.prs[int(endpoint.split("/")[1])]
+        if endpoint == "actions/workflows/ci.yml/runs":
+            return {"workflow_runs": [{"id": 1, "head_sha": query["head_sha"][0],
+                    "head_branch": "main", "event": "push", "head_repository": {"full_name": REPO},
+                    "status": "completed", "conclusion": "success",
+                    "html_url": f"https://github.com/{REPO}/actions/runs/1"}]}
+        if endpoint == "actions/runs/1/jobs":
+            return {"total_count": len(JOBS), "jobs": [{"name": name, "conclusion": "success"} for name in JOBS]}
+        if endpoint == "actions/workflows/release.yml/runs":
+            return {"workflow_runs": ([{"display_title": "Release v0.2.39", "head_branch": "main",
+                    "head_repository": {"full_name": REPO}, "status": "in_progress"}] if self.dispatched else [])}
+        if endpoint == "actions/workflows/release.yml":
+            return {"id": 2, "name": "Release", "path": ".github/workflows/release.yml", "state": "active"}
+        if endpoint in {"actions/workflows/2/dispatches", "actions/workflows/release.yml/dispatches"}:
+            self.assertEqual(method, "POST")
+            self.assertEqual(payload, {"ref": "main", "inputs": {"tag": "v0.2.39"}})
+            self.dispatched = True
+            return None
+        raise AssertionError(f"Unhandled fixture route: {endpoint}")
+
+    def publish_fixture_main(self):
+        self.head = self.git("rev-parse", "HEAD")
+        self.git("push", "origin", "main", "--tags")
+
+    def cli(self):
+        result = self.command(sys.executable, "-B", "scripts/auto-release.py", check=False)
+        self.assertEqual(self.api_errors, [], self.api_errors)
+        return result
+
+    def refs(self):
+        return self.git("--git-dir", str(self.remote), "show-ref")
+
+    def test_automated_merge_signs_exact_commit_pushes_and_dispatches_once(self):
+        self.version("0.2.39")
+        target = self.commit("chore(release): bump version to 0.2.39 (#2)")
+        self.prs[2] = self.release_pr(2, "0.2.39", target)
+        self.publish_fixture_main()
+        result = self.cli()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Dispatched existing signed-release workflow", result.stdout)
+        self.assertEqual(self.git("--git-dir", str(self.remote), "rev-parse", "v0.2.39^{}"), target)
+        self.git("verify-tag", "v0.2.39")
+        self.assertEqual(len(self.effects), 1, self.effects)
+        first_refs = self.refs()
+        retry = self.cli()
+        self.assertEqual(retry.returncode, 0, retry.stderr)
+        self.assertIn("Release build already running", retry.stdout)
+        self.assertEqual(self.refs(), first_refs)
+        self.assertEqual(len(self.effects), 1, "Retry must not dispatch again")
+
+    def test_manual_merge_has_no_sign_push_or_dispatch_effect(self):
+        self.version("0.2.39")
+        target = self.commit("chore(release): bump version to 0.2.39 (#2)")
+        self.prs[2] = self.release_pr(2, "0.2.39", target, automated=False)
+        self.publish_fixture_main()
+        before = self.refs()
+        result = self.cli()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("manually owned", result.stderr)
+        self.assertEqual(self.refs(), before)
+        self.assertEqual(self.git("tag", "--list", "v0.2.39"), "")
+        self.assertEqual(self.effects, [])
+
+    def test_closed_proposal_with_deleted_branch_is_not_recreated(self):
+        self.closed = [{"number": 2, "state": "closed", "merged": False}]
+        self.publish_fixture_main()
+        before = self.refs()
+        result = self.cli()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("proposal was closed", result.stderr)
+        self.assertEqual(self.refs(), before)
+        self.assertEqual(self.git("tag", "--list", "v0.2.39"), "")
+        self.assertEqual(self.effects, [])
+
+    def test_closed_proposal_with_retained_branch_is_not_recreated(self):
+        self.git("checkout", "-b", "release/v0.2.39")
+        self.version("0.2.39")
+        self.git("add", "Cargo.toml", "Cargo.lock")
+        self.git("commit", "-S", "-m", "chore(release): bump version to 0.2.39", "-m", MARKER)
+        self.git("push", "origin", "release/v0.2.39")
+        self.git("checkout", "main")
+        self.test_closed_proposal_with_deleted_branch_is_not_recreated()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Connect merged OCM fixes to the existing signed release pipeline, so a landed fix does not remain unavailable to `ocm self update` indefinitely.

- Reconcile after CI/Release completion, plus an hourly recovery check and manual dispatch.
- Create one version-only release PR, require exact current-main and PR CI, squash the pinned head through normal branch protection, then wait for exact post-merge CI before signing and dispatching the existing release workflow.
- Default to patch releases; skip docs-only intervals and require an explicit minor/major selection for declared breaking changes.
- Serialize version allocation, use exact branch leases, preserve manually owned release PRs, recover interrupted branch creation, and never move tags or overwrite public releases.
- Keep `release.yml`, signed-tag verification, CI verification, macOS signing/notarization and complete-asset publication unchanged.

## Verification

- `python3 -B -m unittest discover -s scripts/tests -p 'test_auto_release*.py' -v`: **27 passed**. Includes real Git version-file fixtures, CI failures/skips/wrong-head/fork rejection, branch races, manual ownership, pinned merges, interrupted push recovery and dispatch/signature failure boundaries.
- `cargo test --locked --test release_script_tests --test release_asset_tests`: 31 passed.
- actionlint v1.7.12: changed workflows pass.
- `git diff --check`: clean.

No live release was published by these tests.

### Review fixes and production-boundary proof

Head `a08b692` addresses both findings on `5347382`:

- P1: `finish_release` rejects a merged manual version PR before invoking CI/signing/tag push/dispatch unless its author is the configured automation identity and its body retains the automation marker.
- P2: before creating or adopting a version branch, query closed PR history for that exact version branch. Deliberately closed proposals require explicit reopening or a different version; deleting the old branch cannot evade the check.

`scripts/tests/test_auto_release_boundary.py` executes the **production Python CLI as a subprocess**, the **unchanged release-tag and CI verification scripts**, **real Git** against a temporary bare remote, **real SSH tag signatures**, and the **installed gh executable**, including its JSON queries and workflow-dispatch HTTP request. Only GitHub's service responses are a fixture, reached over gh's documented Unix-socket transport; no production credential or network destination is available in that test environment.

Observed effects in four passing subprocess cases:

| Scenario | Git/HTTP effect |
| --- | --- |
| Eligible automation-owned merged version | Signed annotated tag verified cryptographically, pushed to the exact checked commit, exactly one dispatch HTTP request; repeat run neither retags nor redispatches |
| Canonical merged manual version | Exit before signing; no local new tag, remote refs unchanged, zero HTTP writes |
| Deliberately closed proposal, old branch deleted | Exit before recreation; remote refs unchanged, zero HTTP writes |
| Deliberately closed proposal, signed automation branch retained | Same rejection; no replacement PR, merge, tag or dispatch |

All four run in CI's Format job alongside the policy tests. The service fixture computes tag verification from `git verify-tag`; it does not merely report signatures as valid. Full external GitHub publication and production GPG-account setup remain unproven until activation. This evidence belongs to this PR, not the separate atomic-update/checkpoint work.

## Activation

Disabled until the repository variable `OCM_AUTO_RELEASE_ENABLED=true` is set. The current repository does not have an unattended release identity configured. A maintainer must configure the repository-scoped `OCM_RELEASE_TOKEN`, `OCM_RELEASE_GPG_PRIVATE_KEY`, and optional `OCM_RELEASE_GPG_PASSPHRASE` through protected GitHub Actions settings. The public GPG key must be registered with the release account. The ordinary workflow token remains read-only; the separate account token is required for generated PR/merge events to start the existing CI protocol.

The setup, recovery, version-selection and pause procedure is in `docs/AUTOMATIC_RELEASES.md`. No credentials, branch protection, production runtime, scheduler or atomic-update/checkpoint code was changed.

## Scope

This is release orchestration only. OCM checkpoint fix #152 is already merged; open atomic-update PRs #146 and #151 remain independently owned and are not modified by this change.
