### PR TITLE
feat(npm): prepare signed binary distribution and OIDC publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,45 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22.15.0'
+          package-manager-cache: false
       - name: Run test suite
         run: cargo test --locked
       - name: Smoke test cargo install
         run: |
           cargo install --locked --path . --root "$RUNNER_TEMP/ocm-install"
           "$RUNNER_TEMP/ocm-install/bin/ocm" --version
+
+  npm:
+    name: npm (${{ matrix.os }}, Node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, node: '22.15.0' }
+          - { os: ubuntu-latest, node: '24' }
+          - { os: macos-15-intel, node: '24' }
+          - { os: macos-15, node: '24' }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ matrix.node }}
+          package-manager-cache: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+      - run: npm install --global --ignore-scripts npm@11.19.0
+      - name: Test npm packaging, recovery, launcher, and isolated installation lifecycle
+        run: python3 -B -m unittest discover -s scripts/tests -p 'test_npm_*.py'
+      - name: Prove signed native byte preservation through npm
+        if: matrix.node == '24'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MACOS_TEAM_ID: ${{ vars.MACOS_TEAM_ID }}
+        run: python3 -B scripts/tests/test_npm_install.py --published-binary-fixture

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,133 @@
+name: Publish npm
+run-name: Publish npm ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Signed tag with an already published binary release
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Verify and package npm
+    if: >-
+      github.repository == 'openclaw/ocm' &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'openclaw/ocm/.github/workflows/publish-npm.yml@refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.prepare.outputs.source }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: 1.88.0
+      - name: Verify signed source, CI, original checksums, and GitHub asset digests
+        id: prepare
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: python3 -B scripts/npm_release.py prepare "$RELEASE_REPO" "$RELEASE_TAG" "$RUNNER_TEMP/npm-packages"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-packages
+          path: ${{ runner.temp }}/npm-packages
+          if-no-files-found: error
+          retention-days: 7
+
+  native:
+    name: Test npm (${{ matrix.os }})
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15-intel, macos-15]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+      - run: npm install --global --ignore-scripts npm@11.19.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-packages
+          path: ${{ runner.temp }}/npm-packages
+      - name: Install exact tarballs and verify native bytes, CLI, and macOS notarization
+        env:
+          MACOS_TEAM_ID: ${{ vars.MACOS_TEAM_ID }}
+        run: python3 -B scripts/tests/test_npm_install.py --packages "$RUNNER_TEMP/npm-packages"
+
+  publish:
+    name: Publish verified npm packages
+    needs: [prepare, native]
+    if: >-
+      github.repository == 'openclaw/ocm' &&
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'openclaw/ocm/.github/workflows/publish-npm.yml@refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: 1.88.0
+      - name: Install the pinned OIDC-capable npm CLI
+        run: |
+          npm install --global --ignore-scripts npm@11.19.0
+          test "$(npm --version)" = 11.19.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-packages
+          path: ${{ runner.temp }}/npm-packages
+      - name: Revalidate source, release assets, and exact tested tarballs before OIDC
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_COMMIT: ${{ needs.prepare.outputs.source }}
+        run: python3 -B scripts/npm_release.py verify "$RUNNER_TEMP/npm-packages" "$RELEASE_REPO" "$RELEASE_TAG" "$RELEASE_COMMIT"
+      - name: Publish platform payloads serially, then advance the root channel
+        run: python3 -B scripts/npm_release.py publish "$RUNNER_TEMP/npm-packages"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to OCM are documented here.
 
 ### Added
 
+- Prepare `@openclaw/ocm` npm distribution of signed Rust binaries, with a
+  no-download launcher, exact platform aliases, and manual OIDC publishing.
 - Prepare the `openclawocm` Cargo package and manual crates.io trusted publishing
   from verified signed releases, while preserving the `ocm` command and library.
 - Let `runtime build-local` assemble repeatable, commit-matched official companion plugins through OpenClaw's release packaging contract, stage them as trusted runtime-owned bundled plugins with isolated dependencies, and record artifact and entrypoint hashes for verification.
@@ -30,6 +32,10 @@ All notable changes to OCM are documented here.
 
 ### Fixed
 
+- Keep npm-owned executable updates with npm, prevent temporary npx caches from
+  owning background services, and preserve process identity during npm-launched
+  gateway refreshes. Protect managed and symlinked installer destinations even
+  with `--force`.
 - Refuse mutating `ocm self update` for Homebrew-owned executables and direct
   users to `brew upgrade openclaw/tap/ocm`; keep release checks available.
 - Keep unrelated supervised gateways on their persisted child specifications when an environment is destroyed, removed, or pruned, so latent metadata or process-environment drift cannot restart sibling gateways during cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to OCM are documented here.
 
 - Prepare `@openclaw/ocm` npm distribution of signed Rust binaries, with a
   no-download launcher, exact platform aliases, and manual OIDC publishing.
+  Include every npm CI lane in automatic-release verification.
 - Prepare the `openclawocm` Cargo package and manual crates.io trusted publishing
   from verified signed releases, while preserving the `ocm` command and library.
 - Let `runtime build-local` assemble repeatable, commit-matched official companion plugins through OpenClaw's release packaging contract, stage them as trusted runtime-owned bundled plugins with isolated dependencies, and record artifact and entrypoint hashes for verification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,19 @@ cargo install --locked --path . --root "$install_root"
 "$install_root/bin/ocm" --version
 ```
 
+The npm launcher integration tests need Node.js `^22.15.0 || >=24.0.0`.
+Packaging tests use Python 3.13 and npm 11.19.0, with a private local fixture
+registry, cache, prefix, and home:
+
+```sh
+python3 -B -m unittest discover -s scripts/tests -p 'test_npm_*.py'
+```
+
+These tests do not publish packages or change installed services. CI also
+checks npm installation of the existing signed v0.2.39 binaries on all three
+release platforms; that fixture proves byte preservation, not support for
+publishing v0.2.39 through the new workflow.
+
 Tests use [tests/support/mod.rs](tests/support/mod.rs) for temporary directories,
 isolated `HOME` and `OCM_HOME`, and service fixtures. Reuse those helpers; do not
 point tests at a real environment or service. Manual state-changing experiments

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Use `ocm` when you want:
 
 ## Install
 
+The npm distribution is prepared but not published yet. Its first publication
+must use a future signed release containing npm ownership protection, not
+v0.2.39. Once available, install with `npm install --global @openclaw/ocm`.
+See [npm installation and updates](npm/README.md) for Node requirements,
+project-local installs, npx, and daemon refresh behavior.
+
 Install with Homebrew on macOS (Apple Silicon or Intel) or Linux x86_64:
 
 ```bash

--- a/docs/AUTOMATIC_RELEASES.md
+++ b/docs/AUTOMATIC_RELEASES.md
@@ -15,7 +15,7 @@ as Odin's scheduled updater still install OCM first, then update OpenClaw.
 3. The automation creates one `release/vX.Y.Z` PR changing only the OCM version
    in `Cargo.toml` and `Cargo.lock`. The default increment is a patch. It refreshes
    a stale automation-owned branch with an exact-head lease, then waits for CI.
-4. Once the release PR is current, all five CI jobs pass and GitHub reports normal
+4. Once the release PR is current, all CI jobs pass and GitHub reports normal
    mergeability, it squash-merges that exact head without bypassing protection.
    No tag is created until the resulting exact `main` commit passes CI too.
 5. The configured signer creates a signed annotated tag for that release commit.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,6 +43,105 @@ availability. The initial formula installs v0.2.39, which predates the ownership
 guard. The guard takes effect only after the next approved OCM release reaches
 the tap, not when this source change merges.
 
