### PR TITLE
feat: prepare crates.io publishing and Homebrew-safe upgrades

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,109 @@
+name: Publish crate
+run-name: Publish crate ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Signed tag with an already published binary release
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: publish-crate-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    name: Verify and package crate
+    if: >-
+      github.repository == 'openclaw/ocm' &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'openclaw/ocm/.github/workflows/publish-crate.yml@refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.verify.outputs.source }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          path: trusted
+          persist-credentials: false
+      - name: Verify signed source, package identity, published release, and CI
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          source="$(./trusted/scripts/verify-crate-release.sh "$RELEASE_REPO" "$RELEASE_TAG")"
+          printf 'source=%s\n' "$source" >>"$GITHUB_OUTPUT"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.verify.outputs.source }}
+          path: release-source
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: 1.88.0
+      - name: Verify crate contents and build without publishing
+        working-directory: release-source
+        run: |
+          cargo package --list --locked --package openclawocm
+          cargo publish --dry-run --locked --package openclawocm --registry crates-io
+
+  publish:
+    name: Publish verified crate
+    needs: verify
+    if: >-
+      github.repository == 'openclaw/ocm' &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'openclaw/ocm/.github/workflows/publish-crate.yml@refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          path: trusted
+          persist-credentials: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.verify.outputs.source }}
+          path: release-source
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: 1.88.0
+      - name: Revalidate immediately before registry authentication
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_COMMIT: ${{ needs.verify.outputs.source }}
+        run: |
+          ./trusted/scripts/verify-crate-release.sh "$RELEASE_REPO" "$RELEASE_TAG" "$RELEASE_COMMIT"
+          test "$(git -C release-source rev-parse HEAD)" = "$RELEASE_COMMIT"
+          git -C release-source diff --exit-code HEAD
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
+      - name: Publish openclawocm
+        working-directory: release-source
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked --package openclawocm --registry crates-io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to OCM are documented here.
 
 ### Added
 
+- Prepare the `openclawocm` Cargo package and manual crates.io trusted publishing
+  from verified signed releases, while preserving the `ocm` command and library.
 - Let `runtime build-local` assemble repeatable, commit-matched official companion plugins through OpenClaw's release packaging contract, stage them as trusted runtime-owned bundled plugins with isolated dependencies, and record artifact and entrypoint hashes for verification.
 
 ### Changed
@@ -28,6 +30,8 @@ All notable changes to OCM are documented here.
 
 ### Fixed
 
+- Refuse mutating `ocm self update` for Homebrew-owned executables and direct
+  users to `brew upgrade openclaw/tap/ocm`; keep release checks available.
 - Keep unrelated supervised gateways on their persisted child specifications when an environment is destroyed, removed, or pruned, so latent metadata or process-environment drift cannot restart sibling gateways during cleanup.
 - Resolve `TMPDIR` from the live OCM daemon whenever a gateway is spawned, create a daemon-scoped private temporary directory, and fall back to a private directory under `/tmp` instead of persisting a per-login path across reboots.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
