### PR TITLE
chore(deps): configure weekly dependency update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What Problem This Solves

OCM has no checked-in schedule for dependency update proposals for its Cargo dependencies and GitHub Actions.

## Why This Change Was Made

Configure Dependabot version 2 with separate weekly Cargo and GitHub Actions checks at the repository root, each limited to five open version-update PRs.

The only changed file is `.github/dependabot.yml`. This PR includes no dependency upgrades and adds no auto-merge behavior, npm configuration, release changes, or repository protection changes.

## User Impact

Maintainers receive bounded dependency update proposals for review. Merging the configuration may trigger an initial dependency check and new proposal PRs; those proposals are outside this change. The five-PR limit applies to version updates, not security updates.

## Evidence

- YAML parsed and compared with the exact approved two-ecosystem configuration.
- Options checked against GitHub's official Dependabot options reference.
- `git diff --cached --check` passed.
- No local Rust suite was run for this configuration-only change. Existing required hosted CI must pass on the exact PR head before merge.
