### PR TITLE
chore(release): bump version to 0.2.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.42"
+version = "0.2.43"
 publish = false
 edition = "2024"
 rust-version = "1.88"


### PR DESCRIPTION
## What Problem This Solves

Prepare v0.2.43 so the completed update and rollback fixes can reach installed OCM users.

## Why This Change Was Made

This version-only change updates OCM in Cargo.toml and Cargo.lock. Publication follows the existing signed-tag and protected-main release workflow after the exact release commit passes CI.

## User Impact

The release includes coordinated OCM self-update recovery from #146, declared independent project-directory preservation from #168, and gateway recovery before displaced-state cleanup from #169. Independent directories remain an explicit operator setting, not an automatic exclusion. Publishing this release does not deploy it to Odin or change any update schedule.

## Evidence

- Product proof for #146 is recorded in https://github.com/openclaw/ocm/pull/146#issuecomment-5594827828.
- Fresh source-blind native validation and its coverage limits are recorded in https://github.com/openclaw/ocm/pull/146#issuecomment-5594914406.
- Local version consistency, locked Cargo metadata, formatting and diff checks passed. Broad local suites are not repeated for this mechanical version bump; release PR and exact-main CI run the full platform checks.
- The release PR changes only the package version. Its required checks and the exact post-merge main CI must pass before tagging.
- The release workflow verifies the signed tag, builds all supported targets, signs and notarizes macOS binaries, and checks the complete asset inventory before publication.
