### PR TITLE
fix: keep restored gateways online when rollback cleanup fails

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -947,9 +947,8 @@ impl Cli {
                             });
                         match service_acceptance {
                             Ok(()) => {
-                                self.environment_service()
-                                    .commit_snapshot_restore_locked(transaction)?;
-                                Ok(restored)
+                                Ok(self.environment_service()
+                                    .commit_snapshot_restore_locked(transaction))
                             }
                             Err(service_error) => {
                                 let rollback_result = self

--- a/src/cli/render/env.rs
+++ b/src/cli/render/env.rs
@@ -2456,6 +2456,14 @@ pub fn env_snapshot_restored(
         rows.push(KeyValueRow::warning("Protected", "yes"));
     }
     push_card(&mut lines, "Environment", rows, profile.color);
+    if !restored.warnings.is_empty() {
+        let rows = restored
+            .warnings
+            .iter()
+            .map(|warning| KeyValueRow::warning("Warning", warning.clone()))
+            .collect::<Vec<_>>();
+        lines.extend(render_key_value_card("Warnings", &rows, profile.color));
+    }
     lines
 }
 
@@ -2481,6 +2489,12 @@ fn env_snapshot_restored_raw(restored: &EnvSnapshotRestoreSummary) -> Vec<String
     if restored.protected {
         lines.push("  protected: true".to_string());
     }
+    lines.extend(
+        restored
+            .warnings
+            .iter()
+            .map(|warning| format!("  warning: {warning}")),
+    );
     lines
 }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1399,25 +1399,28 @@ impl Cli {
             }
         }
 
-        if let Err(error) =
-            self.environment_service()
-                .restore_snapshot_locked(RestoreEnvSnapshotOptions {
-                    env_name: env_name.to_string(),
-                    snapshot_id: plan.record.snapshot_id.clone(),
-                })
-        {
-            return Ok(self.fail_upgrade_rollback_locked(
-                env_name,
-                &plan,
-                transaction,
-                format!("failed to restore the recorded pre-upgrade snapshot: {error}"),
-            ));
-        }
+        let restore = match self.environment_service().prepare_snapshot_restore_locked(
+            RestoreEnvSnapshotOptions {
+                env_name: env_name.to_string(),
+                snapshot_id: plan.record.snapshot_id.clone(),
+            },
+        ) {
+            Ok(restore) => restore,
+            Err(error) => {
+                return Ok(self.fail_upgrade_rollback_locked(
+                    env_name,
+                    &plan,
+                    transaction,
+                    format!("failed to restore the recorded pre-upgrade snapshot: {error}"),
+                ));
+            }
+        };
 
         let service_action = match self.reconcile_rolled_back_service_locked(env_name, &plan.record)
         {
             Ok(action) => action,
             Err(error) => {
+                let error = format!("{error}; {}", restore.retained_operation_note());
                 return Ok(self.fail_upgrade_rollback_locked(env_name, &plan, transaction, error));
             }
         };
@@ -1432,10 +1435,20 @@ impl Cli {
                     env_name,
                     &plan,
                     transaction,
-                    format!("post-rollback verification failed: {error}"),
+                    format!(
+                        "post-rollback verification failed: {error}; {}",
+                        restore.retained_operation_note()
+                    ),
                 ));
             }
         };