+## npm
+
+`@openclaw/ocm` is one public npm package. Its normal version exposes the `ocm`
+launcher; exact optional dependency aliases select platform versions of the
+same package, such as `V-darwin-arm64`. Only macOS ARM64/x64 and Linux x64 glibc
+are supported. There are no install hooks, binary downloads during installation,
+or Rust compiler requirements. See [npm usage](../npm/README.md).
+
+The distribution is prepared, not published. The first npm publication must
+use the next approved signed release containing the npm launcher and native
+ownership guard. The workflow rejects v0.2.39 and other older sources. Merging
+this preparation does not authorize a version bump, release, or publication.
+
+### Account setup
+
+An npm maintainer with write access to the `openclaw` scope must separately
+approve and perform the first legitimate package publication. npm requires an
+existing package before a trusted publisher can be configured.
+
+For that first approved release, use the exact tarballs from the workflow's
+successful read-only preparation and three-platform validation. Bootstrap one
+platform payload under its `platform-latest-<platform>` tag (or
+`platform-next-<platform>` for a prerelease) using an authenticated
+maintainer account with 2FA. Do not publish a placeholder, advance `latest`,
+or put a bootstrap token in GitHub. Until this bootstrap and trust setup are
+complete, the workflow's publication job cannot authenticate.
+
+Configure a GitHub trusted publisher in the package's npm settings:
+
+- Organization: `openclaw`
+- Repository: `ocm`
+- Workflow filename: `publish-npm.yml`
+- Environment: `npm`
+- Permission: allow direct `npm publish`, not only staged publishing
+
+Publisher configurations created since September 3, 2026 default to staging
+permission in npm's new settings UI. Explicitly allow direct publication.
+Alternatively, with npm >=11.15.0, an authenticated account with 2FA and package
+write access can run:
+
+```sh
+npm trust github @openclaw/ocm --repo openclaw/ocm --file publish-npm.yml --env npm --allow-publish
+```
+
+This changes account-side configuration; it is not a dry run. Configure the
+publisher only after the package exists. One configuration covers the root
+and all platform versions because they share the same registry package name.
+
+On GitHub, the `npm` environment must allow only the `main` branch, not tags
+or arbitrary branches. Keep any existing required reviewers and protections.
+The workflow uses GitHub-hosted runners, Node 24, npm 11.19.0, read-only GitHub
+permissions, and `id-token: write` only in the publication job. There is no
+`NPM_TOKEN` or `NODE_AUTH_TOKEN` fallback.
+
+After a real OIDC publication and provenance verification, set npm publishing
+access to **Require two-factor authentication and disallow tokens**, and revoke
+any bootstrap publishing token. Preparation and local registry tests do not
+prove that npm's account-side trust configuration works.
+
+### Publishing and recovery
+
+After the binary release is complete, dispatch `publish-npm.yml` on `main`
+with its signed `v` tag. Preparation verifies the canonical signed source,
+exact-main CI, complete release inventory, original `SHA256SUMS`, and GitHub
+asset digests. It packages the tag's launcher and already signed native bytes
+without rebuilding or modifying the executable. Every native platform installs
+the exact prepared tarballs; macOS also verifies signature and notarization.
+
+All versions come from the verified Cargo version, preserving the existing
+two-file version-bump contract. npm versions with build metadata or a reserved
+`-darwin-arm64`, `-darwin-x64`, or `-linux-x64` suffix are rejected.
+
+The protected publication job revalidates source and assets, publishes the
+platform versions serially under `platform-latest-<platform>` or
+`platform-next-<platform>`, then publishes the root under `latest` for stable
+versions or `next` for prereleases. Every channel is preflighted before any write
+and rechecked immediately before publication. Package-wide concurrency prevents competing
+workflow runs. Do not run concurrent manual publishing against this package.
+
+A retry accepts an existing version only when its SHA-512 integrity matches
+the exact prepared tarball. HTTP errors other than 404 are not absence.
+Matching completed older releases are no-ops and never roll a channel back.
+If the root version exists but its channel needs repair, the workflow stops:
+inspect the published bytes and current channel, then perform separately
+approved maintainer tag recovery. OIDC is not a token fallback for `npm dist-tag`
+or account-management commands.
+
+npm's automatic provenance identifies the protected packaging workflow's
+`GITHUB_SHA`. It does not necessarily identify the native compilation commit.
+Each tarball includes `release.json` with the signed tag, native source commit,
+and release asset digests; payloads also include the executable SHA-256. These
+are package contents covered by its digest, not extra automatically generated
+SLSA materials. Do not override provenance variables or dispatch from an
+unprotected tag to manufacture a matching source identity.
+
+References: [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/),
+[npm trust](https://docs.npmjs.com/cli/v12/commands/npm-trust/), and
+[npm provenance](https://docs.npmjs.com/generating-provenance-statements/).
+
 ## crates.io
 
 The Cargo package is `openclawocm`; the executable and library remain `ocm`.

--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,40 @@ if [[ -z "$bin_dir" ]]; then
   bin_dir="${prefix}/bin"
 fi
 
+destination="${bin_dir}/ocm"
+protect_destination() {
+  local resolved_bin suffix
+  if [[ -L "$destination" ]]; then
+    echo "error: refusing to replace a symlink; update ocm through its owning installer or package manager" >&2
+    exit 1
+  fi
+  resolved_bin="$bin_dir"
+  suffix=""
+  while [[ ! -d "$resolved_bin" ]]; do
+    suffix="/$(basename -- "$resolved_bin")${suffix}"
+    resolved_bin="$(dirname -- "$resolved_bin")"
+  done
+  resolved_bin="$(cd -- "$resolved_bin" && pwd -P)${suffix}"
+  # npm owns files below node_modules even when aliases or manifests change.
+  # Do not execute an existing binary or require Node to protect that boundary.
+  case "${resolved_bin}/" in
+    */node_modules/*)
+      echo "error: npm manages this destination; update @openclaw/ocm with npm" >&2
+      exit 1
+      ;;
+  esac
+  if [[ -f "${resolved_bin}/../INSTALL_RECEIPT.json" ]]; then
+    echo "error: Homebrew manages this destination; run brew upgrade openclaw/tap/ocm" >&2
+    exit 1
+  fi
+  if [[ -e "$destination" && "$force" != "true" ]]; then
+    echo "error: ${destination} already exists; run \"ocm self update\" or rerun with --force to replace it" >&2
+    exit 1
+  fi
+}
+
+protect_destination
+
 target="$(detect_target)"
 asset="ocm-${target}.tar.gz"
 url="$(download_url_for "$version" "$asset")"
@@ -179,11 +213,7 @@ if [[ ! -f "$binary_path" || -L "$binary_path" ]]; then
 fi
 
 mkdir -p "$bin_dir"
-destination="${bin_dir}/ocm"
-if [[ -e "$destination" && "$force" != "true" ]]; then
-  echo "error: ${destination} already exists; run \"ocm self update\" or rerun with --force to replace it" >&2
-  exit 1
-fi
+protect_destination
 
 install -m 0755 "$binary_path" "$destination"
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,41 @@
+# OCM
+
+OCM manages OpenClaw environments, runtimes, and services. This package contains
+a small Node launcher and platform-specific Rust binaries, not a JavaScript
+implementation or an install-time downloader. Rust is not required.
+
+Supported: macOS ARM64/x64 and Linux x64 with glibc. Requires Node.js
+`^22.15.0 || >=24.0.0` and optional dependencies.
+
+```sh
+npm install --global @openclaw/ocm
+ocm --help
+```
+
+Update a global installation with `npm install --global @openclaw/ocm@latest`,
+using the same Node installation and npm prefix. For a project-local installation,
+run `npm install @openclaw/ocm@latest` in that project. `ocm self update` refuses
+to overwrite npm-owned files; `ocm self update --check` reports GitHub binary
+releases, not npm availability. Use `npm view @openclaw/ocm version` to check npm.
+
+`npx --yes @openclaw/ocm@latest --help` is suitable for one-off commands. Its
+temporary cache cannot own a background service. Install globally or in a durable
+project before installing or refreshing services.
+
+An npm update does not restart the running OCM daemon or managed gateways.
+Inspect `ocm service status`, then schedule an explicit refresh:
+
+```sh
+ocm service refresh-daemon --acknowledge-gateway-restarts
+```
+
+Keep the installation path stable while services use it. Changing Node versions,
+prefixes, or deleting a local project requires rebinding the daemon from the new
+durable installation before removing the old one.
+
+Each package's `release.json` records its signed source tag, commit, and GitHub
+asset digests. Native payloads also record the executable SHA-256. npm provenance
+identifies the protected packaging workflow; these embedded fields identify the
+native release source and are covered by the package digest.
+
+Project documentation: https://github.com/openclaw/ocm

--- a/npm/ocm.cjs
+++ b/npm/ocm.cjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+"use strict";
+
+const { createRequire } = require("node:module");
+const { dirname, join } = require("node:path");
+
+function main() {
+  if (typeof process.execve !== "function") {
+    throw new Error("OCM requires Node.js ^22.15.0 or >=24.0.0 with process.execve.");
+  }
+  const targets = {
+    "darwin-arm64": "aarch64-apple-darwin",
+    "darwin-x64": "x86_64-apple-darwin",
+    "linux-x64": "x86_64-unknown-linux-gnu",
+  };
+  const platform = `${process.platform}-${process.arch}`;
+  const target = targets[platform];
+  if (!target || (process.platform === "linux" &&
+      !process.report.getReport().header.glibcVersionRuntime)) {
+    throw new Error(`Unsupported OCM platform: ${platform}. Supported: macOS ARM64/x64 and Linux x64 glibc.`);
+  }
+  const dependency = `@openclaw/ocm-${platform}`;
+  let manifest;
+  try {
+    manifest = createRequire(__filename).resolve(`${dependency}/package.json`);
+  } catch {
+    throw new Error(`Missing ${dependency}. Reinstall @openclaw/ocm with optional dependencies enabled (do not use --omit=optional).`);
+  }
+  const binary = join(dirname(manifest), "vendor", target, "bin", "ocm");
+  // OCM may escape a managed gateway's process group before stopping it.
+  // There must be no Node parent left to forward that group's termination.
+  process.execve(binary, [binary, ...process.argv.slice(2)], process.env);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`ocm: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/auto-release.py
+++ b/scripts/auto-release.py
@@ -19,7 +19,9 @@ VERSION = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\Z")
 SHA = re.compile(r"[0-9a-f]{40}\Z")
 MARKER = "<!-- ocm-auto-release:v1 -->"
 CI_JOBS = {"Format", "Rust 1.88 minimum", "Windows compile",
-           "Test (ubuntu-latest)", "Test (macos-latest)"}
+           "Test (ubuntu-latest)", "Test (macos-latest)",
+           "npm (ubuntu-latest, Node 22.15.0)", "npm (ubuntu-latest, Node 24)",
+           "npm (macos-15-intel, Node 24)", "npm (macos-15, Node 24)"}
 
 
 class ReleaseError(RuntimeError):

--- a/scripts/npm_release.py
+++ b/scripts/npm_release.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Prepare deterministic npm packages from verified, already published binaries."""
+
+import argparse
+import base64
+import gzip
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import tomllib
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import urlopen
+
+ROOT = Path(__file__).resolve().parent.parent
+PACKAGE = "@openclaw/ocm"
+REGISTRY = "https://registry.npmjs.org"
+TARGETS = {
+    "darwin-arm64": "aarch64-apple-darwin",
+    "darwin-x64": "x86_64-apple-darwin",
+    "linux-x64": "x86_64-unknown-linux-gnu",
+}
+SEMVER = re.compile(
+    r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+)
+MAX_ASSET = 512 * 1024 * 1024
+
+
+def version_key(version):
+    match = SEMVER.fullmatch(version)
+    if not match:
+        raise ValueError(f"invalid npm release version: {version}")
+    major, minor, patch, prerelease = match.groups()
+    parts = []
+    for part in prerelease.split(".") if prerelease else []:
+        if part.isdecimal() and len(part) > 1 and part.startswith("0"):
+            raise ValueError(
+                "numeric prerelease identifiers cannot have leading zeroes"
+            )
+        parts.append((0, int(part)) if part.isdecimal() else (1, part))
+    return (int(major), int(minor), int(patch), prerelease is None, tuple(parts))
+
+
+def validate_version(version):
+    version_key(version)
+    if any(version.endswith(f"-{platform}") for platform in TARGETS):
+        raise ValueError("release version uses the reserved npm platform namespace")
+    return version
+
+
+def json_bytes(value):
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def integrity(data):
+    return "sha512-" + base64.b64encode(hashlib.sha512(data).digest()).decode()
+
+
+def github(*args):
+    command = ["ghx", "--no-cache"] if shutil.which("ghx") else ["gh"]
+    return subprocess.check_output([*command, *args])
+
+
+def git_source(commit, filename):
+    return subprocess.check_output(
+        ["git", "-C", str(ROOT), "show", f"{commit}:{filename}"]
+    )
+
+
+def release_snapshot(repo, tag):
+    release = json.loads(github("api", f"repos/{repo}/releases/tags/{tag}"))
+    expected = {f"ocm-{target}.tar.gz" for target in TARGETS.values()} | {
+        "install.sh",
+        "SHA256SUMS",
+    }
+    assets = release["assets"]
+    if (
+        release["tag_name"] != tag
+        or release["draft"]
+        or not release["published_at"]
+        or {asset["name"] for asset in assets} != expected
+        or len(assets) != len(expected)
+    ):
+        raise ValueError("a complete, published binary release is required before npm")
+    snapshot = {}
+    for asset in assets:
+        if (
+            not re.fullmatch(r"sha256:[0-9a-f]{64}", asset.get("digest") or "")
+            or not 0 < asset["size"] <= MAX_ASSET
+            or asset["state"] != "uploaded"
+        ):
+            raise ValueError(f"invalid release asset metadata: {asset['name']}")
+        snapshot[asset["name"]] = {
+            key: asset[key] for key in ("id", "digest", "size", "updated_at")
+        }
+    return snapshot
+
+
+def verify_source(repo, tag, expected=None):
+    if repo != "openclaw/ocm":
+        raise ValueError("npm publication requires openclaw/ocm")
+    args = [str(ROOT / "scripts/verify-crate-release.sh"), repo, tag]
+    if expected:
+        args.append(expected)
+    commit = subprocess.check_output(args, text=True).strip()
+    version = validate_version(
+        tomllib.loads(git_source(commit, "Cargo.toml").decode())["package"]["version"]
+    )
+    if tag != f"v{version}":
+        raise ValueError("release tag and npm version differ")
+    # Older releases lack both the wrapper and the native package-owner guard.
+    # Never combine a new wrapper with an old unprotected Rust executable.
+    git_source(commit, "npm/ocm.cjs")
+    git_source(commit, "src/infra/install_owner.rs")
+    return commit, version
+
+
+def download_assets(repo, tag, snapshot, directory):
+    for name, metadata in snapshot.items():
+        url = (
+            f"https://github.com/{repo}/releases/download/{quote(tag, safe='')}/{name}"
+        )
+        with urlopen(url, timeout=60) as response:
+            data = response.read(MAX_ASSET + 1)
+        if (
+            len(data) != metadata["size"]
+            or "sha256:" + hashlib.sha256(data).hexdigest() != metadata["digest"]
+        ):
+            raise ValueError(f"GitHub digest or size mismatch: {name}")
+        (directory / name).write_bytes(data)
+    checksums = {}
+    for line in (directory / "SHA256SUMS").read_text().splitlines():
+        match = re.fullmatch(r"([0-9a-fA-F]{64}) [ *](\S+)", line)
+        if not match or match[2] in checksums:
+            raise ValueError("invalid or duplicate original SHA256SUMS entry")
+        checksums[match[2]] = match[1].lower()
+    if set(checksums) != set(snapshot) - {"SHA256SUMS"}:
+        raise ValueError("original SHA256SUMS does not cover the exact release")
+    for name, digest in checksums.items():
+        if hashlib.sha256((directory / name).read_bytes()).hexdigest() != digest:
+            raise ValueError(f"original SHA256SUMS mismatch: {name}")
+
+
+def native_bytes(archive):
+    with tarfile.open(archive, "r:gz") as tar:
+        members = tar.getmembers()
+        if (
+            len(members) != 3
+            or {member.name for member in members} != {"ocm", "LICENSE", "README.md"}
+            or any(not member.isfile() or member.size > MAX_ASSET for member in members)
+        ):
+            raise ValueError(
+                "release archive must contain only regular ocm, LICENSE and README.md files"
+            )
+        return tar.extractfile("ocm").read()
+
+
+def pack(path, files):
+    # Normalized metadata makes retries byte-identical across runners and dates.
+    with (
+        path.open("wb") as output,
+        gzip.GzipFile(fileobj=output, mode="wb", filename="", mtime=0) as zipped,
+    ):
+        with tarfile.open(fileobj=zipped, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+            for name, (data, mode) in sorted(files.items()):
+                info = tarfile.TarInfo(f"package/{name}")
+                info.size = len(data)
+                info.mode = mode
+                tar.addfile(info, io.BytesIO(data))
+    return integrity(path.read_bytes())
+
+
+def stage(version, source, assets, wrapper, license_text, readme, output):
+    validate_version(version)
+    channel = "next" if "-" in version else "latest"
+    output.mkdir(parents=True, exist_ok=False)
+    common = {
+        "name": PACKAGE,
+        "description": "Manage OpenClaw environments, runtimes, and services",
+        "license": "MIT",
+        "repository": {"type": "git", "url": "git+https://github.com/openclaw/ocm.git"},
+        "engines": {"node": "^22.15.0 || >=24.0.0"},
+    }
+    packages = []
+    for platform, target in TARGETS.items():
+        archive = assets / f"ocm-{target}.tar.gz"
+        binary = native_bytes(archive)
+        manifest = {
+            **common,
+            "version": f"{version}-{platform}",
+            "os": [platform.split("-")[0]],
+            "cpu": [platform.split("-")[1]],
+        }
+        if platform == "linux-x64":
+            manifest["libc"] = ["glibc"]
+        metadata = {
+            **source,
+            "target": target,
+            "binarySha256": hashlib.sha256(binary).hexdigest(),
+        }
+        filename = f"ocm-{version}-{platform}.tgz"
+        digest = pack(
+            output / filename,
+            {
+                "package.json": (json_bytes(manifest), 0o644),
+                "release.json": (json_bytes(metadata), 0o644),
+                "LICENSE": (license_text, 0o644),
+                f"vendor/{target}/bin/ocm": (binary, 0o755),
+            },
+        )
+        packages.append(
+            {
+                "file": filename,
+                "version": manifest["version"],
+                "tag": f"platform-{channel}-{platform}",
+                "integrity": digest,
+            }
+        )
+    manifest = {
+        **common,
+        "version": version,
+        "bin": {"ocm": "bin/ocm.cjs"},
+        "optionalDependencies": {
+            f"{PACKAGE}-{platform}": f"npm:{PACKAGE}@{version}-{platform}"
+            for platform in TARGETS
+        },
+    }
+    filename = f"ocm-{version}.tgz"
+    digest = pack(
+        output / filename,
+        {
+            "package.json": (json_bytes(manifest), 0o644),
+            "release.json": (json_bytes(source), 0o644),
+            "LICENSE": (license_text, 0o644),
+            "README.md": (readme, 0o644),
+            "bin/ocm.cjs": (wrapper, 0o755),
+        },
+    )
+    packages.append(
+        {"file": filename, "version": version, "tag": channel, "integrity": digest}
+    )
+    receipt = {"version": version, "source": source, "packages": packages}
+    (output / "release.json").write_bytes(json_bytes(receipt))
+    return receipt
+
+
+def prepare(repo, tag, output):
+    commit, version = verify_source(repo, tag)
+    snapshot = release_snapshot(repo, tag)
+    source = {"repository": repo, "tag": tag, "commit": commit, "assets": snapshot}
+    with tempfile.TemporaryDirectory(prefix="ocm-npm-assets-") as temporary:
+        assets = Path(temporary)
+        download_assets(repo, tag, snapshot, assets)
+        receipt = stage(
+            version,
+            source,
+            assets,
+            git_source(commit, "npm/ocm.cjs"),
+            git_source(commit, "LICENSE"),
+            git_source(commit, "npm/README.md"),
+            output,
+        )
+    if release_snapshot(repo, tag) != snapshot:
+        raise ValueError("release assets changed during packaging")
+    verify_source(repo, tag, commit)
+    return receipt
+
+
+def read_receipt(directory):
+    receipt = json.loads((directory / "release.json").read_bytes())
+    version = validate_version(receipt["version"])
+    expected_versions = [f"{version}-{platform}" for platform in TARGETS] + [version]
+    if [entry["version"] for entry in receipt["packages"]] != expected_versions:
+        raise ValueError("incomplete or reordered npm package set")
+    for entry in receipt["packages"]:
+        filename = entry["file"]
+        if Path(filename).name != filename or not filename.endswith(".tgz"):
+            raise ValueError("invalid npm tarball path")
+        if integrity((directory / filename).read_bytes()) != entry["integrity"]:
+            raise ValueError(f"prepared tarball integrity mismatch: {filename}")
+    return receipt
+
+
+def revalidate(directory, repo, tag, commit):
+    receipt = read_receipt(directory)
+    verified, version = verify_source(repo, tag, commit)
+    source = {
+        "repository": repo,
+        "tag": tag,
+        "commit": verified,
+        "assets": release_snapshot(repo, tag),
+    }
+    if receipt["version"] != version or receipt["source"] != source:
+        raise ValueError("release source or assets changed after npm validation")
+
+
+def registry_json(path):
+    try:
+        with urlopen(f"{REGISTRY}/{path}", timeout=30) as response:
+            data = response.read(2 * 1024 * 1024 + 1)
+    except HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+    if len(data) > 2 * 1024 * 1024:
+        raise ValueError("npm registry response is too large")
+    value = json.loads(data)
+    if not isinstance(value, dict):
+        raise ValueError("npm registry returned a non-object JSON response")
+    return value
+
+
+def existing_version(entry):
+    existing = registry_json(
+        f"{quote(PACKAGE, safe='')}/{quote(entry['version'], safe='')}"
+    )
+    if existing is None:
+        return False
+    if existing.get("dist", {}).get("integrity") != entry["integrity"]:
+        raise ValueError(
+            f"npm already has different bytes for {PACKAGE}@{entry['version']}"
+        )
+    return True
+
+
+def require_forward_tag(tags, tag, version, platform=None):
+    if tag not in tags:
+        return
+    current = tags[tag]
+    if not isinstance(current, str):
+        raise ValueError(f"npm returned an invalid version for {tag}")
+    if platform:
+        suffix = f"-{platform}"
+        if not current.endswith(suffix):
+            raise ValueError(f"npm tag {tag} points outside its platform namespace")
+        current = current[: -len(suffix)]
+    if version_key(current) >= version_key(version):
+        raise ValueError(f"refusing to move {tag} backward or replace its version")
+
+
+def publish(directory):
+    receipt = read_receipt(directory)
+    version = receipt["version"]
+    channel = "next" if "-" in version else "latest"
+    if os.environ.get("NODE_AUTH_TOKEN") or os.environ.get("NPM_TOKEN"):
+        raise ValueError(
+            "token fallback is forbidden; use the configured npm trusted publisher"
+        )
+    entries = receipt["packages"]
+    present = [existing_version(entry) for entry in entries]
+    tags_path = f"-/package/{quote(PACKAGE, safe='')}/dist-tags"
+    tags = registry_json(tags_path) or {}
+    if present[-1]:
+        current = tags.get(channel)
+        if (
+            all(present)
+            and isinstance(current, str)
+            and version_key(current) >= version_key(version)
+        ):
+            print(
+                f"Verified completed {PACKAGE}@{version}; {channel} stays at {current}"
+            )
+            return
+        raise ValueError(
+            f"{PACKAGE}@{version} exists but needs explicit maintainer package/tag recovery"
+        )
+
+    channels = [
+        (f"platform-{channel}-{platform}", platform) for platform in TARGETS
+    ] + [(channel, None)]
+    # Preflight the entire transaction before any registry write. Separate stable
+    # and prerelease platform tags so a newer `next` cannot block a stable release.
+    for exists, (tag, platform) in zip(present, channels):
+        if not exists:
+            require_forward_tag(tags, tag, version, platform)
+    for entry, exists, (tag, platform) in zip(entries, present, channels):
+        if exists:
+            print(f"Verified existing {PACKAGE}@{entry['version']}")
+            continue
+        # Explicit --tag disables npm's older-version safeguard. Recheck each
+        # tag immediately before publication, including the root channel last.
+        require_forward_tag(registry_json(tags_path) or {}, tag, version, platform)
+        subprocess.run(
+            [
+                "npm",
+                "publish",
+                str(directory / entry["file"]),
+                "--access",
+                "public",
+                "--ignore-scripts",
+                "--provenance",
+                "--registry",
+                REGISTRY,
+                "--tag",
+                tag,
+            ],
+            check=True,
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    prepare_parser = sub.add_parser("prepare")
+    prepare_parser.add_argument("repo")
+    prepare_parser.add_argument("tag")
+    prepare_parser.add_argument("output", type=Path)
+    verify_parser = sub.add_parser("verify")
+    verify_parser.add_argument("directory", type=Path)
+    verify_parser.add_argument("repo")
+    verify_parser.add_argument("tag")
+    verify_parser.add_argument("commit")
+    publish_parser = sub.add_parser("publish")
+    publish_parser.add_argument("directory", type=Path)
+    args = parser.parse_args()
+    if args.command == "prepare":
+        receipt = prepare(args.repo, args.tag, args.output)
+        if os.environ.get("GITHUB_OUTPUT"):
+            with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+                output.write(f"source={receipt['source']['commit']}\n")
+    elif args.command == "verify":
+        revalidate(args.directory, args.repo, args.tag, args.commit)
+    else:
+        publish(args.directory)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_auto_release.py
+++ b/scripts/tests/test_auto_release.py
@@ -133,8 +133,12 @@ class CIGateTests(unittest.TestCase):
         self.ci = {"id": 42, "head_sha": A, "head_branch": "main", "event": "push",
                    "head_repository": {"full_name": release.REPO}, "status": "completed",
                    "conclusion": "success", "html_url": "https://github.com/openclaw/ocm/actions/runs/42"}
-        self.jobs = {"total_count": 5, "jobs": [{"name": n, "conclusion": "success"}
-                                                for n in release.CI_JOBS]}
+        names = ("Format", "Rust 1.88 minimum", "Windows compile",
+                 "Test (ubuntu-latest)", "Test (macos-latest)",
+                 "npm (ubuntu-latest, Node 22.15.0)", "npm (ubuntu-latest, Node 24)",
+                 "npm (macos-15-intel, Node 24)", "npm (macos-15, Node 24)")
+        self.jobs = {"total_count": len(names), "jobs": [
+            {"name": name, "conclusion": "success"} for name in names]}
 
     def check(self, runs, jobs=None):
         with patch.object(release, "api", side_effect=[{"workflow_runs": runs}, jobs or self.jobs]):
@@ -162,7 +166,27 @@ class CIGateTests(unittest.TestCase):
             with self.assertRaises(release.ReleaseError):
                 self.check([self.ci], jobs)
         with self.assertRaises(release.ReleaseError):
-            self.check([self.ci], {"total_count": 5, "jobs": self.jobs["jobs"][:-1]})
+            self.check([self.ci], {"total_count": self.jobs["total_count"],
+                                   "jobs": self.jobs["jobs"][:-1]})
+
+    def test_missing_failed_or_replaced_npm_jobs_stop_release(self):
+        for index, job in enumerate(self.jobs["jobs"]):
+            if not job["name"].startswith("npm ("):
+                continue
+            for outcome in ["missing", "failure", "skipped", None, "renamed", "duplicate"]:
+                with self.subTest(job=job["name"], outcome=outcome):
+                    jobs = copy.deepcopy(self.jobs)
+                    if outcome == "missing":
+                        jobs["jobs"].pop(index)
+                        jobs["total_count"] -= 1
+                    elif outcome == "renamed":
+                        jobs["jobs"][index]["name"] = "unexpected npm job"
+                    elif outcome == "duplicate":
+                        jobs["jobs"][index]["name"] = "Format"
+                    else:
+                        jobs["jobs"][index]["conclusion"] = outcome
+                    with self.assertRaisesRegex(release.ReleaseError, "every required release job"):
+                        self.check([self.ci], jobs)
 
 
 class ReconciliationTests(unittest.TestCase):

--- a/scripts/tests/test_auto_release_boundary.py
+++ b/scripts/tests/test_auto_release_boundary.py
@@ -22,7 +22,9 @@ ROOT = Path(__file__).resolve().parents[2]
 REPO = "openclaw/ocm"
 MARKER = "<!-- ocm-auto-release:v1 -->"
 JOBS = ("Format", "Rust 1.88 minimum", "Windows compile",
-        "Test (ubuntu-latest)", "Test (macos-latest)")
+        "Test (ubuntu-latest)", "Test (macos-latest)",
+        "npm (ubuntu-latest, Node 22.15.0)", "npm (ubuntu-latest, Node 24)",
+        "npm (macos-15-intel, Node 24)", "npm (macos-15, Node 24)")
 
 
 class ReleaseBoundaryTests(unittest.TestCase):

--- a/scripts/tests/test_npm_install.py
+++ b/scripts/tests/test_npm_install.py
@@ -1,0 +1,407 @@
+"""Real npm installs against a task-local, read-only fixture registry."""
+
+from contextlib import contextmanager
+import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import platform
+import signal
+import subprocess
+import sys
+import tarfile
+import tempfile
+from threading import Thread
+import unittest
+from urllib.parse import unquote
+
+from test_npm_release import release, stage_fixture
+
+
+@contextmanager
+def registry(directories):
+    versions = {}
+    tarballs = {}
+    for directory in directories:
+        receipt = release.read_receipt(directory)
+        for entry in receipt["packages"]:
+            with tarfile.open(directory / entry["file"]) as tar:
+                manifest = json.load(tar.extractfile("package/package.json"))
+            versions[entry["version"]] = manifest
+            tarballs[entry["file"]] = (directory / entry["file"]).read_bytes()
+            manifest["dist"] = {
+                "integrity": entry["integrity"],
+                "tarball": entry["file"],
+            }
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            path = unquote(self.path.split("?")[0])
+            filename = path.rsplit("/", 1)[-1]
+            if filename in tarballs:
+                body = tarballs[filename]
+                content_type = "application/octet-stream"
+            elif path == "/@openclaw/ocm":
+                body = release.json_bytes(
+                    {
+                        "name": release.PACKAGE,
+                        "versions": versions,
+                        "dist-tags": {
+                            "latest": max(
+                                (
+                                    version
+                                    for version in versions
+                                    if not any(
+                                        version.endswith(f"-{p}")
+                                        for p in release.TARGETS
+                                    )
+                                ),
+                                key=release.version_key,
+                            )
+                        },
+                    }
+                )
+                content_type = "application/json"
+            else:
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    url = f"http://127.0.0.1:{server.server_port}"
+    for manifest in versions.values():
+        manifest["dist"]["tarball"] = f"{url}/tarballs/{manifest['dist']['tarball']}"
+    thread = Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield url
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def isolated_env(root, url):
+    home = root / "home"
+    home.mkdir()
+    return {
+        "PATH": os.environ["PATH"],
+        "HOME": str(home),
+        "OCM_HOME": str(root / "ocm-home"),
+        "npm_config_cache": str(root / "cache"),
+        "npm_config_userconfig": str(root / "empty-npmrc"),
+        "npm_config_registry": url,
+        "npm_config_audit": "false",
+        "npm_config_fund": "false",
+        "npm_config_update_notifier": "false",
+        "npm_config_ignore_scripts": "true",
+        "NO_COLOR": "1",
+    }
+
+
+def run(command, cwd, env, **kwargs):
+    result = subprocess.run(
+        command, cwd=cwd, env=env, text=True, capture_output=True, timeout=90, **kwargs
+    )
+    if result.returncode:
+        raise AssertionError(
+            f"{command} exited {result.returncode}\n{result.stdout}\n{result.stderr}"
+        )
+    return result
+
+
+def installed_native(prefix):
+    matches = list(
+        prefix.glob(
+            "lib/node_modules/@openclaw/ocm/node_modules/@openclaw/ocm-*/vendor/*/bin/ocm"
+        )
+    )
+    if len(matches) != 1:
+        raise AssertionError(f"expected one compatible native payload, found {matches}")
+    return matches[0]
+
+
+class NpmInstallTests(unittest.TestCase):
+    def test_real_global_upgrade_reinstall_local_npx_and_missing_optionals(self):
+        with tempfile.TemporaryDirectory(prefix="ocm-npm-test-") as temporary:
+            root = Path(temporary)
+            first, _ = stage_fixture(root, "1.0.0", b"#!/bin/sh\nprintf 'one\\n'\n")
+            second, _ = stage_fixture(root, "2.0.0", b"#!/bin/sh\nprintf 'two\\n'\n")
+            with registry([first, second]) as url:
+                env = isolated_env(root, url)
+                prefix = root / "prefix"
+                entrypoint = prefix / "bin/ocm"
+                run(
+                    [
+                        "npm",
+                        "install",
+                        "--global",
+                        "--prefix",
+                        str(prefix),
+                        "@openclaw/ocm@1.0.0",
+                    ],
+                    root,
+                    env,
+                )
+                native = installed_native(prefix)
+                self.assertEqual(
+                    run([str(entrypoint)], root, env).stdout.strip(), "one"
+                )
+                run(
+                    [
+                        "npm",
+                        "install",
+                        "--global",
+                        "--prefix",
+                        str(prefix),
+                        "@openclaw/ocm@2.0.0",
+                    ],
+                    root,
+                    env,
+                )
+                self.assertEqual(installed_native(prefix), native)
+                self.assertEqual(
+                    run([str(entrypoint)], root, env).stdout.strip(), "two"
+                )
+                run(
+                    [
+                        "npm",
+                        "uninstall",
+                        "--global",
+                        "--prefix",
+                        str(prefix),
+                        "@openclaw/ocm",
+                    ],
+                    root,
+                    env,
+                )
+                run(
+                    [
+                        "npm",
+                        "install",
+                        "--global",
+                        "--prefix",
+                        str(prefix),
+                        "@openclaw/ocm@2.0.0",
+                    ],
+                    root,
+                    env,
+                )
+                self.assertEqual(installed_native(prefix), native)
+                self.assertEqual(run([str(native)], root, env).stdout.strip(), "two")
+                local = root / "project"
+                local.mkdir()
+                (local / "package.json").write_text('{"private":true}')
+                run(["npm", "install", "@openclaw/ocm@2.0.0"], local, env)
+                self.assertEqual(
+                    run(
+                        [str(local / "node_modules/.bin/ocm")], local, env
+                    ).stdout.strip(),
+                    "two",
+                )
+                self.assertEqual(
+                    run(
+                        [
+                            "npm",
+                            "exec",
+                            "--yes",
+                            "--package=@openclaw/ocm@2.0.0",
+                            "--",
+                            "ocm",
+                        ],
+                        root,
+                        env,
+                    ).stdout.strip(),
+                    "two",
+                )
+                omitted = root / "omitted"
+                run(
+                    [
+                        "npm",
+                        "install",
+                        "--prefix",
+                        str(omitted),
+                        "--omit=optional",
+                        "@openclaw/ocm@2.0.0",
+                    ],
+                    root,
+                    env,
+                )
+                missing = subprocess.run(
+                    [str(omitted / "node_modules/.bin/ocm")],
+                    cwd=root,
+                    env=env,
+                    text=True,
+                    capture_output=True,
+                )
+                self.assertNotEqual(missing.returncode, 0)
+                self.assertIn("optional dependencies", missing.stderr)
+
+    def test_launcher_preserves_arguments_stdin_exit_and_signal_identity(self):
+        with tempfile.TemporaryDirectory(prefix="ocm-npm-streams-") as temporary:
+            root = Path(temporary)
+            script = b"""#!/bin/sh
+case "$1" in
+  signal) kill -TERM $$ ;;
+  pid) printf '%s\\n' "$$"; exec sleep 30 ;;
+  *) printf '<%s>\\n' "$@"; cat; exit 17 ;;
+esac
+"""
+            packages, _ = stage_fixture(root, binary=script)
+            with registry([packages]) as url:
+                env = isolated_env(root, url)
+                prefix = root / "prefix"
+                run(
+                    [
+                        "npm",
+                        "install",
+                        "--global",
+                        "--prefix",
+                        str(prefix),
+                        "@openclaw/ocm@1.0.0",
+                    ],
+                    root,
+                    env,
+                )
+                entrypoint = prefix / "bin/ocm"
+                result = subprocess.run(
+                    [str(entrypoint), "--color", "never", "space value", ""],
+                    input="stdin bytes\n",
+                    text=True,
+                    capture_output=True,
+                    env=env,
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode, 17)
+                self.assertEqual(
+                    result.stdout,
+                    "<--color>\n<never>\n<space value>\n<>\nstdin bytes\n",
+                )
+                result = subprocess.run(
+                    [str(entrypoint), "signal"],
+                    env=env,
+                    capture_output=True,
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode, -signal.SIGTERM)
+                child = subprocess.Popen(
+                    [str(entrypoint), "pid"], env=env, stdout=subprocess.PIPE, text=True
+                )
+                try:
+                    self.assertEqual(int(child.stdout.readline()), child.pid)
+                    child.terminate()
+                    self.assertEqual(child.wait(timeout=10), -signal.SIGTERM)
+                finally:
+                    if child.poll() is None:
+                        child.kill()
+                        child.wait()
+                    child.stdout.close()
+
+    def test_unsupported_target_and_missing_execve_fail_clearly(self):
+        wrapper = str(release.ROOT / "npm/ocm.cjs")
+        for override, message in [
+            (
+                "Object.defineProperty(process, 'platform', {value:'win32'});",
+                "Unsupported OCM platform",
+            ),
+            ("process.execve = undefined;", "requires Node.js"),
+        ]:
+            result = subprocess.run(
+                ["node", "-e", override + "require(process.argv[1])", wrapper],
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(message, result.stderr)
+
+
+def smoke(directory):
+    receipt = release.read_receipt(directory)
+    with tempfile.TemporaryDirectory(prefix="ocm-npm-native-") as temporary:
+        root = Path(temporary)
+        with registry([directory]) as url:
+            env = isolated_env(root, url)
+            prefix = root / "prefix"
+            run(
+                [
+                    "npm",
+                    "install",
+                    "--global",
+                    "--prefix",
+                    str(prefix),
+                    f"{release.PACKAGE}@{receipt['version']}",
+                ],
+                root,
+                env,
+            )
+            binary = installed_native(prefix)
+            metadata = json.loads((binary.parents[3] / "release.json").read_bytes())
+            if (
+                hashlib.sha256(binary.read_bytes()).hexdigest()
+                != metadata["binarySha256"]
+            ):
+                raise AssertionError("npm install changed native executable bytes")
+            entrypoint = prefix / "bin/ocm"
+            result = run([str(entrypoint), "--version"], root, env)
+            if receipt["version"] not in result.stdout:
+                raise AssertionError(
+                    "installed executable version differs from package"
+                )
+            run([str(entrypoint), "--help"], root, env)
+            if sys.platform == "darwin":
+                run(
+                    [
+                        str(release.ROOT / "scripts/verify-macos-release.sh"),
+                        "--binary",
+                        str(binary),
+                        "--team-id",
+                        os.environ["MACOS_TEAM_ID"],
+                        "--require-notarization",
+                    ],
+                    root,
+                    env,
+                )
+            print(
+                f"Verified npm install, CLI, and unchanged native bytes on {platform.platform()}"
+            )
+
+
+def published_binary_fixture():
+    # This old release proves signed-byte preservation only. Production prepare
+    # rejects it because the native npm ownership guard had not shipped.
+    repo, tag = "openclaw/ocm", "v0.2.39"
+    snapshot = release.release_snapshot(repo, tag)
+    with tempfile.TemporaryDirectory(prefix="ocm-npm-release-fixture-") as temporary:
+        root = Path(temporary)
+        assets = root / "assets"
+        assets.mkdir()
+        release.download_assets(repo, tag, snapshot, assets)
+        output = root / "npm"
+        release.stage(
+            "0.2.39",
+            {"repository": repo, "tag": tag, "assets": snapshot},
+            assets,
+            (release.ROOT / "npm/ocm.cjs").read_bytes(),
+            (release.ROOT / "LICENSE").read_bytes(),
+            (release.ROOT / "npm/README.md").read_bytes(),
+            output,
+        )
+        smoke(output)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 3 and sys.argv[1] == "--packages":
+        smoke(Path(sys.argv[2]).resolve())
+    elif sys.argv[1:] == ["--published-binary-fixture"]:
+        published_binary_fixture()
+    else:
+        unittest.main()

--- a/scripts/tests/test_npm_release.py
+++ b/scripts/tests/test_npm_release.py
@@ -1,0 +1,322 @@
+import importlib.util
+import hashlib
+import io
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+SPEC = importlib.util.spec_from_file_location(
+    "npm_release", Path(__file__).parents[1] / "npm_release.py"
+)
+release = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release)
+
+
+def fixture_assets(directory, binary=b"native bytes"):
+    directory.mkdir()
+    for target in release.TARGETS.values():
+        with tarfile.open(directory / f"ocm-{target}.tar.gz", "w:gz") as tar:
+            for name, data in {
+                "ocm": binary,
+                "LICENSE": b"license",
+                "README.md": b"readme",
+            }.items():
+                info = tarfile.TarInfo(name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+
+def stage_fixture(root, version="1.0.0", binary=b"native bytes"):
+    assets = root / f"assets-{version}"
+    fixture_assets(assets, binary)
+    output = root / f"npm-{version}"
+    receipt = release.stage(
+        version,
+        {"tag": f"v{version}", "commit": "1" * 40},
+        assets,
+        (release.ROOT / "npm/ocm.cjs").read_bytes(),
+        b"license",
+        b"readme",
+        output,
+    )
+    return output, receipt
+
+
+class NpmReleaseTests(unittest.TestCase):
+    def test_original_release_checksums_are_verified_not_regenerated(self):
+        for fault in [
+            "none",
+            "github-digest",
+            "original-checksum",
+            "duplicate-checksum",
+        ]:
+            with self.subTest(fault=fault), tempfile.TemporaryDirectory() as temporary:
+                files = {
+                    f"ocm-{target}.tar.gz": b"archive"
+                    for target in release.TARGETS.values()
+                }
+                files["install.sh"] = b"installer"
+                checksums = "".join(
+                    f"{hashlib.sha256(data).hexdigest()}  {name}\n"
+                    for name, data in files.items()
+                )
+                if fault == "original-checksum":
+                    checksums = "0" * 64 + checksums[64:]
+                elif fault == "duplicate-checksum":
+                    checksums += checksums.splitlines()[0] + "\n"
+                files["SHA256SUMS"] = checksums.encode()
+                snapshot = {
+                    name: {
+                        "size": len(data),
+                        "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
+                    }
+                    for name, data in files.items()
+                }
+                if fault == "github-digest":
+                    snapshot["install.sh"]["digest"] = "sha256:" + "0" * 64
+
+                def download(url, **_):
+                    return io.BytesIO(files[url.rsplit("/", 1)[-1]])
+
+                with patch.object(release, "urlopen", side_effect=download):
+                    if fault == "none":
+                        release.download_assets(
+                            "openclaw/ocm", "v1.0.0", snapshot, Path(temporary)
+                        )
+                        self.assertEqual(
+                            (Path(temporary) / "SHA256SUMS").read_bytes(),
+                            files["SHA256SUMS"],
+                        )
+                    else:
+                        with self.assertRaises(ValueError):
+                            release.download_assets(
+                                "openclaw/ocm", "v1.0.0", snapshot, Path(temporary)
+                            )
+
+    def test_reserved_versions_and_semver_order(self):
+        for version in [
+            "1.0.0+build",
+            "1.0.0-darwin-arm64",
+            "1.0.0-rc.1-linux-x64",
+            "1.0.0-01",
+            "01.0.0",
+        ]:
+            with self.subTest(version=version), self.assertRaises(ValueError):
+                release.validate_version(version)
+        versions = ["1.0.0-alpha", "1.0.0-alpha.2", "1.0.0-alpha.10", "1.0.0", "1.0.1"]
+        self.assertEqual(sorted(reversed(versions), key=release.version_key), versions)
+
+    def test_packages_are_deterministic_and_alias_exact_native_bytes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output, receipt = stage_fixture(root)
+            second = root / "second"
+            second.mkdir()
+            other, again = stage_fixture(second)
+            self.assertEqual(receipt, again)
+            for entry in receipt["packages"]:
+                self.assertEqual(
+                    (output / entry["file"]).read_bytes(),
+                    (other / entry["file"]).read_bytes(),
+                )
+                with tarfile.open(output / entry["file"]) as tar:
+                    manifest = json.load(tar.extractfile("package/package.json"))
+                    self.assertEqual(manifest["name"], "@openclaw/ocm")
+                    self.assertNotIn("scripts", manifest)
+                    if entry["version"] == "1.0.0":
+                        self.assertEqual(
+                            manifest["optionalDependencies"]["@openclaw/ocm-linux-x64"],
+                            "npm:@openclaw/ocm@1.0.0-linux-x64",
+                        )
+                        self.assertEqual(manifest["bin"], {"ocm": "bin/ocm.cjs"})
+                    else:
+                        platform = entry["version"].removeprefix("1.0.0-")
+                        native = tar.extractfile(
+                            f"package/vendor/{release.TARGETS[platform]}/bin/ocm"
+                        ).read()
+                        self.assertEqual(native, b"native bytes")
+                        self.assertNotIn("bin", manifest)
+                        if platform == "linux-x64":
+                            self.assertEqual(manifest["libc"], ["glibc"])
+
+    def test_native_archive_rejects_links_extra_entries_and_traversal(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = Path(temporary) / "bad.tar.gz"
+            for bad_name, kind in [
+                ("../ocm", tarfile.REGTYPE),
+                ("ocm", tarfile.SYMTYPE),
+                ("extra", tarfile.REGTYPE),
+            ]:
+                with self.subTest(bad_name=bad_name, kind=kind):
+                    with tarfile.open(archive, "w:gz") as tar:
+                        for name in ["LICENSE", "README.md", bad_name]:
+                            info = tarfile.TarInfo(name)
+                            info.type = kind if name == bad_name else tarfile.REGTYPE
+                            info.linkname = (
+                                "elsewhere" if kind == tarfile.SYMTYPE else ""
+                            )
+                            tar.addfile(info)
+                    with self.assertRaises(ValueError):
+                        release.native_bytes(archive)
+
+    def test_registry_only_treats_404_as_absent(self):
+        for code in [401, 403, 429, 500, 404]:
+            error = HTTPError(
+                "https://registry.npmjs.org/test", code, "failure", {}, None
+            )
+            with patch.object(release, "urlopen", side_effect=error):
+                if code == 404:
+                    self.assertIsNone(release.registry_json("test"))
+                else:
+                    with self.assertRaises(HTTPError):
+                        release.registry_json("test")
+        for body in [b"null", b"[]", b"42", b'"text"']:
+            with (
+                self.subTest(body=body),
+                patch.object(release, "urlopen", return_value=io.BytesIO(body)),
+            ):
+                with self.assertRaisesRegex(ValueError, "non-object"):
+                    release.registry_json("test")
+
+    def test_partial_retry_publishes_missing_payloads_then_root(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output, receipt = stage_fixture(Path(temporary))
+            first = receipt["packages"][0]
+
+            def registry(path):
+                if path.endswith(first["version"]):
+                    return {"dist": {"integrity": first["integrity"]}}
+                return None
+
+            with (
+                patch.object(release, "registry_json", side_effect=registry),
+                patch.object(release.subprocess, "run") as publish,
+            ):
+                release.publish(output)
+                files = [Path(call.args[0][2]).name for call in publish.call_args_list]
+                self.assertEqual(
+                    files, [entry["file"] for entry in receipt["packages"][1:]]
+                )
+                self.assertEqual(publish.call_args_list[-1].args[0][-1], "latest")
+
+    def test_existing_integrity_mismatch_and_tag_rollback_fail_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output, receipt = stage_fixture(Path(temporary))
+            cases = ["integrity", "rollback", "repair", "complete"]
+            for case in cases:
+
+                def registry(path):
+                    if path.endswith("/dist-tags"):
+                        return {
+                            "latest": "2.0.0"
+                            if case in ("rollback", "complete")
+                            else "0.9.0"
+                        }
+                    entry = next(
+                        entry
+                        for entry in receipt["packages"]
+                        if path.endswith("/" + entry["version"])
+                    )
+                    if case == "integrity":
+                        return {"dist": {"integrity": "sha512-different"}}
+                    if case == "rollback" and entry["version"] == "1.0.0":
+                        return None
+                    return {"dist": {"integrity": entry["integrity"]}}
+
+                with (
+                    self.subTest(case=case),
+                    patch.object(release, "registry_json", side_effect=registry),
+                    patch.object(release.subprocess, "run") as publish,
+                ):
+                    if case == "complete":
+                        release.publish(output)
+                    else:
+                        with self.assertRaises(ValueError):
+                            release.publish(output)
+                    publish.assert_not_called()
+
+    def test_tampered_prepared_tarball_is_never_published(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output, receipt = stage_fixture(Path(temporary))
+            (output / receipt["packages"][0]["file"]).write_bytes(b"tampered")
+            with (
+                patch.object(release.subprocess, "run") as publish,
+                self.assertRaises(ValueError),
+            ):
+                release.publish(output)
+            publish.assert_not_called()
+
+    def test_stale_root_or_platform_channel_is_rejected_before_any_write(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output, _ = stage_fixture(Path(temporary))
+            for tags in [
+                {"latest": "2.0.0"},
+                {"platform-latest-linux-x64": "2.0.0-linux-x64"},
+                {"latest": None},
+            ]:
+                with (
+                    self.subTest(tags=tags),
+                    patch.object(
+                        release,
+                        "registry_json",
+                        side_effect=lambda path: tags
+                        if path.endswith("/dist-tags")
+                        else None,
+                    ),
+                    patch.object(release.subprocess, "run") as publish,
+                ):
+                    with self.assertRaises(ValueError):
+                        release.publish(output)
+                    publish.assert_not_called()
+
+    def test_newer_next_does_not_block_stable_and_root_is_rechecked(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output, receipt = stage_fixture(Path(temporary))
+            tags = {
+                "next": "2.0.0-rc.1",
+                "platform-next-linux-x64": "2.0.0-rc.1-linux-x64",
+            }
+            for move_latest in [False, True]:
+                calls = []
+
+                def registry(path):
+                    if path.endswith("/dist-tags"):
+                        return {
+                            **tags,
+                            **(
+                                {"latest": "2.0.0"}
+                                if move_latest and len(calls) == 3
+                                else {}
+                            ),
+                        }
+                    return None
+
+                with (
+                    self.subTest(move_latest=move_latest),
+                    patch.object(release, "registry_json", side_effect=registry),
+                    patch.object(
+                        release.subprocess,
+                        "run",
+                        side_effect=lambda command, **_: calls.append(command),
+                    ),
+                ):
+                    if move_latest:
+                        with self.assertRaisesRegex(
+                            ValueError, "refusing to move latest"
+                        ):
+                            release.publish(output)
+                        self.assertEqual(len(calls), 3)
+                    else:
+                        release.publish(output)
+                        self.assertEqual(
+                            [call[-1] for call in calls],
+                            [entry["tag"] for entry in receipt["packages"]],
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cli/self_cmd.rs
+++ b/src/cli/self_cmd.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 
 use crate::infra::archive::extract_tar_gz;
 use crate::infra::download::{download_to_file, http_agent, verify_file_sha256};
+use crate::infra::install_owner::NpmInstallation;
 use crate::store::resolve_ocm_home;
 
 use super::{Cli, render};
@@ -61,6 +62,8 @@ pub(crate) struct SelfUpdateSummary {
     pub asset_name: String,
     pub daemon_refresh_required: bool,
     pub daemon_refresh_note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package_manager_note: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -212,7 +215,11 @@ impl Cli {
         let version = Self::require_option_value(version, "--version")?;
         Self::assert_no_extra_args(&args)?;
 
+        let npm = NpmInstallation::from_executable(&self.current_binary_path()?);
         if !check {
+            if let Some(npm) = &npm {
+                return Err(npm.update_guidance());
+            }
             let binary = self
                 .current_binary_path()?
                 .canonicalize()
@@ -234,13 +241,19 @@ impl Cli {
         }
 
         let target_display = version.clone().unwrap_or_else(|| "latest".to_string());
-        let summary = if check {
+        let mut summary = if check {
             self.self_update_check(version.as_deref())?
         } else {
             self.with_progress(format!("Updating ocm to {target_display}"), || {
                 self.self_update_install(version.as_deref())
             })?
         };
+        if let Some(npm) = npm {
+            summary.package_manager_note = Some(format!(
+                "This checks GitHub binary releases, not npm availability. {}",
+                npm.update_guidance()
+            ));
+        }
 
         if json_flag {
             self.print_json(&summary)?;
@@ -252,6 +265,9 @@ impl Cli {
             profile,
             &self.command_example(),
         ));
+        if let Some(note) = summary.package_manager_note {
+            self.stdout_lines([note]);
+        }
         Ok(0)
     }
 
@@ -291,6 +307,7 @@ impl Cli {
             asset_name,
             daemon_refresh_required: false,
             daemon_refresh_note: None,
+            package_manager_note: None,
         })
     }
 
@@ -311,6 +328,7 @@ impl Cli {
                 asset_name,
                 daemon_refresh_required: false,
                 daemon_refresh_note: None,
+                package_manager_note: None,
             });
         }
 
@@ -365,6 +383,7 @@ impl Cli {
             asset_name,
             daemon_refresh_required,
             daemon_refresh_note,
+            package_manager_note: None,
         })
     }
 

--- a/src/infra/install_owner.rs
+++ b/src/infra/install_owner.rs
@@ -1,0 +1,96 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct NpmInstallation {
+    location: NpmLocation,
+}
+
+enum NpmLocation {
+    Global(PathBuf),
+    Local(PathBuf),
+    Ephemeral,
+}
+
+impl NpmInstallation {
+    pub(crate) fn from_executable(executable: &Path) -> Option<Self> {
+        let executable = executable.canonicalize().ok()?;
+        let bin = executable.parent()?;
+        let target = bin.parent()?;
+        let vendor = target.parent()?;
+        let package = vendor.parent()?;
+        if executable.file_name()? != "ocm"
+            || bin.file_name()? != "bin"
+            || vendor.file_name()? != "vendor"
+            || !matches!(
+                target.file_name()?.to_str()?,
+                "aarch64-apple-darwin" | "x86_64-apple-darwin" | "x86_64-unknown-linux-gnu"
+            )
+        {
+            return None;
+        }
+        let manifest: serde_json::Value =
+            serde_json::from_reader(File::open(package.join("package.json")).ok()?.take(65536))
+                .ok()?;
+        if manifest.get("name")?.as_str()? != "@openclaw/ocm" {
+            return None;
+        }
+
+        // Alias directories and the manifest version are not ownership identities.
+        // npm can hoist a payload, and a running daemon can outlive an upgrade.
+        let mut location = NpmLocation::Local(package.to_path_buf());
+        for ancestor in package.ancestors() {
+            if ancestor
+                .file_name()
+                .is_some_and(|name| name == "node_modules")
+                && let Some(parent) = ancestor.parent()
+            {
+                if parent
+                    .parent()
+                    .and_then(Path::file_name)
+                    .is_some_and(|name| name == "_npx")
+                {
+                    return Some(Self {
+                        location: NpmLocation::Ephemeral,
+                    });
+                }
+                location = if parent.file_name().is_some_and(|name| name == "lib")
+                    && let Some(prefix) = parent.parent()
+                    && let Ok(launcher) = prefix.join("bin/ocm").canonicalize()
+                    && launcher.starts_with(ancestor)
+                    && launcher.file_name().is_some_and(|name| name == "ocm.cjs")
+                {
+                    NpmLocation::Global(prefix.to_path_buf())
+                } else {
+                    NpmLocation::Local(parent.to_path_buf())
+                };
+            }
+        }
+        Some(Self { location })
+    }
+
+    pub(crate) fn update_guidance(&self) -> String {
+        match &self.location {
+            NpmLocation::Global(prefix) => format!(
+                "npm manages this ocm installation; run `npm install --global @openclaw/ocm@latest` with the same npm prefix ({})",
+                prefix.display()
+            ),
+            NpmLocation::Local(project) => format!(
+                "npm manages this ocm installation; run `npm install @openclaw/ocm@latest` in its owning project ({})",
+                project.display()
+            ),
+            NpmLocation::Ephemeral =>
+                "npx manages this temporary ocm installation; rerun with `npx --yes @openclaw/ocm@latest` or install OCM globally for background services".to_string(),
+        }
+    }
+
+    pub(crate) fn require_durable(&self) -> Result<(), String> {
+        if matches!(self.location, NpmLocation::Ephemeral) {
+            return Err(
+                "cannot create or rebind the OCM background service from a temporary npx cache; install with `npm install --global @openclaw/ocm`, then rerun using the installed `ocm` command"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,6 +1,7 @@
 pub mod archive;
 pub(crate) mod command_output;
 pub mod download;
+pub(crate) mod install_owner;
 pub mod process;
 pub mod shell;
 mod sqlite_snapshot;

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -464,6 +464,10 @@ fn update_service(
     let _lifecycle_lock = supervisor.lock_daemon_lifecycle()?;
     supervisor.validate_daemon_owner_locked()?;
     let daemon_before = supervisor.daemon_status()?;
+    if matches!(supervisor_policy, ServiceSupervisorPolicy::EnsureRunning) && !daemon_before.running
+    {
+        supervisor.require_durable_daemon_executable()?;
+    }
     let change = set_environment_service_policy(name, service_enabled, service_running, env, cwd)?;
     let update_result = match supervisor_policy {
         ServiceSupervisorPolicy::EnsureRunning => sync_supervisor_env_if_present(env, cwd, name)

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -429,6 +429,7 @@ impl<'a> SupervisorService<'a> {
     }
 
     pub fn install_daemon(&self) -> Result<SupervisorDaemonSummary, String> {
+        self.require_durable_daemon_executable()?;
         let _lifecycle_lock = self.lock_daemon_lifecycle()?;
         self.refresh_daemon("install")
     }
@@ -437,6 +438,7 @@ impl<'a> SupervisorService<'a> {
         &self,
         acknowledge_gateway_restarts: bool,
     ) -> Result<SupervisorDaemonRefreshSummary, String> {
+        self.require_durable_daemon_executable()?;
         let _lifecycle_lock = self.lock_daemon_lifecycle()?;
         let before = self.daemon_status()?;
         if !before.installed {
@@ -488,6 +490,7 @@ impl<'a> SupervisorService<'a> {
         if status.running {
             return Ok(status);
         }
+        self.require_durable_daemon_executable()?;
         let _ = self.sync()?;
         self.activate_daemon("install")
     }
@@ -501,6 +504,9 @@ impl<'a> SupervisorService<'a> {
         &self,
         before: &SupervisorDaemonSummary,
     ) -> Result<(), String> {
+        if before.installed {
+            self.require_durable_daemon_executable()?;
+        }
         let definition = self.supervisor_daemon_definition()?;
         deactivate_managed_service(&definition, self.env)?;
         if before.installed {
@@ -709,6 +715,7 @@ impl<'a> SupervisorService<'a> {
     }
 
     fn activate_daemon(&self, action: &str) -> Result<SupervisorDaemonSummary, String> {
+        self.require_durable_daemon_executable()?;
         let definition = self.supervisor_daemon_definition()?;
         write_managed_service_definition(&definition, self.env)?;
         activate_managed_service(&definition.label, &definition.definition_path, self.env)?;
@@ -805,6 +812,15 @@ impl<'a> SupervisorService<'a> {
             self.cwd,
             &current_exe,
         ))
+    }
+
+    pub(crate) fn require_durable_daemon_executable(&self) -> Result<(), String> {
+        if let Some(npm) = crate::infra::install_owner::NpmInstallation::from_executable(
+            &self.supervisor_executable_path()?,
+        ) {
+            npm.require_durable()?;
+        }
+        Ok(())
     }
 
     fn read_runtime_state(&self) -> Result<Option<SupervisorRuntimeState>, String> {

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -441,6 +441,7 @@ fn write_self_refreshing_gateway_script(
     refresh_pid_path: &Path,
     refresh_output_path: &Path,
     process_groups_path: &Path,
+    ocm: &Path,
 ) {
     let refresh_launcher = path.with_extension("refresh-ocm");
     write_executable_script(
@@ -453,7 +454,7 @@ printf 'gateway_pid=%s gateway_pgid=%s refresh_pid=%s refresh_pgid=%s\n' \
 exec '{ocm}' "$@"
 "#,
             process_groups_path = path_string(process_groups_path),
-            ocm = path_string(&ocm_test_binary_path()),
+            ocm = path_string(ocm),
         ),
     );
     write_executable_script(
@@ -1372,6 +1373,17 @@ exec '{ocm}' "$@"
 #[cfg(unix)]
 #[test]
 fn gateway_owned_daemon_refresh_survives_its_source_process_group() {
+    gateway_owned_daemon_refresh(false);
+}
+
+#[cfg(unix)]
+#[test]
+fn npm_gateway_owned_daemon_refresh_survives_its_source_process_group() {
+    gateway_owned_daemon_refresh(true);
+}
+
+#[cfg(unix)]
+fn gateway_owned_daemon_refresh(npm: bool) {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("gateway-owned-daemon-refresh");
     let cwd = root.child("workspace");
@@ -1401,6 +1413,16 @@ fn gateway_owned_daemon_refresh_survives_its_source_process_group() {
     let refresh_output_path = root.child("refresh-output");
     let process_groups_path = root.child("process-groups");
     let runtime_path = root.child("bin/openclaw");
+    let ocm = if npm {
+        let Some((entrypoint, _)) =
+            crate::support::npm_fixture(&root.child("prefix/lib/node_modules/@openclaw/ocm"))
+        else {
+            return;
+        };
+        entrypoint
+    } else {
+        ocm_test_binary_path()
+    };
     write_self_refreshing_gateway_script(
         &runtime_path,
         &started_path,
@@ -1408,6 +1430,7 @@ fn gateway_owned_daemon_refresh_survives_its_source_process_group() {
         &refresh_pid_path,
         &refresh_output_path,
         &process_groups_path,
+        &ocm,
     );
 
     let add = run_ocm(

--- a/tests/install_script_tests.rs
+++ b/tests/install_script_tests.rs
@@ -136,3 +136,162 @@ fn installer_rejects_linux_aarch64_before_downloading() {
         stderr(&output)
     );
 }
+
+#[test]
+fn installer_force_preserves_managed_destinations_before_download() {
+    let root = TestDir::new("install-managed-destination");
+    let fake_bin = root.child("fake-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let log = root.child("curl.log");
+    write_executable_script(
+        &fake_bin.join("curl"),
+        "#!/bin/sh\nprintf 'called\\n' >> \"$TEST_CURL_LOG\"\nexit 1\n",
+    );
+    let native_dir = root.child(
+        "prefix/lib/node_modules/@openclaw/ocm-linux-x64/vendor/x86_64-unknown-linux-gnu/bin",
+    );
+    let brew_dir = root.child("Cellar/ocm/0.2.39/bin");
+    let linked_dir = root.child("bin");
+    let dangling_dir = root.child("dangling");
+    for directory in [&native_dir, &brew_dir, &linked_dir, &dangling_dir] {
+        fs::create_dir_all(directory).unwrap();
+    }
+    fs::write(native_dir.join("ocm"), "npm-owned").unwrap();
+    fs::write(brew_dir.join("ocm"), "brew-owned").unwrap();
+    fs::write(brew_dir.join("../INSTALL_RECEIPT.json"), "{}").unwrap();
+    std::os::unix::fs::symlink(native_dir.join("ocm"), linked_dir.join("ocm")).unwrap();
+    std::os::unix::fs::symlink(root.child("missing"), dangling_dir.join("ocm")).unwrap();
+    let missing = root.child("project/node_modules/alias/vendor/target/bin");
+    fs::create_dir_all(root.child("project/node_modules")).unwrap();
+    std::os::unix::fs::symlink(root.child("project/node_modules"), root.child("packages")).unwrap();
+    let linked_missing = root.child("packages/alias/vendor/target/bin");
+    for directory in [
+        &native_dir,
+        &brew_dir,
+        &linked_dir,
+        &dangling_dir,
+        &missing,
+        &linked_missing,
+    ] {
+        let output = Command::new("bash")
+            .arg(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+            .args(["--force", "--bin-dir", &path_string(directory)])
+            .env("HOME", root.child("home"))
+            .env("TEST_CURL_LOG", &log)
+            .env(
+                "PATH",
+                format!("{}:{}", fake_bin.display(), std::env::var("PATH").unwrap()),
+            )
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(
+            !log.exists(),
+            "installer downloaded before protecting {}",
+            directory.display()
+        );
+    }
+    assert_eq!(
+        fs::read_to_string(native_dir.join("ocm")).unwrap(),
+        "npm-owned"
+    );
+    assert_eq!(
+        fs::read_to_string(brew_dir.join("ocm")).unwrap(),
+        "brew-owned"
+    );
+    assert!(linked_dir.join("ocm").is_symlink());
+    assert!(dangling_dir.join("ocm").is_symlink());
+    assert!(!missing.exists());
+    assert!(!linked_missing.exists());
+}
+
+#[test]
+fn installer_preserves_destination_changes_and_standalone_force() {
+    use flate2::{Compression, write::GzEncoder};
+    for action in ["force", "new-file", "new-symlink", "managed-parent"] {
+        let root = TestDir::new("install-force-standalone");
+        let fake_bin = root.child("fake-bin");
+        fs::create_dir_all(&fake_bin).unwrap();
+        let archive = root.child("archive.tar.gz");
+        let mut builder = tar::Builder::new(GzEncoder::new(
+            fs::File::create(&archive).unwrap(),
+            Compression::default(),
+        ));
+        let bytes = b"new standalone binary";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder.append_data(&mut header, "ocm", &bytes[..]).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+        let digest = ocm::infra::download::file_sha256(&archive).unwrap();
+        write_executable_script(
+            &fake_bin.join("uname"),
+            "#!/bin/sh\ncase \"$1\" in -s) echo Linux;; -m) echo x86_64;; esac\n",
+        );
+        write_executable_script(
+            &fake_bin.join("curl"),
+            &format!(
+                r#"#!/bin/sh
+case "$2" in
+  */SHA256SUMS)
+    printf '{digest}  ocm-x86_64-unknown-linux-gnu.tar.gz\n' > "$4"
+    case "$TEST_ACTION" in
+      new-file) printf 'appeared' > "$TEST_DESTINATION";;
+      new-symlink) ln -s "$TEST_MANAGED_DEST" "$TEST_DESTINATION";;
+      managed-parent)
+        mv "$TEST_BIN_DIR" "$TEST_BIN_DIR.original"
+        ln -s "$(dirname "$TEST_MANAGED_DEST")" "$TEST_BIN_DIR"
+        ;;
+    esac
+    ;;
+  *) cp "$TEST_ARCHIVE" "$4";;
+esac
+"#
+            ),
+        );
+        let destination = root.child("standalone/ocm");
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        let managed = root.child("node_modules/@openclaw/ocm/bin/ocm");
+        fs::create_dir_all(managed.parent().unwrap()).unwrap();
+        fs::write(&managed, "managed").unwrap();
+        let mut command = Command::new("bash");
+        if action == "force" {
+            fs::write(&destination, "old").unwrap();
+            command
+                .arg(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+                .arg("--force");
+        } else {
+            command.arg(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("install.sh"));
+        }
+        let output = command
+            .args(["--bin-dir", &path_string(destination.parent().unwrap())])
+            .env("HOME", root.child("home"))
+            .env("TEST_ARCHIVE", archive)
+            .env("TEST_ACTION", action)
+            .env("TEST_DESTINATION", &destination)
+            .env("TEST_BIN_DIR", destination.parent().unwrap())
+            .env("TEST_MANAGED_DEST", &managed)
+            .env(
+                "PATH",
+                format!("{}:{}", fake_bin.display(), std::env::var("PATH").unwrap()),
+            )
+            .output()
+            .unwrap();
+        if action == "force" {
+            assert!(output.status.success(), "{}", stderr(&output));
+            assert_eq!(fs::read(&destination).unwrap(), bytes);
+        } else {
+            assert!(!output.status.success(), "{action}");
+            assert_eq!(
+                fs::read(&destination).unwrap(),
+                if action == "new-file" {
+                    b"appeared".as_slice()
+                } else {
+                    b"managed".as_slice()
+                }
+            );
+        }
+        assert_eq!(fs::read(managed).unwrap(), b"managed");
+    }
+}

