### PR TITLE
docs: document OCM contributor and agent workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+OCM is the Rust CLI for managing OpenClaw environments, runtimes, launchers, and
+services. Read [README.md](README.md) for the product workflow and
+[CONTRIBUTING.md](CONTRIBUTING.md) for setup, checks, and pull requests.
+`AGENTS.md` is canonical; `CLAUDE.md` is a relative symlink to this file.
+
+## Working in this repository
+
+- Inspect `git status -sb` before edits. Preserve unrelated changes and use a
+  task-owned branch or worktree.
+- Read the affected source and tests before changing behavior. CLI handlers and
+  rendering live in `src/cli/`; environment, runtime, service, and store behavior
+  live in their corresponding `src/` modules.
+- Use Cargo and the Rust version declared in `Cargo.toml`. Keep `Cargo.lock`
+  changes scoped to intentional dependency or version changes.
+- Use `cargo fmt --check`, `cargo check --workspace --all-targets --locked`, and
+  focused tests such as `cargo test --locked --test cli_invocation_tests`.
+  [CI](.github/workflows/ci.yml) defines the full platform checks.
+- Reuse `TestDir`, `ocm_env`, and the service fixtures in
+  [tests/support/mod.rs](tests/support/mod.rs). Keep test homes, OCM state, and
+  subprocesses isolated from installed environments and services.
+- Follow the [PR template](.github/pull_request_template.md). Describe the
+  problem, solution, impact, and actual proof; identify checks not run.
+
+## Safety and releases
+
+- Do not commit credentials, private configuration, checkpoint contents, or
+  personal machine details. Use synthetic fixtures and redact public evidence.
+- Do not stop, restart, migrate, or clean up a real OCM/OpenClaw environment
+  without explicit operator approval.
+- Code-change or merge authority does not authorize a version bump, signed tag,
+  release publication, or changes to release credentials and automation.
+- Follow [release prerequisites](docs/RELEASING.md) and
+  [automatic releases](docs/AUTOMATIC_RELEASES.md) for authorized release work.
+  Preserve the signed-tag, CI, and macOS signing/notarization checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to OCM
+
+Start with [README.md](README.md) for OCM's workflow and
+[docs/USAGE.md](docs/USAGE.md) for command behavior. Keep changes focused on one
+problem and include enough context to reproduce it.
+
+## Development and checks
+
+Install Rust 1.88 or newer, Cargo, and rustfmt. The minimum supported version is
+declared in [Cargo.toml](Cargo.toml); [CI](.github/workflows/ci.yml) checks that
+version and Windows compilation, and runs tests on stable Rust on Linux and
+macOS.
+
+Run these checks from the repository root:
+
+```sh
+cargo fmt --check
+cargo check --workspace --all-targets --locked
+cargo test --locked
+```
+
+For a focused integration test, use its filename without `.rs`:
+
+```sh
+cargo test --locked --test cli_invocation_tests
+```
+
+CI also checks installation into a temporary prefix. To reproduce that smoke
+check without replacing an installed `ocm`:
+
+```sh
+install_root="$(mktemp -d)"
+cargo install --locked --path . --root "$install_root"
+"$install_root/bin/ocm" --version
+```
+
+Tests use [tests/support/mod.rs](tests/support/mod.rs) for temporary directories,
+isolated `HOME` and `OCM_HOME`, and service fixtures. Reuse those helpers; do not
+point tests at a real environment or service. Manual state-changing experiments
+also need isolated state and must not disturb an operator's running services.
+Keep credentials, private configuration, and checkpoint data out of fixtures
+and public logs.
+
+For automatic-release script changes, the additional Python test command and
+its prerequisites are in [docs/AUTOMATIC_RELEASES.md](docs/AUTOMATIC_RELEASES.md).
+
+## Issues and pull requests
+
+Check existing issues and pull requests before starting overlapping work. Bug
+reports should include the OCM version, OS, reproducing steps, expected behavior,
+and actual behavior, with secrets and personal paths removed.
+
+Use the [PR template](.github/pull_request_template.md) and keep **Allow edits
+from maintainers** enabled. Titles use `type: description`, with an optional
+scope when useful, such as `fix(auth): ...`. Accepted types are `feat`, `fix`,
+`improve`, `refactor`, `docs`, and `chore`. Link a fixed issue with `Closes #123`.
+Explain user impact and provide relevant tests or other evidence, including
+limitations. Required CI must pass before merging.
+
+## Release work
+
+Release preparation and publication are separate from ordinary contributions.
+Do not bump versions, publish releases, or change signing credentials or
+automation without explicit maintainer authorization. Follow
+[docs/RELEASING.md](docs/RELEASING.md) and
+[docs/AUTOMATIC_RELEASES.md](docs/AUTOMATIC_RELEASES.md); preserve the existing
+signed-release and macOS signing/notarization safeguards.
+
+Coding agents should also read [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
## What Problem This Solves

OCM contributors and coding agents lack a repository entry point for the existing Rust checks, isolated test fixtures, and release-safety boundaries.

## Why This Change Was Made

Add concise contributor and agent guidance based on the current Cargo manifest, CI workflow, test helpers, PR template, and release documentation. `AGENTS.md` is canonical, with `CLAUDE.md` as a relative symlink.

This is documentation-only. It does not change runtime behavior, CI or branch protection, release automation, signing credentials, or distribution.

## User Impact

Contributors can find the supported commands and PR expectations without reconstructing them from CI. Agents receive the same guidance and explicit boundaries around live state and releases. No end-user behavior changes.

## Evidence

- Verified Rust minimum, check commands, installation smoke command, focused test target, and fixture helpers against current source.
- All Markdown links resolve; `CLAUDE.md` resolves to `AGENTS.md` with Git mode `120000`.
- `git diff --cached --check` passed.
- No local Rust suite was run for this documentation-only change. Existing required hosted CI must pass on the exact PR head before merge.
