### PR TITLE
fix(snapshot): stop Unix sockets from blocking upgrades

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -446,6 +446,15 @@ sidecars, modes, symlinks, plugin data, and unknown future paths. Restore stages
 an exclusive candidate beside the live root and retains the displaced root
 until service acceptance; failed acceptance restores the displaced root.
 
+Unix sockets are transient process endpoints and are omitted from checkpoints,
+including inactive socket files left by stopped processes. Snapshot creation
+leaves source endpoints untouched. Restore does not recreate sockets; their
+owning processes create them when needed. This rule uses the entry's file type,
+so ordinary files named `*.sock` and symlinks remain part of the checkpoint.
+Other unsupported special entries, such as FIFOs and devices, are rejected
+during preparation before a running gateway is stopped. Final capture also
+checks for unsupported entries introduced after preparation.
+
 APFS checkpoints begin as space-efficient copy-on-write clones. Other
 filesystems require a full metadata-preserving copy. Plan space for checkpoint
 divergence and a temporary restore candidate. These same-disk, secret-bearing

--- a/src/infra/tree_digest.rs
+++ b/src/infra/tree_digest.rs
@@ -14,6 +14,19 @@ pub(crate) struct TreeInventoryEntry {
     sha256: Option<[u8; 32]>,
 }
 
