### PR TITLE
fix: stop dev sessions before destroying environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ Use `ocm dev stop <env>` from another terminal to cancel an owned source-watch s
 
 After a watch controller crashes, `dev stop` verifies its recorded process start identity and ownership before recovering the session. It retains an unfinished session when cleanup or service restoration cannot be verified, and rejects a stale generation or a different boot/process namespace. Older watches without ownership records must be stopped from their original terminal. Windows uses the existing process job for owned child cleanup; a controller crash before child ownership is published cannot be verified automatically and requires operator recovery. Updating OCM does not add ownership records to a watch that is already running.
 
+`ocm env destroy <env> --yes` stops the recorded source-watch generation and verifies shutdown before removing the environment. It rechecks the binding after stopping and preserves state if another owner or binding appears. While a watch is running, previews defer the changing process-tree inspection until after shutdown (`processInspectionDeferred` in JSON). `env remove` and `env prune` refuse active or unfinished watches; stop those sessions first. A guarded destroy with `--if-state-token` also requires `dev stop` followed by a fresh preview, so its original state guarantee remains intact. Completed watch records are removed with the env; synchronization lock files remain reusable.
+
 ### Try beta or pin a specific release
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -583,6 +583,20 @@ ocm env destroy mira
 ocm env destroy mira --yes
 ```
 
+Destroy first stops the recorded source-watch session, including any required
+service restoration, and verifies that its owned processes exited. It then
+rechecks the environment binding and protection before removing state. A
+replacement session or changed binding prevents removal. While a watch is
+running, the preview reports deferred process inspection; the remaining process
+tree is inspected after the watch stops.
+
+`env remove` and `env prune` require active or unfinished source watches to be
+stopped first with `ocm dev stop <env>`. The same applies to a destroy guarded by
+`--if-state-token`: stop the watch, then request a fresh preview. A watch created
+by an older OCM without usable stop ownership must be stopped from its original
+terminal. Environment removal clears completed watch records and retains the
+reusable synchronization lock files.
+
 `destroy` is the stronger cleanup path.
 
 ## Updating `ocm` itself

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -186,12 +186,28 @@ impl Cli {
     }
 
     pub(super) fn stop_source_watch(&self, env_name: &str) -> Result<DevStopSummary, String> {
+        self.stop_source_watch_generation(env_name, None)
+    }
+
+    pub(super) fn stop_source_watch_generation(
+        &self,
+        env_name: &str,
+        expected_generation: Option<&str>,
+    ) -> Result<DevStopSummary, String> {
         let env_service = self.environment_service();
         let deadline = std::time::Instant::now() + Duration::from_secs(90);
         let mut requested_lease: Option<String> = None;
         loop {
             let operation = env_service.lock_operation(env_name)?;
             let session = env_service.source_watch_session(env_name)?;
+            if expected_generation.is_some_and(|expected| {
+                session.as_ref().map(|session| session.lease_id.as_str()) != Some(expected)
+            }) {
+                return Err(
+                    "source watch generation changed; the replacement session was not stopped"
+                        .to_string(),
+                );
+            }
             if let Some(lease_id) = &requested_lease
                 && let Some(completion) = env_service.source_watch_completion(env_name, lease_id)?
             {

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -16,7 +16,7 @@ use super::{Cli, render};
 use crate::env::{
     CloneEnvironmentOptions, CreateEnvSnapshotOptions, CreateEnvironmentOptions, EnvMeta,
     EnvSnapshotSummary, EnvSummary, ExportEnvironmentOptions, ImportEnvironmentOptions,
-    RemoveEnvSnapshotOptions, RestoreEnvSnapshotOptions,
+    RemoveEnvSnapshotOptions, RestoreEnvSnapshotOptions, SourceWatchSession, SourceWatchState,
 };
 use crate::infra::process::{run_direct, run_shell};
 use crate::infra::process_identity::ProcessIdentity;
@@ -136,7 +136,12 @@ pub(crate) struct EnvDestroySummary {
     pub service_loaded: bool,
     pub service_running: bool,
     pub service_label: String,
+    pub source_watch_pid: Option<u32>,
+    pub source_watch_stopped: bool,
+    #[serde(skip)]
+    pub(crate) source_watch_session: Option<SourceWatchSession>,
     pub process_count: usize,
+    pub process_inspection_deferred: bool,
     #[serde(skip)]
     pub(crate) process_candidates: Vec<EnvDestroyProcessIdentity>,
     pub state_token: String,
@@ -161,6 +166,7 @@ struct EnvDestroyState<'a> {
     service: &'a ServiceSummary,
     process_candidates: &'a [EnvDestroyProcessIdentity],
     snapshots: &'a [EnvSnapshotSummary],
+    source_watch: Option<&'a SourceWatchSession>,
 }
 
 fn should_clear_skip_bootstrap_for_openclaw_args(args: &[String]) -> bool {
@@ -264,7 +270,7 @@ impl Cli {
 
         // Service and binding mutations use the same per-env lock. Keep it
         // through validation and teardown so a successful guard cannot go stale.
-        let _operation_lock = self.environment_service().lock_operation(name)?;
+        let mut operation_lock = Some(self.environment_service().lock_operation(name)?);
         let mut summary = self.build_env_destroy_summary(name, true, force)?;
         if expected_state_token
             .as_deref()
@@ -300,6 +306,78 @@ impl Cli {
             return Ok(1);
         }
 
+        let env_before = self.environment_service().get(name)?;
+        if let Some(session) = summary.source_watch_session.clone() {
+            if expected_state_token.is_some() {
+                summary.code = Some("source_watch_active".to_string());
+                summary.blockers.push("guarded destruction requires a stopped source watch; run dev stop, then request a fresh destroy preview".to_string());
+                if json_flag {
+                    self.print_json(&summary)?;
+                } else {
+                    self.stdout_lines(render::env::env_destroy_preview(
+                        &summary,
+                        profile,
+                        &self.command_example(),
+                    ));
+                }
+                return Ok(1);
+            }
+            // The controller may need the operation lock to restore its service.
+            // Stop only the generation accepted by this apply, then revalidate.
+            drop(operation_lock.take());
+            self.stop_source_watch_generation(name, Some(&session.lease_id))?;
+            operation_lock = Some(self.environment_service().lock_operation(name)?);
+            let current = self.environment_service().get(name)?;
+            if env_destroy_binding_state(&env_before)? != env_destroy_binding_state(&current)? {
+                return Err("environment binding or protected state changed while stopping source watch; no state was removed, request a fresh destroy preview".to_string());
+            }
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+            loop {
+                let completed = self.environment_service().source_watch_session(name)?;
+                if !completed
+                    .as_ref()
+                    .is_some_and(|current| current.closed && current.lease_id == session.lease_id)
+                {
+                    return Err("source watch generation changed before removal; the replacement session and environment were preserved".to_string());
+                }
+                if self
+                    .environment_service()
+                    .ensure_source_watch_stopped(name)
+                    .is_ok()
+                {
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    return Err("source watch still holds its session after stop; no environment state was removed".to_string());
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            summary = self.build_env_destroy_summary(name, true, force)?;
+            summary.source_watch_stopped = true;
+            summary.steps.insert(
+                0,
+                EnvDestroyStepSummary {
+                    kind: "source-watch".to_string(),
+                    description:
+                        "stopped the recorded source watch and verified its processes exited"
+                            .to_string(),
+                },
+            );
+            if !summary.blockers.is_empty() {
+                if json_flag {
+                    self.print_json(&summary)?;
+                } else {
+                    self.stdout_lines(render::env::env_destroy_preview(
+                        &summary,
+                        profile,
+                        &self.command_example(),
+                    ));
+                }
+                return Ok(1);
+            }
+        }
+        self.environment_service()
+            .ensure_source_watch_stopped(name)?;
         let env_meta = self.environment_service().get(name)?;
 
         let snapshot_ids = self
@@ -370,6 +448,7 @@ impl Cli {
         }
 
         self.environment_service().remove_locked(name, force)?;
+        let _ = &operation_lock;
         summary.removed = true;
         summary.worktree_removed = env_meta
             .dev
@@ -1160,21 +1239,57 @@ impl Cli {
         let mut snapshots = self.environment_service().list_snapshots(Some(name))?;
         snapshots.sort_by(|left, right| left.id.cmp(&right.id));
         let mut blockers = Vec::new();
-        let process_candidates = self.destroy_process_candidates(&env_meta)?;
-        let state_token =
-            env_destroy_state_token(&env_meta, &service, &process_candidates, &snapshots)?;
+        let source_watch_session = self
+            .environment_service()
+            .source_watch_session(name)?
+            .filter(|session| !session.closed);
+        let source_watch_active = !matches!(
+            self.environment_service().observe_source_watch(name)?,
+            SourceWatchState::Inactive
+        );
+        if source_watch_session.is_none() && source_watch_active {
+            blockers.push("an active source watch has no usable stop ownership; stop it from its original terminal before destroying the env".to_string());
+        }
+        // The recorded controller owns a changing process tree. Stop it through
+        // its generation-bound protocol before taking the ordinary stable
+        // process snapshot; a token-guarded apply refuses unfinished sessions.
+        let process_inspection_deferred = source_watch_session.is_some() || source_watch_active;
+        let process_candidates = if process_inspection_deferred {
+            Vec::new()
+        } else {
+            self.destroy_process_candidates(&env_meta)?
+        };
+        let state_token = env_destroy_state_token(
+            &env_meta,
+            &service,
+            &process_candidates,
+            &snapshots,
+            source_watch_session.as_ref(),
+        )?;
 
         if env_meta.protected && !force {
             blockers.push("env is protected; re-run with --force to destroy it".to_string());
         }
         let mut steps = Vec::new();
+        if source_watch_session.is_some() {
+            steps.push(EnvDestroyStepSummary {
+                kind: "source-watch".to_string(),
+                description: "stop the recorded source watch and verify its processes exited"
+                    .to_string(),
+            });
+        }
         if service.installed || service.loaded || service.running {
             steps.push(EnvDestroyStepSummary {
                 kind: "service".to_string(),
                 description: "disable env gateway in the OCM background service".to_string(),
             });
         }
-        if !process_candidates.is_empty() {
+        if process_inspection_deferred {
+            steps.push(EnvDestroyStepSummary {
+                kind: "processes".to_string(),
+                description: "inspect remaining environment processes after source watch stops, then terminate those owned by the env".to_string(),
+            });
+        } else if !process_candidates.is_empty() {
             steps.push(EnvDestroyStepSummary {
                 kind: "processes".to_string(),
                 description: "terminate live OpenClaw processes for the env".to_string(),
@@ -1209,7 +1324,13 @@ impl Cli {
             service_loaded: service.loaded,
             service_running: service.running,
             service_label: "ocm".to_string(),
+            source_watch_pid: source_watch_session
+                .as_ref()
+                .map(|session| session.controller.pid),
+            source_watch_stopped: false,
+            source_watch_session,
             process_count: process_candidates.len(),
+            process_inspection_deferred,
             process_candidates,
             state_token,
             code: None,
@@ -1619,11 +1740,23 @@ impl Cli {
     }
 }
 
+fn env_destroy_binding_state(meta: &EnvMeta) -> Result<serde_json::Value, String> {
+    let mut value = serde_json::to_value(meta).map_err(|error| error.to_string())?;
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "invalid environment metadata".to_string())?;
+    for key in ["serviceEnabled", "serviceRunning", "updatedAt"] {
+        object.remove(key);
+    }
+    Ok(value)
+}
+
 fn env_destroy_state_token(
     environment: &EnvMeta,
     service: &ServiceSummary,
     process_candidates: &[EnvDestroyProcessIdentity],
     snapshots: &[EnvSnapshotSummary],
+    source_watch: Option<&SourceWatchSession>,
 ) -> Result<String, String> {
     let state = EnvDestroyState {
         kind: "ocm-env-destroy-state-v1",
@@ -1631,6 +1764,7 @@ fn env_destroy_state_token(
         service,
         process_candidates,
         snapshots,
+        source_watch,
     };
     let encoded = serde_json::to_vec(&state)
         .map_err(|error| format!("failed to encode environment destroy state: {error}"))?;

--- a/src/cli/render/env.rs
+++ b/src/cli/render/env.rs
@@ -189,6 +189,14 @@ pub fn env_destroyed(
             KeyValueRow::plain("Root", summary.root.clone()),
             KeyValueRow::plain("Snapshots", summary.snapshots_removed.to_string()),
             KeyValueRow::plain("Processes", summary.processes_terminated.to_string()),
+            KeyValueRow::plain(
+                "Source watch",
+                if summary.source_watch_stopped {
+                    "stopped"
+                } else {
+                    "none"
+                },
+            ),
             KeyValueRow::new(
                 "Worktree",
                 if summary.dev_worktree.is_some() {
@@ -256,6 +264,9 @@ fn env_destroyed_raw(summary: &EnvDestroySummary, command_example: &str) -> Vec<
             "  snapshots removed: {}",
             summary.snapshots_removed
         ));
+    }
+    if summary.source_watch_stopped {
+        lines.push("  source watch stopped".to_string());
     }
     if summary.processes_terminated > 0 {
         lines.push(format!(
@@ -1756,7 +1767,11 @@ mod tests {
             service_loaded: true,
             service_running: false,
             service_label: "ocm".to_string(),
+            source_watch_pid: None,
+            source_watch_stopped: false,
+            source_watch_session: None,
             process_count: 0,
+            process_inspection_deferred: false,
             process_candidates: Vec::new(),
             state_token: "v1:test".to_string(),
             code: None,

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1540,6 +1540,8 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "Destroy removes env snapshots for that env and uninstalls its OCM-managed service when present.",
+                "An ordinary --yes apply first stops and verifies the recorded source-watch generation. Unverifiable ownership blocks removal.",
+                "Guarded --if-state-token apply requires a stopped watch: run dev stop, then request a fresh destroy preview.",
                 "Destroy does not remove shared runtimes or launchers.",
                 "If the separate machine-wide OpenClaw service is using the env, destroy refuses to apply.",
                 "TTY output uses cards by default. Piped output stays plain.",
@@ -1563,7 +1565,10 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
                 format!("{cmd} env remove mira"),
                 format!("{cmd} env remove mira --force"),
             ],
-            &["Protected environments require `--force`."],
+            &[
+                "Protected environments require `--force`.",
+                "Active or unfinished source watches must be stopped with dev stop before remove or prune can delete their state.",
+            ],
         ),
         "prune" => render_leaf(
             "Prune old environments",
@@ -1587,7 +1592,9 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
                 format!("{cmd} env prune"),
                 format!("{cmd} env prune --older-than 30 --yes"),
             ],
-            &[],
+            &[
+                "Active or unfinished source watches block removal; run dev stop for those envs first.",
+            ],
         ),
         "snapshot" => env_snapshot_help(cmd),
         _ => return None,

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -11,8 +11,9 @@ use crate::store::{
     EnvironmentOperationLock, clone_environment, clone_environment_for_simulation,
     create_environment_with_validated_runtime, export_environment, get_environment,
     get_runtime_verified, import_environment, list_environments, lock_environment_operation,
-    now_utc, remove_environment, resolve_config_gateway_port, resolve_effective_gateway_ports,
-    resolve_env_gateway_port, save_environment, set_environment_service_policy,
+    now_utc, remove_environment_locked, resolve_config_gateway_port,
+    resolve_effective_gateway_ports, resolve_env_gateway_port, save_environment,
+    set_environment_service_policy,
 };
 use crate::supervisor::{sync_supervisor_env_if_present, sync_supervisor_if_present};
 
@@ -367,13 +368,14 @@ impl<'a> EnvironmentService<'a> {
     }
 
     pub(crate) fn remove_locked(&self, name: &str, force: bool) -> Result<EnvMeta, String> {
-        let meta = remove_environment(name, force, self.env, self.cwd)?;
+        let meta = remove_environment_locked(name, force, self.env, self.cwd)?;
         sync_supervisor_env_if_present(self.env, self.cwd, name)?;
         Ok(meta)
     }
 
     pub(crate) fn remove_simulation(&self, name: &str) -> Result<EnvMeta, String> {
         let _lock = self.lock_operation(name)?;
+        self.ensure_source_watch_stopped(name)?;
         let meta = get_environment(name, self.env, self.cwd)?;
         if let Some(dev) = meta.dev.as_ref() {
             prepare_openclaw_simulation_worktree_cleanup(

--- a/src/env/source_watch_session.rs
+++ b/src/env/source_watch_session.rs
@@ -270,6 +270,40 @@ impl SourceWatchSession {
 }
 
 impl<'a> EnvironmentService<'a> {
+    pub(crate) fn ensure_source_watch_stopped(&self, env_name: &str) -> Result<(), String> {
+        if self
+            .source_watch_session(env_name)?
+            .is_some_and(|session| !session.closed)
+        {
+            return Err(format!(
+                "source watch for env {env_name} has unfinished ownership; run `ocm dev stop {env_name}` before removing its state"
+            ));
+        }
+        if !matches!(
+            self.observe_source_watch(env_name)?,
+            super::SourceWatchState::Inactive
+        ) {
+            return Err(format!(
+                "source watch for env {env_name} is still active or cannot be verified; stop it before removing its state"
+            ));
+        }
+        Ok(())
+    }
+
+    // The caller holds the operation and admission locks before the registry
+    // lock, matching environment creation and service-policy writes.
+    pub(crate) fn remove_stopped_source_watch_state_locked(
+        &self,
+        env_name: &str,
+    ) -> Result<(), String> {
+        self.ensure_source_watch_stopped(env_name)?;
+        let paths = self.source_watch_session_paths(env_name)?;
+        remove_file_if_present(&paths.session)?;
+        remove_file_if_present(&paths.request)?;
+        remove_file_if_present(&source_watch_override_path(env_name, self.env, self.cwd)?)
+        // Keep lock inodes stable for waiters and later reuse of this env name.
+    }
+
     pub(crate) fn source_watch_session(
         &self,
         env_name: &str,

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -1027,7 +1027,20 @@ pub fn remove_environment(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
+    let _operation = lock_environment_operation(name, env, cwd)?;
+    remove_environment_locked(name, force, env, cwd)
+}
+
+pub(crate) fn remove_environment_locked(
+    name: &str,
+    force: bool,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
     let safe_name = validate_name(name, "Environment name")?;
+    let source_service = crate::env::EnvironmentService::new(env, cwd);
+    let _admission = source_service.lock_gateway_admission(&safe_name)?;
+    source_service.ensure_source_watch_stopped(&safe_name)?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
     let meta = find_environment(&registry, &safe_name)
@@ -1049,6 +1062,7 @@ pub fn remove_environment(
         fs::remove_dir_all(&paths.root).map_err(|error| error.to_string())?;
     }
 
+    source_service.remove_stopped_source_watch_state_locked(&safe_name)?;
     registry.envs.retain(|entry| entry.name != meta.name);
     // Keep a monotonic tombstone so a stale rollback token cannot target a
     // later environment that reuses the same name.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -24,7 +24,10 @@ pub(crate) use common::{
     ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, try_lock_file,
     write_json,
 };
-pub(crate) use envs::{EnvironmentOperationLock, lock_env_registry, lock_environment_operation};
+pub(crate) use envs::{
+    EnvironmentOperationLock, lock_env_registry, lock_environment_operation,
+    remove_environment_locked,
+};
 pub(crate) use envs::{
     EnvironmentServicePolicyChange, restore_environment_service_policy,
     set_environment_service_policy,

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -2673,6 +2673,151 @@ fn dev_watch_rejects_service_activation_until_the_watch_exits() {
 
 #[cfg(unix)]
 #[test]
+fn dev_destroy_stops_the_recorded_watch_before_removing_state() {
+    for runtime_backed in [false, true] {
+        let root = TestDir::new("dev-destroy-watch");
+        let repo = init_openclaw_repo(&root);
+        let cwd = root.child("workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let mut env = service_env(&root);
+        let (started, _, _) = install_blocking_fake_dev_runners(&root, &mut env);
+        if runtime_backed {
+            create_runtime_backed_env(&cwd, &env);
+            let start = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+            assert!(start.status.success(), "{}", stderr(&start));
+        }
+        let watch = DevWatchFixture::spawn(
+            &root,
+            &cwd,
+            &env,
+            &[
+                "dev",
+                "demo",
+                "--repo",
+                &path_string(&repo),
+                "--watch",
+                "--force",
+            ],
+        );
+        assert!(wait_for_path(&started, Duration::from_secs(10)));
+        assert!(wait_for_path(
+            &source_watch_override_path(&root, "demo"),
+            Duration::from_secs(10)
+        ));
+        let mut before = get_environment("demo", &env, &cwd).unwrap();
+        before.last_used_at = Some(time::OffsetDateTime::UNIX_EPOCH);
+        save_environment(before.clone(), &env, &cwd).unwrap();
+        let session_path = source_watch_override_path(&root, "demo").with_extension("session");
+        let session_before = fs::read(&session_path).unwrap();
+        let preview = run_ocm(&cwd, &env, &["env", "destroy", "demo", "--json"]);
+        assert!(preview.status.success(), "{}", stderr(&preview));
+        let preview: Value = serde_json::from_str(&stdout(&preview)).unwrap();
+        assert!(preview["sourceWatchPid"].is_number());
+        assert_eq!(preview["processInspectionDeferred"], true);
+        assert!(
+            preview["steps"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|step| step["kind"] == "source-watch")
+        );
+        let guarded = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "env",
+                "destroy",
+                "demo",
+                "--yes",
+                "--if-state-token",
+                preview["stateToken"].as_str().unwrap(),
+                "--json",
+            ],
+        );
+        assert!(!guarded.status.success());
+        let guarded: Value = serde_json::from_str(&stdout(&guarded)).unwrap();
+        assert_eq!(guarded["code"], "source_watch_active");
+        assert_eq!(fs::read(&session_path).unwrap(), session_before);
+        for args in [
+            vec!["env", "remove", "demo", "--force"],
+            vec!["env", "prune", "--older-than", "1", "--yes"],
+        ] {
+            let refused = run_ocm(&cwd, &env, &args);
+            assert!(!refused.status.success());
+            assert!(
+                stderr(&refused).contains("unfinished ownership"),
+                "{}",
+                stderr(&refused)
+            );
+        }
+        let direct = ocm::store::remove_environment("demo", true, &env, &cwd);
+        assert!(direct.unwrap_err().contains("unfinished ownership"));
+        let destroyed = run_ocm(&cwd, &env, &["env", "destroy", "demo", "--yes", "--json"]);
+        let watch = watch.finish();
+        assert!(destroyed.status.success(), "{}", stderr(&destroyed));
+        let destroyed: Value = serde_json::from_str(&stdout(&destroyed)).unwrap();
+        assert_eq!(destroyed["sourceWatchStopped"], true);
+        assert_eq!(destroyed["processInspectionDeferred"], false);
+        assert_eq!(destroyed["removed"], true);
+        assert_eq!(watch.status.code(), Some(130), "{}", stderr(&watch));
+        assert!(!Path::new(&before.root).exists());
+        assert!(!session_path.exists());
+        assert!(source_watch_lock_path(&root, "demo").exists());
+        assert!(repo.exists());
+        if let Some(dev) = before.dev {
+            assert!(!Path::new(&dev.worktree_root).exists());
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_destroy_preserves_state_when_binding_changes_during_stop() {
+    let root = TestDir::new("dev-destroy-watch-binding-race");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = service_env(&root);
+    let (started, _) = install_stubborn_fake_dev_runners(&root, &mut env);
+    let watch = DevWatchFixture::spawn(
+        &root,
+        &cwd,
+        &env,
+        &["dev", "demo", "--repo", &path_string(&repo), "--watch"],
+    );
+    assert!(wait_for_path(&started, Duration::from_secs(10)));
+    let before = get_environment("demo", &env, &cwd).unwrap();
+    let destroy = Command::new(env!("CARGO_BIN_EXE_ocm"))
+        .current_dir(&cwd)
+        .args(["env", "destroy", "demo", "--yes", "--json"])
+        .env_clear()
+        .envs(&env)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    assert!(wait_for_path(
+        &source_watch_override_path(&root, "demo").with_extension("stop"),
+        Duration::from_secs(5)
+    ));
+    ocm::env::EnvironmentService::new(&env, &cwd)
+        .set_protected("demo", true)
+        .unwrap();
+    let destroyed = destroy.wait_with_output().unwrap();
+    let watch = watch.finish();
+    assert!(!destroyed.status.success());
+    assert!(
+        stderr(&destroyed).contains("changed while stopping source watch"),
+        "{}",
+        stderr(&destroyed)
+    );
+    assert_eq!(watch.status.code(), Some(130));
+    assert!(Path::new(&before.root).exists());
+    assert!(get_environment("demo", &env, &cwd).unwrap().protected);
+}
+
+#[cfg(unix)]
+#[test]
 fn dev_stop_restores_service_and_preserves_the_env_and_borrowed_source() {
     let root = TestDir::new("dev-stop-runtime");
     let repo = init_openclaw_repo(&root);

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -2679,7 +2679,7 @@ fn dev_destroy_stops_the_recorded_watch_before_removing_state() {
         let repo = init_openclaw_repo(&root);
         let cwd = root.child("workspace");
         fs::create_dir_all(&cwd).unwrap();
-        let mut env = service_env(&root);
+        let mut env = service_env_with_gateway_admission(&root);
         let (started, _, _) = install_blocking_fake_dev_runners(&root, &mut env);
         if runtime_backed {
             create_runtime_backed_env(&cwd, &env);

--- a/tests/source_watch_tests.rs
+++ b/tests/source_watch_tests.rs
@@ -205,6 +205,17 @@ fn dev_stop_refuses_legacy_ownership_and_leaves_an_inactive_env_unchanged() {
     assert_eq!(fs::read(path).unwrap(), before);
     assert!(!root.child("ocm-home/source-watch/demo.session").exists());
     assert!(!root.child("ocm-home/source-watch/demo.stop").exists());
+    let destroyed = run_ocm(&cwd, &env, &["env", "destroy", "demo", "--yes", "--json"]);
+    assert!(!destroyed.status.success());
+    let destroyed: Value = serde_json::from_str(&stdout(&destroyed)).unwrap();
+    assert!(
+        destroyed["blockers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item.as_str().unwrap().contains("original terminal"))
+    );
+    assert!(EnvironmentService::new(&env, &cwd).get("demo").is_ok());
 }
 
 #[test]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where destroying an environment could remove state while its foreground source-watch session still owned processes or needed to restore a managed service.

## Why This Change Was Made

Destroy uses the recorded session generation to stop and verify its owner, then rechecks the environment binding and protection before continuing teardown. Running-watch previews explicitly defer process inspection until shutdown. Direct removal, pruning, and simulation cleanup share the stopped-session guard, and record cleanup follows the existing operation/admission/registry lock order.

Depends on #178.

## User Impact

`ocm env destroy <env> --yes` safely completes dev shutdown before removing the environment. A replacement session or changed binding preserves state. `env remove`, `env prune`, and token-guarded destruction require `ocm dev stop` first; guarded destruction then needs a fresh preview. Completed records are cleared while reusable lock files remain.

## Evidence

- Remote `cargo fmt --check` and `cargo check --workspace --all-targets --locked` passed.
- All192 tests in the dev-command, source-watch, environment-destroy, store-flow, service-command, and launcher-help suites passed on the updated integration.
- Native command cases cover ordinary destruction, forced service takeover/restoration, preview/token refusal, direct remove/prune refusal, a protection change during shutdown, and legacy sessions without usable stop ownership.
- Independent source review passed after correcting a lock-order inversion and deferring the changing watch-process snapshot.