+        let restored = self
+            .environment_service()
+            .commit_snapshot_restore_locked(restore);
+        transaction.cleanup_note =
+            (!restored.warnings.is_empty()).then(|| restored.warnings.join("; "));
+        let verification_note =
+            join_optional_warnings(verification_note, transaction.cleanup_note.clone());
         transaction.mark_post_update_not_needed();
 
         let history_summary = UpgradeEnvSummary {
@@ -1534,18 +1547,27 @@ impl Cli {
         &self,
         env_name: &str,
         plan: &UpgradeRollbackPlan,
-        transaction: UpgradeTransaction,
+        mut transaction: UpgradeTransaction,
         error: String,
     ) -> UpgradeRollbackSummary {
         let rollback_transaction_id = transaction.id.clone();
         let safety_snapshot_id = transaction.snapshot_id.clone();
         let restore_result = self.rollback_upgrade_locked(env_name, &transaction);
+        if let Ok(cleanup_note) = &restore_result {
+            transaction.cleanup_note = cleanup_note.clone();
+        }
         let restored_pre_rollback_state = restore_result.is_ok();
         let (outcome, rollback, note) = match restore_result {
-            Ok(()) => (
+            Ok(cleanup_warning) => (
                 "failed".to_string(),
                 "restored".to_string(),
-                format!("rollback failed, so ocm restored the pre-rollback state: {error}"),
+                join_optional_warnings(
+                    Some(format!(
+                        "rollback failed, so ocm restored the pre-rollback state: {error}"
+                    )),
+                    cleanup_warning,
+                )
+                .unwrap(),
             ),
             Err(restore_error) => (
                 "rollback-failed".to_string(),
@@ -4418,6 +4440,7 @@ impl Cli {
 
         Ok(UpgradeTransaction {
             id,
+            cleanup_note: None,
             _checkpoint_cleanup: checkpoint_cleanup,
             snapshot_id: snapshot.id,
             runtime_backups,
@@ -4623,7 +4646,9 @@ impl Cli {
             },
             rollback: summary.rollback.clone(),
             rollback_of: transaction.rollback_of.clone(),
-            note: None,
+            // Only OCM-generated cleanup diagnostics belong in history. The
+            // general summary may contain private OpenClaw command output.
+            note: transaction.cleanup_note.clone(),
         };
         save_upgrade_history_record(&record, &self.env, &self.cwd)
     }
@@ -4703,7 +4728,7 @@ impl Cli {
         binding_name: String,
         runtime_release_version: Option<String>,
         runtime_release_channel: Option<String>,
-        transaction: UpgradeTransaction,
+        mut transaction: UpgradeTransaction,
         error: String,
     ) -> Result<UpgradeEnvSummary, String> {
         if !transaction.rollback_enabled {
@@ -4748,9 +4773,12 @@ impl Cli {
         }
 
         let rollback_result = self.rollback_upgrade_locked(env_name, &transaction);
+        if let Ok(cleanup_note) = &rollback_result {
+            transaction.cleanup_note = cleanup_note.clone();
+        }
         let snapshot_id = transaction.snapshot_id.clone();
         let mut summary = match rollback_result {
-            Ok(()) => UpgradeEnvSummary {
+            Ok(cleanup_warning) => UpgradeEnvSummary {
                 env_name: env_name.to_string(),
                 previous_binding_kind: previous_binding_kind.to_string(),
                 previous_binding_name,
@@ -4762,9 +4790,12 @@ impl Cli {
                 service_action: None,
                 snapshot_id: Some(snapshot_id),
                 rollback: Some("restored".to_string()),
-                note: Some(format!(
-                    "upgrade failed, so ocm restored the pre-upgrade snapshot: {error}"
-                )),
+                note: join_optional_warnings(
+                    Some(format!(
+                        "upgrade failed, so ocm restored the pre-upgrade snapshot: {error}"
+                    )),
+                    cleanup_warning,
+                ),
             },
             Err(rollback_error) => UpgradeEnvSummary {
                 env_name: env_name.to_string(),
@@ -4797,7 +4828,7 @@ impl Cli {
         &self,
         env_name: &str,
         transaction: &UpgradeTransaction,
-    ) -> Result<(), String> {
+    ) -> Result<Option<String>, String> {
         let changes_runtime_trees = !transaction.mutated_runtime_names.is_empty();
         let changes_binding = transaction.source.kind != transaction.target.kind
             || transaction.source.name != transaction.target.name;
@@ -4815,32 +4846,47 @@ impl Cli {
         }) {
             self.restore_runtime_backup(runtime_backup)?;
         }
-        self.environment_service()
-            .restore_snapshot_locked(RestoreEnvSnapshotOptions {
+        let restore = self.environment_service().prepare_snapshot_restore_locked(
+            RestoreEnvSnapshotOptions {
                 env_name: env_name.to_string(),
                 snapshot_id: transaction.snapshot_id.clone(),
-            })?;
-        if changes_runtime_trees {
-            self.service_service().wait_for_binding_convergence_locked(
-                env_name,
-                &transaction.source.kind,
-                &transaction.source.name,
-            )?;
-        }
+            },
+        )?;
+        // Keep displaced state until the restored service has recovered. Slow or
+        // failed discard-only cleanup must not extend the outage.
+        let acceptance = (|| {
+            if changes_runtime_trees {
+                self.service_service().wait_for_binding_convergence_locked(
+                    env_name,
+                    &transaction.source.kind,
+                    &transaction.source.name,
+                )?;
+            }
+            if transaction.service_before.enabled && transaction.service_before.running {
+                let started = self
+                    .service_service()
+                    .start_locked(env_name)
+                    .map_err(|error| format!("failed to restart the restored service: {error}"))?;
+                self.wait_for_restarted_gateway_health(env_name, started.desired_running)?;
+            }
+            Ok::<(), String>(())
+        })();
+        acceptance.map_err(|error| format!("{error}; {}", restore.retained_operation_note()))?;
+        let mut restored = self
+            .environment_service()
+            .commit_snapshot_restore_locked(restore);
         for runtime_name in transaction
             .created_runtime_names
             .iter()
             .filter(|runtime_name| transaction.mutated_runtime_names.contains(*runtime_name))
         {
-            self.remove_runtime_created_during_upgrade(runtime_name)?;
+            if let Err(error) = self.remove_runtime_created_during_upgrade(runtime_name) {
+                restored.warnings.push(format!(
+                    "unused runtime {runtime_name} cleanup requires attention: {error}"
+                ));
+            }
         }
-        if transaction.service_before.enabled && transaction.service_before.running {
-            self.service_service()
-                .start_locked(env_name)
-                .map(|_| ())
-                .map_err(|error| format!("failed to restart the restored service: {error}"))?;
-        }
-        Ok(())
+        Ok((!restored.warnings.is_empty()).then(|| restored.warnings.join("; ")))
     }
 
     fn remove_runtime_created_during_upgrade(&self, runtime_name: &str) -> Result<(), String> {
@@ -5068,6 +5114,7 @@ impl UpgradeSimulationScenario {
 #[derive(Debug)]
 struct UpgradeTransaction {
     id: String,
+    cleanup_note: Option<String>,
     // Retain failed/displaced preparation trees through restart or rollback.
     _checkpoint_cleanup: crate::store::CheckpointCleanup,
     snapshot_id: String,

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -58,6 +58,8 @@ pub struct EnvSnapshotRestoreSummary {
     pub default_runtime: Option<String>,
     pub default_launcher: Option<String>,
     pub protected: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -228,7 +230,7 @@ impl<'a> EnvironmentService<'a> {
     pub(crate) fn commit_snapshot_restore_locked(
         &self,
         transaction: EnvSnapshotRestoreTransaction,
-    ) -> Result<(), String> {
+    ) -> EnvSnapshotRestoreSummary {
         commit_env_snapshot_restore(transaction)
     }
 

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -74,6 +74,15 @@ pub(crate) struct EnvSnapshotRestoreTransaction {
     independent: Vec<PathBuf>,
 }
 
+impl EnvSnapshotRestoreTransaction {
+    pub(crate) fn retained_operation_note(&self) -> String {
+        format!(
+            "restore operation retained at {}",
+            display_path(&self.operation_root)
+        )
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct PreparedEnvSnapshotCapture {
     env_name: String,
@@ -436,9 +445,7 @@ pub fn restore_env_snapshot(
     cwd: &Path,
 ) -> Result<EnvSnapshotRestoreSummary, String> {
     let transaction = prepare_env_snapshot_restore(options, env, cwd)?;
-    let summary = transaction.summary.clone();
-    commit_env_snapshot_restore(transaction)?;
-    Ok(summary)
+    Ok(commit_env_snapshot_restore(transaction))
 }
 
 pub(crate) fn prepare_env_snapshot_restore(
@@ -588,6 +595,7 @@ pub(crate) fn prepare_env_snapshot_restore(
                     default_runtime: meta.default_runtime.clone(),
                     default_launcher: meta.default_launcher.clone(),
                     protected: meta.protected,
+                    warnings: Vec::new(),
                 },
                 original: current.clone(),
                 operation_root: operation.root.clone(),
@@ -628,14 +636,17 @@ pub(crate) fn prepare_env_snapshot_restore(
 }
 
 pub(crate) fn commit_env_snapshot_restore(
-    transaction: EnvSnapshotRestoreTransaction,
-) -> Result<(), String> {
-    remove_tree_if_present(&transaction.operation_root).map_err(|error| {
-        format!(
-            "restored snapshot was accepted, but its operation namespace {} could not be removed: {error}",
+    mut transaction: EnvSnapshotRestoreTransaction,
+) -> EnvSnapshotRestoreSummary {
+    // Acceptance is complete. Discarding displaced bytes cannot undo it or
+    // prevent the caller from recovering the restored service.
+    if let Err(error) = remove_tree_if_present(&transaction.operation_root) {
+        transaction.summary.warnings.push(format!(
+            "restored snapshot was accepted; cleanup requires attention at {}: {error}",
             display_path(&transaction.operation_root)
-        )
-    })
+        ));
+    }
+    transaction.summary
 }
 
 pub(crate) fn rollback_env_snapshot_restore(

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -221,9 +221,23 @@ if [ "${{1:-}}" = "gateway" ] && [ "${{2:-}}" = "status" ]; then
   exit 0
 fi
 if [ "${{1:-}}" = "gateway" ]; then
-  trap 'printf "%s\n" "$$" >> "{stopped}"; exit 0' TERM INT
   printf '%s\n' "$$" >> '{started}'
-  while :; do sleep 3600; done
+  exec node - "${{4:-0}}" '{stopped}' <<'NODE'
+const http = require('node:http');
+const fs = require('node:fs');
+const port = Number(process.argv[2]);
+const stop = () => {{
+  fs.appendFileSync(process.argv[3], `${{process.pid}}\n`);
+  process.exit(0);
+}};
+process.on('SIGTERM', stop);
+process.on('SIGINT', stop);
+const server = http.createServer((request, response) => {{
+  response.writeHead(request.url === '/health' ? 200 : 404);
+  response.end(request.url === '/health' ? 'ok' : 'not found');
+}});
+server.listen(port, '127.0.0.1');
+NODE
 fi
 case "${{1:-}}" in
   --version)

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -341,6 +341,76 @@ fn env_snapshot_restore_reverts_state_from_the_selected_snapshot() {
     );
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn accepted_snapshot_restore_reports_cleanup_failure_without_failing() {
+    for json in [false, true] {
+        let root = TestDir::new("snapshot-cleanup-warning");
+        let cwd = root.child("workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let env = ocm_env(&root);
+        let create = run_ocm(&cwd, &env, &["env", "create", "source"]);
+        assert!(create.status.success(), "{}", stderr(&create));
+        let notes = root.child("ocm-home/envs/source/.openclaw/workspace/notes.txt");
+        write_text(&notes, "checkpoint bytes\n");
+        let snapshot = run_ocm(
+            &cwd,
+            &env,
+            &["env", "snapshot", "create", "source", "--json"],
+        );
+        assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+        let snapshot: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+        write_text(&notes, "displaced bytes\n");
+        assert!(
+            Command::new("/usr/bin/chflags")
+                .arg("uchg")
+                .arg(&notes)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let mut args = vec![
+            "env",
+            "snapshot",
+            "restore",
+            "source",
+            snapshot["id"].as_str().unwrap(),
+        ];
+        args.push(if json { "--json" } else { "--raw" });
+        let restore = run_ocm(&cwd, &env, &args);
+        let retained = fs::read_dir(root.child("ocm-home/envs"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .find(|entry| entry.file_name().to_string_lossy().contains("ocm-restore"))
+            .expect("cleanup residue must remain available");
+        let displaced = retained
+            .path()
+            .join("displaced/.openclaw/workspace/notes.txt");
+        assert!(
+            Command::new("/usr/bin/chflags")
+                .arg("nouchg")
+                .arg(&displaced)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(restore.status.success(), "{}", stderr(&restore));
+        assert_eq!(fs::read_to_string(notes).unwrap(), "checkpoint bytes\n");
+        assert_eq!(fs::read_to_string(displaced).unwrap(), "displaced bytes\n");
+        assert!(
+            stdout(&restore).contains("cleanup requires attention"),
+            "{}",
+            stdout(&restore)
+        );
+        if json {
+            let result: Value = serde_json::from_str(&stdout(&restore)).unwrap();
+            assert_eq!(result["warnings"].as_array().unwrap().len(), 1);
+        } else {
+            assert!(stdout(&restore).contains("warning: "));
+        }
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn env_snapshot_restores_the_complete_durable_root_with_metadata_and_sqlite() {

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -3393,16 +3393,14 @@ fn upgrade_rolls_back_runtime_when_service_restart_fails() {
     assert_eq!(runtime_json["releaseVersion"], "2026.3.24");
 
     let target_runtime = run_ocm(&cwd, &env, &["runtime", "show", "2026.3.25", "--json"]);
+    // Recovery has not been accepted. Preserve diagnostic/recovery state rather
+    // than discarding it before the restored service can start.
     assert!(
-        !target_runtime.status.success(),
-        "{}",
-        stdout(&target_runtime)
-    );
-    assert!(
-        stderr(&target_runtime).contains("runtime \"2026.3.25\" does not exist"),
+        target_runtime.status.success(),
         "{}",
         stderr(&target_runtime)
     );
+    assert!(output.contains("restore operation retained at"), "{output}");
 
     let restored = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
     assert!(restored.status.success(), "{}", stderr(&restored));
@@ -4045,7 +4043,7 @@ fn upgrade_holds_the_environment_operation_lock_until_completion() {
 }
 
 #[cfg(unix)]
-fn assert_interrupted_upgrade_restores_service(start_running: bool) {
+fn assert_interrupted_upgrade_restores_service(start_running: bool, cleanup_failure: bool) {
     let root = TestDir::new(if start_running {
         "upgrade-interrupt-running"
     } else {
@@ -4198,6 +4196,18 @@ fn assert_interrupted_upgrade_restores_service(start_running: bool) {
         );
     }
 
+    if cleanup_failure {
+        let retained = root.child("ocm-home/envs/demo/.openclaw/workspace/cleanup-blocker");
+        write_text(&retained, "displaced target bytes\n");
+        assert!(
+            Command::new("/usr/bin/chflags")
+                .arg("uchg")
+                .arg(&retained)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
     let signal_result = unsafe { libc::kill(upgrade.id() as i32, libc::SIGTERM) };
     assert_eq!(signal_result, 0, "failed to signal upgrade process");
     fs::write(&finalize_release, "").unwrap();
@@ -4206,6 +4216,45 @@ fn assert_interrupted_upgrade_restores_service(start_running: bool) {
     observer.join().unwrap();
     stop_converging_health_server(health_port, &health_stop, health_handle);
 
+    if cleanup_failure {
+        let retained = fs::read_dir(root.child("ocm-home/envs"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .find(|entry| entry.file_name().to_string_lossy().contains("ocm-restore"))
+            .expect("failed cleanup must preserve its operation namespace");
+        let blocker = retained
+            .path()
+            .join("displaced/.openclaw/workspace/cleanup-blocker");
+        // Release only the test-owned flag before any assertion can panic.
+        assert!(
+            Command::new("/usr/bin/chflags")
+                .arg("nouchg")
+                .arg(&blocker)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert_eq!(
+            fs::read_to_string(blocker).unwrap(),
+            "displaced target bytes\n"
+        );
+        assert!(
+            stdout(&output).contains("cleanup requires attention"),
+            "{}",
+            stdout(&output)
+        );
+        let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
+        assert!(
+            stdout(&history).contains("cleanup requires attention"),
+            "{}",
+            stdout(&history)
+        );
+        assert!(
+            !root
+                .child("ocm-home/envs/demo/.openclaw/workspace/cleanup-blocker")
+                .exists()
+        );
+    }
     assert!(!output.status.success(), "{}", stdout(&output));
     let receipt: Value = serde_json::from_str(&stdout(&output)).unwrap();
     assert_eq!(receipt["outcome"], "rolled-back");
@@ -4228,13 +4277,25 @@ fn assert_interrupted_upgrade_restores_service(start_running: bool) {
 #[cfg(unix)]
 #[test]
 fn interrupted_upgrade_restores_a_running_service() {
-    assert_interrupted_upgrade_restores_service(true);
+    assert_interrupted_upgrade_restores_service(true, false);
 }
 
 #[cfg(unix)]
 #[test]
 fn interrupted_upgrade_keeps_a_stopped_service_stopped() {
-    assert_interrupted_upgrade_restores_service(false);
+    assert_interrupted_upgrade_restores_service(false, false);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn rollback_cleanup_failure_does_not_prevent_service_recovery() {
+    assert_interrupted_upgrade_restores_service(true, true);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn rollback_cleanup_failure_keeps_stopped_service_stopped() {
+    assert_interrupted_upgrade_restores_service(false, true);
 }
 
 #[test]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users rolling back a failed upgrade would be left with an offline gateway when deleting the displaced environment failed after the snapshot had already been restored. A permission error in discard-only cleanup incorrectly stopped recovery before the source service restart.

## Why This Change Was Made

Separate accepted restoration from cleanup. Automatic and explicit upgrade rollback now recover and verify the required source service before discarding displaced state. Cleanup failures preserve the remaining directory and become warnings, including an OCM-generated history note. Direct snapshot restore exposes the same warnings in JSON and human output.

Invalid restoration, failed startup and failed readiness remain errors. If service acceptance fails, diagnostic and recovery state remains available. Arbitrary OpenClaw subprocess output is not copied into upgrade history.

## User Impact

A cleanup-only permission failure no longer strands a successfully restored environment offline or falsely reports that restoration failed. Previously stopped environments remain stopped. Operators receive the retained cleanup location.

This does not change checkpoint contents, independent-project ownership, OpenClaw atomic-update policy, process/writer settlement, service schedules or production runtimes. It does not claim recovery from invalid/missing snapshots or uncatchable host/process crashes. No version bump, release or deployment is included.

## Evidence

Base: `2efad750b6c0cc228f711c2605c42e9f6a19e063`; head: `840f8c3cfbc68056dec5b9455dc7c7312262b855`.

The final update changes only the synthetic daemon gateway fixture to serve `/health` while retaining PID and signal accounting. All 38 daemon runtime tests now pass, including the sibling rollback test that correctly failed against the earlier sleeping-only fixture. Production source and executable SHA-256 remain identical to recorded head `abe73e2a8280a17b71fadabe65f179807c7827a2`; the linked videos and manifest retain that original capture provenance. The executable SHA-256 is `37b042d978b5a5ffd232506577db75385fb816cbc41cc4367ffc2cce07fc8a81`.

- Same local macOS/APFS public CLI fixture on both revisions: target finalization creates an immutable file after checkpoint capture and fails. Base reports `rollback-failed` despite restored source bytes/binding; head reports `rolled-back/restored` with the cleanup warning and retained directory. Removing only the immutable restriction produces normal rollback.
- 131 tests pass across `env_snapshot_tests`, `store_flow_tests`, `upgrade_checkpoint_scope_tests` and `upgrade_command_tests`. Coverage includes cleanup failure with a running source, stopped policy, failed service acceptance, explicit rollback and independent-project preservation. Service integration fixtures isolate the native manager; no real environment was operated by the tests.
- `cargo fmt --check`, `cargo check --workspace --all-targets --locked`, and `git diff --check` pass. The five cleanup-selected tests also pass on the exact committed head. An isolated Rust/OS tool PATH avoids host pnpm fixture interference, reproduced on unchanged base.
- Autoreview is scoped-clean at its configured P0 threshold, including a separate review of the final fixture-only increment. Independent candidate-source-blind CLI validation passed five stopped-fixture clauses; it did not independently exercise native service ordering or corrupt-snapshot refusal, and the reused validator disclosed prior OCM architecture exposure. Those paths are covered by integration tests rather than a fresh-context black-box certification.

Sanitized proof: [red/base video](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm-restore-cleanup-abe73e2/base.mp4?X-Amz-Expires=604800&X-Amz-Date=20260909T005344Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=34c5249f107b01d5c3844817e10faea2b75c789c9d5ffe3d2b312e62f3c0899a), [green/head video](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm-restore-cleanup-abe73e2/head.mp4?X-Amz-Expires=604800&X-Amz-Date=20260909T005344Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=33a57230974007f073a28cc60a5a2788ae2bfc72692d4ee908d91a55b7b31e9c), [contract and validation scope](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm-restore-cleanup-abe73e2/contract.md?X-Amz-Expires=604800&X-Amz-Date=20260909T005344Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=b4bc5edd732adb5031a10eb56fd7c23a5be763a7518745ed6267bd68adea9e91), [artifact manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm-restore-cleanup-abe73e2/proof-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260909T005344Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f931cb8c0711600ba4b9bdc6c05d3c26dad74fdd15904277a00f94b370b321f2). Videos are deterministic renders of actual PTY-captured CLI responses, not generated reenactments. Signed links expire September 16, 2026. No private runtime state, transcript or proof assets are committed.
