### PR TITLE
fix: resume dev environments from their recorded worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ ocm dev existing-env --repo ~/src/openclaw --watch --force
 
 Use `ocm dev` when you want an isolated source-run checkout with its own env root and gateway port, or when you want to temporarily run source against an existing env in watch mode without rebinding it. While watch mode is running, OCM's OpenClaw-running commands for that env resolve to the watched checkout, so one-shot checks use the same built `openclaw.mjs` that the watcher is maintaining. Existing-env watch output is saved under that env's `.openclaw/logs/` directory, so `ocm logs <env>` remains useful while the foreground watcher is running. If you are already inside an OpenClaw checkout, `ocm setup` can detect that and suggest a local path automatically.
 
+An existing dev env resumes its recorded worktree, preserving its uncommitted changes. If that worktree is missing or has been replaced by an unrelated checkout, `dev` reports an error instead of recreating it; restore the recorded checkout before retrying. An explicit `--repo` must still identify the env's original repository, including equivalent path aliases, and cannot rebind the env to another checkout.
+
 ### Try beta or pin a specific release
 
 ```bash

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -33,7 +33,7 @@ use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::infra::terminal::{Cell, KeyValueRow, Tone, paint, render_key_value_card, render_table};
 use crate::openclaw_repo::{
     detect_openclaw_checkout, discover_openclaw_checkout, ensure_checkout_owned_dependencies,
-    ensure_openclaw_worktree,
+    ensure_openclaw_worktree, validate_openclaw_worktree,
 };
 use crate::service::service_backend_support_error;
 use crate::store::{
@@ -554,7 +554,19 @@ impl Cli {
             let existing_repo = PathBuf::from(&dev.repo_root);
             if let Some(repo_root) = repo_root {
                 let requested = resolve_absolute_path(&repo_root, &self.env, &self.cwd)?;
-                if requested != existing_repo {
+                let requested = fs::canonicalize(&requested).map_err(|error| {
+                    format!(
+                        "failed to resolve OpenClaw repo {}: {error}",
+                        display_path(&requested)
+                    )
+                })?;
+                let saved_repo = fs::canonicalize(&existing_repo).map_err(|error| {
+                    format!(
+                        "failed to resolve saved OpenClaw repo {}: {error}",
+                        display_path(&existing_repo)
+                    )
+                })?;
+                if requested != saved_repo {
                     return Err(format!(
                         "dev cannot change the repo for existing env {}; current repo is {}",
                         existing.name, dev.repo_root
@@ -572,7 +584,7 @@ impl Cli {
                 }
             }
 
-            ensure_openclaw_worktree(&existing_repo, &existing.name)?;
+            validate_openclaw_worktree(&existing_repo, Path::new(&dev.worktree_root))?;
             let meta = self
                 .environment_service()
                 .apply_effective_gateway_port(existing)?;

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -86,6 +86,32 @@ pub(crate) fn default_worktree_root(repo_root: &Path, env_name: &str) -> PathBuf
     clean_path(&repo_root.join(".worktrees").join(env_name))
 }
 
+pub(crate) fn validate_openclaw_worktree(
+    repo_root: &Path,
+    worktree_root: &Path,
+) -> Result<(), String> {
+    if !worktree_root.exists() {
+        return Err(format!(
+            "saved dev worktree is missing: {}; restore that checkout before resuming the env",
+            display_path(worktree_root)
+        ));
+    }
+    let registered = registered_worktree_paths(repo_root)?;
+    if !contains_worktree_path(&registered, worktree_root) {
+        return Err(format!(
+            "saved dev worktree is not registered to this OpenClaw checkout: {}",
+            display_path(worktree_root)
+        ));
+    }
+    if !is_existing_openclaw_worktree(repo_root, worktree_root) {
+        return Err(format!(
+            "registered worktree is not a valid OpenClaw checkout: {}",
+            display_path(worktree_root)
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) fn ensure_openclaw_worktree(
     repo_root: &Path,
     env_name: &str,

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -14,7 +14,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use ocm::store::{now_utc, supervisor_runtime_path};
+use ocm::store::{get_environment, now_utc, save_environment, supervisor_runtime_path};
 use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
 use serde_json::Value;
 
@@ -577,7 +577,7 @@ fn dev_command_rejects_an_unregistered_clone_at_the_managed_path() {
 }
 
 #[test]
-fn dev_command_recreates_an_exactly_registered_missing_worktree() {
+fn dev_command_does_not_recreate_a_missing_saved_worktree() {
     let root = TestDir::new("dev-command-missing-worktree");
     let repo = init_openclaw_repo(&root);
     let cwd = root.child("workspace");
@@ -590,19 +590,138 @@ fn dev_command_recreates_an_exactly_registered_missing_worktree() {
     let show = run_ocm(&cwd, &env, &["env", "show", "demo", "--json"]);
     let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     let worktree_root = PathBuf::from(show_json["devWorktreeRoot"].as_str().unwrap());
+    let registered = git_worktree_paths(&repo);
     fs::remove_dir_all(&worktree_root).unwrap();
+    fs::remove_file(root.child("pnpm.log")).unwrap();
 
     let second = run_ocm(&cwd, &env, &["dev", "demo"]);
-    assert!(second.status.success(), "{}", stderr(&second));
-    assert!(worktree_root.join(".git").exists());
-    let canonical_worktree_root = fs::canonicalize(&worktree_root).unwrap();
+    assert!(!second.status.success());
+    assert!(stderr(&second).contains("saved dev worktree is missing"));
+    assert!(!worktree_root.exists());
+    assert_eq!(git_worktree_paths(&repo), registered);
+    assert!(!root.child("pnpm.log").exists());
+    let meta = get_environment("demo", &env, &cwd).unwrap();
+    assert_eq!(meta.dev.unwrap().worktree_root, path_string(&worktree_root));
+}
+
+#[test]
+fn dev_command_resumes_the_recorded_worktree_without_recreating_the_default() {
+    let root = TestDir::new("dev-command-recorded-worktree");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let first = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(first.status.success(), "{}", stderr(&first));
+    let mut meta = get_environment("demo", &env, &cwd).unwrap();
+    let dev = meta.dev.as_mut().unwrap();
+    let original_worktree = PathBuf::from(&dev.worktree_root);
+    let recorded_worktree = repo.join(".worktrees/recorded-source");
+    let moved = Command::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["worktree", "move"])
+        .arg(&original_worktree)
+        .arg(&recorded_worktree)
+        .output()
+        .unwrap();
+    assert!(moved.status.success(), "{}", stderr(&moved));
+    dev.worktree_root = path_string(&recorded_worktree);
+    save_environment(meta, &env, &cwd).unwrap();
+    fs::write(recorded_worktree.join("SENTINEL"), "keep my edits\n").unwrap();
+    fs::write(
+        recorded_worktree.join("scripts/run-node.mjs"),
+        "console.log('edited');\n",
+    )
+    .unwrap();
+    fs::remove_file(root.child("pnpm.log")).unwrap();
+
+    let resumed = run_ocm(&cwd, &env, &["dev", "demo"]);
+    assert!(resumed.status.success(), "{}", stderr(&resumed));
+    assert!(!original_worktree.exists());
     assert_eq!(
-        git_worktree_paths(&repo)
-            .into_iter()
-            .filter(|path| fs::canonicalize(path).ok().as_ref() == Some(&canonical_worktree_root))
-            .count(),
-        1
+        fs::read_to_string(recorded_worktree.join("SENTINEL")).unwrap(),
+        "keep my edits\n"
     );
+    assert_eq!(
+        fs::read_to_string(recorded_worktree.join("scripts/run-node.mjs")).unwrap(),
+        "console.log('edited');\n"
+    );
+    let pnpm_log = fs::read_to_string(root.child("pnpm.log")).unwrap();
+    assert!(pnpm_log.contains("openclaw gateway run --port"));
+    let source_prefix = format!(
+        "{}|",
+        path_string(&fs::canonicalize(&recorded_worktree).unwrap())
+    );
+    assert!(
+        pnpm_log
+            .lines()
+            .all(|line| line.starts_with(&source_prefix))
+    );
+}
+
+#[test]
+fn dev_command_rejects_an_unrelated_recorded_worktree_before_running_source() {
+    let root = TestDir::new("dev-command-unrelated-recorded-worktree");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let first = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(first.status.success(), "{}", stderr(&first));
+    let unrelated_worktree = root.child("unrelated-source");
+    init_nested_openclaw_repo(&unrelated_worktree);
+    let mut meta = get_environment("demo", &env, &cwd).unwrap();
+    meta.dev.as_mut().unwrap().worktree_root = path_string(&unrelated_worktree);
+    save_environment(meta, &env, &cwd).unwrap();
+    fs::remove_file(root.child("pnpm.log")).unwrap();
+
+    let resumed = run_ocm(&cwd, &env, &["dev", "demo"]);
+    assert!(!resumed.status.success());
+    assert!(stderr(&resumed).contains("saved dev worktree is not registered"));
+    assert!(!root.child("pnpm.log").exists());
+    assert_eq!(
+        fs::read_to_string(unrelated_worktree.join("SENTINEL")).unwrap(),
+        "preserve me\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_command_accepts_a_repo_alias_without_rebinding_the_env() {
+    let root = TestDir::new("dev-command-repo-alias");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    let first = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
+    assert!(first.status.success(), "{}", stderr(&first));
+    let before = get_environment("demo", &env, &cwd).unwrap().dev.unwrap();
+    let alias = root.child("source-alias");
+    std::os::unix::fs::symlink(&repo, &alias).unwrap();
+
+    let resumed = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&alias)]);
+    assert!(resumed.status.success(), "{}", stderr(&resumed));
+    let after = get_environment("demo", &env, &cwd).unwrap().dev.unwrap();
+    assert_eq!(after.repo_root, before.repo_root);
+    assert_eq!(after.worktree_root, before.worktree_root);
+
+    let unrelated_repo = root.child("unrelated-repo");
+    init_nested_openclaw_repo(&unrelated_repo);
+    fs::remove_file(&alias).unwrap();
+    std::os::unix::fs::symlink(&unrelated_repo, &alias).unwrap();
+    let changed = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&alias)]);
+    assert!(!changed.status.success());
+    assert!(stderr(&changed).contains("dev cannot change the repo for existing env"));
+    let after = get_environment("demo", &env, &cwd).unwrap().dev.unwrap();
+    assert_eq!(after.repo_root, before.repo_root);
+    assert_eq!(after.worktree_root, before.worktree_root);
 }
 
 #[test]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rerunning `ocm dev <env>` could recreate a deleted source worktree or provision the default worktree without validating the source recorded for the environment.

## Why This Change Was Made

Existing dev environments now validate and reuse their recorded worktree. Missing sources and unrelated replacements fail before dependency preparation or source execution, using the existing Git registration and checkout identity checks. An explicit `--repo` keeps its original-repository meaning and accepts aliases resolving to that same directory.

## User Impact

Developers can resume the recorded worktree with its existing changes. OCM no longer recreates missing source during resumption or silently rebinds the environment to a different repository.

## Evidence

Passed remotely on Linux with Rust 1.98.1:

- `cargo fmt --check`
- `cargo check --workspace --all-targets --locked`
- `cargo test --locked --test dev_command_tests --test source_watch_tests` — 44 + 10 passed
- `cargo test --locked --test env_destroy_tests` — 14 passed

The CLI fixtures exercise real Git worktrees and cover missing saved source, a moved recorded worktree with tracked and untracked edits, unrelated source substitution, and repository aliases. Existing cleanup, relative-link, backlink, source-watch lifetime, service restoration, and routing controls also passed.

Hosted CI provides the full Linux/macOS suites, minimum Rust version, and Windows compilation checks.