+impl TreeInventoryEntry {
+    pub(crate) fn is_socket(&self) -> bool {
+        #[cfg(unix)]
+        {
+            self.mode & u32::from(libc::S_IFMT) == u32::from(libc::S_IFSOCK)
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
+    }
+}
+
 /// Returns a deterministic inventory of a tree without following symlinks.
 pub(crate) fn inventory_tree(root: &Path) -> Result<BTreeMap<PathBuf, TreeInventoryEntry>, String> {
     let mut out = BTreeMap::new();
@@ -151,6 +164,26 @@ fn metadata_mode(metadata: &fs::Metadata) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::tree_sha256;
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_digest_still_refuses_unix_sockets() {
+        let root = tempfile::Builder::new()
+            .prefix("ocmr-")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let _listener =
+            std::os::unix::net::UnixListener::bind(root.path().join("endpoint")).unwrap();
+        assert!(
+            super::inventory_tree(root.path()).unwrap()[std::path::Path::new("endpoint")]
+                .is_socket()
+        );
+        assert!(
+            tree_sha256(root.path())
+                .unwrap_err()
+                .contains("unsupported entry type")
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -210,9 +210,10 @@ pub(crate) fn create_tree_checkpoint_from_preparation(
         sync_tree_root(&candidate)?;
         fs::rename(&candidate, destination).map_err(|error| error.to_string())?;
         return Ok(STORAGE_APFS_CLONE.to_string());
-    } else {
-        copyfile_tree(&prepared.source, &candidate)?;
     }
+
+    #[cfg(target_os = "macos")]
+    copy_checkpoint_tree(&prepared.source, &candidate)?;
 
     #[cfg(not(target_os = "macos"))]
     copy_tree_preserving_metadata(&prepared.source, &candidate)?;
@@ -230,8 +231,12 @@ pub(crate) fn copy_tree_checkpoint(source: &Path, destination: &Path) -> Result<
 }
 
 pub(crate) fn verify_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String> {
-    let source_entries = inventory_tree(source)?;
-    let destination_entries = inventory_tree(destination)?;
+    let mut source_entries = inventory_tree(source)?;
+    let mut destination_entries = inventory_tree(destination)?;
+    // Process endpoints have no durable payload. Keep this policy local to
+    // checkpoints; immutable runtime inventories must still reject sockets.
+    source_entries.retain(|_, entry| !entry.is_socket());
+    destination_entries.retain(|_, entry| !entry.is_socket());
     if source_entries != destination_entries {
         return Err(format!(
             "checkpoint verification failed: {} does not exactly match {}",
@@ -410,8 +415,32 @@ fn prepare_entry_path(
                 Err(error) => return Err(error.to_string()),
             }
         }
+        return Ok(());
     }
-    Ok(())
+    if is_socket(&metadata) {
+        return Ok(());
+    }
+    Err(unsupported_checkpoint_entry(path))
+}
+
+fn is_socket(metadata: &fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileTypeExt;
+        metadata.file_type().is_socket()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        false
+    }
+}
+
+fn unsupported_checkpoint_entry(path: &Path) -> String {
+    format!(
+        "unsupported special file in checkpoint: {}",
+        display_path(path)
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -546,6 +575,12 @@ fn capture_prepared_path(
     let unchanged = prior
         .and_then(|entry| entry.fingerprint)
         .is_some_and(|fingerprint| fingerprint == file_fingerprint(&metadata));
+    if is_socket(&metadata) {
+        // A native seed can contain a socket inode, but restoring it cannot
+        // restore its process or connection. Retire only the candidate entry.
+        cleanup.retire(&destination_path)?;
+        return Ok(true);
+    }
     if metadata.file_type().is_symlink() {
         if unchanged {
             return Ok(false);
@@ -627,10 +662,7 @@ fn capture_prepared_path(
         }
         return Ok(created);
     }
-    Err(format!(
-        "unsupported special file in checkpoint: {}",
-        display_path(path)
-    ))
+    Err(unsupported_checkpoint_entry(path))
 }
 
 #[cfg(target_os = "macos")]
@@ -890,8 +922,12 @@ fn collect_regular_files(path: &Path, out: &mut Vec<PathBuf>) -> Result<(), Stri
         for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
             collect_regular_files(&entry.map_err(|error| error.to_string())?.path(), out)?;
         }
+        return Ok(());
     }
-    Ok(())
+    if is_socket(&metadata) {
+        return Ok(());
+    }
+    Err(unsupported_checkpoint_entry(path))
 }
 
 fn sync_tree_root(root: &Path) -> Result<(), String> {
@@ -1021,6 +1057,30 @@ fn clone_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String
 }
 
 #[cfg(target_os = "macos")]
+fn copy_checkpoint_tree(source: &Path, destination: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    if is_socket(&metadata) {
+        return Ok(());
+    }
+    if metadata.is_dir() {
+        // Native recursive copyfile rejects sockets before it can copy the
+        // durable siblings. Walk entries here, retaining native metadata copy.
+        ensure_dir(destination)?;
+        for entry in fs::read_dir(source).map_err(|error| error.to_string())? {
+            let entry = entry.map_err(|error| error.to_string())?;
+            copy_checkpoint_tree(&entry.path(), &destination.join(entry.file_name()))?;
+        }
+        copyfile_metadata(source, destination)?;
+        preserve_special_mode(destination, &metadata)?;
+        return Ok(());
+    }
+    if metadata.is_file() || metadata.file_type().is_symlink() {
+        return copyfile_tree(source, destination);
+    }
+    Err(unsupported_checkpoint_entry(source))
+}
+
+#[cfg(target_os = "macos")]
 fn copyfile_tree(source: &Path, destination: &Path) -> Result<(), String> {
     const COPYFILE_ALL: u32 = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
     const COPYFILE_RECURSIVE: u32 = 1 << 15;
@@ -1090,6 +1150,9 @@ fn copy_tree_preserving_metadata(source: &Path, destination: &Path) -> Result<()
 #[cfg(not(target_os = "macos"))]
 fn copy_path_preserving_metadata(source: &Path, destination: &Path) -> Result<(), String> {
     let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    if is_socket(&metadata) {
+        return Ok(());
+    }
     let file_type = metadata.file_type();
     if file_type.is_symlink() {
         let target = fs::read_link(source).map_err(|error| error.to_string())?;
@@ -1129,10 +1192,7 @@ fn copy_path_preserving_metadata(source: &Path, destination: &Path) -> Result<()
         preserve_metadata(source, destination, &metadata, false)?;
         return Ok(());
     }
-    Err(format!(
-        "unsupported special file in checkpoint: {}",
-        display_path(source)
-    ))
+    Err(unsupported_checkpoint_entry(source))
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -1166,6 +1226,8 @@ fn preserve_metadata(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::FileTypeExt;
     use std::path::Path;
 
     #[cfg(target_os = "macos")]
@@ -1174,6 +1236,183 @@ mod tests {
         prepare_tree_checkpoint, sqlite_primary_for_sidecar, verify_tree_checkpoint,
     };
     use crate::infra::tree_digest::inventory_tree;
+
+    #[cfg(unix)]
+    #[test]
+    fn checkpoints_skip_socket_endpoints_but_preserve_durable_entries() {
+        use std::io::{Read, Write};
+        use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+        use std::os::unix::net::{UnixListener, UnixStream};
+
+        #[cfg(target_os = "macos")]
+        let variants = [false, true];
+        #[cfg(not(target_os = "macos"))]
+        let variants = [false];
+        for force_full_copy in variants {
+            let fixture = tempfile::Builder::new()
+                .prefix("ocms-")
+                .tempdir_in("/tmp")
+                .unwrap();
+            let source = fixture.path().join("source");
+            let destination = fixture.path().join("checkpoint");
+            fs::create_dir_all(source.join("nested")).unwrap();
+            let regular = source.join("nested/regular.sock");
+            fs::write(&regular, b"durable\0bytes").unwrap();
+            fs::set_permissions(&regular, fs::Permissions::from_mode(0o4750)).unwrap();
+            symlink("../endpoint", source.join("nested/socket-link")).unwrap();
+            fs::set_permissions(source.join("nested"), fs::Permissions::from_mode(0o1550)).unwrap();
+            let endpoint = source.join("endpoint");
+            let listener = UnixListener::bind(&endpoint).unwrap();
+            let inode = fs::symlink_metadata(&endpoint).unwrap().ino();
+            let stale = source.join("stale");
+            drop(UnixListener::bind(&stale).unwrap());
+            let prepared = super::prepare_tree_checkpoint(&source).unwrap();
+            #[cfg(target_os = "macos")]
+            let prepared = {
+                let mut prepared = prepared;
+                assert!(prepared.cloned);
+                if force_full_copy {
+                    prepared
+                        .cleanup
+                        .retire(&prepared.cleanup.candidate())
+                        .unwrap();
+                    prepared.cloned = false;
+                }
+                prepared
+            };
+            let storage =
+                super::create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+            #[cfg(target_os = "macos")]
+            assert_eq!(
+                storage,
+                if force_full_copy {
+                    super::STORAGE_FULL_COPY
+                } else {
+                    super::STORAGE_APFS_CLONE
+                }
+            );
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = force_full_copy;
+                assert_eq!(storage, super::STORAGE_FULL_COPY);
+            }
+            super::verify_tree_checkpoint(&source, &destination).unwrap();
+            assert!(!destination.join("endpoint").exists());
+            assert!(!destination.join("stale").exists());
+            assert_eq!(fs::symlink_metadata(&endpoint).unwrap().ino(), inode);
+            assert!(
+                fs::symlink_metadata(&stale)
+                    .unwrap()
+                    .file_type()
+                    .is_socket()
+            );
+            assert_eq!(
+                fs::read(destination.join("nested/regular.sock")).unwrap(),
+                b"durable\0bytes"
+            );
+            assert_eq!(
+                fs::metadata(destination.join("nested/regular.sock"))
+                    .unwrap()
+                    .mode()
+                    & 0o7777,
+                0o4750
+            );
+            assert_eq!(
+                fs::metadata(destination.join("nested")).unwrap().mode() & 0o7777,
+                0o1550
+            );
+            assert_eq!(
+                fs::read_link(destination.join("nested/socket-link")).unwrap(),
+                Path::new("../endpoint")
+            );
+
+            let mut client = UnixStream::connect(&endpoint).unwrap();
+            let (mut server, _) = listener.accept().unwrap();
+            client.write_all(b"ok").unwrap();
+            let mut message = [0; 2];
+            server.read_exact(&mut message).unwrap();
+            assert_eq!(&message, b"ok");
+
+            fs::write(destination.join("nested/regular.sock"), b"corrupted").unwrap();
+            assert!(super::verify_tree_checkpoint(&source, &destination).is_err());
+            super::remove_tree_if_present(&source).unwrap();
+            super::remove_tree_if_present(&destination).unwrap();
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn checkpoint_reconciles_socket_file_type_changes_after_preparation() {
+        use std::os::unix::net::UnixListener;
+
+        for initially_socket in [false, true] {
+            let fixture = tempfile::Builder::new()
+                .prefix("ocms-")
+                .tempdir_in("/tmp")
+                .unwrap();
+            let source = fixture.path().join("source");
+            fs::create_dir(&source).unwrap();
+            let path = source.join("entry");
+            if initially_socket {
+                drop(UnixListener::bind(&path).unwrap());
+            } else {
+                fs::write(&path, b"before").unwrap();
+            }
+            let prepared = super::prepare_tree_checkpoint(&source).unwrap();
+            fs::remove_file(&path).unwrap();
+            if initially_socket {
+                fs::write(&path, b"after").unwrap();
+            } else {
+                drop(UnixListener::bind(&path).unwrap());
+            }
+            let destination = fixture.path().join("checkpoint");
+            super::create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+            super::verify_tree_checkpoint(&source, &destination).unwrap();
+            if initially_socket {
+                assert_eq!(fs::read(destination.join("entry")).unwrap(), b"after");
+            } else {
+                assert!(!destination.join("entry").exists());
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn checkpoint_refuses_fifos_during_preparation_and_final_capture() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        for before_preparation in [true, false] {
+            let fixture = tempfile::tempdir().unwrap();
+            let source = fixture.path().join("source");
+            fs::create_dir(&source).unwrap();
+            let fifo = source.join("unsupported");
+            let create_fifo = || {
+                let path = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+                assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+            };
+            if before_preparation {
+                create_fifo();
+            }
+            let error = if before_preparation {
+                super::prepare_tree_checkpoint(&source).unwrap_err()
+            } else {
+                let prepared = super::prepare_tree_checkpoint(&source).unwrap();
+                create_fifo();
+                super::create_tree_checkpoint_from_preparation(
+                    prepared,
+                    &fixture.path().join("checkpoint"),
+                )
+                .unwrap_err()
+            };
+            assert!(
+                error.contains("unsupported special file in checkpoint"),
+                "{error}"
+            );
+            assert!(fs::symlink_metadata(&fifo).unwrap().file_type().is_fifo());
+            assert!(!fixture.path().join("checkpoint").exists());
+        }
+    }
 
     #[cfg(target_os = "macos")]
     fn directory_roundtrip_during_preparation(replacement: bool) {

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -1703,6 +1703,70 @@ fn env_snapshot_removes_partial_artifacts_when_sqlite_snapshot_fails() {
     assert_eq!(shown["serviceRunning"], true);
 }
 
+#[cfg(unix)]
+#[test]
+fn env_snapshot_refuses_fifo_before_stopping_the_running_gateway() {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::FileTypeExt;
+
+    let root = TestDir::new("env-snapshot-fifo-preflight");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "launchd".to_string(),
+    );
+    install_fake_launchctl(&root, &mut env);
+    let health = TestHttpServer::serve_bytes_times("/health", "text/plain", b"ok", 10);
+    let port = url::Url::parse(&health.url()).unwrap().port().unwrap() as u32;
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &["launcher", "add", "stable", "--command", "openclaw"],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    let create = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "create",
+            "source",
+            "--port",
+            &port.to_string(),
+            "--launcher",
+            "stable",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr(&create));
+    let started = run_ocm(&cwd, &env, &["service", "start", "source"]);
+    assert!(started.status.success(), "{}", stderr(&started));
+    write_running_snapshot_service(&root, &cwd, &env, port);
+
+    let fifo = root.child("ocm-home/envs/source/unsupported");
+    let fifo_c = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+    assert_eq!(unsafe { libc::mkfifo(fifo_c.as_ptr(), 0o600) }, 0);
+    fs::write(root.child("launchctl.log"), "").unwrap();
+    let snapshot = run_ocm(&cwd, &env, &["env", "snapshot", "create", "source"]);
+    assert_eq!(snapshot.status.code(), Some(1));
+    assert!(
+        stderr(&snapshot).contains("unsupported special file in checkpoint"),
+        "{}",
+        stderr(&snapshot)
+    );
+    assert!(fs::symlink_metadata(&fifo).unwrap().file_type().is_fifo());
+    assert!(!root.child("ocm-home/snapshots/source").exists());
+    let lifecycle = fs::read_to_string(root.child("launchctl.log")).unwrap();
+    assert!(!lifecycle.contains("bootout "), "{lifecycle}");
+    let shown = run_ocm(&cwd, &env, &["env", "show", "source", "--json"]);
+    assert!(shown.status.success(), "{}", stderr(&shown));
+    let shown: Value = serde_json::from_str(&stdout(&shown)).unwrap();
+    assert_eq!(shown["serviceEnabled"], true);
+    assert_eq!(shown["serviceRunning"], true);
+}
+
 #[test]
 fn env_snapshot_rechecks_sqlite_mutated_after_preflight_and_restores_service() {
     let root = TestDir::new("env-snapshot-sqlite-mutated-after-preflight");


### PR DESCRIPTION
## Summary

Fix a repeated production upgrade failure caused by Unix sockets in environment state.

- Omit Unix socket entries from APFS checkpoints, full-copy checkpoints, and checkpoint comparison without touching source endpoints.
- Keep ordinary files, including `*.sock` names, symlinks, modes, SQLite databases, and sidecars under the existing strict checks.
- Refuse other unsupported special entries during online preparation and recheck at final capture.
- Leave immutable runtime-tree verification and restore-before-cleanup ownership unchanged.

## Root cause

Online preparation skipped special entries, but final APFS capture rejected all of them after service shutdown. A stale IPC socket therefore blocked every subsequent upgrade. The general environment copier already treats Unix sockets as transient endpoints; checkpoints now follow that type-based policy. Native recursive macOS `copyfile` also rejects sockets, so the full-copy fallback walks entries while retaining native per-entry metadata copying.

## Evidence

Base: `95c63405591d453186173d1ca26c9f2068fbeb64`
Head: `94bc0044cea198abe7d9a596e1bd20054f189c4c`

The same public CLI fixture succeeds without a socket, fails on the base after adding one stale socket, and succeeds again when only that socket is removed. The head passes with stale and active sockets and preserves source connectivity. Restore retains regular file bytes, permissions, symlinks, and SQLite content. A regular `.sock` file remains included; a FIFO remains refused.

- [Red/base terminal recording](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/checkpoint-unix-sockets/94bc0044cea198abe7d9a596e1bd20054f189c4c/red-base.mp4?X-Amz-Expires=604800&X-Amz-Date=20260908T185023Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=63e62a816b7522824a0dba0b8b87ea85eb32a4b1b7a39f517fcc7d2f4edf37a6)
- [Green/head terminal recording](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/checkpoint-unix-sockets/94bc0044cea198abe7d9a596e1bd20054f189c4c/green-head.mp4?X-Amz-Expires=604800&X-Amz-Date=20260908T185023Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=3c59f563521e5d6422c31b078f5276ff5fbfc7cabdcd4f88fdce4c902f3c4416)
- [Artifact manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/checkpoint-unix-sockets/94bc0044cea198abe7d9a596e1bd20054f189c4c/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260908T185036Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=adaa26525eb4fbdd69583d0a2ae4e059b04d93c9642dc6d2851069bdf9bd9de0)
- [Reproduction contract](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/checkpoint-unix-sockets/94bc0044cea198abe7d9a596e1bd20054f189c4c/contract.md?X-Amz-Expires=604800&X-Amz-Date=20260908T185023Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=46ebf7e60ade3c1a0ef01598ca220dc8a74cebc8cad4adea05f0d9150d5e45a6)
- [Behavior report and limits](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/checkpoint-unix-sockets/94bc0044cea198abe7d9a596e1bd20054f189c4c/behavior-report.json?X-Amz-Expires=604800&X-Amz-Date=20260908T185023Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=5f290f2b99d31a8ab953bff3c4ea29abd2780ba2205c889d4548654416b9fd2a)
- [Exact-head upgrade receipt](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/checkpoint-unix-sockets/94bc0044cea198abe7d9a596e1bd20054f189c4c/upgrade-green.json?X-Amz-Expires=604800&X-Amz-Date=20260908T185023Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=2bea374f92e4fba5f6c7b8547ea1050cf64b627367ef2872f47a4e88ad5cdf9c)

The videos are non-generative renders of recorded terminal output. Only synthetic fixture evidence is included. The standalone upgrade proof uses a stopped environment with synthetic runtime responses; running-service lifecycle is covered by integration tests.

## Validation

140 focused native tests passed:

- 19 checkpoint-related unit tests, including forced full-copy capture, endpoint preservation, file-type changes, late special-entry rejection, directory round trips, SQLite checks, and cleanup ownership.
- 37 snapshot, 18 clone, 5 runtime verification, and 57 upgrade integration tests.
- 4 runtime tree-digest tests, including continued socket refusal.

Formatting and diff checks passed. Autoreview is scoped-clean at P0 on the unchanged change bundle. The initial review invocation was invalidated by a generated Crabbox capture appearing in the checkout; evidence was moved outside the repository and the guard then completed.

The Linux Crabbox attempt lacked `cargo`; its AWS lease was released. Exact-head Linux, macOS, Windows, and MSRV CI remain required before merge.

No release, live deployment, scheduler change, or production-state cleanup is included.

