### PR TITLE
fix: preserve declared project directories during upgrade rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ checkpoint and previous runtime as the coherent rollback state. A running
 managed service is considered recovered only
 after its HTTP health endpoint responds and OpenClaw's gateway status proves the
 gateway is reachable; otherwise the upgrade follows the normal rollback path.
-New snapshots preserve the complete environment root, including credentials,
+By default, checkpoints preserve the complete environment root, including credentials,
 browser profiles, plugin payloads, unknown future directories, modes, symlinks,
 and SQLite sidecars. OCM verifies tree contents and SQLite integrity before
 publishing the checkpoint. APFS uses copy-on-write clones when available;
@@ -177,6 +177,24 @@ rotation, mode changes, SQLite (even at a log path), and all other state still
 require strict verification. Full-copy checkpoints remain exact. Restore discards only
 explicit process residue such as locks, sockets, PIDs, and temporary runtime
 directories. Legacy tar snapshots remain readable.
+
+If a workspace contains projects that OpenClaw does not migrate, declare their
+directories as independent before upgrading:
+
+```bash
+ocm env set-independent-paths mira .openclaw/workspace/projects
+```
+
+Upgrade checkpoints then omit those directories without reading their contents,
+and rollback restores the surrounding owned state while leaving those directories
+in place. The list is explicit and empty by default; names such as `node_modules`
+never imply ownership. Whole workspaces and configuration files cannot be excluded.
+Memory, identity documents, and legacy migration inputs remain covered unless
+they belong to a directory explicitly declared independent. Declarations require
+operator knowledge of migration ownership: OCM does not prevent OpenClaw itself
+from writing to these directories. See [checkpoint scope](docs/USAGE.md#upgrade-checkpoint-scope)
+for the contract and limitations. Separately requested `env snapshot create`
+backups still include the entire environment.
 
 On APFS, snapshot preparation clones the bulk tree while the gateway is running.
 The final service pause reconciles changed or removed entries and checks changed
@@ -194,7 +212,7 @@ linked upgrade recovery or staged artifact cleanup still needs attention.
 When both OpenClaw versions are known, `upgrade` rejects an older target before
 creating a snapshot, downloading the target, or changing runtime metadata.
 Switching only the binary cannot reverse newer OpenClaw config or SQLite state
-migrations; returning to an older release requires a complete snapshot captured
+migrations; returning to an older release requires a checkpoint of its owned state captured
 while that release and its state schema were active.
 `ocm upgrade history <env>` lists completed upgrade transactions newest first,
 including source and target bindings and versions, the pre-upgrade snapshot,

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -437,6 +437,51 @@ Clone copies the workspace and env config into a new environment, gives the clon
 ocm start rowan
 ```
 
+### Upgrade checkpoint scope
+
+By default, upgrade and rollback safety checkpoints cover the full environment.
+To keep independent projects current across core upgrades and rollbacks, declare
+their directories before the upgrade:
+
+```bash
+ocm env set-independent-paths mira .openclaw/workspace/projects .openclaw/workspace/worktrees
+ocm env show mira --json
+ocm env set-independent-paths mira none
+```
+
+The command replaces the list. Paths are relative to the environment root, must
+be strictly beneath a configured workspace, and must name directories. A declared
+directory may be absent if its parents exist. Parents must be real directories;
+symlinks within an independent directory remain untouched. Individual files cannot
+be declared independently, keeping SQLite databases and their adjacent WAL and
+journal files together. Paths cannot overlap, escape the environment, contain
+configuration or its includes, or encompass a configured workspace.
+
+Only declare content that OpenClaw and its migrations do not own. Workspace memory,
+identity, legacy state, and other meaningful files are not disposable. OCM cannot
+discover every plugin or migration's write footprint, and this setting does not
+sandbox runtime writes. Unclassified state remains covered, including credentials,
+unknown runtime directories, and migration inputs outside the declared directories.
+
+Preparation, stopped capture, and rollback validation do not traverse independent
+directories. Restore replaces owned entries around them; it leaves current
+independent bytes, modes, timestamps, extended attributes, symlinks, additions,
+and deletions in place. Shared ancestor directories stay in place, but their
+metadata can change when owned siblings are replaced. Existing service-log and
+socket rules and SQLite validation still apply to the captured state.
+
+Each upgrade checkpoint records its scope. Changing the environment's current
+list affects future checkpoints only. Old whole-root checkpoints still restore
+the whole root; declaring independent paths does not retrofit them. Scoped
+checkpoints use a new kind that older OCM versions refuse to restore. Missing or
+invalid scope metadata is rejected. Restore reverses completed moves if a later
+move fails and retains displaced owned entries until service acceptance; it does
+not add crash recovery for an uncatchable process or machine failure.
+
+This policy belongs to the environment registration. Clone and import start with
+an empty list. A separately requested full snapshot, export, or clone still
+includes independent content. Full snapshot restore still rewinds that content.
+
 ### Snapshots
 
 Snapshot create and restore stop a running OCM-managed gateway before copying or

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -1141,6 +1141,7 @@ impl Cli {
             "exec" => self.handle_env_exec(args),
             "resolve" => self.handle_env_resolve(args),
             "run" => self.handle_env_run(args),
+            "set-independent-paths" => self.handle_env_set_independent_paths(args),
             "set-runtime" => self.handle_env_set_runtime(args),
             "set-launcher" => self.handle_env_set_launcher(args),
             "protect" => self.handle_env_protect(args),
@@ -1549,6 +1550,40 @@ impl Cli {
             &default_runtime,
             profile,
         ));
+        Ok(0)
+    }
+
+    pub(super) fn handle_env_set_independent_paths(
+        &self,
+        args: Vec<String>,
+    ) -> Result<i32, String> {
+        let (args, json, _) = self.consume_human_output_flags(args, "env set-independent-paths")?;
+        if args.len() < 2 {
+            return Err(
+                "usage: ocm env set-independent-paths <env> <relative-path>... | none".to_string(),
+            );
+        }
+        let paths = if args.len() == 2 && args[1] == "none" {
+            Vec::new()
+        } else {
+            args[1..].iter().map(std::path::PathBuf::from).collect()
+        };
+        let meta = self
+            .environment_service()
+            .set_upgrade_independent_paths(&args[0], paths)?;
+        if json {
+            self.print_json(&meta)?;
+        } else {
+            self.stdout_lines(vec![format!(
+                "Updated independent upgrade paths for {}: {}",
+                meta.name,
+                meta.upgrade_independent_paths
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )]);
+        }
         Ok(0)
     }
 

--- a/src/cli/render/env.rs
+++ b/src/cli/render/env.rs
@@ -1217,6 +1217,7 @@ mod tests {
     #[test]
     fn env_list_pretty_uses_a_table() {
         let summaries = vec![EnvSummary {
+            upgrade_independent_paths: Vec::new(),
             name: "demo".to_string(),
             root: "/tmp/demo".to_string(),
             openclaw_home: "/tmp/demo/.openclaw".to_string(),
@@ -1247,6 +1248,7 @@ mod tests {
     fn env_show_pretty_uses_cards() {
         let lines = env_show(
             &EnvSummary {
+                upgrade_independent_paths: Vec::new(),
                 name: "demo".to_string(),
                 root: "/tmp/demo".to_string(),
                 openclaw_home: "/tmp/demo".to_string(),
@@ -1278,6 +1280,7 @@ mod tests {
     fn env_show_pretty_suggests_start_for_unbound_env() {
         let lines = env_show(
             &EnvSummary {
+                upgrade_independent_paths: Vec::new(),
                 name: "bare".to_string(),
                 root: "/tmp/bare".to_string(),
                 openclaw_home: "/tmp/bare".to_string(),
@@ -1723,6 +1726,7 @@ mod tests {
 
     fn sample_snapshot(env_name: &str, label: &str) -> EnvSnapshotSummary {
         EnvSnapshotSummary {
+            upgrade_scope: None,
             id: "snap-001".to_string(),
             env_name: env_name.to_string(),
             label: Some(label.to_string()),
@@ -2308,7 +2312,31 @@ pub fn env_snapshot_show(
         profile.color,
     );
 
+    if let Some(scope) = &snapshot.upgrade_scope {
+        push_card(
+            &mut lines,
+            "Upgrade checkpoint",
+            vec![KeyValueRow::plain(
+                "Preserved on restore",
+                independent_path_names(&scope.independent_paths),
+            )],
+            profile.color,
+        );
+    }
+
     Ok(lines)
+}
+
+fn independent_path_names(paths: &[std::path::PathBuf]) -> String {
+    if paths.is_empty() {
+        "none (whole environment)".to_string()
+    } else {
+        paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 }
 
 fn env_snapshot_show_raw(snapshot: &EnvSnapshotSummary) -> Result<Vec<String>, String> {
@@ -2319,6 +2347,13 @@ fn env_snapshot_show_raw(snapshot: &EnvSnapshotSummary) -> Result<Vec<String>, S
         format!("storageKind: {}", snapshot.storage_kind),
         format!("sourceRoot: {}", snapshot.source_root),
     ];
+    if let Some(scope) = &snapshot.upgrade_scope {
+        lines.push("purpose: upgrade checkpoint".to_string());
+        lines.push(format!(
+            "preservedOnRestore: {}",
+            independent_path_names(&scope.independent_paths)
+        ));
+    }
     if let Some(label) = snapshot.label.as_deref() {
         lines.push(format!("label: {label}"));
     }

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -751,6 +751,10 @@ pub fn env_help(cmd: &str) -> String {
                 &[
                     ("set-launcher", "Bind or clear a launcher"),
                     ("set-runtime", "Bind or clear a runtime"),
+                    (
+                        "set-independent-paths",
+                        "Preserve declared project paths during upgrades",
+                    ),
                     ("resolve", "Show what the environment would run"),
                 ],
             ),
@@ -1373,6 +1377,23 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
                 "When source watch is active for this env, OCM runs node <checkout>/openclaw.mjs directly instead of rebuilding through the package script.",
                 "If an environment is active, you can also use the root-level `--` shortcut.",
                 "For one-shot explicit env runs, use the root-level `@<env>` shortcut.",
+            ],
+        ),
+        "set-independent-paths" => render_leaf(
+            "Set independent upgrade paths",
+            "Declare content beneath configured workspaces that core upgrades must not checkpoint or rewind. This replaces the previous list; use none to clear it.",
+            vec![
+                format!("{cmd} env set-independent-paths <name> <relative-path>... [--json]"),
+                format!("{cmd} env set-independent-paths <name> none [--json]"),
+            ],
+            &[],
+            vec![format!(
+                "{cmd} env set-independent-paths mira .openclaw/workspace/projects"
+            )],
+            &[
+                "Paths name directories relative to the environment root. Configuration, config includes and entire configured workspaces cannot be declared independent.",
+                "Declare only content that core and plugin migrations do not own. OCM does not sandbox runtime writes into declared paths.",
+                "Full snapshots still include these paths. Existing checkpoints keep the scope recorded when they were captured.",
             ],
         ),
         "set-runtime" => render_leaf(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -956,7 +956,7 @@ impl Cli {
         let interrupt_fence = UpgradeInterruptFence::enter()?;
         let prepared = self
             .environment_service()
-            .prepare_snapshot_capture_locked(env_name)?;
+            .prepare_upgrade_checkpoint_locked(env_name)?;
         let _checkpoint_cleanup = prepared.cleanup_guard();
         let service_state = self
             .service_service()
@@ -4304,7 +4304,7 @@ impl Cli {
         let env_meta = self.environment_service().get(env_name)?;
         let prepared = self
             .environment_service()
-            .prepare_snapshot_capture_locked(env_name)?;
+            .prepare_upgrade_checkpoint_locked(env_name)?;
         let mut seen = BTreeSet::new();
         let checkpoint_cleanup = prepared.cleanup_guard();
         let mut runtime_backups: Vec<RuntimeRollbackBackup> = Vec::new();

--- a/src/env/binding.rs
+++ b/src/env/binding.rs
@@ -6,6 +6,18 @@ use crate::store::{
 use crate::supervisor::sync_supervisor_env_if_present;
 
 impl<'a> EnvironmentService<'a> {
+    pub fn set_upgrade_independent_paths(
+        &self,
+        name: &str,
+        paths: Vec<std::path::PathBuf>,
+    ) -> Result<EnvMeta, String> {
+        let _lock = self.lock_operation(name)?;
+        let mut meta = get_environment(name, self.env, self.cwd)?;
+        crate::store::validate_upgrade_independent_paths(&meta, &paths, self.env)?;
+        meta.upgrade_independent_paths = paths;
+        save_environment(meta, self.env, self.cwd)
+    }
+
     pub fn set_launcher(&self, name: &str, launcher_name: &str) -> Result<EnvMeta, String> {
         let _lock = self.lock_operation(name)?;
         let mut meta = get_environment(name, self.env, self.cwd)?;

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -41,6 +41,8 @@ pub struct EnvMeta {
     pub kind: String,
     pub name: String,
     pub root: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub upgrade_independent_paths: Vec<std::path::PathBuf>,
     pub gateway_port: Option<u32>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub gateway_port_auto_assigned: bool,
@@ -70,6 +72,7 @@ pub struct EnvSummary {
     pub state_dir: String,
     pub config_path: String,
     pub workspace_dir: String,
+    pub upgrade_independent_paths: Vec<std::path::PathBuf>,
     pub gateway_port: Option<u32>,
     pub service_enabled: bool,
     pub service_running: bool,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use lifecycle::{CloneEnvironmentResult, ImportEnvironmentResult};
 pub use snapshots::{
     CreateEnvSnapshotOptions, EnvSnapshotRemoveSummary, EnvSnapshotRestoreSummary,
     EnvSnapshotSummary, RemoveEnvSnapshotOptions, RestoreEnvSnapshotOptions,
-    select_snapshot_prune_candidates,
+    UpgradeCheckpointScope, select_snapshot_prune_candidates,
 };
 pub use source_watch::SourceWatchOverride;
 pub(crate) use source_watch::{CreateSourceWatchOverrideOptions, SourceWatchLease};

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
 
 use super::EnvironmentService;
@@ -8,10 +8,16 @@ use crate::store::{
     EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
     create_env_snapshot, create_env_snapshot_from_preparation, get_env_snapshot,
     list_all_env_snapshots, list_env_snapshots, now_utc, prepare_env_snapshot_capture,
-    prepare_env_snapshot_restore, remove_env_snapshot, restore_env_snapshot,
-    rollback_env_snapshot_restore, summarize_snapshot,
+    prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture, remove_env_snapshot,
+    restore_env_snapshot, rollback_env_snapshot_restore, summarize_snapshot,
 };
 use crate::supervisor::sync_supervisor_env_if_present;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpgradeCheckpointScope {
+    pub independent_paths: Vec<std::path::PathBuf>,
+}
 
 #[derive(Clone, Debug)]
 pub struct CreateEnvSnapshotOptions {
@@ -27,6 +33,8 @@ pub struct EnvSnapshotSummary {
     pub label: Option<String>,
     pub archive_path: String,
     pub storage_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upgrade_scope: Option<UpgradeCheckpointScope>,
     pub source_root: String,
     pub gateway_port: Option<u32>,
     pub service_enabled: bool,
@@ -144,6 +152,13 @@ impl<'a> EnvironmentService<'a> {
         env_name: &str,
     ) -> Result<PreparedEnvSnapshotCapture, String> {
         prepare_env_snapshot_capture(env_name, self.env, self.cwd)
+    }
+
+    pub(crate) fn prepare_upgrade_checkpoint_locked(
+        &self,
+        env_name: &str,
+    ) -> Result<PreparedEnvSnapshotCapture, String> {
+        prepare_upgrade_checkpoint_capture(env_name, self.env, self.cwd)
     }
 
     pub(crate) fn create_snapshot_locked_from_preparation(
@@ -332,6 +347,7 @@ mod tests {
 
     fn snapshot(id: &str, env_name: &str, created_at: OffsetDateTime) -> EnvSnapshotSummary {
         EnvSnapshotSummary {
+            upgrade_scope: None,
             id: id.to_string(),
             env_name: env_name.to_string(),
             label: None,

--- a/src/infra/shell.rs
+++ b/src/infra/shell.rs
@@ -273,6 +273,7 @@ mod tests {
     #[test]
     fn build_openclaw_env_preserves_diagnostics_passthrough_only() {
         let meta = EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name: "demo".to_string(),
             root: "/tmp/ocm/envs/demo".to_string(),
@@ -372,6 +373,7 @@ mod tests {
     #[test]
     fn build_openclaw_dev_source_env_points_bundled_plugins_at_source_extensions() {
         let meta = EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name: "demo".to_string(),
             root: "/tmp/ocm/envs/demo".to_string(),
@@ -415,6 +417,7 @@ mod tests {
     #[test]
     fn activation_unsets_only_valid_stale_control_names() {
         let meta = EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name: "demo".to_string(),
             root: "/tmp/ocm/envs/demo".to_string(),

--- a/src/infra/tree_digest.rs
+++ b/src/infra/tree_digest.rs
@@ -29,16 +29,28 @@ impl TreeInventoryEntry {
 
 /// Returns a deterministic inventory of a tree without following symlinks.
 pub(crate) fn inventory_tree(root: &Path) -> Result<BTreeMap<PathBuf, TreeInventoryEntry>, String> {
+    inventory_tree_except(root, &[])
+}
+
+/// Checkpoint-owned selection; runtime inventories always use the complete tree.
+pub(crate) fn inventory_tree_except(
+    root: &Path,
+    independent: &[PathBuf],
+) -> Result<BTreeMap<PathBuf, TreeInventoryEntry>, String> {
     let mut out = BTreeMap::new();
-    inventory_path(root, root, &mut out)?;
+    inventory_path(root, root, independent, &mut out)?;
     Ok(out)
 }
 
 fn inventory_path(
     root: &Path,
     path: &Path,
+    independent: &[PathBuf],
     out: &mut BTreeMap<PathBuf, TreeInventoryEntry>,
 ) -> Result<(), String> {
+    if independent.iter().any(|entry| path == root.join(entry)) {
+        return Ok(());
+    }
     let metadata = fs::symlink_metadata(path)
         .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
     let relative = path.strip_prefix(root).unwrap_or(path).to_path_buf();
@@ -73,7 +85,7 @@ fn inventory_path(
             .map_err(|error| error.to_string())?;
         entries.sort_by_key(|entry| entry.file_name());
         for entry in entries {
-            inventory_path(root, &entry.path(), out)?;
+            inventory_path(root, &entry.path(), independent, out)?;
         }
     }
     Ok(())

--- a/src/store/checkpoint_scope.rs
+++ b/src/store/checkpoint_scope.rs
@@ -1,0 +1,267 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use super::common::path_exists;
+use super::layout::display_path;
+
+/// The declared paths are opaque to checkpoints. In particular, checking their
+/// contents to decide whether to omit them would repeat the original scope bug.
+pub(crate) fn validate_independent_paths(paths: &[PathBuf]) -> Result<(), String> {
+    for (index, path) in paths.iter().enumerate() {
+        if path.as_os_str().is_empty()
+            || path
+                .components()
+                .any(|part| !matches!(part, Component::Normal(_)))
+        {
+            return Err(
+                "independent paths must be nonempty environment-relative paths without . or .."
+                    .to_string(),
+            );
+        }
+        if paths[..index]
+            .iter()
+            .any(|other| path.starts_with(other) || other.starts_with(path))
+        {
+            return Err("independent paths must not overlap or repeat".to_string());
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_ancestors(root: &Path, paths: &[PathBuf]) -> Result<(), String> {
+    validate_independent_paths(paths)?;
+    for relative in paths {
+        let mut ancestor = root.to_path_buf();
+        require_directory(&ancestor)?;
+        let parts = relative.components().collect::<Vec<_>>();
+        for part in &parts[..parts.len() - 1] {
+            ancestor.push(part);
+            require_directory(&ancestor)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_scoped_artifact(root: &Path, paths: &[PathBuf]) -> Result<(), String> {
+    validate_ancestors(root, paths)?;
+    for relative in paths {
+        if path_exists(&root.join(relative)) {
+            return Err(format!(
+                "upgrade checkpoint unexpectedly contains independent path: {}",
+                display_path(relative)
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn require_directory(path: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.is_dir() => Ok(()),
+        _ => Err(format!(
+            "independent path ancestor must remain a real directory: {}",
+            display_path(path)
+        )),
+    }
+}
+
+fn collect_owned_entries(
+    current: &Path,
+    candidate: &Path,
+    relative: &Path,
+    independent: &[PathBuf],
+    entries: &mut Vec<PathBuf>,
+    ancestors: &mut Vec<PathBuf>,
+) -> Result<(), String> {
+    if independent.iter().any(|path| path == relative) {
+        return Ok(());
+    }
+    if !independent.iter().any(|path| path.starts_with(relative)) {
+        entries.push(relative.to_path_buf());
+        return Ok(());
+    }
+    ancestors.push(relative.to_path_buf());
+    let mut names = BTreeSet::new();
+    for root in [current, candidate] {
+        let dir = root.join(relative);
+        require_directory(&dir)?;
+        for entry in fs::read_dir(dir).map_err(|error| error.to_string())? {
+            names.insert(entry.map_err(|error| error.to_string())?.file_name());
+        }
+    }
+    for name in names {
+        collect_owned_entries(
+            current,
+            candidate,
+            &relative.join(name),
+            independent,
+            entries,
+            ancestors,
+        )?;
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct Replacement {
+    relative: PathBuf,
+    displaced: bool,
+    installed: bool,
+}
+
+/// Replace owned entries, leaving independent paths and all their ancestors in
+/// place. The displaced owned entries are retained until service acceptance.
+/// On any publication failure, reverse completed moves before returning.
+pub(crate) fn replace_owned_entries(
+    current: &Path,
+    candidate: &Path,
+    displaced: &Path,
+    independent: &[PathBuf],
+) -> Result<(), String> {
+    validate_ancestors(current, independent)?;
+    validate_ancestors(candidate, independent)?;
+    let mut entries = Vec::new();
+    let mut ancestors = Vec::new();
+    collect_owned_entries(
+        current,
+        candidate,
+        Path::new(""),
+        independent,
+        &mut entries,
+        &mut ancestors,
+    )?;
+    // The sparse backup needs the same directory skeleton for compensation and
+    // later service-acceptance rollback, even when an ancestor has no owned child.
+    for relative in ancestors {
+        fs::create_dir_all(displaced.join(relative)).map_err(|error| error.to_string())?;
+    }
+    for relative in &entries {
+        if path_exists(&displaced.join(relative)) {
+            return Err(format!(
+                "scoped restore destination already exists: {}",
+                display_path(&displaced.join(relative))
+            ));
+        }
+    }
+    let mut completed: Vec<Replacement> = Vec::new();
+    let result = (|| {
+        for relative in entries {
+            completed.push(Replacement {
+                relative: relative.clone(),
+                ..Default::default()
+            });
+            let replacement = completed.last_mut().expect("replacement just inserted");
+            let live = current.join(&relative);
+            if path_exists(&live) {
+                fs::rename(&live, displaced.join(&relative)).map_err(|error| error.to_string())?;
+                replacement.displaced = true;
+            }
+            let staged = candidate.join(&relative);
+            if path_exists(&staged) {
+                fs::rename(&staged, &live).map_err(|error| error.to_string())?;
+                replacement.installed = true;
+            }
+        }
+        Ok(())
+    })();
+    if let Err(error) = result {
+        for replacement in completed.iter().rev() {
+            let live = current.join(&replacement.relative);
+            let revert = (|| {
+                if replacement.installed {
+                    fs::rename(&live, candidate.join(&replacement.relative))?;
+                }
+                if replacement.displaced {
+                    fs::rename(displaced.join(&replacement.relative), &live)?;
+                }
+                Ok::<_, std::io::Error>(())
+            })();
+            if let Err(revert_error) = revert {
+                return Err(format!(
+                    "scoped restore failed ({error}); compensation failed ({revert_error}); recovery entries retained at {}",
+                    display_path(displaced)
+                ));
+            }
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    #[test]
+    fn partial_publication_failure_reinstates_owned_entries_and_leaves_project_in_place() {
+        // Permission denial requires an unprivileged test process.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join("current");
+        let candidate = temp.path().join("candidate");
+        let backup = temp.path().join("backup");
+        for root in [&current, &candidate] {
+            fs::create_dir_all(root.join("z-parent")).unwrap();
+            fs::write(
+                root.join("a-first"),
+                root.file_name().unwrap().as_encoded_bytes(),
+            )
+            .unwrap();
+            fs::write(root.join("z-parent/owned"), "runtime").unwrap();
+        }
+        fs::create_dir(current.join("z-parent/project")).unwrap();
+        fs::write(current.join("z-parent/project/file"), "developer").unwrap();
+        let before = fs::metadata(current.join("z-parent/project/file")).unwrap();
+        fs::set_permissions(current.join("z-parent"), fs::Permissions::from_mode(0o500)).unwrap();
+        let result = replace_owned_entries(
+            &current,
+            &candidate,
+            &backup,
+            &[PathBuf::from("z-parent/project")],
+        );
+        fs::set_permissions(current.join("z-parent"), fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(result.is_err());
+        assert_eq!(fs::read(current.join("a-first")).unwrap(), b"current");
+        assert_eq!(fs::read(candidate.join("a-first")).unwrap(), b"candidate");
+        assert_eq!(
+            fs::metadata(current.join("z-parent/project/file"))
+                .unwrap()
+                .ino(),
+            before.ino()
+        );
+        assert_eq!(
+            fs::read(current.join("z-parent/project/file")).unwrap(),
+            b"developer"
+        );
+    }
+
+    #[test]
+    fn acceptance_rollback_preserves_new_independent_work_and_removes_new_owned_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join("current");
+        let candidate = temp.path().join("candidate");
+        let backup = temp.path().join("backup");
+        let rejected = temp.path().join("rejected");
+        for root in [&current, &candidate] {
+            fs::create_dir_all(root.join("workspace")).unwrap();
+        }
+        fs::create_dir(current.join("workspace/project")).unwrap();
+        fs::write(current.join("owned"), "original").unwrap();
+        fs::write(candidate.join("owned"), "restored").unwrap();
+        let paths = [PathBuf::from("workspace/project")];
+        replace_owned_entries(&current, &candidate, &backup, &paths).unwrap();
+        fs::write(current.join("workspace/project/new"), "new work").unwrap();
+        fs::write(current.join("new-runtime-state"), "new runtime").unwrap();
+        replace_owned_entries(&current, &backup, &rejected, &paths).unwrap();
+        assert_eq!(fs::read(current.join("owned")).unwrap(), b"original");
+        assert_eq!(
+            fs::read(current.join("workspace/project/new")).unwrap(),
+            b"new work"
+        );
+        assert!(!current.join("new-runtime-state").exists());
+    }
+}

--- a/src/store/checkpoints.rs
+++ b/src/store/checkpoints.rs
@@ -18,7 +18,7 @@ use std::io::Write;
 
 use super::common::{ensure_dir, path_exists};
 use super::layout::display_path;
-use crate::infra::tree_digest::inventory_tree;
+use crate::infra::tree_digest::{inventory_tree, inventory_tree_except};
 
 pub(crate) const STORAGE_APFS_CLONE: &str = "apfs-clone-v1";
 pub(crate) const STORAGE_FULL_COPY: &str = "full-copy-v1";
@@ -27,6 +27,7 @@ pub(crate) const STORAGE_TAR_ARCHIVE: &str = "tar-archive-v1";
 #[derive(Debug)]
 pub(crate) struct PreparedTreeCheckpoint {
     source: PathBuf,
+    independent: Vec<PathBuf>,
     cleanup: CheckpointCleanup,
     #[cfg(target_os = "macos")]
     cloned: bool,
@@ -148,6 +149,14 @@ pub(crate) fn prepare_tree_checkpoint_in(
     source: &Path,
     parent: &Path,
 ) -> Result<PreparedTreeCheckpoint, String> {
+    prepare_scoped_tree_checkpoint_in(source, parent, &[])
+}
+
+pub(crate) fn prepare_scoped_tree_checkpoint_in(
+    source: &Path,
+    parent: &Path,
+    independent: &[PathBuf],
+) -> Result<PreparedTreeCheckpoint, String> {
     if !path_exists(source) {
         return Err(format!(
             "checkpoint source does not exist: {}",
@@ -156,16 +165,17 @@ pub(crate) fn prepare_tree_checkpoint_in(
     }
 
     #[cfg(target_os = "macos")]
-    let mut entries = prepare_entries(source)?;
+    let mut entries = prepare_entries(source, independent)?;
     #[cfg(not(target_os = "macos"))]
-    preflight_sqlite_databases(source)?;
+    preflight_sqlite_databases(source, independent)?;
 
     let cleanup = CheckpointCleanup::new(parent)?;
     #[cfg(target_os = "macos")]
     let cloned = {
         // This live copy is only a seed. Fingerprints were recorded BEFORE cloning;
         // capture must reconcile everything that changed before publishing it.
-        let cloned = clone_tree_checkpoint(source, &cleanup.candidate()).is_ok();
+        let cloned =
+            copy_selected_tree(source, source, &cleanup.candidate(), independent, true).is_ok();
         if !cloned {
             cleanup.retire(&cleanup.candidate())?;
         } else {
@@ -176,6 +186,7 @@ pub(crate) fn prepare_tree_checkpoint_in(
 
     Ok(PreparedTreeCheckpoint {
         source: source.to_path_buf(),
+        independent: independent.to_vec(),
         cleanup,
         #[cfg(target_os = "macos")]
         cloned,
@@ -206,19 +217,21 @@ pub(crate) fn create_tree_checkpoint_from_preparation(
             &candidate,
             prepared.entries,
             &prepared.cleanup,
+            &prepared.independent,
         )?;
         sync_tree_root(&candidate)?;
         fs::rename(&candidate, destination).map_err(|error| error.to_string())?;
         return Ok(STORAGE_APFS_CLONE.to_string());
     }
 
-    #[cfg(target_os = "macos")]
-    copy_checkpoint_tree(&prepared.source, &candidate)?;
-
-    #[cfg(not(target_os = "macos"))]
-    copy_tree_preserving_metadata(&prepared.source, &candidate)?;
-
-    verify_tree_checkpoint(&prepared.source, &candidate)?;
+    copy_selected_tree(
+        &prepared.source,
+        &prepared.source,
+        &candidate,
+        &prepared.independent,
+        false,
+    )?;
+    verify_selected_tree_checkpoint(&prepared.source, &candidate, &prepared.independent)?;
     verify_sqlite_databases(&candidate)?;
     sync_tree_root(&candidate)?;
     fs::rename(&candidate, destination).map_err(|error| error.to_string())?;
@@ -230,8 +243,17 @@ pub(crate) fn copy_tree_checkpoint(source: &Path, destination: &Path) -> Result<
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn verify_tree_checkpoint(source: &Path, destination: &Path) -> Result<(), String> {
-    let mut source_entries = inventory_tree(source)?;
+    verify_selected_tree_checkpoint(source, destination, &[])
+}
+
+fn verify_selected_tree_checkpoint(
+    source: &Path,
+    destination: &Path,
+    independent: &[PathBuf],
+) -> Result<(), String> {
+    let mut source_entries = inventory_tree_except(source, independent)?;
     let mut destination_entries = inventory_tree(destination)?;
     // Process endpoints have no durable payload. Keep this policy local to
     // checkpoints; immutable runtime inventories must still reject sockets.
@@ -255,8 +277,8 @@ fn verify_sqlite_databases(root: &Path) -> Result<(), String> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn preflight_sqlite_databases(root: &Path) -> Result<(), String> {
-    for path in regular_files(root)? {
+fn preflight_sqlite_databases(root: &Path, independent: &[PathBuf]) -> Result<(), String> {
+    for path in regular_files_except(root, independent)? {
         let _ = check_sqlite_database(&path)?;
     }
     Ok(())
@@ -320,9 +342,12 @@ fn sqlite_is_busy(error: &rusqlite::Error) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn prepare_entries(root: &Path) -> Result<HashMap<Box<[u8]>, PreparedEntry>, String> {
+fn prepare_entries(
+    root: &Path,
+    independent: &[PathBuf],
+) -> Result<HashMap<Box<[u8]>, PreparedEntry>, String> {
     let mut out = HashMap::new();
-    prepare_entry_path(root, root, &mut out)?;
+    prepare_entry_path(root, root, independent, &mut out)?;
     Ok(out)
 }
 
@@ -330,8 +355,12 @@ fn prepare_entries(root: &Path) -> Result<HashMap<Box<[u8]>, PreparedEntry>, Str
 fn prepare_entry_path(
     root: &Path,
     path: &Path,
+    independent: &[PathBuf],
     out: &mut HashMap<Box<[u8]>, PreparedEntry>,
 ) -> Result<(), String> {
+    if independent.iter().any(|entry| path == root.join(entry)) {
+        return Ok(());
+    }
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -410,7 +439,7 @@ fn prepare_entry_path(
         };
         for entry in entries {
             match entry {
-                Ok(entry) => prepare_entry_path(root, &entry.path(), out)?,
+                Ok(entry) => prepare_entry_path(root, &entry.path(), independent, out)?,
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                 Err(error) => return Err(error.to_string()),
             }
@@ -499,6 +528,7 @@ fn capture_prepared_clone(
     destination: &Path,
     mut prepared: HashMap<Box<[u8]>, PreparedEntry>,
     cleanup: &CheckpointCleanup,
+    independent: &[PathBuf],
 ) -> Result<(), String> {
     let mut candidates = HashSet::new();
     capture_prepared_path(
@@ -508,6 +538,7 @@ fn capture_prepared_clone(
         &mut prepared,
         &mut candidates,
         cleanup,
+        independent,
     )?;
     for (relative, prior) in prepared {
         let relative = PathBuf::from(std::ffi::OsStr::from_bytes(&relative).to_os_string());
@@ -565,9 +596,16 @@ fn capture_prepared_path(
     prepared: &mut HashMap<Box<[u8]>, PreparedEntry>,
     sqlite_candidates: &mut HashSet<PathBuf>,
     cleanup: &CheckpointCleanup,
+    independent: &[PathBuf],
 ) -> Result<bool, String> {
     use std::os::unix::fs::PermissionsExt;
 
+    if independent.iter().any(|entry| path == root.join(entry)) {
+        cleanup.retire(
+            &destination.join(path.strip_prefix(root).map_err(|error| error.to_string())?),
+        )?;
+        return Ok(false);
+    }
     let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
     let relative = path.strip_prefix(root).map_err(|error| error.to_string())?;
     let destination_path = destination.join(relative);
@@ -647,6 +685,7 @@ fn capture_prepared_path(
                 prepared,
                 sqlite_candidates,
                 cleanup,
+                independent,
             )?;
         }
         for entry in fs::read_dir(&destination_path).map_err(|error| error.to_string())? {
@@ -904,12 +943,24 @@ fn sqlite_primary_for_sidecar(path: &Path) -> Option<PathBuf> {
 }
 
 fn regular_files(root: &Path) -> Result<Vec<PathBuf>, String> {
+    regular_files_except(root, &[])
+}
+
+fn regular_files_except(root: &Path, independent: &[PathBuf]) -> Result<Vec<PathBuf>, String> {
     let mut out = Vec::new();
-    collect_regular_files(root, &mut out)?;
+    collect_regular_files(root, root, independent, &mut out)?;
     Ok(out)
 }
 
-fn collect_regular_files(path: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+fn collect_regular_files(
+    root: &Path,
+    path: &Path,
+    independent: &[PathBuf],
+    out: &mut Vec<PathBuf>,
+) -> Result<(), String> {
+    if independent.iter().any(|entry| path == root.join(entry)) {
+        return Ok(());
+    }
     let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
     if metadata.file_type().is_symlink() {
         return Ok(());
@@ -920,7 +971,12 @@ fn collect_regular_files(path: &Path, out: &mut Vec<PathBuf>) -> Result<(), Stri
     }
     if metadata.is_dir() {
         for entry in fs::read_dir(path).map_err(|error| error.to_string())? {
-            collect_regular_files(&entry.map_err(|error| error.to_string())?.path(), out)?;
+            collect_regular_files(
+                root,
+                &entry.map_err(|error| error.to_string())?.path(),
+                independent,
+                out,
+            )?;
         }
         return Ok(());
     }
@@ -1016,6 +1072,72 @@ unsafe extern "C" {
         destination: *const libc::c_char,
         flags: u32,
     ) -> libc::c_int;
+}
+
+/// Partition only ancestors of independent entries. Reuse the existing native
+/// clone/copy for owned subtrees without visiting the independent content.
+fn copy_selected_tree(
+    root: &Path,
+    source: &Path,
+    destination: &Path,
+    independent: &[PathBuf],
+    clone: bool,
+) -> Result<(), String> {
+    let relative = source
+        .strip_prefix(root)
+        .map_err(|error| error.to_string())?;
+    if independent.iter().any(|entry| entry == relative) {
+        return Ok(());
+    }
+    if independent.iter().any(|entry| entry.starts_with(relative)) {
+        let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+        if !metadata.is_dir() {
+            return Err(format!(
+                "independent checkpoint path has a non-directory ancestor: {}",
+                display_path(source)
+            ));
+        }
+        fs::create_dir(destination).map_err(|error| error.to_string())?;
+        for entry in fs::read_dir(source).map_err(|error| error.to_string())? {
+            let entry = entry.map_err(|error| error.to_string())?;
+            copy_selected_tree(
+                root,
+                &entry.path(),
+                &destination.join(entry.file_name()),
+                independent,
+                clone,
+            )?;
+        }
+        return copy_checkpoint_directory_metadata(source, destination);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if clone {
+            clone_tree_checkpoint(source, destination)
+        } else {
+            copy_checkpoint_tree(source, destination)
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = clone;
+        copy_tree_preserving_metadata(source, destination)
+    }
+}
+
+pub(crate) fn copy_checkpoint_directory_metadata(
+    source: &Path,
+    destination: &Path,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        copyfile_metadata(source, destination)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let metadata = fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+        preserve_metadata(source, destination, &metadata, false)
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -1237,6 +1359,54 @@ mod tests {
     };
     use crate::infra::tree_digest::inventory_tree;
 
+    #[test]
+    fn selected_checkpoint_never_reads_independent_databases_in_clone_or_full_copy() {
+        for full_copy in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let source = temp.path().join("source");
+            let project = source.join("workspace/project");
+            fs::create_dir_all(&project).unwrap();
+            fs::write(
+                project.join("arbitrary.data"),
+                b"SQLite format 3\0invalid database fixture",
+            )
+            .unwrap();
+            fs::write(source.join("owned"), b"runtime").unwrap();
+            let independent = [std::path::PathBuf::from("workspace/project")];
+            let prepared =
+                super::prepare_scoped_tree_checkpoint_in(&source, temp.path(), &independent)
+                    .unwrap();
+            #[cfg(target_os = "macos")]
+            let prepared = {
+                let mut prepared = prepared;
+                if full_copy {
+                    prepared
+                        .cleanup
+                        .retire(&prepared.cleanup.candidate())
+                        .unwrap();
+                    prepared.cloned = false;
+                }
+                prepared
+            };
+            #[cfg(not(target_os = "macos"))]
+            let _ = full_copy;
+            let destination = temp.path().join("snapshot");
+            super::create_tree_checkpoint_from_preparation(prepared, &destination).unwrap();
+            assert!(!destination.join("workspace/project").exists());
+            assert_eq!(fs::read(destination.join("owned")).unwrap(), b"runtime");
+            assert!(project.join("arbitrary.data").exists());
+            fs::write(
+                source.join("unknown.data"),
+                b"SQLite format 3\0invalid database fixture",
+            )
+            .unwrap();
+            assert!(
+                super::prepare_scoped_tree_checkpoint_in(&source, temp.path(), &independent)
+                    .is_err()
+            );
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn checkpoints_skip_socket_endpoints_but_preserve_durable_entries() {
@@ -1425,7 +1595,7 @@ mod tests {
             fs::create_dir_all(original.join("nested")).unwrap();
             fs::write(original.join("nested/value"), "original").unwrap();
             symlink("value", original.join("nested/link")).unwrap();
-            let mut entries = super::prepare_entries(&source).unwrap();
+            let mut entries = super::prepare_entries(&source, &[]).unwrap();
             let before = super::file_fingerprint(
                 &fs::symlink_metadata(original.join("nested/value")).unwrap(),
             );
@@ -1457,6 +1627,7 @@ mod tests {
                 )
             );
             let prepared = super::PreparedTreeCheckpoint {
+                independent: Vec::new(),
                 source: source.clone(),
                 cleanup,
                 cloned: true,

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -438,6 +438,7 @@ fn create_environment_with_runtime_validation(
     });
     let created_at = now_utc();
     let meta = EnvMeta {
+        upgrade_independent_paths: Vec::new(),
         kind: "ocm-env".to_string(),
         name,
         root: display_path(&paths.root),
@@ -636,6 +637,7 @@ fn clone_environment_with_policy(
         };
 
         let meta = EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name,
             root: display_path(&target_paths.root),
@@ -956,6 +958,7 @@ pub(crate) fn import_environment_with_sandbox_origin(
 
             let created_at = now_utc();
             let meta = EnvMeta {
+                upgrade_independent_paths: Vec::new(),
                 kind: "ocm-env".to_string(),
                 name: name.clone(),
                 root: display_path(&target_paths.root),

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,3 +1,4 @@
+mod checkpoint_scope;
 mod checkpoints;
 mod common;
 mod envs;
@@ -85,7 +86,8 @@ pub use runtimes::{
 pub(crate) use snapshots::{
     EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
     create_env_snapshot_from_preparation, prepare_env_snapshot_capture,
-    prepare_env_snapshot_restore, rollback_env_snapshot_restore,
+    prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture,
+    rollback_env_snapshot_restore, validate_upgrade_independent_paths,
 };
 pub use snapshots::{
     create_env_snapshot, get_env_snapshot, list_all_env_snapshots, list_env_snapshots,
@@ -127,6 +129,7 @@ pub fn summarize_env(meta: &EnvMeta) -> EnvSummary {
         state_dir: display_path(&paths.state_dir),
         config_path: display_path(&paths.config_path),
         workspace_dir: display_path(&paths.workspace_dir),
+        upgrade_independent_paths: meta.upgrade_independent_paths.clone(),
         gateway_port: meta.gateway_port,
         service_enabled: meta.service_enabled,
         service_running: meta.service_running,

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -1313,6 +1313,7 @@ mod tests {
 
     fn meta(name: &str, root: &str, gateway_port: Option<u32>) -> EnvMeta {
         EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name: name.to_string(),
             root: root.to_string(),

--- a/src/store/openclaw_state.rs
+++ b/src/store/openclaw_state.rs
@@ -908,6 +908,7 @@ mod tests {
 
     fn meta(name: &str, root: &str) -> EnvMeta {
         EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name: name.to_string(),
             root: root.to_string(),

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::env::{
     CreateEnvSnapshotOptions, EnvMeta, EnvSnapshotRemoveSummary, EnvSnapshotRestoreSummary,
     EnvSnapshotSummary, RemoveEnvSnapshotOptions, RestoreEnvSnapshotOptions,
-    default_service_enabled, default_service_running,
+    UpgradeCheckpointScope, default_service_enabled, default_service_running,
 };
 use crate::infra::archive::{EnvArchiveMetadata, extract_env_archive};
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ use time::OffsetDateTime;
 use super::checkpoints::{
     CheckpointCleanup, PreparedTreeCheckpoint, STORAGE_TAR_ARCHIVE, copy_tree_checkpoint,
     create_tree_checkpoint_from_preparation, default_snapshot_storage_kind,
-    prepare_tree_checkpoint_in, remove_tree_if_present,
+    prepare_scoped_tree_checkpoint_in, remove_tree_if_present,
 };
 use super::common::{
     copy_dir_recursive, copy_path_recursive, load_json_files, path_exists, read_json, write_json,
@@ -31,6 +31,8 @@ use super::{
     rewrite_openclaw_config_for_target, save_environment,
 };
 
+const UPGRADE_CHECKPOINT_KIND: &str = "ocm-env-upgrade-checkpoint-v1";
+
 static NEXT_REMOVAL_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -44,6 +46,8 @@ pub struct EnvSnapshotMeta {
     pub archive_path: String,
     #[serde(default = "default_snapshot_storage_kind")]
     pub storage_kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upgrade_scope: Option<UpgradeCheckpointScope>,
     pub source_root: String,
     pub gateway_port: Option<u32>,
     #[serde(default)]
@@ -67,6 +71,7 @@ pub(crate) struct EnvSnapshotRestoreTransaction {
     displaced_root: Option<PathBuf>,
     rejected_root: PathBuf,
     restored_root: PathBuf,
+    independent: Vec<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -74,6 +79,7 @@ pub(crate) struct PreparedEnvSnapshotCapture {
     env_name: String,
     source_root: PathBuf,
     checkpoint: PreparedTreeCheckpoint,
+    upgrade_scope: Option<UpgradeCheckpointScope>,
 }
 
 impl PreparedEnvSnapshotCapture {
@@ -89,6 +95,80 @@ struct RestoreOperationNamespace {
     backup_root: PathBuf,
     legacy_staging_root: PathBuf,
     rejected_root: PathBuf,
+}
+
+pub(crate) fn validate_upgrade_independent_paths(
+    meta: &EnvMeta,
+    independent: &[PathBuf],
+    env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    if independent.is_empty() {
+        return Ok(());
+    }
+    let paths = derive_env_paths(Path::new(&meta.root));
+    super::checkpoint_scope::validate_ancestors(&paths.root, independent)?;
+    let workspaces = super::resolve_env_openclaw_workspaces(
+        &paths,
+        env,
+        OpenClawWorkspaceRuntime::for_env(&meta.name, meta.gateway_port),
+    )?;
+    let mut configuration =
+        super::openclaw_config_include_paths(&paths.config_path, &paths.state_dir)?;
+    configuration.push(paths.config_path.clone());
+    for config in configuration.clone() {
+        match fs::canonicalize(&config) {
+            Ok(target) => configuration.push(target),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    for relative in independent {
+        let absolute = paths.root.join(relative);
+        // A directory boundary keeps a database together with adjacent WAL and
+        // journal files. Never infer ownership from extensions or inspect the
+        // declared directory's contents.
+        match fs::symlink_metadata(&absolute) {
+            Ok(metadata) if metadata.is_dir() => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            _ => return Err("independent paths must name directories (which may not yet exist); declare a parent directory for files or symlinks".to_string()),
+        }
+        let resolved =
+            fs::canonicalize(absolute.parent().ok_or("missing independent path parent")?)
+                .map_err(|error| error.to_string())?
+                .join(
+                    absolute
+                        .file_name()
+                        .ok_or("missing independent path name")?,
+                );
+        if configuration
+            .iter()
+            .any(|config| config.starts_with(&absolute) || config.starts_with(&resolved))
+        {
+            return Err(format!(
+                "independent path includes rollback-owned configuration: {}",
+                display_path(relative)
+            ));
+        }
+        if workspaces
+            .workspace_roots()
+            .any(|workspace| workspace.starts_with(&absolute))
+        {
+            return Err(format!(
+                "a configured workspace can contain migration-owned state; declare only independent content beneath it: {}",
+                display_path(relative)
+            ));
+        }
+        if !workspaces
+            .workspace_roots()
+            .any(|workspace| absolute.starts_with(workspace))
+        {
+            return Err(format!(
+                "independent paths must be beneath a configured workspace: {}",
+                display_path(relative)
+            ));
+        }
+    }
+    Ok(())
 }
 
 pub fn create_env_snapshot(
@@ -114,6 +194,23 @@ pub(crate) fn prepare_env_snapshot_capture(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<PreparedEnvSnapshotCapture, String> {
+    prepare_snapshot_capture(env_name, false, env, cwd)
+}
+
+pub(crate) fn prepare_upgrade_checkpoint_capture(
+    env_name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PreparedEnvSnapshotCapture, String> {
+    prepare_snapshot_capture(env_name, true, env, cwd)
+}
+
+fn prepare_snapshot_capture(
+    env_name: &str,
+    upgrade: bool,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PreparedEnvSnapshotCapture, String> {
     let env_name = validate_name(env_name, "Environment name")?;
     let meta = get_environment(&env_name, env, cwd)?;
     let env_paths = derive_env_paths(Path::new(&meta.root));
@@ -123,12 +220,28 @@ pub(crate) fn prepare_env_snapshot_capture(
             display_path(&env_paths.root)
         ));
     }
-    let checkpoint =
-        prepare_tree_checkpoint_in(&env_paths.root, &snapshot_env_dir(&env_name, env, cwd)?)?;
+    let upgrade_scope = if upgrade {
+        validate_upgrade_independent_paths(&meta, &meta.upgrade_independent_paths, env)?;
+        Some(UpgradeCheckpointScope {
+            independent_paths: meta.upgrade_independent_paths.clone(),
+        })
+    } else {
+        None
+    };
+    let independent = upgrade_scope
+        .as_ref()
+        .map(|scope| scope.independent_paths.as_slice())
+        .unwrap_or_default();
+    let checkpoint = prepare_scoped_tree_checkpoint_in(
+        &env_paths.root,
+        &snapshot_env_dir(&env_name, env, cwd)?,
+        independent,
+    )?;
     Ok(PreparedEnvSnapshotCapture {
         env_name,
         source_root: env_paths.root,
         checkpoint,
+        upgrade_scope,
     })
 }
 
@@ -164,6 +277,15 @@ pub(crate) fn create_env_snapshot_from_preparation(
         ));
     }
 
+    if let Some(scope) = &prepared.upgrade_scope {
+        if scope.independent_paths != meta.upgrade_independent_paths {
+            return Err(
+                "independent upgrade paths changed after checkpoint preparation".to_string(),
+            );
+        }
+        validate_upgrade_independent_paths(&meta, &scope.independent_paths, env)?;
+    }
+
     let created_at = now_utc();
     let snapshot_id = format!(
         "{}-{:09}",
@@ -177,8 +299,20 @@ pub(crate) fn create_env_snapshot_from_preparation(
     let result = (|| {
         let storage_kind =
             create_tree_checkpoint_from_preparation(prepared.checkpoint, &checkpoint_path)?;
+        if let Some(scope) = &prepared.upgrade_scope {
+            super::checkpoint_scope::validate_scoped_artifact(
+                &checkpoint_path,
+                &scope.independent_paths,
+            )?;
+        }
         let snapshot = EnvSnapshotMeta {
-            kind: "ocm-env-snapshot".to_string(),
+            kind: if prepared.upgrade_scope.is_some() {
+                UPGRADE_CHECKPOINT_KIND
+            } else {
+                "ocm-env-snapshot"
+            }
+            .to_string(),
+            upgrade_scope: prepared.upgrade_scope,
             id: snapshot_id,
             env_name: meta.name.clone(),
             label: options.label,
@@ -238,6 +372,7 @@ pub fn summarize_snapshot(meta: &EnvSnapshotMeta) -> EnvSnapshotSummary {
         label: meta.label.clone(),
         archive_path: meta.archive_path.clone(),
         storage_kind: meta.storage_kind.clone(),
+        upgrade_scope: meta.upgrade_scope.clone(),
         source_root: meta.source_root.clone(),
         gateway_port: meta.gateway_port,
         service_enabled: meta.service_enabled,
@@ -270,6 +405,18 @@ pub(crate) fn prepare_env_snapshot_restore(
     let current = get_environment(&env_name, env, cwd)?;
     let current_paths = derive_env_paths(Path::new(&current.root));
     let root_exists = path_exists(&current_paths.root);
+    let independent = snapshot
+        .upgrade_scope
+        .as_ref()
+        .map(|scope| scope.independent_paths.clone())
+        .unwrap_or_default();
+    if !independent.is_empty() {
+        super::checkpoint_scope::validate_ancestors(&current_paths.root, &independent)?;
+        super::checkpoint_scope::validate_scoped_artifact(
+            Path::new(&snapshot.archive_path),
+            &independent,
+        )?;
+    }
 
     let operation = create_restore_operation_namespace(&current_paths.root)?;
     let staging_dir = operation.legacy_staging_root.clone();
@@ -298,6 +445,7 @@ pub(crate) fn prepare_env_snapshot_restore(
             let archived = extracted.metadata.env;
             (
                 EnvMeta {
+                    upgrade_independent_paths: current.upgrade_independent_paths.clone(),
                     kind: "ocm-env".to_string(),
                     name: current.name.clone(),
                     root: current.root.clone(),
@@ -320,6 +468,7 @@ pub(crate) fn prepare_env_snapshot_restore(
             clear_snapshot_runtime_residue(&candidate_root)?;
             (
                 EnvMeta {
+                    upgrade_independent_paths: current.upgrade_independent_paths.clone(),
                     kind: "ocm-env".to_string(),
                     name: current.name.clone(),
                     root: current.root.clone(),
@@ -340,13 +489,24 @@ pub(crate) fn prepare_env_snapshot_restore(
         };
 
         let mut renamed = false;
-        if root_exists {
+        if !independent.is_empty() {
+            super::checkpoint_scope::replace_owned_entries(
+                &current_paths.root,
+                &candidate_root,
+                &backup_root,
+                &independent,
+            )?;
+            renamed = true;
+        } else if root_exists {
             fs::rename(&current_paths.root, &backup_root).map_err(|error| error.to_string())?;
             renamed = true;
         }
 
         let restore_result = (|| {
-            fs::rename(&candidate_root, &current_paths.root).map_err(|error| error.to_string())?;
+            if independent.is_empty() {
+                fs::rename(&candidate_root, &current_paths.root)
+                    .map_err(|error| error.to_string())?;
+            }
             if legacy_archive {
                 rewrite_openclaw_config_for_target(
                     &current_paths,
@@ -388,6 +548,7 @@ pub(crate) fn prepare_env_snapshot_restore(
                 displaced_root: renamed.then_some(backup_root.clone()),
                 rejected_root: operation.rejected_root.clone(),
                 restored_root: current_paths.root.clone(),
+                independent: independent.clone(),
             }),
             Err(error) => {
                 match reinstate_displaced_environment_root(
@@ -395,6 +556,7 @@ pub(crate) fn prepare_env_snapshot_restore(
                     renamed.then_some(backup_root.as_path()),
                     &operation.rejected_root,
                     current.clone(),
+                    &independent,
                     env,
                     cwd,
                 ) {
@@ -440,6 +602,7 @@ pub(crate) fn rollback_env_snapshot_restore(
         transaction.displaced_root.as_deref(),
         &transaction.rejected_root,
         transaction.original,
+        &transaction.independent,
         env,
         cwd,
     )?;
@@ -460,9 +623,33 @@ fn reinstate_displaced_environment_root(
     displaced_root: Option<&Path>,
     rejected_root: &Path,
     original: EnvMeta,
+    independent: &[PathBuf],
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<(), String> {
+    if !independent.is_empty() {
+        let displaced =
+            displaced_root.ok_or("scoped restore is missing displaced owned entries")?;
+        super::checkpoint_scope::replace_owned_entries(
+            restored_root,
+            displaced,
+            rejected_root,
+            independent,
+        )?;
+        if let Err(error) = save_environment(original, env, cwd) {
+            super::checkpoint_scope::replace_owned_entries(
+                restored_root,
+                rejected_root,
+                displaced,
+                independent,
+            )
+            .map_err(|compensation| {
+                format!("{error}; scoped restore compensation failed: {compensation}")
+            })?;
+            return Err(error);
+        }
+        return Ok(());
+    }
     fs::rename(restored_root, rejected_root).map_err(|error| {
         format!(
             "failed to retain rejected restored root {} at {}: {error}",
@@ -763,8 +950,17 @@ fn validate_env_snapshot_identity(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<(), String> {
-    if snapshot.kind != "ocm-env-snapshot" {
-        return Err(format!("unsupported snapshot kind: {}", snapshot.kind));
+    match (snapshot.kind.as_str(), &snapshot.upgrade_scope) {
+        ("ocm-env-snapshot", None) => {}
+        (UPGRADE_CHECKPOINT_KIND, Some(scope)) if snapshot.storage_kind != STORAGE_TAR_ARCHIVE => {
+            super::checkpoint_scope::validate_independent_paths(&scope.independent_paths)?;
+        }
+        _ => {
+            return Err(format!(
+                "unsupported snapshot kind or scope: {}",
+                snapshot.kind
+            ));
+        }
     }
     if snapshot.env_name != env_name {
         return Err(format!(

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -97,6 +97,42 @@ struct RestoreOperationNamespace {
     rejected_root: PathBuf,
 }
 
+/// Resolve existing aliases while retaining absent descendants. An unresolved
+/// symlink is ambiguous ownership, not evidence that a workspace is unrelated.
+fn resolve_scope_path(path: &Path) -> Result<PathBuf, String> {
+    let mut existing = path;
+    let mut missing = Vec::new();
+    loop {
+        match fs::canonicalize(existing) {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match fs::symlink_metadata(existing) {
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    _ => {
+                        return Err(format!(
+                            "cannot resolve workspace ownership: {}",
+                            display_path(path)
+                        ));
+                    }
+                }
+                missing.push(
+                    existing
+                        .file_name()
+                        .ok_or("missing workspace path name")?
+                        .to_os_string(),
+                );
+                existing = existing.parent().ok_or("missing workspace path parent")?;
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+}
+
 pub(crate) fn validate_upgrade_independent_paths(
     meta: &EnvMeta,
     independent: &[PathBuf],
@@ -112,6 +148,10 @@ pub(crate) fn validate_upgrade_independent_paths(
         env,
         OpenClawWorkspaceRuntime::for_env(&meta.name, meta.gateway_port),
     )?;
+    let workspace_targets = workspaces
+        .workspace_roots()
+        .map(|workspace| resolve_scope_path(workspace))
+        .collect::<Result<Vec<_>, _>>()?;
     let mut configuration =
         super::openclaw_config_include_paths(&paths.config_path, &paths.state_dir)?;
     configuration.push(paths.config_path.clone());
@@ -152,6 +192,9 @@ pub(crate) fn validate_upgrade_independent_paths(
         if workspaces
             .workspace_roots()
             .any(|workspace| workspace.starts_with(&absolute))
+            || workspace_targets
+                .iter()
+                .any(|workspace| workspace.starts_with(&resolved))
         {
             return Err(format!(
                 "a configured workspace can contain migration-owned state; declare only independent content beneath it: {}",
@@ -161,6 +204,9 @@ pub(crate) fn validate_upgrade_independent_paths(
         if !workspaces
             .workspace_roots()
             .any(|workspace| absolute.starts_with(workspace))
+            && !workspace_targets
+                .iter()
+                .any(|workspace| resolved.starts_with(workspace))
         {
             return Err(format!(
                 "independent paths must be beneath a configured workspace: {}",

--- a/tests/execution_tests.rs
+++ b/tests/execution_tests.rs
@@ -12,6 +12,7 @@ use time::OffsetDateTime;
 
 fn sample_env(default_runtime: Option<&str>, default_launcher: Option<&str>) -> EnvMeta {
     EnvMeta {
+        upgrade_independent_paths: Vec::new(),
         kind: "ocm-env".to_string(),
         name: "demo".to_string(),
         root: "/tmp/demo".to_string(),

--- a/tests/store_compatibility_tests.rs
+++ b/tests/store_compatibility_tests.rs
@@ -90,6 +90,7 @@ fn prune_selection_uses_last_used_at_and_skips_protected_envs() {
     let now = now_utc();
     let envs = vec![
         EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name: "old".to_string(),
             root: "/tmp/old".to_string(),
@@ -106,6 +107,7 @@ fn prune_selection_uses_last_used_at_and_skips_protected_envs() {
             last_used_at: None,
         },
         EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name: "recently-used".to_string(),
             root: "/tmp/recent".to_string(),
@@ -122,6 +124,7 @@ fn prune_selection_uses_last_used_at_and_skips_protected_envs() {
             last_used_at: Some(now - Duration::days(1)),
         },
         EnvMeta {
+            upgrade_independent_paths: Vec::new(),
             kind: "ocm-env".to_string(),
             name: "protected-old".to_string(),
             root: "/tmp/protected".to_string(),

--- a/tests/upgrade_checkpoint_scope_tests.rs
+++ b/tests/upgrade_checkpoint_scope_tests.rs
@@ -1,0 +1,411 @@
+#![cfg(unix)]
+mod support;
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use rusqlite::Connection;
+use serde_json::Value;
+use support::{TestDir, ocm_env, run_ocm, stderr, stdout, write_executable_script, write_text};
+
+struct Fixture {
+    root: TestDir,
+    env: BTreeMap<String, String>,
+    state: PathBuf,
+    project: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = TestDir::new("upgrade-independent-project");
+        let env = ocm_env(&root);
+        for (name, version) in [("old", "2026.9.1"), ("new", "2026.9.2")] {
+            let executable = root.child(name);
+            write_executable_script(
+                &executable,
+                &format!(
+                    r#"#!/bin/sh
+case "$1 $2" in
+  '--version ') echo '{version}';;
+  'config validate') echo 'Config valid';;
+  'doctor --lint') echo '{{"ok":true,"checksRun":1,"checksSkipped":0,"findings":[]}}';;
+  'update finalize')
+    : > "$OCM_PROOF_READY"
+    n=0
+    while [ ! -f "$OCM_PROOF_RELEASE" ]; do
+      n=$((n+1)); [ "$n" -lt 200 ] || exit 92
+      sleep 0.025
+    done
+    if [ "$OCM_PROOF_FAIL" = 1 ]; then echo 'partial migration failed' >&2; exit 23; fi
+    echo '{{"status":"ok","mode":"finalize","postUpdate":{{"doctor":{{"status":"ok"}},"plugins":{{"status":"ok"}}}}}}';;
+  'gateway status') echo '{{"rpc":{{"ok":true}}}}';;
+  *) echo "unexpected fixture invocation $*" >&2; exit 91;;
+esac
+"#
+                ),
+            );
+            let result = run_ocm(
+                root.path(),
+                &env,
+                &[
+                    "runtime",
+                    "add",
+                    name,
+                    "--path",
+                    executable.to_str().unwrap(),
+                ],
+            );
+            assert!(result.status.success(), "{}", stderr(&result));
+        }
+        let result = run_ocm(
+            root.path(),
+            &env,
+            &["env", "create", "demo", "--runtime", "old"],
+        );
+        assert!(result.status.success(), "{}", stderr(&result));
+        let state = root.child("ocm-home/envs/demo/.openclaw");
+        let project = state.join("workspace/projects/example");
+        write_text(&state.join("openclaw.json"), "{}\n");
+        write_text(&project.join("code"), "before\n");
+        write_text(&project.join("deleted"), "before\n");
+        write_text(
+            &project.join("node_modules/package/index.js"),
+            "dependency\n",
+        );
+        symlink("code", project.join("link")).unwrap();
+        write_text(&state.join("workspace/.openclaw/legacy-state"), "legacy\n");
+        write_text(&state.join("workspace/IDENTITY.md"), "identity\n");
+        write_text(
+            &state.join("unknown/node_modules/payload"),
+            "runtime-before\n",
+        );
+        write_text(&state.join("unknown/regular.sock"), "ordinary file\n");
+        write_text(&state.join("credentials/synthetic"), "fixture-only\n");
+        fs::set_permissions(
+            state.join("credentials/synthetic"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        let db = Connection::open(state.join("arbitrary.data")).unwrap();
+        db.execute_batch(
+            "CREATE TABLE durable(value TEXT); INSERT INTO durable VALUES ('before');",
+        )
+        .unwrap();
+        drop(db);
+        let fixture = Self {
+            root,
+            env,
+            state,
+            project,
+        };
+        let result = fixture.run(&[
+            "env",
+            "set-independent-paths",
+            "demo",
+            ".openclaw/workspace/projects",
+        ]);
+        assert!(result.status.success(), "{}", stderr(&result));
+        fixture
+    }
+
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        run_ocm(self.root.path(), &self.env, args)
+    }
+
+    fn edit_project(&self) -> fs::Metadata {
+        write_text(&self.project.join("code"), "current developer work\n");
+        fs::set_permissions(self.project.join("code"), fs::Permissions::from_mode(0o600)).unwrap();
+        fs::remove_file(self.project.join("deleted")).unwrap();
+        write_text(&self.project.join("created"), "new work\n");
+        fs::remove_file(self.project.join("link")).unwrap();
+        symlink("created", self.project.join("link")).unwrap();
+        fs::metadata(self.project.join("code")).unwrap()
+    }
+
+    fn assert_project(&self, expected: &fs::Metadata) {
+        assert_eq!(
+            fs::read_to_string(self.project.join("code")).unwrap(),
+            "current developer work\n"
+        );
+        let current = fs::metadata(self.project.join("code")).unwrap();
+        assert_eq!(
+            (
+                current.ino(),
+                current.mode(),
+                current.mtime(),
+                current.mtime_nsec()
+            ),
+            (
+                expected.ino(),
+                expected.mode(),
+                expected.mtime(),
+                expected.mtime_nsec()
+            )
+        );
+        assert!(!self.project.join("deleted").exists());
+        assert_eq!(
+            fs::read_to_string(self.project.join("created")).unwrap(),
+            "new work\n"
+        );
+        assert_eq!(
+            fs::read_link(self.project.join("link")).unwrap(),
+            PathBuf::from("created")
+        );
+    }
+}
+
+#[test]
+fn independent_project_survives_success_failure_interrupt_and_explicit_rollback() {
+    for mode in ["success", "failure", "interrupt"] {
+        let fixture = Fixture::new();
+        let ready = fixture.root.child("ready");
+        let release = fixture.root.child("release");
+        let mut child = Command::new(env!("CARGO_BIN_EXE_ocm"))
+            .args(["upgrade", "demo", "--runtime", "new", "--json"])
+            .current_dir(fixture.root.path())
+            .env_clear()
+            .envs(&fixture.env)
+            .env("OCM_PROOF_READY", &ready)
+            .env("OCM_PROOF_RELEASE", &release)
+            .env("OCM_PROOF_FAIL", if mode == "failure" { "1" } else { "0" })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while !ready.exists() && Instant::now() < deadline && child.try_wait().unwrap().is_none() {
+            sleep(Duration::from_millis(10));
+        }
+        if !ready.exists() {
+            write_text(&release, "release");
+            let output = child.wait_with_output().unwrap();
+            panic!(
+                "finalizer not reached: {} {}",
+                stdout(&output),
+                stderr(&output)
+            );
+        }
+        let expected = fixture.edit_project();
+        let db = Connection::open(fixture.state.join("arbitrary.data")).unwrap();
+        db.execute_batch(
+            "ALTER TABLE durable ADD COLUMN migrated TEXT; UPDATE durable SET value='after';",
+        )
+        .unwrap();
+        drop(db);
+        write_text(
+            &fixture.state.join("openclaw.json"),
+            "{\"migration\":\"partial\"}\n",
+        );
+        write_text(
+            &fixture.state.join("unknown/node_modules/payload"),
+            "runtime-after\n",
+        );
+        fs::remove_file(fixture.state.join("workspace/.openclaw/legacy-state")).unwrap();
+        write_text(&fixture.state.join("migration-receipt"), "partial\n");
+        if mode == "interrupt" {
+            // This child belongs exclusively to this fixture.
+            assert_eq!(unsafe { libc::kill(child.id() as i32, libc::SIGTERM) }, 0);
+        }
+        write_text(&release, "release");
+        let output = child.wait_with_output().unwrap();
+        assert_eq!(
+            output.status.success(),
+            mode == "success",
+            "{} {}",
+            stdout(&output),
+            stderr(&output)
+        );
+        fixture.assert_project(&expected);
+        let receipt: Value = serde_json::from_str(&stdout(&output)).unwrap();
+        if mode == "success" {
+            let rollback = fixture.run(&["upgrade", "rollback", "demo", "--json"]);
+            assert!(
+                rollback.status.success(),
+                "{} {}",
+                stdout(&rollback),
+                stderr(&rollback)
+            );
+        } else {
+            assert_eq!(receipt["rollback"], "restored");
+        }
+        fixture.assert_project(&expected);
+        assert_eq!(
+            fs::read_to_string(fixture.state.join("openclaw.json")).unwrap(),
+            "{}\n"
+        );
+        assert_eq!(
+            fs::read_to_string(fixture.state.join("unknown/node_modules/payload")).unwrap(),
+            "runtime-before\n"
+        );
+        assert_eq!(
+            fs::read_to_string(fixture.state.join("unknown/regular.sock")).unwrap(),
+            "ordinary file\n"
+        );
+        assert_eq!(
+            fs::metadata(fixture.state.join("credentials/synthetic"))
+                .unwrap()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        assert!(
+            fixture
+                .state
+                .join("workspace/.openclaw/legacy-state")
+                .exists()
+        );
+        assert!(!fixture.state.join("migration-receipt").exists());
+        let db = Connection::open(fixture.state.join("arbitrary.data")).unwrap();
+        assert_eq!(
+            db.query_row("SELECT value FROM durable", [], |row| row
+                .get::<_, String>(0))
+                .unwrap(),
+            "before"
+        );
+        assert!(db.prepare("SELECT migrated FROM durable").is_err());
+        let snapshot = fixture.run(&[
+            "env",
+            "snapshot",
+            "show",
+            "demo",
+            receipt["snapshotId"].as_str().unwrap(),
+            "--json",
+        ]);
+        assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+        let snapshot: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+        assert!(
+            !PathBuf::from(snapshot["archivePath"].as_str().unwrap())
+                .join(".openclaw/workspace/projects")
+                .exists()
+        );
+    }
+}
+
+#[test]
+fn scope_refuses_configuration_workspace_and_path_escape_exclusions() {
+    let fixture = Fixture::new();
+    write_text(&fixture.state.join("workspace/projects/include.json"), "{}");
+    write_text(
+        &fixture.state.join("openclaw.json"),
+        "{\"$include\":\"workspace/projects/include.json\"}",
+    );
+    for path in [
+        ".openclaw/workspace",
+        ".openclaw",
+        "../escape",
+        "/absolute",
+        ".openclaw/credentials",
+        ".openclaw/workspace/IDENTITY.md",
+        ".openclaw/workspace/projects",
+    ] {
+        let result = fixture.run(&["env", "set-independent-paths", "demo", path]);
+        assert!(
+            !result.status.success(),
+            "unsafe exclusion accepted: {path}"
+        );
+    }
+    write_text(&fixture.state.join("openclaw.json"), "{}");
+    symlink("projects", fixture.state.join("workspace/alias")).unwrap();
+    let result = fixture.run(&[
+        "env",
+        "set-independent-paths",
+        "demo",
+        ".openclaw/workspace/alias/example",
+    ]);
+    assert!(!result.status.success(), "symlink ancestor accepted");
+    fs::remove_file(fixture.state.join("openclaw.json")).unwrap();
+    symlink(
+        "workspace/projects/include.json",
+        fixture.state.join("openclaw.json"),
+    )
+    .unwrap();
+    let result = fixture.run(&[
+        "env",
+        "set-independent-paths",
+        "demo",
+        ".openclaw/workspace/projects",
+    ]);
+    assert!(
+        !result.status.success(),
+        "symlinked configuration target excluded"
+    );
+}
+
+#[test]
+fn frozen_scope_and_invalid_metadata_never_fall_back_to_whole_root_restore() {
+    let fixture = Fixture::new();
+    let ready = fixture.root.child("ready");
+    let release = fixture.root.child("release");
+    write_text(&release, "continue");
+    let output = Command::new(env!("CARGO_BIN_EXE_ocm"))
+        .args(["upgrade", "demo", "--runtime", "new", "--json"])
+        .current_dir(fixture.root.path())
+        .env_clear()
+        .envs(&fixture.env)
+        .env("OCM_PROOF_READY", ready)
+        .env("OCM_PROOF_RELEASE", release)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    let receipt: Value = serde_json::from_str(&stdout(&output)).unwrap();
+    let id = receipt["snapshotId"].as_str().unwrap();
+    let show = fixture.run(&["env", "snapshot", "show", "demo", id, "--json"]);
+    let snapshot: Value = serde_json::from_str(&stdout(&show)).unwrap();
+    let archive = PathBuf::from(snapshot["archivePath"].as_str().unwrap());
+    let snapshot_meta = archive.parent().unwrap().join(format!("{id}.json"));
+    let original = fs::read(&snapshot_meta).unwrap();
+    let expected = fixture.edit_project();
+    let clear = fixture.run(&["env", "set-independent-paths", "demo", "none"]);
+    assert!(clear.status.success(), "{}", stderr(&clear));
+    let mut invalid: Value = serde_json::from_slice(&original).unwrap();
+    invalid.as_object_mut().unwrap().remove("upgradeScope");
+    fs::write(&snapshot_meta, serde_json::to_vec(&invalid).unwrap()).unwrap();
+    let restore = fixture.run(&["env", "snapshot", "restore", "demo", id]);
+    assert!(!restore.status.success(), "missing scope was accepted");
+    fixture.assert_project(&expected);
+    fs::write(&snapshot_meta, original).unwrap();
+    // An artifact with an undeclared captured copy must also be refused.
+    write_text(
+        &archive.join(".openclaw/workspace/projects/injected"),
+        "unsafe",
+    );
+    let restore = fixture.run(&["env", "snapshot", "restore", "demo", id]);
+    assert!(
+        !restore.status.success(),
+        "conflicting artifact was accepted"
+    );
+    fixture.assert_project(&expected);
+    fs::remove_dir_all(archive.join(".openclaw/workspace/projects")).unwrap();
+    let restore = fixture.run(&["env", "snapshot", "restore", "demo", id]);
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    fixture.assert_project(&expected);
+}
+
+#[test]
+fn full_backup_still_rewinds_declared_independent_content() {
+    let fixture = Fixture::new();
+    let snapshot = fixture.run(&["env", "snapshot", "create", "demo", "--json"]);
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    assert!(snapshot.get("upgradeScope").is_none());
+    fixture.edit_project();
+    let restore = fixture.run(&[
+        "env",
+        "snapshot",
+        "restore",
+        "demo",
+        snapshot["id"].as_str().unwrap(),
+    ]);
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    assert_eq!(
+        fs::read_to_string(fixture.project.join("code")).unwrap(),
+        "before\n"
+    );
+    assert!(fixture.project.join("deleted").exists());
+    assert!(!fixture.project.join("created").exists());
+}

--- a/tests/upgrade_checkpoint_scope_tests.rs
+++ b/tests/upgrade_checkpoint_scope_tests.rs
@@ -337,6 +337,73 @@ fn scope_refuses_configuration_workspace_and_path_escape_exclusions() {
 }
 
 #[test]
+fn configured_workspace_alias_cannot_hide_a_whole_workspace_exclusion() {
+    let fixture = Fixture::new();
+    let alias = fixture.state.join("workspace/workspace-alias");
+    symlink("projects", &alias).unwrap();
+    for workspace in [alias.clone(), alias.join("future-agent")] {
+        fs::write(
+            fixture.state.join("openclaw.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "agents": {"defaults": {"workspace": workspace}}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let result = fixture.run(&[
+            "env",
+            "set-independent-paths",
+            "demo",
+            ".openclaw/workspace/projects",
+        ]);
+        assert!(
+            !result.status.success(),
+            "configured workspace target excluded: {}",
+            workspace.display()
+        );
+    }
+    fs::write(
+        fixture.state.join("openclaw.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "agents": {"defaults": {"workspace": alias}}
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let nested = fixture.run(&[
+        "env",
+        "set-independent-paths",
+        "demo",
+        ".openclaw/workspace/projects/example",
+    ]);
+    assert!(
+        nested.status.success(),
+        "independent child beneath workspace alias refused: {}",
+        stderr(&nested)
+    );
+    fs::remove_file(&alias).unwrap();
+    symlink("missing-projects", &alias).unwrap();
+    let dangling = fixture.run(&[
+        "env",
+        "set-independent-paths",
+        "demo",
+        ".openclaw/workspace/missing-projects",
+    ]);
+    assert!(
+        !dangling.status.success(),
+        "unresolved workspace alias accepted"
+    );
+    let upgrade = fixture.run(&["upgrade", "demo", "--runtime", "new", "--json"]);
+    assert!(
+        !upgrade.status.success(),
+        "changed unresolved scope reached upgrade"
+    );
+    let env = fixture.run(&["env", "show", "demo", "--json"]);
+    let env: Value = serde_json::from_str(&stdout(&env)).unwrap();
+    assert_eq!(env["defaultRuntime"], "old");
+}
+
+#[test]
 fn frozen_scope_and_invalid_metadata_never_fall_back_to_whole_root_restore() {
     let fixture = Fixture::new();
     let ready = fixture.root.child("ready");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading an environment with independent projects beneath its workspace would have developer changes rewound by a failed-upgrade or later explicit rollback. Those projects also made checkpoint preparation, stopped capture, and restore validation traverse development dependency trees.

## Why This Change Was Made

Add an explicit per-environment directory ownership declaration, used together by upgrade checkpoint capture and restore. Capture omits declared independent directories; restore replaces the surrounding owned entries while leaving independent content in place, with compensation for partial publication failures and failed service acceptance. Each checkpoint freezes its scope under a new kind that older OCM versions reject.

Whole workspaces, configuration/includes (including symlink targets), path escapes, and individual files are refused. Directory boundaries keep SQLite databases with adjacent sidecars. Unknown runtime data remains covered. The declaration is empty by default and requires operator knowledge of migration ownership; it does not sandbox OpenClaw or plugin writes. Workspace memory, identity documents, and legacy migration inputs are not assumed disposable or automatically independent. Shared ancestor directories stay in place; this does not add crash recovery for uncatchable process/machine failure.

Separately requested full snapshots, exports, and clones retain their existing content semantics. Historical full-root checkpoints still restore the full root. No Doctor, timeout, deployment, or release changes.

## User Impact

Declare independent project directories before upgrading:

```sh
ocm env set-independent-paths mira .openclaw/workspace/projects
```

Subsequent upgrade checkpoints preserve current developer bytes and metadata during rollback while restoring configuration, credentials, runtime data, and migration state outside those directories. Changing the declaration affects future checkpoints only. `env snapshot show` displays an upgrade checkpoint's preserved paths.

## Evidence

Base: `3f3f89829105f6ed6f5b94a9328cb4e50f3422a2`; tested head: `da98f077830ee93ae10c73fb8f54d8e8d4aba628`.

- Public CLI red/base: automatic, interrupted-migration, and explicit rollback lost project changes. Moving only the project outside the environment preserved it; moving the whole workspace outside lost a consumed migration input. A capture-only omission caused restore to delete the live entry.
- Public CLI green/head: success, automatic rollback, SIGTERM migration, and explicit rollback preserve project bytes, inode, mode, mtime, xattrs, symlinks, additions, and deletions. Failed/interrupted migration restores config, SQLite schema/data, unknown runtime/plugin payloads, and consumed legacy workspace state together. The head fixture adds only the new explicit directory declaration.
- Corrupt development SQLite no longer prevents upgrade; equally corrupt arbitrary-named runtime SQLite still prevents mutation. Full backups still rewind project content. Frozen-scope, malformed-metadata, configuration/symlink overlap, and partial-publication controls pass.
- Local checks: `cargo fmt --check`; `cargo check --workspace --all-targets --locked`; 5 new CLI integration tests, 2 restore-compensation tests, 19 checkpoint tests, 13 existing rollback tests, and the complete-durable-root snapshot regression passed. Resource-bounded synthetic macOS/APFS fixtures; no live environment operations. Full platform suite is delegated to PR CI.
- Autoreview: scoped clean at the configured P0 threshold. An independent source-blind validator found a whole-workspace symlink-target bypass on the first candidate. The successor rejects that alias and unresolved workspace ownership; exact-head independent revalidation passed 12 targeted behavioral checks, including prior unsafe scope and unreadable-content controls. No syscall-level absence-of-open trace is claimed. The named patch-readiness-audit skill was unavailable; manual competing-hypothesis/falsifier assessment was retained.

Raw CLI/state evidence stays local. Sanitized task-only proof: [red/base video](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/pr168-da98f07-public/20260908-231456-892596000/red-base.mp4?X-Amz-Expires=604800&X-Amz-Date=20260908T231456Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=543890ca083bcb5a78cb28b5e6d056abb6d2e8ff11acf9cdf7a183664abcd3be), [green/head video](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/pr168-da98f07-public/20260908-231456-892596000/green-head.mp4?X-Amz-Expires=604800&X-Amz-Date=20260908T231456Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=921633a84cb80790dfa350034392b0d1e94918069bfebd7a834abd42eab30190), [contract](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/pr168-da98f07-public/20260908-231456-892596000/contract.md?X-Amz-Expires=604800&X-Amz-Date=20260908T231456Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=9222d0e16309a56cbd635527712aff766be76dbeb93fbf5bad89314c5511d199), [independent validation](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/pr168-da98f07-public/20260908-231456-892596000/independent-validation.json?X-Amz-Expires=604800&X-Amz-Date=20260908T231456Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=14ddf578a8dfcf043b361e4544d05d89fa8961e5530e5bbc9e2a0c91f7d3c333), [artifact manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/publish/pr168-da98f07-public/20260908-231456-892596000/proof-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260908T231456Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=d08ec6e0fe97544ef5149350d9b1bd8b82e8a5e11b5b5a0c6f8eda76f45983e4). Signed links expire September 15, 2026. No private state, raw logs, session transcript, or committed proof assets are included.

The non-required macOS npm jobs failed because `MACOS_TEAM_ID` was empty during published-binary verification. The workflow, verifier, and fixture are byte-identical to base; the same empty-ID invocation reproduces the same refusal on the unmodified base. No check was disabled, and no signing/configuration change is included. All five required checks passed at the tested head: Format, Rust 1.88 minimum, Windows compile, Test ubuntu-latest, and Test macos-latest, including installation smoke checks. [CI run](https://github.com/openclaw/ocm/actions/runs/34289567874).

### Atomic compatibility and deployment boundary

Compared against PR140339 published head `35b60fd89765cc9b301e47b6f4a0b26447a8b57f` (all 361 files) and sealed `final50-review-prep-2109`, source-set digest `a3f6048cec36e76f8eca365ad5dbc57892186e21a2a82379741b0f2916cb3995`, reconciled main `690b6ea3f268923a13d1e3f7b972f89e837ecfcd`. This OCM change does not replace native writer exclusion, executor/source ownership, maintenance leases, sealed after-images, process settlement, or terminal/history commits. It neither supplies nor clears the integration's unresolved lifetime/settlement contract.

The scope is safe only for directories that the operator establishes contain no migration, config/include, database, plugin, or atomic-owned resources. Workspace-root memory/identity and legacy migration inputs remain captured outside those directories. Before any future deployment, the operator must approve the exact environment-relative directory list for the selected core/plugin versions and ensure it is disjoint from those owners and retained recovery resources. No real environment declaration or deployment is part of this PR; no existing snapshot is retroactively changed. An OCM checkpoint is not authority to supersede pending native recovery or active writers.

The coordinator renewed atomic scope compatibility clearance for exact successor `da98f077830ee93ae10c73fb8f54d8e8d4aba628` after checking its workspace-alias validation and regression delta. This is scope clearance, not an atomic-owner endorsement or deployment approval. All five required checks passed before landing.