-name = "ocm"
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openclawocm"
 version = "0.2.39"
 dependencies = [
  "base64",
@@ -576,12 +582,6 @@ dependencies = [
  "xattr",
  "zip",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ocm"
+name = "openclawocm"
 version = "0.2.39"
 edition = "2024"
 rust-version = "1.88"
@@ -10,6 +10,14 @@ repository = "https://github.com/openclaw/ocm"
 homepage = "https://github.com/openclaw/ocm"
 keywords = ["openclaw", "cli", "manager", "environment", "service"]
 categories = ["command-line-utilities", "development-tools"]
+
+[lib]
+name = "ocm"
+path = "src/lib.rs"
+
+[[bin]]
+name = "ocm"
+path = "src/main.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Use `ocm` when you want:
 
 ## Install
 
+Install with Homebrew on macOS (Apple Silicon or Intel) or Linux x86_64:
+
+```bash
+brew install openclaw/tap/ocm
+```
+
+Upgrade Homebrew installations with `brew upgrade openclaw/tap/ocm`, not
+`ocm self update`. The initial Homebrew package, v0.2.39, does not yet enforce this
+restriction; the next OCM release will refuse to overwrite a Homebrew-managed
+executable. `ocm self update --check` remains available.
+
 Install the latest release:
 
 ```bash
@@ -50,7 +61,7 @@ Install a specific release:
 curl -fsSL https://github.com/openclaw/ocm/releases/download/v<ocm-version>/install.sh | bash -s -- --version v<ocm-version>
 ```
 
-Update an existing install:
+Update an installer-managed install:
 
 ```bash
 ocm self update
@@ -64,6 +75,12 @@ cargo install --locked --path .
 ```
 
 Source installs require Rust 1.88 or newer. Release installers verify the selected archive against the published `SHA256SUMS` before extraction.
+
+The crates.io package is prepared as `openclawocm`, but is not yet published.
+After the first crate release, `cargo install --locked openclawocm` will install
+the same `ocm` command. The existing crates.io package named `ocm` is unrelated.
+See [release prerequisites](docs/RELEASING.md#cratesio) for the initial publication
+and trusted-publisher setup.
 
 Inside this repo, use the development wrapper:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -28,3 +28,96 @@ References:
 - [Apple: Packaging Mac software for distribution](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution)
 - [Apple: Code Signing Tasks](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html)
 - [GitHub: Installing an Apple certificate on macOS runners](https://docs.github.com/actions/how-tos/deploy/deploy-to-third-party-platforms/sign-xcode-applications)
+
+## Homebrew
+
+The formula in [openclaw/homebrew-tap](https://github.com/openclaw/homebrew-tap)
+uses the published, checksummed release archives for macOS ARM64, macOS x86_64,
+and Linux x86_64. The tap's existing scheduled reconciliation discovers stable
+releases; OCM does not need a cross-repository publishing token or dispatch hook.
+Do not add Linux ARM64 until the release workflow publishes and tests that target.
+
+Homebrew owns upgrades to its installed executable. Use
+`brew upgrade openclaw/tap/ocm`; `ocm self update --check` can still inspect release
+availability. The initial formula installs v0.2.39, which predates the ownership
+guard. The guard takes effect only after the next approved OCM release reaches
+the tap, not when this source change merges.
+
+## crates.io
+
+The Cargo package is `openclawocm`; the executable and library remain `ocm`.
+The registry's existing `ocm` crate is unrelated. Renaming this package does not
+publish it or change its version. Historical binary-release verification accepts
+both package names, but crate publication requires `openclawocm`.
+
+`.github/workflows/publish-crate.yml` is manual-only. Dispatch it on `main` after
+the complete binary release for the **same signed tag** has been published.
+It verifies the canonical repository, signed tag, protected-main ancestry,
+version PR, package identity, published release, and exact-SHA CI. A job without
+OIDC permission packages and builds the crate with `cargo publish --dry-run`;
+the publishing job revalidates the release before obtaining its short-lived
+registry token. The existing binary-release and automatic-release workflows
+do not dispatch crate publication.
+
+### Initial publication and ownership
+
+Trusted publishing cannot create a new crate: crates.io requires an API token
+for the first publication. This is a separate, explicitly approved release step.
+Do not publish the existing v0.2.39 tag: its package name is still `ocm`.
+
+1. Select the next approved signed release that includes the `openclawocm`
+   package, and complete its binary release first.
+2. From an up-to-date, trusted `main` checkout, verify that tag and create a
+   separate checkout of the returned commit:
+
+   ```bash
+   tag=v<approved-version>
+   source="$(./scripts/verify-crate-release.sh openclaw/ocm "$tag")"
+   git worktree add --detach ../ocm-crate-release "$source"
+   cd ../ocm-crate-release
+   cargo package --list --locked --package openclawocm
+   cargo publish --dry-run --locked --package openclawocm --registry crates-io
+   ```
+
+3. A maintainer with a verified crates.io account must authenticate locally with
+   a short-lived publish API token, then run
+   `cargo publish --locked --package openclawocm --registry crates-io` from that
+   verified checkout. Do not add the bootstrap token as a repository secret.
+4. Verify the published version and add the intended OpenClaw maintainers or
+   GitHub team as crate owners. Confirm the actual team slug and membership
+   before using `cargo owner --add github:openclaw:<team-slug> openclawocm`.
+   Keep an individual owner who can administer ownership; team owners have
+   more limited permissions. Do not remove the bootstrap owner before the new
+   owners have accepted and verified access.
+
+### Trusted publisher settings
+
+In the `openclawocm` crate's **Settings > Trusted Publishing**, add GitHub with:
+
+| Field | Value |
+| --- | --- |
+| Repository owner | `openclaw` |
+| Repository name | `ocm` |
+| Workflow filename | `publish-crate.yml` |
+| Environment | `crates-io` |
+
+The GitHub repository environment `crates-io` must allow deployment from the
+`main` **branch only**, not arbitrary branches or tags. Preserve any existing
+reviewer requirements. The workflow has no long-lived token fallback.
+After the initial publication and ownership/trusted-publisher configuration,
+revoke the bootstrap token.
+
+For each subsequent approved release, publish the binary release first, then:
+
+```bash
+gh workflow run publish-crate.yml --repo openclaw/ocm --ref main -f tag=v<approved-version>
+```
+
+Verify the workflow result and the exact version on crates.io. A failed dispatch
+does not authorize changing the tag, disabling verification, or republishing
+different source under the same version.
+
+References:
+
+- [crates.io trusted publishing](https://crates.io/docs/trusted-publishing)
+- [Cargo publishing and crate ownership](https://doc.rust-lang.org/cargo/reference/publishing.html)

--- a/scripts/auto-release.py
+++ b/scripts/auto-release.py
@@ -214,14 +214,19 @@ class Reconciler:
             raise ReleaseError("Release version must increase")
         # Verify bytes, not just filenames: no dependency or package changes may
         # be smuggled into a PR that this automation can merge.
-        for name in paths:
-            before = self.git("show", f"{parent}:{name}")
-            after = self.git("show", f"{commit}:{name}")
-            pattern = (r'(?m)^(version = ")[^"]+("\s*)$' if name == "Cargo.toml" else
-                       r'(\[\[package\]\]\nname = "ocm"\nversion = ")[^"]+(")')
-            expected, count = re.subn(pattern, lambda m: m[1] + version + m[2], before, count=1)
-            if count != 1 or after != expected:
-                raise ReleaseError("Release PR contains changes beyond the package version")
+        with tempfile.TemporaryDirectory(prefix="ocm-version-diff-") as directory:
+            expected = Path(directory)
+            (expected / "scripts").mkdir()
+            for name in ("update-version.sh", "read-package-version.sh", "validate-version.sh"):
+                target = expected / "scripts" / name
+                target.write_bytes((ROOT / "scripts" / name).read_bytes())
+                target.chmod(0o755)
+            for name in paths:
+                (expected / name).write_text(self.git("show", f"{parent}:{name}"))
+            run(str(expected / "scripts/update-version.sh"), version)
+            for name in paths:
+                if self.git("show", f"{commit}:{name}") != (expected / name).read_text():
+                    raise ReleaseError("Release PR contains changes beyond the package version")
         return parent
 
     def pending(self):

--- a/scripts/read-package-version.sh
+++ b/scripts/read-package-version.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+print_name=0
+if [[ "${1:-}" == "--name" ]]; then
+  print_name=1
+  shift
+fi
 if [[ $# -ne 2 ]]; then
-  echo "Usage: scripts/read-package-version.sh <Cargo.toml> <Cargo.lock>" >&2
+  echo "Usage: scripts/read-package-version.sh [--name] <Cargo.toml> <Cargo.lock>" >&2
   exit 1
 fi
 
@@ -18,7 +23,7 @@ lockfile="$2"
   exit 1
 }
 
-manifest_version="$(
+manifest_data="$(
   perl -0e '
     use strict;
     use warnings;
@@ -33,17 +38,19 @@ manifest_version="$(
     my @names = ($section =~ /^name\s*=\s*"([^"]+)"\s*$/mg);
     my @versions = ($section =~ /^version\s*=\s*"([^"]+)"\s*$/mg);
     die "expected exactly one package name\n" unless @names == 1;
-    die "package name must be ocm\n" unless $names[0] eq "ocm";
+    die "package name must be ocm or openclawocm\n"
+      unless $names[0] eq "ocm" || $names[0] eq "openclawocm";
     die "expected exactly one package version\n" unless @versions == 1;
-    print "$versions[0]\n";
+    print "$names[0] $versions[0]\n";
   ' "$manifest"
 )" || {
-  echo "error: could not read a unique ocm package version from $manifest" >&2
+  echo "error: could not read a unique OCM package version from $manifest" >&2
   exit 1
 }
+read -r package_name manifest_version <<<"$manifest_data"
 
 lock_version="$(
-  perl -0e '
+  OCM_PACKAGE_NAME="$package_name" perl -0e '
     use strict;
     use warnings;
 
@@ -53,21 +60,21 @@ lock_version="$(
     while ($content =~ /(?:\A|\n)\[\[package\]\]\s*\n(.*?)(?=\n\[\[package\]\]\s*\n|\z)/sg) {
       my $block = $1;
       my @names = ($block =~ /^name\s*=\s*"([^"]+)"\s*$/mg);
-      next unless grep { $_ eq "ocm" } @names;
+      next unless grep { $_ eq $ENV{OCM_PACKAGE_NAME} } @names;
       push @matches, $block;
     }
-    die "expected exactly one ocm package record\n" unless @matches == 1;
+    die "expected exactly one matching package record\n" unless @matches == 1;
 
     my $block = $matches[0];
     my @names = ($block =~ /^name\s*=\s*"([^"]+)"\s*$/mg);
     my @versions = ($block =~ /^version\s*=\s*"([^"]+)"\s*$/mg);
-    die "expected one ocm package name\n" unless @names == 1 && $names[0] eq "ocm";
-    die "expected one ocm package version\n" unless @versions == 1;
-    die "ocm package record must be local\n" if $block =~ /^(?:source|checksum)\s*=/m;
+    die "expected one matching package name\n" unless @names == 1 && $names[0] eq $ENV{OCM_PACKAGE_NAME};
+    die "expected one package version\n" unless @versions == 1;
+    die "package record must be local\n" if $block =~ /^(?:source|checksum)\s*=/m;
     print "$versions[0]\n";
   ' "$lockfile"
 )" || {
