### PR TITLE
chore(release): bump version to 0.2.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.41"
+version = "0.2.42"
 publish = false
 edition = "2024"
 rust-version = "1.88"


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users cannot install the Unix-socket checkpoint fix from #166 because the latest published OCM release is still v0.2.41.

## Why This Change Was Made

Prepare the maintainer-authorized v0.2.42 patch release. Change only the OCM version in Cargo.toml and Cargo.lock. The release branch starts at canonical main `f12db73e8e09814790a62a4fde2aa5e1e067b19c`.

## User Impact

The release includes checkpoint handling that omits transient Unix sockets without disturbing source endpoints or weakening durable-state validation. Other unsupported special files found during preparation are rejected before service shutdown.

## Evidence

- The fix, reproduction contract, raw red/green proof, and exact-head CI are in #166. The fix passed 1,035 Linux tests and 1,049 macOS tests.
- Version files agree at 0.2.42; formatting and all-target checks are run locally. This PR must pass its own platform CI before merging.
- After this version-only PR merges, the exact main commit must pass CI before the release script creates a signed annotated tag and dispatches the canonical binary workflow.
- macOS signing/notarization, complete public asset verification, and npm OIDC publication remain required. No release credentials or protection settings are changed.
