### PR TITLE
fix: prevent background services from competing with source watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,13 @@ ocm dev luna --watch
 ocm dev existing-env --repo ~/src/openclaw --watch --force
 ```
 
-Use `ocm dev` when you want an isolated source-run checkout with its own env root and gateway port, or when you want to temporarily run source against an existing env in watch mode without rebinding it. While watch mode is running, OCM's OpenClaw-running commands for that env resolve to the watched checkout, so one-shot checks use the same built `openclaw.mjs` that the watcher is maintaining. Existing-env watch output is saved under that env's `.openclaw/logs/` directory, so `ocm logs <env>` remains useful while the foreground watcher is running. If you are already inside an OpenClaw checkout, `ocm setup` can detect that and suggest a local path automatically.
+Use `ocm dev` when you want an isolated source-run checkout with its own env root and gateway port, or when you want to temporarily run source against an existing env in watch mode without rebinding it. While watch mode is running, OCM's OpenClaw-running commands for that env resolve to the watched checkout, so one-shot checks use the same built `openclaw.mjs` that the watcher is maintaining. OCM refuses background service installation, start, and restart for that env until watch exits; a running service taken over with `--watch --force` is restored by the watch session after its source processes stop. Existing-env watch output is saved under that env's `.openclaw/logs/` directory, so `ocm logs <env>` remains useful while the foreground watcher is running. If you are already inside an OpenClaw checkout, `ocm setup` can detect that and suggest a local path automatically.
+
+After updating OCM, a background daemon still running the previous code needs an
+explicit refresh to enforce this watch exclusion. `ocm service status` reports
+CLI and daemon versions. During a maintenance window, run
+`ocm service refresh-daemon --acknowledge-gateway-restarts`; this restarts the
+managed gateways.
 
 An existing dev env resumes its recorded worktree, preserving its uncommitted changes. If that worktree is missing or has been replaced by an unrelated checkout, `dev` reports an error instead of recreating it; restore the recorded checkout before retrying. An explicit `--repo` must still identify the env's original repository, including equivalent path aliases, and cannot rebind the env to another checkout.
 

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -211,8 +211,7 @@ impl Cli {
             .as_ref()
             .ok_or_else(|| format!("environment \"{}\" is missing its dev binding", meta.name))?;
         let stderr_profile = self.dev_stderr_profile();
-        let watch_takes_over_service = watch && force && meta.service_running;
-        if !service_requested && meta.service_running && !watch_takes_over_service {
+        if !watch && !service_requested && meta.service_running {
             return Err(format!(
                 "dev env {} is already running in the background; stop it first with {} service stop {}, inspect it with {} logs {} --follow, or rerun with --watch --force to take it over temporarily",
                 meta.name,
@@ -225,11 +224,14 @@ impl Cli {
         let mut source_watch_lease = if watch {
             Some(
                 self.environment_service()
-                    .acquire_source_watch_lease(&meta.name)?,
+                    .acquire_source_watch_lease(&meta.name, force)?,
             )
         } else {
             None
         };
+        let watch_takes_over_service = source_watch_lease
+            .as_ref()
+            .is_some_and(SourceWatchLease::service_was_running);
         self.stderr_lines(render_dev_run_summary(
             &meta,
             created,
@@ -410,7 +412,7 @@ impl Cli {
             .apply_effective_gateway_port(existing)?;
         let mut source_watch_lease = Some(
             self.environment_service()
-                .acquire_source_watch_lease(&meta.name)?,
+                .acquire_source_watch_lease(&meta.name, true)?,
         );
         let stderr_profile = self.dev_stderr_profile();
         self.stderr_lines(render_source_watch_takeover_summary(
@@ -424,7 +426,9 @@ impl Cli {
             stderr_profile,
         ));
 
-        let restore_service = meta.service_running;
+        let restore_service = source_watch_lease
+            .as_ref()
+            .is_some_and(SourceWatchLease::service_was_running);
         if restore_service {
             self.stderr_lines(render_dev_run_step(
                 "Takeover",

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -242,7 +242,7 @@ pub fn logs_help(cmd: &str) -> String {
 pub fn dev_help(cmd: &str) -> String {
     render_group(
         "Development envs",
-        "Provision OpenClaw dev envs from a checkout worktree, bootstrap the minimum local config, and run the gateway in the foreground with bundled plugins resolved from that source checkout. Existing runtime or launcher envs can also be temporarily taken over with --repo <path> --watch --force; OCM keeps their binding unchanged, routes OpenClaw commands for that env through the watched checkout while watch is active, warns for installed plugins not present in the source tree, tees the foreground output to the env gateway logs, and restores a running background service when watch exits. New envs use the explicit --repo checkout or the checkout enclosing the current directory. Outside a checkout, pass --repo; neighboring and remembered repositories are not selected. Existing dev envs use their recorded source.",
+        "Provision OpenClaw dev envs from a checkout worktree, bootstrap the minimum local config, and run the gateway in the foreground with bundled plugins resolved from that source checkout. Existing runtime or launcher envs can also be temporarily taken over with --repo <path> --watch --force; OCM keeps their binding unchanged, routes OpenClaw commands for that env through the watched checkout while watch is active, warns for installed plugins not present in the source tree, tees the foreground output to the env gateway logs, and restores a running background service when watch exits. Background service installation, start, and restart are refused while source watch is active. After updating OCM, refresh an older running daemon during a maintenance window with service refresh-daemon --acknowledge-gateway-restarts so it enforces the same watch exclusion. New envs use the explicit --repo checkout or the checkout enclosing the current directory. Outside a checkout, pass --repo; neighboring and remembered repositories are not selected. Existing dev envs use their recorded source.",
         vec![format!(
             "{cmd} dev <env> [--repo <path>] [--root <path>] [--port <port>] [--watch] [--force] [--service] [--onboard]"
         )],
@@ -261,7 +261,10 @@ pub fn dev_help(cmd: &str) -> String {
             format!("{cmd} dev status"),
             format!("{cmd} dev status shaks --json"),
         ],
-        vec![format!("{cmd} help dev status")],
+        vec![
+            format!("{cmd} help dev status"),
+            format!("{cmd} help service refresh-daemon"),
+        ],
     )
 }
 

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -21,7 +21,7 @@ use time::OffsetDateTime;
 use super::EnvironmentService;
 use crate::store::{
     ExclusiveFileLock, display_path, ensure_dir, lock_file, now_utc, read_json,
-    source_watch_override_path, validate_name, write_json,
+    source_watch_override_path, try_lock_file, validate_name, write_json,
 };
 
 const SOURCE_WATCH_OVERRIDE_KIND: &str = "ocm-source-watch-override";
@@ -149,10 +149,20 @@ impl<'a> EnvironmentService<'a> {
         &self,
         env_name: &str,
     ) -> Result<ExclusiveFileLock, String> {
+        lock_file(&self.gateway_admission_path(env_name)?, "gateway admission")
+    }
+
+    pub(crate) fn try_lock_gateway_admission(
+        &self,
+        env_name: &str,
+    ) -> Result<Option<ExclusiveFileLock>, String> {
+        try_lock_file(&self.gateway_admission_path(env_name)?, "gateway admission")
+    }
+
+    fn gateway_admission_path(&self, env_name: &str) -> Result<PathBuf, String> {
         let env_name = validate_name(env_name, "Environment name")?;
-        let path = source_watch_override_path(&env_name, self.env, self.cwd)?
-            .with_extension("admission.lock");
-        lock_file(&path, "gateway admission")
+        Ok(source_watch_override_path(&env_name, self.env, self.cwd)?
+            .with_extension("admission.lock"))
     }
 
     pub(crate) fn ensure_source_watch_allows_service(&self, env_name: &str) -> Result<(), String> {

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -20,8 +20,8 @@ use time::OffsetDateTime;
 
 use super::EnvironmentService;
 use crate::store::{
-    display_path, ensure_dir, now_utc, read_json, source_watch_override_path, validate_name,
-    write_json,
+    ExclusiveFileLock, display_path, ensure_dir, lock_file, now_utc, read_json,
+    source_watch_override_path, validate_name, write_json,
 };
 
 const SOURCE_WATCH_OVERRIDE_KIND: &str = "ocm-source-watch-override";
@@ -52,6 +52,7 @@ pub(crate) struct SourceWatchLease {
     env_name: String,
     lease_id: String,
     lock_file: File,
+    service_was_running: bool,
     #[cfg(windows)]
     lease_event: windows_sys::Win32::Foundation::HANDLE,
 }
@@ -66,6 +67,10 @@ impl Drop for SourceWatchLease {
 }
 
 impl SourceWatchLease {
+    pub(crate) fn service_was_running(&self) -> bool {
+        self.service_was_running
+    }
+
     pub(crate) fn begin_service_restore(&mut self) -> Result<(), String> {
         write_source_watch_lock(&mut self.lock_file, &format!("restoring:{}", self.lease_id))
     }
@@ -140,11 +145,41 @@ impl SourceWatchOverride {
 }
 
 impl<'a> EnvironmentService<'a> {
+    pub(crate) fn lock_gateway_admission(
+        &self,
+        env_name: &str,
+    ) -> Result<ExclusiveFileLock, String> {
+        let env_name = validate_name(env_name, "Environment name")?;
+        let path = source_watch_override_path(&env_name, self.env, self.cwd)?
+            .with_extension("admission.lock");
+        lock_file(&path, "gateway admission")
+    }
+
+    pub(crate) fn ensure_source_watch_allows_service(&self, env_name: &str) -> Result<(), String> {
+        if self.active_source_watch_override(env_name)?.is_some() {
+            return Err(format!(
+                "background service for env \"{env_name}\" cannot start while source watch is active; stop the watch session first"
+            ));
+        }
+        Ok(())
+    }
+
     pub(crate) fn acquire_source_watch_lease(
         &self,
         env_name: &str,
+        allow_service_takeover: bool,
     ) -> Result<SourceWatchLease, String> {
         let env_name = validate_name(env_name, "Environment name")?;
+        // Commands keep the operation lock while changing service policy; the
+        // shorter admission lock also covers starts from an already planned daemon.
+        let _operation_lock = self.lock_operation(&env_name)?;
+        let _admission_lock = self.lock_gateway_admission(&env_name)?;
+        let meta = self.get(&env_name)?;
+        if meta.service_running && !allow_service_takeover {
+            return Err(format!(
+                "dev env {env_name} is already running in the background; stop it first or rerun with --watch --force to take it over temporarily"
+            ));
+        }
         let override_path = source_watch_override_path(&env_name, self.env, self.cwd)?;
         let lock_path = override_path.with_extension("lock");
         if let Ok(meta) = read_json::<SourceWatchOverride>(&override_path)
@@ -212,6 +247,7 @@ impl<'a> EnvironmentService<'a> {
             env_name,
             lease_id,
             lock_file,
+            service_was_running: meta.service_running,
             #[cfg(windows)]
             lease_event,
         })

--- a/src/service/manage.rs
+++ b/src/service/manage.rs
@@ -180,6 +180,7 @@ pub fn restart_service(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<ServiceActionSummary, String> {
+    EnvironmentService::new(env, cwd).ensure_source_watch_allows_service(name)?;
     ensure_gateway_binding(name, env, cwd)?;
     let env_service = EnvironmentService::new(env, cwd);
     let meta = env_service.get(name)?;
@@ -455,6 +456,9 @@ fn update_service(
 ) -> Result<ServiceActionSummary, String> {
     let (action, service_enabled, service_running, require_binding, supervisor_policy) =
         update.settings();
+    if service_running == Some(true) || matches!(update, ServiceUpdate::Install) {
+        EnvironmentService::new(env, cwd).ensure_source_watch_allows_service(name)?;
+    }
     if require_binding {
         ensure_gateway_binding(name, env, cwd)?;
     }

--- a/src/store/common.rs
+++ b/src/store/common.rs
@@ -64,6 +64,27 @@ pub(crate) fn lock_file(path: &Path, label: &str) -> Result<ExclusiveFileLock, S
     Ok(ExclusiveFileLock { file })
 }
 
+pub(crate) fn try_lock_file(path: &Path, label: &str) -> Result<Option<ExclusiveFileLock>, String> {
+    if let Some(parent) = path.parent() {
+        ensure_dir(parent)?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| format!("failed to open {label} lock at {}: {error}", path.display()))?;
+    match FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(Some(ExclusiveFileLock { file })),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(format!(
+            "failed to acquire {label} lock at {}: {error}",
+            path.display()
+        )),
+    }
+}
+
 pub(crate) fn lock_file_shared(path: &Path, label: &str) -> Result<SharedFileLock, String> {
     if let Some(parent) = path.parent() {
         ensure_dir(parent)?;

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -247,12 +247,17 @@ pub fn save_environment(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
+    let service = crate::env::EnvironmentService::new(env, cwd);
+    let _admission_lock = service.lock_gateway_admission(&meta.name)?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
     let policy_changed = find_environment(&registry, &meta.name).is_some_and(|current| {
         current.service_enabled != meta.service_enabled
             || current.service_running != meta.service_running
     });
+    if policy_changed && meta.service_enabled && meta.service_running {
+        service.ensure_source_watch_allows_service(&meta.name)?;
+    }
     meta = upsert_environment(&mut registry, meta)?;
     if policy_changed {
         bump_service_policy_revision(&mut registry, &meta.name);
@@ -301,6 +306,8 @@ pub(crate) fn set_environment_service_policy(
     cwd: &Path,
 ) -> Result<EnvironmentServicePolicyChange, String> {
     let safe_name = validate_name(name, "Environment name")?;
+    let service = crate::env::EnvironmentService::new(env, cwd);
+    let _admission_lock = service.lock_gateway_admission(&safe_name)?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
     let (applied, previous_service_enabled, previous_service_running) = {
@@ -316,6 +323,9 @@ pub(crate) fn set_environment_service_policy(
         }
         if let Some(service_running) = service_running {
             meta.service_running = service_running;
+        }
+        if meta.service_enabled && meta.service_running {
+            service.ensure_source_watch_allows_service(&safe_name)?;
         }
         meta.updated_at = now_utc();
         (
@@ -339,6 +349,8 @@ pub(crate) fn restore_environment_service_policy(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<bool, String> {
+    let service = crate::env::EnvironmentService::new(env, cwd);
+    let _admission_lock = service.lock_gateway_admission(&change.applied.name)?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
     let current_revision = registry
@@ -385,6 +397,11 @@ fn create_environment_with_runtime_validation(
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
     let name = validate_name(&options.name, "Environment name")?;
+    let service = crate::env::EnvironmentService::new(env, cwd);
+    let _admission_lock = service.lock_gateway_admission(&name)?;
+    if options.service_enabled && options.service_running {
+        service.ensure_source_watch_allows_service(&name)?;
+    }
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
     if find_environment(&registry, &name).is_some() {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -21,7 +21,8 @@ use crate::env::EnvMeta;
 use crate::env::EnvSummary;
 pub(crate) use checkpoints::CheckpointCleanup;
 pub(crate) use common::{
-    ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, write_json,
+    ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, try_lock_file,
+    write_json,
 };
 pub(crate) use envs::{EnvironmentOperationLock, lock_env_registry, lock_environment_operation};
 pub(crate) use envs::{

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -651,7 +651,10 @@ impl<'a> SupervisorService<'a> {
                 });
                 continue;
             }
-            match env_service.resolve_gateway_process(&env_meta.name, false) {
+            match env_service
+                .ensure_source_watch_allows_service(&env_meta.name)
+                .and_then(|()| env_service.resolve_gateway_process(&env_meta.name, false))
+            {
                 Ok(process) => {
                     let restart_handoff_pid_bound = process.restart_handoff_pid_bound();
                     let args = process.args.clone();
@@ -850,7 +853,10 @@ impl<'a> SupervisorService<'a> {
                 spec.env_name,
                 child_binding_label(&spec)
             );
-            let mut child = spawn_supervisor_child(&spec)?;
+            let mut child = {
+                let _admission = admit_supervisor_child_start(&spec, self.env, self.cwd)?;
+                spawn_supervisor_child(&spec)?
+            };
             let status = child.wait().map_err(|error| {
                 format!("failed waiting for env \"{}\": {error}", spec.env_name)
             })?;
@@ -890,7 +896,13 @@ impl<'a> SupervisorService<'a> {
             0,
             Instant::now(),
         );
-        start_due_children(&mut running, &mut pending, &mut inactive)?;
+        start_due_children(
+            &mut running,
+            &mut pending,
+            &mut inactive,
+            self.env,
+            self.cwd,
+        )?;
         write_supervisor_runtime_state(
             &runtime_path,
             &active_state.ocm_home,
@@ -923,7 +935,13 @@ impl<'a> SupervisorService<'a> {
                 },
             )?;
 
-            runtime_dirty |= start_due_children(&mut running, &mut pending, &mut inactive)?;
+            runtime_dirty |= start_due_children(
+                &mut running,
+                &mut pending,
+                &mut inactive,
+                self.env,
+                self.cwd,
+            )?;
             if runtime_dirty {
                 write_supervisor_runtime_state(
                     &runtime_path,
@@ -1026,8 +1044,8 @@ fn spawn_running_child(
     spec: SupervisorChildSpec,
     restart_count: usize,
     quick_clean_restart_count: usize,
+    restart_handoff_support: RestartHandoffSupport,
 ) -> Result<RunningSupervisorChild, String> {
-    let restart_handoff_support = probe_restart_handoff_support(&spec);
     let prepared_spec = prepare_supervisor_child_spec(&spec, &restart_handoff_support);
     eprintln!(
         "ocm service: starting {} ({})",
@@ -1853,6 +1871,8 @@ fn start_due_children(
     running: &mut BTreeMap<String, RunningSupervisorChild>,
     pending: &mut BTreeMap<String, PendingSupervisorChild>,
     inactive: &mut BTreeMap<String, InactiveSupervisorChild>,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
 ) -> Result<bool, String> {
     let now = Instant::now();
     let due = pending
@@ -1865,7 +1885,9 @@ fn start_due_children(
         let Some(next_child) = pending.get(&env_name).cloned() else {
             continue;
         };
-        if let Err(error) = preflight_supervisor_child_start(&next_child, running) {
+        if let Err(error) = preflight_supervisor_child_start(&next_child, running).and_then(|()| {
+            EnvironmentService::new(env, cwd).ensure_source_watch_allows_service(&env_name)
+        }) {
             if let Some(entry) = pending.get_mut(&env_name) {
                 entry.restart_count += 1;
                 let delay_ms = restart_delay_ms(entry.restart_count);
@@ -1886,11 +1908,19 @@ fn start_due_children(
             eprintln!("{error}");
             continue;
         }
-        match spawn_running_child(
-            next_child.spec.clone(),
-            next_child.restart_count,
-            next_child.quick_clean_restart_count,
-        ) {
+        // Capability probing can invoke OpenClaw. Keep it outside admission,
+        // then recheck ownership immediately before spawning the gateway.
+        let restart_handoff_support = probe_restart_handoff_support(&next_child.spec);
+        let start_result = (|| {
+            let _admission = admit_supervisor_child_start(&next_child.spec, env, cwd)?;
+            spawn_running_child(
+                next_child.spec.clone(),
+                next_child.restart_count,
+                next_child.quick_clean_restart_count,
+                restart_handoff_support,
+            )
+        })();
+        match start_result {
             Ok(running_child) => {
                 pending.remove(&env_name);
                 running.insert(env_name.clone(), running_child);
@@ -2106,6 +2136,30 @@ fn preflight_supervisor_child_start(
     }
 
     Ok(())
+}
+
+fn admit_supervisor_child_start(
+    spec: &SupervisorChildSpec,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<crate::store::ExclusiveFileLock, String> {
+    let service = EnvironmentService::new(env, cwd);
+    let admission = service.lock_gateway_admission(&spec.env_name)?;
+    service.ensure_source_watch_allows_service(&spec.env_name)?;
+    if spec.binding_kind == "source-watch" {
+        return Err(format!(
+            "refusing to start env \"{}\": its saved service plan belongs to a source-watch session; start the background service again after watch exits to resolve its registered binding",
+            spec.env_name
+        ));
+    }
+    let meta = service.get(&spec.env_name)?;
+    if !meta.service_enabled || !meta.service_running {
+        return Err(format!(
+            "refusing to start env \"{}\": its background service is disabled or stopped",
+            spec.env_name
+        ));
+    }
+    Ok(admission)
 }
 
 fn supervisor_service_environment(
@@ -3077,7 +3131,8 @@ mod tests {
             descendant_pid_path.to_string_lossy().into_owned(),
         );
 
-        let mut running_child = spawn_running_child(spec, 0, 0).unwrap();
+        let support = probe_restart_handoff_support(&spec);
+        let mut running_child = spawn_running_child(spec, 0, 0, support).unwrap();
         let process_group = format!("-{}", running_child.child.id());
         let status = running_child.child.wait().unwrap();
         assert_eq!(status.code(), Some(1));
@@ -3125,7 +3180,8 @@ mod tests {
         spec.stdout_path = test_dir.join("stdout.log").to_string_lossy().into_owned();
         spec.stderr_path = test_dir.join("stderr.log").to_string_lossy().into_owned();
 
-        let mut running_child = spawn_running_child(spec, 0, 0).unwrap();
+        let support = probe_restart_handoff_support(&spec);
+        let mut running_child = spawn_running_child(spec, 0, 0, support).unwrap();
         let child_pid = running_child.child.id().to_string();
         sleep(Duration::from_millis(50));
 

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -853,10 +853,10 @@ impl<'a> SupervisorService<'a> {
                 spec.env_name,
                 child_binding_label(&spec)
             );
-            let mut child = {
-                let _admission = admit_supervisor_child_start(&spec, self.env, self.cwd)?;
-                spawn_supervisor_child(&spec)?
-            };
+            // This diagnostic mode has no runtime acknowledgement. Keep its
+            // admission until the child exits instead of exposing an unseen child.
+            let _admission = admit_supervisor_child_start(&spec, self.env, self.cwd)?;
+            let mut child = spawn_supervisor_child(&spec)?;
             let status = child.wait().map_err(|error| {
                 format!("failed waiting for env \"{}\": {error}", spec.env_name)
             })?;
@@ -1874,6 +1874,8 @@ fn start_due_children(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<bool, String> {
+    let runtime_path = supervisor_runtime_path(env, cwd)?;
+    let ocm_home = display_path(&resolve_ocm_home(env, cwd)?);
     let now = Instant::now();
     let due = pending
         .iter()
@@ -1908,23 +1910,40 @@ fn start_due_children(
             eprintln!("{error}");
             continue;
         }
-        // Capability probing can invoke OpenClaw. Keep it outside admission,
-        // then recheck ownership immediately before spawning the gateway.
-        let restart_handoff_support = probe_restart_handoff_support(&next_child.spec);
-        let start_result = (|| {
-            let _admission = admit_supervisor_child_start(&next_child.spec, env, cwd)?;
-            spawn_running_child(
+        let start_result: Result<_, String> = (|| {
+            // Do not probe a contended child. Probing itself stays outside
+            // admission, so a slow OpenClaw command cannot block watch claims.
+            drop(admit_supervisor_child_start(&next_child.spec, env, cwd)?);
+            let restart_handoff_support = probe_restart_handoff_support(&next_child.spec);
+            let admission = admit_supervisor_child_start(&next_child.spec, env, cwd)?;
+            let child = spawn_running_child(
                 next_child.spec.clone(),
                 next_child.restart_count,
                 next_child.quick_clean_restart_count,
                 restart_handoff_support,
-            )
+            )?;
+            Ok((child, admission))
         })();
         match start_result {
-            Ok(running_child) => {
+            Ok((running_child, _admission)) => {
                 pending.remove(&env_name);
                 running.insert(env_name.clone(), running_child);
                 inactive.remove(&env_name);
+                // A forced watch may claim admission as soon as this guard
+                // drops. Publish the process identity that service stop reads
+                // before any slow work for another environment can intervene.
+                if let Err(error) = write_supervisor_runtime_state(
+                    &runtime_path,
+                    &ocm_home,
+                    running,
+                    pending,
+                    inactive,
+                ) {
+                    if let Some(mut child) = running.remove(&env_name) {
+                        stop_supervisor_child(&mut child);
+                    }
+                    return Err(error);
+                }
                 runtime_dirty = true;
             }
             Err(error) => {
@@ -2144,7 +2163,9 @@ fn admit_supervisor_child_start(
     cwd: &Path,
 ) -> Result<crate::store::ExclusiveFileLock, String> {
     let service = EnvironmentService::new(env, cwd);
-    let admission = service.lock_gateway_admission(&spec.env_name)?;
+    let admission = service
+        .try_lock_gateway_admission(&spec.env_name)?
+        .ok_or_else(|| format!("gateway admission for env \"{}\" is busy", spec.env_name))?;
     service.ensure_source_watch_allows_service(&spec.env_name)?;
     if spec.binding_kind == "source-watch" {
         return Err(format!(
@@ -2503,7 +2524,15 @@ fn write_supervisor_runtime_state(
         .map(supervisor_runtime_service_running)
         .collect::<Vec<_>>();
     services.extend(pending.values().map(|child| {
-        supervisor_runtime_service_inactive(&inactive_from_pending(child, "backoff"))
+        // A per-child acknowledgement can expose siblings before their first
+        // attempt. Keep those pending; reporting backoff would fail readiness
+        // while a sibling's capability probe is still running.
+        let state = if child.last_event_at.is_none() {
+            "pending"
+        } else {
+            "backoff"
+        };
+        supervisor_runtime_service_inactive(&inactive_from_pending(child, state))
     }));
     services.extend(
         inactive

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1822,6 +1822,159 @@ fn daemon_defers_a_saved_service_start_until_source_watch_releases_the_env() {
 }
 
 #[test]
+fn contended_admission_preserves_sibling_supervision_and_desired_starts() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-admission-contention");
+    let (cwd, env, launcher_marker, _) = setup_daemon_run_fixture_with_child_sleep(&root, 60);
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+    let supervisor = SupervisorService::new(&env, &cwd);
+    supervisor.sync().unwrap();
+    let admission_path = root.child("ocm-home/source-watch/demo.admission.lock");
+    fs::create_dir_all(admission_path.parent().unwrap()).unwrap();
+    let hold_admission = || {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&admission_path)
+            .unwrap();
+        FileExt::lock_exclusive(&file).unwrap();
+        file
+    };
+
+    let admission = hold_admission();
+    let plan = to_value(supervisor.plan().unwrap()).unwrap();
+    assert_eq!(plan["children"].as_array().unwrap().len(), 2);
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let during = wait_for_runtime_children(&runtime_path, 1, Some("prod"), Duration::from_secs(5));
+    let source_was_started = launcher_marker.exists();
+    drop(admission);
+    let resumed =
+        wait_for_runtime_children(&runtime_path, 2, Some("demo"), Duration::from_secs(10));
+
+    let admission = hold_admission();
+    let restart = supervisor.request_child_restart("demo");
+    let deferred_restart =
+        wait_for_runtime_children(&runtime_path, 1, Some("prod"), Duration::from_secs(5));
+    let signal = Command::new("kill")
+        .args(["-INT", &daemon.id().to_string()])
+        .status();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let graceful = loop {
+        if daemon.try_wait().unwrap().is_some() {
+            break true;
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        sleep(Duration::from_millis(25));
+    };
+    drop(admission);
+    if !graceful {
+        stop_process(&mut daemon);
+    }
+
+    assert!(
+        during.is_some(),
+        "contention prevented the sibling from starting"
+    );
+    assert!(
+        !source_was_started,
+        "contended env started without admission"
+    );
+    assert!(resumed.is_some(), "contention discarded the desired start");
+    assert!(restart.is_ok(), "{}", restart.unwrap_err());
+    assert!(
+        deferred_restart.is_some(),
+        "contended restart stopped sibling supervision"
+    );
+    assert!(signal.is_ok_and(|status| status.success()));
+    assert!(graceful, "admission contention blocked daemon shutdown");
+}
+
+#[test]
+fn daemon_publishes_a_started_child_before_a_sibling_probe_can_block() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-spawn-publication");
+    let (cwd, mut env, launcher_marker, _) = setup_daemon_run_fixture_with_child_sleep(&root, 60);
+    install_fake_service_manager(&root, &mut env);
+    let probe_started = root.child("probe-started");
+    let probe_release = root.child("probe-release");
+    let slow_script = root.child("slow/openclaw.mjs");
+    write_executable_script(
+        &slow_script,
+        &format!(
+            "#!/bin/sh\nif [ \"${{1:-}}\" = gateway ] && [ \"${{2:-}}\" = restart-handoff ]; then\n  printf 'ready\\n' > '{}'\n  while [ ! -f '{}' ]; do /bin/sleep 0.01; done\n  exit 64\nfi\ntrap 'exit 0' TERM INT\nwhile :; do /bin/sleep 1; done\n",
+            path_string(&probe_started),
+            path_string(&probe_release),
+        ),
+    );
+    let launcher = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "launcher",
+            "add",
+            "slow",
+            "--command",
+            &path_string(&slow_script),
+        ],
+    );
+    assert!(launcher.status.success(), "{}", stderr(&launcher));
+    EnvironmentService::new(&env, &cwd)
+        .set_launcher("prod", "slow")
+        .unwrap();
+    let install = run_ocm(&cwd, &env, &["service", "install", "prod"]);
+    assert!(install.status.success(), "{}", stderr(&install));
+    EnvironmentService::new(&env, &cwd)
+        .set_service_running("prod", true)
+        .unwrap();
+    SupervisorService::new(&env, &cwd).sync().unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let probe_is_blocked = wait_for_file(&probe_started, Duration::from_secs(10));
+    let first_child_started = wait_for_file(&launcher_marker, Duration::from_secs(5));
+    let status = run_ocm(&cwd, &env, &["service", "status", "demo", "--json"]);
+    let sibling_status = run_ocm(&cwd, &env, &["service", "status", "prod", "--json"]);
+    let runtime =
+        fs::read_to_string(root.child("ocm-home/supervisor/runtime.json")).unwrap_or_default();
+    let admission = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(root.child("ocm-home/source-watch/demo.admission.lock"))
+        .unwrap();
+    let admission_available = FileExt::try_lock_exclusive(&admission).is_ok();
+    fs::write(&probe_release, "release\n").unwrap();
+    drop(admission);
+    stop_process(&mut daemon);
+
+    assert!(
+        probe_is_blocked,
+        "sibling did not reach the controlled probe"
+    );
+    assert!(first_child_started, "first gateway did not start");
+    assert!(status.status.success(), "{}", stderr(&status));
+    assert!(
+        sibling_status.status.success(),
+        "{}",
+        stderr(&sibling_status)
+    );
+    let status: Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(
+        status["running"], true,
+        "service stop could not observe the started gateway; status={status}; runtime={runtime}"
+    );
+    assert!(status["childPid"].as_u64().is_some());
+    assert!(
+        admission_available,
+        "sibling probe retained another env's admission"
+    );
+    let sibling_status: Value = serde_json::from_slice(&sibling_status.stdout).unwrap();
+    assert_eq!(sibling_status["gatewayState"], "pending");
+}
+
+#[test]
 fn daemon_run_persists_live_runtime_children() {
     let _guard = daemon_runtime_test_lock();
     let root = TestDir::new("daemon-runtime-state");

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -2,6 +2,7 @@ mod support;
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::io::Write;
 use std::net::{Ipv4Addr, TcpListener};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
@@ -9,6 +10,7 @@ use std::sync::{Mutex, MutexGuard};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
+use fs2::FileExt;
 use ocm::env::{CreateEnvSnapshotOptions, EnvironmentService};
 use ocm::supervisor::{SupervisorService, sync_supervisor_binding_if_present};
 use serde_json::{Value, to_value};
@@ -1779,6 +1781,44 @@ fn service_state_plans_runnable_children_and_skips_disabled_envs() {
             .iter()
             .any(|entry| entry["envName"] == "demo" && entry["reason"] == "service is stopped")
     );
+}
+
+#[test]
+fn daemon_defers_a_saved_service_start_until_source_watch_releases_the_env() {
+    let _guard = daemon_runtime_test_lock();
+    let root = TestDir::new("daemon-source-watch-exclusion");
+    let (cwd, env, launcher_marker, runtime_marker) =
+        setup_daemon_run_fixture_with_child_sleep(&root, 30);
+    let runtime_path = root.child("ocm-home/supervisor/runtime.json");
+    SupervisorService::new(&env, &cwd).sync().unwrap();
+    let watch_path = root.child("ocm-home/source-watch/demo.lock");
+    fs::create_dir_all(watch_path.parent().unwrap()).unwrap();
+    let mut source_watch = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(watch_path)
+        .unwrap();
+    FileExt::lock_exclusive(&source_watch).unwrap();
+    writeln!(source_watch, "starting-lease").unwrap();
+
+    let mut daemon = spawn_daemon_process(&cwd, &env);
+    let during = wait_for_runtime_children(&runtime_path, 1, Some("prod"), Duration::from_secs(5));
+    let source_was_started = launcher_marker.exists();
+    let sibling_was_started = runtime_marker.exists();
+    drop(source_watch);
+    let after = wait_for_runtime_children(&runtime_path, 2, Some("demo"), Duration::from_secs(10));
+    stop_process(&mut daemon);
+
+    assert!(during.is_some(), "unwatched sibling should remain runnable");
+    assert!(!source_was_started, "saved plan started the watched env");
+    assert!(sibling_was_started);
+    assert!(
+        after.is_some(),
+        "service did not resume after watch released"
+    );
+    assert!(launcher_marker.exists());
 }
 
 #[test]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1749,6 +1749,70 @@ fn dev_watch_force_restores_runtime_service_when_source_watch_cannot_spawn() {
 
 #[cfg(unix)]
 #[test]
+fn dev_watch_rejects_service_activation_until_the_watch_exits() {
+    for runtime_backed in [false, true] {
+        let root = TestDir::new("dev-command-watch-service-exclusion");
+        let repo = init_openclaw_repo(&root);
+        let cwd = root.child("workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let mut env = service_env(&root);
+        let (started, release, _) = install_blocking_fake_dev_runners(&root, &mut env);
+        if runtime_backed {
+            create_runtime_backed_env(&cwd, &env);
+        }
+        let mut watch = Command::new(env!("CARGO_BIN_EXE_ocm"));
+        watch
+            .current_dir(&cwd)
+            .args([
+                "dev",
+                "demo",
+                "--repo",
+                &path_string(&repo),
+                "--watch",
+                "--force",
+            ])
+            .env_clear()
+            .envs(&env)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let watch = watch.spawn().unwrap();
+        let did_start = wait_for_path(&started, Duration::from_secs(30));
+        let did_publish = wait_for_path(
+            &source_watch_override_path(&root, "demo"),
+            Duration::from_secs(30),
+        );
+        let attempts = [
+            vec!["service", "install", "demo"],
+            vec!["service", "start", "demo"],
+            vec!["service", "restart", "demo"],
+            vec!["service", "restart", "demo", "--force"],
+        ]
+        .map(|args| run_ocm(&cwd, &env, &args));
+        let during = ocm::env::EnvironmentService::new(&env, &cwd)
+            .get("demo")
+            .unwrap();
+        fs::write(&release, "release\n").unwrap();
+        let watch = watch.wait_with_output().unwrap();
+
+        assert!(did_start && did_publish, "{}", stderr(&watch));
+        assert!(watch.status.success(), "{}", stderr(&watch));
+        for attempt in attempts {
+            assert!(!attempt.status.success(), "{}", stdout(&attempt));
+            assert!(
+                stderr(&attempt).contains("source watch is active"),
+                "{}",
+                stderr(&attempt)
+            );
+        }
+        assert!(!during.service_enabled);
+        assert!(!during.service_running);
+        let start = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+        assert!(start.status.success(), "{}", stderr(&start));
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn dev_watch_rejects_overlap_and_reclaims_the_released_lock() {
     let root = TestDir::new("dev-command-watch-overlap");
     let repo = init_openclaw_repo(&root);

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -6,11 +6,13 @@ use std::fs::{self, File, OpenOptions};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use fs2::FileExt;
 use ocm::env::EnvironmentService;
+use ocm::supervisor::SupervisorService;
 use serde_json::{Value, json};
 
 use crate::support::{
@@ -235,6 +237,122 @@ fn source_watch_override_takes_precedence_for_resolve_and_run() {
         path_string(&source_repo.join("extensions")),
         path_string(&source_repo)
     )));
+}
+
+#[test]
+fn source_watch_blocks_direct_service_policy_changes() {
+    let root = TestDir::new("source-watch-service-policy");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let source_repo = create_source_repo(&root);
+    let env = ocm_env(&root);
+    create_runtime_backed_env(&root, &cwd, &env);
+    let service = EnvironmentService::new(&env, &cwd);
+    let before = service.get("demo").unwrap();
+    let _source_watch = lock_source_watch(&root);
+    write_active_source_watch_override(&root, &source_repo);
+
+    let error = service
+        .set_service_policy("demo", Some(true), Some(true))
+        .unwrap_err();
+    assert!(error.contains("source watch is active"), "{error}");
+    let mut changed = before.clone();
+    changed.service_enabled = true;
+    changed.service_running = true;
+    let error = ocm::store::save_environment(changed, &env, &cwd).unwrap_err();
+    assert!(error.contains("source watch is active"), "{error}");
+    let after = service.get("demo").unwrap();
+    assert_eq!(after.service_enabled, before.service_enabled);
+    assert_eq!(after.service_running, before.service_running);
+}
+
+#[test]
+fn service_policy_admission_rechecks_a_watch_claimed_while_waiting() {
+    let root = TestDir::new("source-watch-service-admission");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+    create_runtime_backed_env(&root, &cwd, &env);
+    let admission_path = root.child("ocm-home/source-watch/demo.admission.lock");
+    fs::create_dir_all(admission_path.parent().unwrap()).unwrap();
+    let admission = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&admission_path)
+        .unwrap();
+    FileExt::lock_exclusive(&admission).unwrap();
+    let (started_tx, started_rx) = mpsc::channel();
+    let (result_tx, result_rx) = mpsc::channel();
+    let worker_env = env.clone();
+    let worker_cwd = cwd.clone();
+    let worker = thread::spawn(move || {
+        started_tx.send(()).unwrap();
+        let result = EnvironmentService::new(&worker_env, &worker_cwd).set_service_policy(
+            "demo",
+            Some(true),
+            Some(true),
+        );
+        result_tx.send(result).unwrap();
+    });
+    started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    let early_result = result_rx.recv_timeout(Duration::from_millis(100));
+    let _source_watch = lock_source_watch_with_id(&root, "starting-lease");
+    drop(admission);
+    let result = match early_result {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            result_rx.recv_timeout(Duration::from_secs(5)).unwrap()
+        }
+        Err(error) => panic!("service policy worker disconnected: {error}"),
+    };
+    worker.join().unwrap();
+
+    let error = result.unwrap_err();
+    assert!(error.contains("source watch"), "{error}");
+    let meta = EnvironmentService::new(&env, &cwd).get("demo").unwrap();
+    assert!(!meta.service_enabled);
+    assert!(!meta.service_running);
+}
+
+#[test]
+fn source_watch_blocks_planning_and_execution_of_a_saved_service_plan() {
+    let root = TestDir::new("source-watch-service-plan");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let source_repo = create_source_repo(&root);
+    let env = ocm_env(&root);
+    create_runtime_backed_env(&root, &cwd, &env);
+    EnvironmentService::new(&env, &cwd)
+        .set_service_policy("demo", Some(true), Some(true))
+        .unwrap();
+    let supervisor = SupervisorService::new(&env, &cwd);
+    supervisor.sync().unwrap();
+    let source_watch = lock_source_watch(&root);
+    write_active_source_watch_override(&root, &source_repo);
+
+    let plan = serde_json::to_value(supervisor.plan().unwrap()).unwrap();
+    assert!(plan["children"].as_array().unwrap().is_empty());
+    assert!(plan["skippedEnvs"].as_array().unwrap().iter().any(|entry| {
+        entry["envName"] == "demo" && entry["reason"].as_str().unwrap().contains("source watch")
+    }));
+    let error = supervisor.run(true).unwrap_err();
+    assert!(error.contains("source watch is active"), "{error}");
+
+    drop(source_watch);
+    let run = supervisor.run(true).unwrap();
+    assert_eq!(run.child_results.len(), 1);
+    assert!(run.child_results[0].success);
+
+    // Older versions could persist the temporary source resolution as a service
+    // plan. Ending its lease must not make that temporary binding runnable.
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let mut saved: Value = serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+    saved["children"][0]["bindingKind"] = json!("source-watch");
+    fs::write(&state_path, serde_json::to_vec(&saved).unwrap()).unwrap();
+    let error = supervisor.run(true).unwrap_err();
+    assert!(error.contains("saved service plan belongs to a source-watch session"));
 }
 
 #[test]
@@ -505,8 +623,9 @@ fn live_legacy_source_watch_remains_active_until_its_process_exits() {
             path_string(&release)
         ),
     );
-    let mut legacy_watch = Command::new(&legacy_bin);
+    let mut legacy_watch = Command::new("/bin/sh");
     legacy_watch
+        .arg(&legacy_bin)
         .args([
             "scripts/watch-node.mjs",
             "gateway",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where starting or restarting an OCM background service could schedule a competing Gateway while `ocm dev --watch` was active, including during rebuilds when its port was temporarily free.

## Why This Change Was Made

Serialize source-watch claims with service activation and actual daemon spawning. Background service installation, start, and restart are refused during watch, while forced takeover and restoration keep their existing behavior. Saved service plans cannot resurrect an expired source-watch binding.

## User Impact

OCM preserves the watch session's Gateway ownership while source commands continue to resolve to the watched checkout. README and help explain the explicit daemon refresh needed when an older background daemon remains running after an OCM update.

## Evidence

Verified remotely on an isolated Cargo target:

- Formatting and `cargo check --workspace --all-targets --locked` passed.
- All 13 `source_watch_tests` passed, including policy admission and saved-plan controls.
- Focused CLI service-activation and daemon saved-plan regressions passed.
- The existing legacy-watch fixture keeps its long-path and process-identity assertions while invoking its shell stand-in explicitly, avoiding a reproduced baseline `ETXTBSY` failure.

CI covers the full platform suite. Validation used synthetic environments and service fixtures.
