### PR TITLE
chore(release): bump version to 0.2.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.38"
+version = "0.2.39"
 edition = "2024"
 rust-version = "1.88"
 description = "OpenClaw Manager: the local control plane for isolated OpenClaw environments, launchers, runtimes, and services."


### PR DESCRIPTION
## Release

Prepare OCM v0.2.39 using the existing manual signed-release flow.

- Change only the OCM package version in Cargo.toml and Cargo.lock.
- Include the already-merged APFS checkpoint service-log fix from #152.
- Include the already-merged automatic-release implementation from #153. Recurring automatic releases remain disabled until their dedicated identity is configured.

## Verification

- Exact current-main CI passed at 9d8845c7efe35d5130eb8afd072b99d68204860c.
- Version-only diff and cargo fmt checks passed.
- Local wrapper and daemon test failures caused by missing or mismatched tool paths were resolved without source changes.
- Two local upgrade tests encountered an installed-pnpm collision. The same failure reproduced on unchanged main; both tests passed after isolating Node from pnpm on PATH.
- Full hosted PR CI is required before squash merge. Exact post-merge main CI is required before signing or publication.

After squash merge and main CI, sign v0.2.39 with the established release identity, run the unchanged release verifiers, and dispatch release.yml. Existing Foundation Apple signing and notarization credentials remain unchanged. No runtime deployment or scheduler change is part of this release task.
