### PR TITLE
chore(release): bump version to 0.2.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.40"
+version = "0.2.41"
 publish = false
 edition = "2024"
 rust-version = "1.88"


### PR DESCRIPTION
## What Problem This Solves

PR #151 is merged but not yet available in a published OCM release.

## Why This Change Was Made

Prepare v0.2.41 through the existing manual release flow. This PR changes only the package version in Cargo.toml and Cargo.lock.

## User Impact

The release will include online checkpoint preparation and service restoration before failed-backup cleanup. The version bump alone does not change running services.

## Evidence

The base commit fd57f34b6fd42baaae315ca65374c061cd9778d5 passed all CI jobs after rerunning the two initially failing gateway-refresh test jobs: https://github.com/openclaw/ocm/actions/runs/34154045246.

Local formatting, Rust 1.88 all-target compilation, the release build, and every Rust test target passed. The built binary reports 0.2.41. Test execution initially exposed compiler, Node, and Python setup problems in the local test PATH. After correcting that task-local setup, the failed targets and remaining tests passed. No product code or global toolchain settings changed.

The release helper's local checks were skipped only for PR creation because those checks were run separately. All CI jobs must pass before landing: https://github.com/openclaw/ocm/actions/runs/34159222459. The signed tag and release publication follow successful CI on the resulting main commit. No signing credentials, automation settings, or running services changed.