--- a/tests/self_command_tests.rs
+++ b/tests/self_command_tests.rs
@@ -198,6 +198,110 @@ fn homebrew_self_update_preserves_the_keg_and_allows_checks_through_symlinks() {
     assert_eq!(file_sha256(&binary).unwrap(), original);
 }
 
+#[cfg(unix)]
+#[test]
+fn npm_self_update_preserves_global_local_and_npx_payloads() {
+    use crate::support::npm_fixture;
+
+    for (location, guidance) in [
+        (
+            "custom-prefix/lib/node_modules/@openclaw/ocm",
+            "same npm prefix",
+        ),
+        ("project/node_modules/@openclaw/ocm", "owning project"),
+        ("lib/node_modules/@openclaw/ocm", "owning project"),
+        (
+            "custom-cache/_npx/hash/node_modules/@openclaw/ocm",
+            "temporary",
+        ),
+    ] {
+        let root = TestDir::new("self-update-npm");
+        let cwd = root.child("workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let Some((entrypoint, binary)) = npm_fixture(&root.child(location)) else {
+            return;
+        };
+        if location.starts_with("custom-prefix/") {
+            let global = root.child("custom-prefix/bin/ocm");
+            fs::create_dir_all(global.parent().unwrap()).unwrap();
+            std::os::unix::fs::symlink(&entrypoint, &global).unwrap();
+        }
+        let linked = root.child("linked-ocm");
+        std::os::unix::fs::symlink(&entrypoint, &linked).unwrap();
+        let release = TestHttpServer::serve_bytes(
+            "/release.json",
+            "application/json",
+            br#"{"tag_name":"v9.9.9","assets":[]}"#,
+        );
+        let env = release_env(&root, &release.url());
+        let original = file_sha256(&binary).unwrap();
+        for command in [&binary, &entrypoint, &linked] {
+            let output = run_ocm_binary(
+                command,
+                &cwd,
+                &env,
+                &["--color", "never", "self", "update", "--raw"],
+            );
+            assert!(!output.status.success());
+            assert!(stderr(&output).contains(guidance), "{}", stderr(&output));
+        }
+        assert!(release.requests().is_empty());
+        assert_eq!(file_sha256(&binary).unwrap(), original);
+        assert_eq!(fs::read_dir(binary.parent().unwrap()).unwrap().count(), 1);
+        let output = run_ocm_binary(
+            &linked,
+            &cwd,
+            &env,
+            &["self", "update", "--check", "--json"],
+        );
+        assert!(output.status.success(), "{}", stderr(&output));
+        let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(
+            result["packageManagerNote"]
+                .as_str()
+                .unwrap()
+                .contains("not npm availability")
+        );
+        assert_eq!(release.requests().len(), 1);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn npm_owner_requires_manifest_identity_not_path_or_environment_alone() {
+    let root = TestDir::new("self-update-npm-identity");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let Some((_, binary)) = crate::support::npm_fixture(&root.child("node_modules/ocm-alias"))
+    else {
+        return;
+    };
+    let package = binary
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+    let release = TestHttpServer::serve_bytes_times(
+        "/release.json",
+        "application/json",
+        br#"{"tag_name":"v0.0.0","assets":[]}"#,
+        2,
+    );
+    let mut env = release_env(&root, &release.url());
+    env.insert("OCM_MANAGED_BY_NPM".to_string(), "1".to_string());
+    for manifest in ["not json", r#"{"name":"unrelated","version":"9.0.0"}"#] {
+        fs::write(package.join("package.json"), manifest).unwrap();
+        let output = run_ocm_binary(&binary, &cwd, &env, &["self", "update", "--raw"]);
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert!(stdout(&output).contains("up_to_date"));
+    }
+    assert_eq!(release.requests().len(), 2);
+}
+
 #[test]
 fn self_update_check_ignores_older_latest_release_when_current_is_newer() {
     let root = TestDir::new("self-update-check-older-latest");

--- a/tests/service_command_tests.rs
+++ b/tests/service_command_tests.rs
@@ -1043,6 +1043,55 @@ fn service_refresh_daemon_requires_interruption_ack_and_preserves_desired_state(
     assert_eq!(fs::read(&state_path).unwrap(), state_before);
 }
 
+#[cfg(unix)]
+#[test]
+fn npx_cannot_rebind_daemon_but_can_inspect_and_stop_it() {
+    let root = TestDir::new("npx-daemon-owner");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = launchd_env(&root);
+    setup_launcher_env(&cwd, &env);
+    let Some((entrypoint, _)) =
+        crate::support::npm_fixture(&root.child("cache/_npx/hash/node_modules/@openclaw/ocm"))
+    else {
+        return;
+    };
+    let before =
+        crate::support::run_ocm_binary(&entrypoint, &cwd, &env, &["service", "start", "demo"]);
+    assert!(!before.status.success());
+    assert!(
+        stderr(&before).contains("temporary npx cache"),
+        "{}",
+        stderr(&before)
+    );
+
+    let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    let definition = managed_service_definition_path(&env, &cwd, "ocm");
+    let original = fs::read(&definition).unwrap();
+    let refresh = crate::support::run_ocm_binary(
+        &entrypoint,
+        &cwd,
+        &env,
+        &[
+            "service",
+            "refresh-daemon",
+            "--acknowledge-gateway-restarts",
+        ],
+    );
+    assert!(!refresh.status.success());
+    assert!(
+        stderr(&refresh).contains("temporary npx cache"),
+        "{}",
+        stderr(&refresh)
+    );
+    assert_eq!(fs::read(&definition).unwrap(), original);
+    for args in [vec!["service", "status"], vec!["service", "stop", "demo"]] {
+        let output = crate::support::run_ocm_binary(&entrypoint, &cwd, &env, &args);
+        assert!(output.status.success(), "{}", stderr(&output));
+    }
+}
+
 #[test]
 fn systemd_service_install_writes_the_ocm_unit() {
     let root = TestDir::new("service-systemd-install");

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -298,6 +298,29 @@ pub fn write_executable_script(path: &Path, contents: &str) {
     }
 }
 
+#[cfg(unix)]
+pub fn npm_fixture(package: &Path) -> Option<(PathBuf, PathBuf)> {
+    let (platform, target) = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => ("darwin-arm64", "aarch64-apple-darwin"),
+        ("macos", "x86_64") => ("darwin-x64", "x86_64-apple-darwin"),
+        ("linux", "x86_64") if cfg!(target_env = "gnu") => {
+            ("linux-x64", "x86_64-unknown-linux-gnu")
+        }
+        _ => return None,
+    };
+    let payload = package.join(format!("node_modules/@openclaw/ocm-{platform}"));
+    write_text(
+        &payload.join("package.json"),
+        r#"{"name":"@openclaw/ocm","version":"9.0.0"}"#,
+    );
+    let binary = payload.join(format!("vendor/{target}/bin/ocm"));
+    fs::create_dir_all(binary.parent().unwrap()).unwrap();
+    fs::hard_link(ocm_test_binary_path(), &binary).unwrap();
+    let entrypoint = package.join("bin/ocm.cjs");
+    write_executable_script(&entrypoint, include_str!("../../npm/ocm.cjs"));
+    Some((entrypoint, binary))
+}
+
 pub fn install_fake_launchctl(root: &TestDir, env: &mut BTreeMap<String, String>) {
     let bin_dir = root.child("fake-bin");
     fs::create_dir_all(&bin_dir).unwrap();


### PR DESCRIPTION
## What Problem This Solves

OCM's Rust executable cannot currently be installed through npm. A wrapper alone would also allow native self-update to overwrite package-managed files, leave daemon bindings in temporary npx caches, or break gateway-owned refreshes by forwarding termination from a Node parent.

## Why This Change Was Made

Prepare one public package, `@openclaw/ocm`, with exact optional aliases to same-name platform versions. The launcher uses `process.execve`; installation has no lifecycle hooks, downloads, or Rust compiler dependency.

Add manual, protected-main OIDC publication of the already signed binary release. Preparation checks the signed source, exact-main CI, complete release inventory, original checksums, and GitHub asset digests. It generates deterministic tarballs from the tagged source, tests those exact files, then publishes platform payloads serially and the root channel last. Full preflight, SHA-512 retry identity, separate stable/prerelease platform tags, and immediate channel rechecks prevent stale publication from rolling tags backward.

Keep updates with the installation owner, refuse temporary npx daemon bindings, and protect shell-installer destinations before and after downloading. Preserve explicit daemon refresh and the existing Homebrew ownership guard.

Keep automatic-release verification synchronized with all nine CI jobs, including the four npm lanes, without relaxing exact identity, inventory, or success checks.

## User Impact

- Supported npm targets: macOS ARM64/x64 and Linux x64 glibc; Node `^22.15.0 || >=24.0.0`.
- Global/local npm installations update through their owning npm installation. `self update --check` explicitly reports GitHub release availability, not npm availability.
- npx can inspect and stop services but cannot create or rebind a daemon to its temporary cache.
- The package is not published by this PR. The first npm publication requires a separately approved future signed release, a legitimate package bootstrap, and npm-side trusted-publisher setup with direct `npm publish` permission.
- GitHub environment `npm` is configured for the `main` branch only. No tokens, tags, versions, releases, signing credentials, or automatic release settings were changed.

## Evidence

- `cargo check --workspace --all-targets --locked` passed.
- All 18 installer/self-update tests passed, including missing managed directories, symlinked parents, destinations changing during download, direct native invocation, aliases, and custom prefixes.
- npm-launched gateway refresh survived its caller process-group teardown.
- npx inspection/stop and daemon-binding refusal passed. An existing detached recovery-handoff test missed its log once in the broader local suite; its isolated rerun passed unchanged.
- 13 Python tests passed: actual isolated npm global install/upgrade/reinstall, local installation, npx, omitted optionals, argv/stdin/exit/signals, deterministic packaging, original checksum verification, integrity mismatch, partial retries, and zero-write stale-channel rejection.
- All 33 automatic-release tests passed. The updated nine-job unit and production CLI fixtures reproduced the old gate failure before the repair; missing, failed, skipped, renamed, and duplicate npm jobs remain rejected.
- macOS ARM64 installation of the existing v0.2.39 signed fixture preserved executable bytes and passed CLI, Developer ID, and online notarization checks. That fixture is not eligible for production npm publication; production preparation rejected it.
- Rust formatting, Ruff formatting/lint, actionlint, and `git diff --check` passed.
- Hosted CI adds Node-minimum coverage and all three native npm platforms. Live OIDC publication remains unverified until the separately approved npm account setup/publication.