-  echo "error: could not read a unique local ocm package version from $lockfile" >&2
+  echo "error: could not read a unique local ${package_name} package version from $lockfile" >&2
   exit 1
 }
 
@@ -76,8 +83,12 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 "${script_dir}/validate-version.sh" "$lock_version"
 
 if [[ "$manifest_version" != "$lock_version" ]]; then
-  echo "error: Cargo.toml and Cargo.lock ocm versions do not match" >&2
+  echo "error: Cargo.toml and Cargo.lock ${package_name} versions do not match" >&2
   exit 1
 fi
 
-printf '%s\n' "$manifest_version"
+if [[ "$print_name" == 1 ]]; then
+  printf '%s\n' "$package_name"
+else
+  printf '%s\n' "$manifest_version"
+fi

--- a/scripts/tests/test_auto_release.py
+++ b/scripts/tests/test_auto_release.py
@@ -38,6 +38,8 @@ class PolicyTests(unittest.TestCase):
 
 
 class GitVersionTests(unittest.TestCase):
+    package_name = "ocm"
+
     def setUp(self):
         self.directory = tempfile.TemporaryDirectory()
         self.root = Path(self.directory.name)
@@ -56,8 +58,15 @@ class GitVersionTests(unittest.TestCase):
             target = self.root / "scripts" / name
             target.write_bytes((SOURCE.parent / name).read_bytes())
             target.chmod(0o755)
