### PR TITLE
chore(release): bump version to 0.2.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.39"
+version = "0.2.40"
 publish = false
 edition = "2024"
 rust-version = "1.88"


### PR DESCRIPTION
## What Problem This Solves

The signed OCM release still predates npm distribution and package-manager ownership safeguards. Version 0.2.40 prepares the approved release containing those already-merged changes.

## Why This Change Was Made

Use the repository's version updater to change only the root package version in `Cargo.toml` and `Cargo.lock` from `0.2.39` to `0.2.40`. Keep the internal `ocm` name, library and executable targets, dependencies, and `publish = false` unchanged.

## User Impact

This PR reserves the next release version. Merging it alone does not publish binaries or npm packages; signed-tag verification, exact merged-main CI, native signing/notarization, and npm publication validation remain required.

## Evidence

- Exact two-file diff: one version-line replacement in each Cargo file.
- `scripts/read-package-version.sh Cargo.toml Cargo.lock`: `0.2.40`.
- `cargo metadata --no-deps --locked --format-version 1`: package `ocm` version `0.2.40`, Cargo publication disabled, `ocm` library and executable retained.
- `cargo fmt --check` and `git diff --check`: passed.
- Independent review through P2: scoped-clean; exact version-only change confirmed.
- All nine CI jobs passed on exact head `1974f886834202a2501d1b7c912e3c100e1556c9`, including Linux/macOS Rust tests and source-install smoke checks, Windows compilation, minimum Rust, and all four npm lanes: https://github.com/openclaw/ocm/actions/runs/34111789893.
- CodeQL passed. Independent and maintainer reviews identified no actionable findings.