-        (self.root / "Cargo.toml").write_text('[package]\nname = "ocm"\nversion = "0.2.38"\n')
-        (self.root / "Cargo.lock").write_text('version = 4\n\n[[package]]\nname = "ocm"\nversion = "0.2.38"\n')
+        other_name = "ocm" if self.package_name == "openclawocm" else "openclawocm"
+        (self.root / "Cargo.toml").write_text(
+            '[lib]\nname = "ocm"\npath = "src/lib.rs"\n\n'
+            f'[package]\nname = "{self.package_name}"\nversion = "0.2.38"\n'
+            '\n[[bin]]\nname = "ocm"\npath = "src/main.rs"\n')
+        (self.root / "Cargo.lock").write_text(
+            f'version = 4\n\n[[package]]\nname = "{other_name}"\nversion = "0.1.0"\n'
+            'source = "registry+https://github.com/rust-lang/crates.io-index"\n'
+            f'\n[[package]]\nname = "{self.package_name}"\nversion = "0.2.38"\n')
         self.r.git("add", ".")
         self.r.git("commit", "-m", "initial")
         self.base = self.r.git("rev-parse", "HEAD")
@@ -103,6 +112,19 @@ class GitVersionTests(unittest.TestCase):
         self.r.git("commit", "--amend", "--no-edit")
         with self.assertRaisesRegex(release.ReleaseError, "only the two"):
             self.r.verify_version_diff(self.r.git("rev-parse", "HEAD"), "0.2.39")
+
+    def test_rejects_target_changes_alongside_the_version(self):
+        self.commit_version()
+        manifest = self.root / "Cargo.toml"
+        manifest.write_text(manifest.read_text().replace('path = "src/main.rs"', 'path = "src/other.rs"'))
+        self.r.git("add", "Cargo.toml")
+        self.r.git("commit", "--amend", "--no-edit")
+        with self.assertRaisesRegex(release.ReleaseError, "beyond"):
+            self.r.verify_version_diff(self.r.git("rev-parse", "HEAD"), "0.2.39")
+
+
+class RenamedGitVersionTests(GitVersionTests):
+    package_name = "openclawocm"
 
 
 class CIGateTests(unittest.TestCase):

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -28,6 +28,7 @@ cd "$repo_root"
 "${script_dir}/validate-version.sh" "$new_version"
 
 current_version="$("${script_dir}/read-package-version.sh" Cargo.toml Cargo.lock)"
+package_name="$("${script_dir}/read-package-version.sh" --name Cargo.toml Cargo.lock)"
 
 if [[ "$current_version" == "$new_version" ]]; then
   echo "ocm is already on ${new_version}"
@@ -35,6 +36,7 @@ if [[ "$current_version" == "$new_version" ]]; then
 fi
 
 export OCM_NEW_VERSION="$new_version"
+export OCM_PACKAGE_NAME="$package_name"
 
 echo "Updating Cargo.toml and Cargo.lock from ${current_version} to ${new_version}" >&2
 
@@ -53,9 +55,24 @@ rollback() {
 }
 trap rollback EXIT
 
-perl -0pi -e 's/^(version = ")[^"]+(")/$1.$ENV{OCM_NEW_VERSION}.$2/me' Cargo.toml
+perl -0pi -e '
+  my @sections = split(/(?=^\[)/m, $_);
+  for my $section (@sections) {
+    next unless $section =~ /^\[package\]\s*$/m;
+    $section =~ s/^(version\s*=\s*")[^"]+(")/$1.$ENV{OCM_NEW_VERSION}.$2/me;
+  }
+  $_ = join("", @sections);
+' Cargo.toml
 
-perl -0pi -e 's/(\[\[package\]\]\nname = "ocm"\nversion = ")[^"]+(")/$1.$ENV{OCM_NEW_VERSION}.$2/se' Cargo.lock
+perl -0pi -e '
+  my @sections = split(/(?=^\[\[package\]\])/m, $_);
+  for my $section (@sections) {
+    next unless $section =~ /^\[\[package\]\]\s*$/m;
+    next unless $section =~ /^name\s*=\s*"\Q$ENV{OCM_PACKAGE_NAME}\E"\s*$/m;
+    $section =~ s/^(version\s*=\s*")[^"]+(")/$1.$ENV{OCM_NEW_VERSION}.$2/me;
+  }
+  $_ = join("", @sections);
+' Cargo.lock
 
 updated_version="$("${script_dir}/read-package-version.sh" Cargo.toml Cargo.lock)"
 if [[ "$updated_version" != "$new_version" ]]; then

--- a/scripts/verify-crate-release.sh
+++ b/scripts/verify-crate-release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "Usage: scripts/verify-crate-release.sh <owner/repo> <tag> [expected-commit]" >&2
+  exit 1
+fi
+
+github() {
+  if [[ -n "${OCM_GH_BIN:-}" ]]; then
+    "$OCM_GH_BIN" "$@"
+  elif command -v ghx >/dev/null 2>&1; then
+    ghx --no-cache "$@"
+  else
+    gh "$@"
+  fi
+}
+
+repo="$1"
+tag="$2"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+verify_args=(--repo "$repo" --tag "$tag")
+if [[ -n "${3:-}" ]]; then
+  verify_args+=(--commit "$3")
+fi
+commit="$("${script_dir}/verify-release-tag.sh" "${verify_args[@]}")"
+
+# Binary release recovery accepts the historical name; crates.io must not.
+target_dir="$(mktemp -d "${TMPDIR:-/tmp}/ocm-crate-target.XXXXXX")"
+trap 'rm -rf "$target_dir"' EXIT
+git -C "$repo_root" show "${commit}:Cargo.toml" >"${target_dir}/Cargo.toml"
+git -C "$repo_root" show "${commit}:Cargo.lock" >"${target_dir}/Cargo.lock"
+package_name="$(
+  "${script_dir}/read-package-version.sh" --name \
+    "${target_dir}/Cargo.toml" "${target_dir}/Cargo.lock"
+)"
+if [[ "$package_name" != "openclawocm" ]]; then
+  echo "error: crates.io publishing requires openclawocm; ${tag} uses ${package_name}" >&2
+  exit 1
+fi
+
+release_data="$(
+  github api "repos/${repo}/releases/tags/${tag}" \
+    --jq '[.tag_name, (.draft | tostring), (.published_at // "")] | @tsv'
+)"
+IFS=$'\t' read -r published_tag draft published_at extra <<<"$release_data"
+if [[ "$published_tag" != "$tag" || "$draft" != "false" ||
+  ! "$published_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ||
+  -n "${extra:-}" ]]; then
+  echo "error: publish the complete binary release for ${tag} before its crate" >&2
+  exit 1
+fi
+"${script_dir}/verify-release-ci.sh" --repo "$repo" --commit "$commit" >&2
+
+# Recheck the immutable source after the intervening GitHub requests.
+"${script_dir}/verify-release-tag.sh" --repo "$repo" --tag "$tag" --commit "$commit"

--- a/src/cli/self_cmd.rs
+++ b/src/cli/self_cmd.rs
@@ -212,6 +212,27 @@ impl Cli {
         let version = Self::require_option_value(version, "--version")?;
         Self::assert_no_extra_args(&args)?;
 
+        if !check {
+            let binary = self
+                .current_binary_path()?
+                .canonicalize()
+                .map_err(|error| format!("failed to resolve the current ocm binary: {error}"))?;
+            if let Some(bin) = binary.parent()
+                && bin.file_name().is_some_and(|name| name == "bin")
+                && let Some(keg) = bin.parent()
+                && keg
+                    .parent()
+                    .and_then(Path::file_name)
+                    .is_some_and(|name| name == "ocm")
+                && keg.join("INSTALL_RECEIPT.json").is_file()
+            {
+                return Err(
+                    "Homebrew manages this ocm installation; run `brew upgrade openclaw/tap/ocm` instead"
+                        .to_string(),
+                );
+            }
+        }
+
         let target_display = version.clone().unwrap_or_else(|| "latest".to_string());
         let summary = if check {
             self.self_update_check(version.as_deref())?

--- a/tests/release_script_tests.rs
+++ b/tests/release_script_tests.rs
@@ -59,15 +59,16 @@ impl ReleaseRepo {
     }
 
     fn verify_crate_release(&self, tag: &str, commit: &str) -> Output {
-        Command::new(self.repo.join("scripts/verify-crate-release.sh"))
+        let mut command = Command::new(self.repo.join("scripts/verify-crate-release.sh"));
+        command
             .current_dir(&self.repo)
             .args(["openclaw/ocm", tag, commit])
             .env_clear()
             .env("HOME", &self.home)
             .env("PATH", &self.env_path)
-            .env("OCM_GH_BIN", &self.ghx)
-            .output()
-            .unwrap()
+            .env("OCM_GH_BIN", &self.ghx);
+        self.apply_toolchain_env(&mut command);
+        command.output().unwrap()
     }
 
     fn git_output(&self, args: &[&str]) -> Output {
@@ -764,7 +765,11 @@ fn crate_publication_requires_the_new_package_and_a_published_verified_release()
         let output = repo.verify_crate_release("v0.2.8", &commit);
         assert!(!output.status.success());
         if name == "ocm" {
-            assert!(stderr(&output).contains("crates.io publishing requires openclawocm"));
+            assert!(
+                stderr(&output).contains("crates.io publishing requires openclawocm"),
+                "{}",
+                stderr(&output)
+            );
             continue;
         }
         assert!(stderr(&output).contains("publish the complete binary release"));

--- a/tests/release_script_tests.rs
+++ b/tests/release_script_tests.rs
@@ -58,6 +58,18 @@ impl ReleaseRepo {
         command.output().unwrap()
     }
 
+    fn verify_crate_release(&self, tag: &str, commit: &str) -> Output {
+        Command::new(self.repo.join("scripts/verify-crate-release.sh"))
+            .current_dir(&self.repo)
+            .args(["openclaw/ocm", tag, commit])
+            .env_clear()
+            .env("HOME", &self.home)
+            .env("PATH", &self.env_path)
+            .env("OCM_GH_BIN", &self.ghx)
+            .output()
+            .unwrap()
+    }
+
     fn git_output(&self, args: &[&str]) -> Output {
         Command::new("git")
             .current_dir(&self.repo)
@@ -126,25 +138,29 @@ fn stderr(output: &Output) -> String {
     String::from_utf8(output.stderr.clone()).unwrap()
 }
 
-fn write_release_fixture(path: &Path) {
+fn write_release_fixture(path: &Path, package_name: &str) {
     fs::create_dir_all(path.join("scripts")).unwrap();
     fs::write(
         path.join("Cargo.toml"),
-        r#"[package]
-name = "ocm"
+        format!(
+            r#"[package]
+name = "{package_name}"
 version = "0.2.7"
 edition = "2024"
-"#,
+"#
+        ),
     )
     .unwrap();
     fs::write(
         path.join("Cargo.lock"),
-        r#"version = 4
+        format!(
+            r#"version = 4
 
 [[package]]
-name = "ocm"
+name = "{package_name}"
 version = "0.2.7"
-"#,
+"#
+        ),
     )
     .unwrap();
     fs::write(path.join("README.md"), "release fixture\n").unwrap();
@@ -162,6 +178,10 @@ fn copy_script(repo: &Path, relative: &str) {
 }
 
 fn init_release_repo(label: &str) -> ReleaseRepo {
+    init_release_repo_named(label, "ocm")
+}
+
+fn init_release_repo_named(label: &str, package_name: &str) -> ReleaseRepo {
     let root = TestDir::new(label);
     let repo = root.child("repo");
     let remote = root.child("remote.git");
@@ -171,7 +191,7 @@ fn init_release_repo(label: &str) -> ReleaseRepo {
     fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(&fake_bin).unwrap();
 
-    write_release_fixture(&repo);
+    write_release_fixture(&repo, package_name);
     for script in [
         "scripts/release.sh",
         "scripts/update-version.sh",
@@ -179,6 +199,7 @@ fn init_release_repo(label: &str) -> ReleaseRepo {
         "scripts/read-package-version.sh",
         "scripts/verify-release-ci.sh",
         "scripts/verify-release-tag.sh",
+        "scripts/verify-crate-release.sh",
     ] {
         copy_script(&repo, script);
     }
@@ -236,6 +257,14 @@ if [[ "${1:-}" == "api" ]]; then
         exit 0
       }
       cat .git/test-ci-run
+      exit 0
+      ;;
+    repos/openclaw/ocm/releases/tags/*)
+      [[ -f .git/test-published-release ]] || {
+        printf '%s\ttrue\t\n' "${endpoint##*/}"
+        exit 0
+      }
+      cat .git/test-published-release
       exit 0
       ;;
     repos/openclaw/ocm/git/ref/tags/*)
@@ -654,4 +683,116 @@ fn update_version_accepts_semver_build_metadata_without_running_cargo() {
             .unwrap()
             .contains("version = \"0.2.8+build.1\"")
     );
+}
+
+#[test]
+fn update_version_changes_only_the_selected_root_package() {
+    let repo = init_release_repo("update-version-package-identity");
+    for name in ["ocm", "openclawocm"] {
+        let other = if name == "ocm" { "openclawocm" } else { "ocm" };
+        let manifest = format!(
+            "[lib]\nname = \"ocm\"\npath = \"src/lib.rs\"\n\n[package]\nname = \"{name}\"\nversion = \"0.2.7\"\n\n[[bin]]\nname = \"ocm\"\npath = \"src/main.rs\"\n"
+        );
+        let dependency = format!(
+            "[[package]]\nname = \"{other}\"\nversion = \"0.1.0\"\nsource = \"registry+https://github.com/rust-lang/crates.io-index\"\nchecksum = \"{}\"\n",
+            "0".repeat(64)
+        );
+        let lockfile = format!(
+            "version = 4\n\n{dependency}\n[[package]]\nname = \"{name}\"\nversion = \"0.2.7\"\n"
+        );
+        fs::write(repo.repo.join("Cargo.toml"), &manifest).unwrap();
+        fs::write(repo.repo.join("Cargo.lock"), &lockfile).unwrap();
+        let output = repo.run_update_version("0.2.8");
+        assert!(output.status.success(), "{name}: {}", stderr(&output));
+        assert_eq!(
+            fs::read_to_string(repo.repo.join("Cargo.toml")).unwrap(),
+            manifest.replace("\"0.2.7\"", "\"0.2.8\"")
+        );
+        assert_eq!(
+            fs::read_to_string(repo.repo.join("Cargo.lock")).unwrap(),
+            lockfile.replace("\"0.2.7\"", "\"0.2.8\"")
+        );
+    }
+}
+
+#[test]
+fn package_version_rejects_ambiguous_remote_or_mismatched_root_records() {
+    let repo = init_release_repo("package-version-invalid-records");
+    for name in ["ocm", "openclawocm"] {
+        let manifest = format!("[package]\nname = \"{name}\"\nversion = \"0.2.7\"\n");
+        let record = format!("[[package]]\nname = \"{name}\"\nversion = \"0.2.7\"\n");
+        for lockfile in [
+            record.replace("0.2.7", "0.2.8"),
+            record.replace("0.2.7", "0.2.7..1"),
+            record.replace(name, "unrelated"),
+            format!("{record}\n{record}"),
+            format!("{record}name = \"duplicate\"\n"),
+            format!("{record}source = \"registry+https://github.com/rust-lang/crates.io-index\"\n"),
+            format!("{record}checksum = \"{}\"\n", "0".repeat(64)),
+        ] {
+            fs::write(repo.repo.join("Cargo.toml"), &manifest).unwrap();
+            fs::write(repo.repo.join("Cargo.lock"), &lockfile).unwrap();
+            let output = repo.run_update_version("0.2.9");
+            assert!(!output.status.success(), "{name}: {lockfile}");
+            assert_eq!(
+                fs::read_to_string(repo.repo.join("Cargo.toml")).unwrap(),
+                manifest
+            );
+            assert_eq!(
+                fs::read_to_string(repo.repo.join("Cargo.lock")).unwrap(),
+                lockfile
+            );
+        }
+    }
+}
+
+#[test]
+fn crate_publication_requires_the_new_package_and_a_published_verified_release() {
+    for name in ["ocm", "openclawocm"] {
+        let repo = init_release_repo_named("crate-release-identity", name);
+        let prepare = repo.run_release("0.2.8");
+        assert!(prepare.status.success(), "{}", stderr(&prepare));
+        let commit = repo.merge_release_pr("0.2.8");
+        repo.record_ci(&commit, "completed", "success");
+        let binary_release = repo.run_release("0.2.8");
+        assert!(
+            binary_release.status.success(),
+            "{}",
+            stderr(&binary_release)
+        );
+
+        let output = repo.verify_crate_release("v0.2.8", &commit);
+        assert!(!output.status.success());
+        if name == "ocm" {
+            assert!(stderr(&output).contains("crates.io publishing requires openclawocm"));
+            continue;
+        }
+        assert!(stderr(&output).contains("publish the complete binary release"));
+        for metadata in [
+            "v0.2.8\ttrue\t2026-09-07T00:00:00Z\n",
+            "v0.2.7\tfalse\t2026-09-07T00:00:00Z\n",
+            "v0.2.8\tfalse\t\n",
+        ] {
+            fs::write(repo.repo.join(".git/test-published-release"), metadata).unwrap();
+            let output = repo.verify_crate_release("v0.2.8", &commit);
+            assert!(!output.status.success());
+            assert!(stderr(&output).contains("publish the complete binary release"));
+        }
+        fs::write(
+            repo.repo.join(".git/test-published-release"),
+            "v0.2.8\tfalse\t2026-09-07T00:00:00Z\n",
+        )
+        .unwrap();
+        let output = repo.verify_crate_release("v0.2.8", &commit);
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert_eq!(stdout(&output).trim(), commit);
+
+        repo.record_ci(&commit, "completed", "failure");
+        let output = repo.verify_crate_release("v0.2.8", &commit);
+        assert!(!output.status.success());
+        assert!(stderr(&output).contains("concluded failure"));
+        let output = repo.verify_crate_release("v0.2.8", &"0".repeat(40));
+        assert!(!output.status.success());
+        assert!(stderr(&output).contains("moved away from verified commit"));
+    }
 }

--- a/tests/self_command_tests.rs
+++ b/tests/self_command_tests.rs
@@ -151,6 +151,53 @@ fn self_update_check_reports_when_a_newer_release_exists() {
     assert!(text.contains(&format!("assetName: {asset_name}")));
 }
 
+#[cfg(unix)]
+#[test]
+fn homebrew_self_update_preserves_the_keg_and_allows_checks_through_symlinks() {
+    let root = TestDir::new("self-update-homebrew");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let keg = root.child("brew/custom-cellar/ocm/0.2.39");
+    let binary = keg.join("bin/ocm");
+    fs::create_dir_all(binary.parent().unwrap()).unwrap();
+    fs::copy(env!("CARGO_BIN_EXE_ocm"), &binary).unwrap();
+    fs::write(
+        keg.join("INSTALL_RECEIPT.json"),
+        r#"{"homebrew_version":"4.6.0","source":{"tap":"openclaw/tap"}}"#,
+    )
+    .unwrap();
+    let linked = root.child("brew/bin/ocm");
+    fs::create_dir_all(linked.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&binary, &linked).unwrap();
+    let original = file_sha256(&binary).unwrap();
+    let release = TestHttpServer::serve_bytes(
+        "/release.json",
+        "application/json",
+        br#"{"tag_name":"v9.9.9","assets":[]}"#,
+    );
+    let env = release_env(&root, &release.url());
+
+    for command in [&binary, &linked] {
+        let output = run_ocm_binary(command, &cwd, &env, &["self", "update", "--raw"]);
+        assert!(!output.status.success());
+        assert!(
+            stderr(&output).contains("brew upgrade openclaw/tap/ocm"),
+            "{}",
+            stderr(&output)
+        );
+    }
+    assert!(release.requests().is_empty());
+    assert_eq!(file_sha256(&binary).unwrap(), original);
+    assert_eq!(fs::read_dir(keg.join("bin")).unwrap().count(), 1);
+    assert_eq!(fs::read_dir(root.child("ocm-home")).unwrap().count(), 0);
+
+    let output = run_ocm_binary(&linked, &cwd, &env, &["self", "update", "--check", "--raw"]);
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(stdout(&output).contains("status: update_available"));
+    assert_eq!(release.requests().len(), 1);
+    assert_eq!(file_sha256(&binary).unwrap(), original);
+}
+
 #[test]
 fn self_update_check_ignores_older_latest_release_when_current_is_newer() {
     let root = TestDir::new("self-update-check-older-latest");


### PR DESCRIPTION
## What Problem This Solves

OCM has signed binary releases but no crates.io publishing path, and `ocm self update` can overwrite a Homebrew-owned executable. The existing crates.io package named `ocm` is unrelated to OpenClaw.

## Why This Change Was Made

Prepare `openclawocm` for crates.io while retaining the `ocm` library and executable. A manual-only workflow packages without registry credentials, then uses OIDC in the `crates-io` environment after revalidating the canonical signed release, package identity, published binary release, and exact-SHA CI. Historical `ocm`-named tags remain valid for binary-release recovery.

Mutating self-update now recognizes the resolved OCM keg and its Homebrew receipt, including symlinks and custom cellar locations, and directs users to `brew upgrade openclaw/tap/ocm`. Checks remain available.

## User Impact

- No version bump, tag, package publication, signing changes, or automatic-release enablement. Cargo dependency records are unchanged.
- The `crates-io` GitHub environment was created only after confirming it was absent; live readback allows the `main` branch only. No registry secret was added.
- First crate publication remains a separately approved maintainer operation with a short-lived bootstrap token. The release guide specifies ownership setup, trusted-publisher fields, and token revocation.
- The initial Homebrew formula uses v0.2.39, which does not contain this guard. Protection starts with the next approved binary release, not this merge.

Related: https://github.com/openclaw/ocm/pull/146 remains untouched. Its eventual rebase needs to account for the explicit Cargo library/binary targets and the root package rename in its candidate fixture.

## Evidence

- Demonstrated failing pre-change tests for the Brew ownership boundary and renamed-root version editing, then passing results after the fixes.
- 44 focused Rust tests passed across self commands, release scripts, and release assets, including no release request/replacement for a copied Brew keg, symlink invocation, unchanged `--check`, ordinary self-update, both package names, invalid lock records, and crate publication rejection cases.
- 32 Python automatic-release policy and production-boundary tests passed.
- Rust 1.88: `cargo check --workspace --all-targets --locked` passed.
- Rust 1.88: credential-free `cargo publish --dry-run --locked --allow-dirty --package openclawocm --registry crates-io` built the packaged source and aborted upload as expected. Inspected all 179 packaged paths.
- Installed that packaged source with Rust 1.88 into a temporary prefix. The installed `ocm --version` returned `0.2.39`; `ocm --help` identified OpenClaw Manager and its command set. Both ran with an empty environment and isolated home/OCM home; no state files were created.
- `cargo fmt --check`, `actionlint`, shell syntax checks, and `git diff --check` passed.
- Fresh independent P2 review found no actionable issues.
- Live historical v0.2.39 signed-tag verification still resolves to its original release commit; the new crate verifier rejects the same tag because it uses the legacy package name.
- Investigated both initial CI failures and reproduced the exact new-test assertion failure on isolated Linux. The crate-verification fixture omitted the existing Cargo/Rustup environment forwarding, so the Rustup shim failed before package identity validation. Reusing `apply_toolchain_env` fixes the fixture without changing production behavior or assertion matching. All 17 release-script tests then passed on the same Linux lease; the failing assertion now reports actual stderr.

All five required CI jobs passed on repaired head `e951d936162599c6a971e527799229ca55d56c60`, including full Linux/macOS suites and Cargo-install smokes: https://github.com/openclaw/ocm/actions/runs/34075381401. All three CodeQL analyses and the aggregate CodeQL check also passed: https://github.com/openclaw/ocm/actions/runs/34075379115. Independent review and coordinator source review found no blocking production findings.

Actual OIDC authentication/publication cannot be exercised until the first approved crate publication and crates.io-side trusted publisher configuration. The new verifier checks the matching release's published/non-draft state, not its asset inventory; completing the binary release remains an operator prerequisite.
