### PR TITLE
feat: borrow existing checkouts for dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ ocm dev shaks --service
 ocm dev shaks --onboard
 ```
 
-`dev` creates or reuses an isolated env, provisions an OpenClaw worktree under the repo's own `.worktrees/`, bootstraps the minimum local config so the gateway can run immediately, and then starts the gateway in the foreground. `--root` lets you choose the environment location. `--watch` keeps a source-run gateway rebuilding in place. While a foreground dev session is active, `ocm @<env> -- ...`, `ocm env run <env> -- ...`, `ocm env resolve <env> -- ...`, service resolution, and `ocm env exec <env> -- openclaw ...` use the same source checkout and run `node <checkout>/openclaw.mjs` directly instead of rebuilding through the package script. `--service` installs and starts the dev env in the OCM background service instead of keeping the process in the current terminal. If a dev env is already running in the background, `--watch --force` temporarily takes it over for the watch session and restores the background service when watch exits. For an existing runtime or launcher env, `--repo <path> --watch --force` temporarily runs that source checkout against the env's real root, config, state, and port without changing its binding, tees foreground output to the env gateway logs, then restores a running background service when watch exits. `--onboard` runs local onboarding first and then starts the dev gateway. For a new env, `dev` uses the explicit `--repo` checkout or the checkout enclosing the current directory. Outside an OpenClaw checkout, pass `--repo`; `dev` does not select a neighboring or previously remembered repository. Existing dev envs continue to use their recorded source.
+`dev` creates or reuses an isolated env, uses the selected OpenClaw checkout directly, bootstraps the minimum local config so the gateway can run immediately, and then starts the gateway in the foreground. `--root` lets you choose the environment location. `--watch` keeps a source-run gateway rebuilding in place. While a foreground dev session is active, `ocm @<env> -- ...`, `ocm env run <env> -- ...`, `ocm env resolve <env> -- ...`, service resolution, and `ocm env exec <env> -- openclaw ...` use the same source checkout and run `node <checkout>/openclaw.mjs` directly instead of rebuilding through the package script. `--service` installs and starts the dev env in the OCM background service instead of keeping the process in the current terminal. If a dev env is already running in the background, `--watch --force` temporarily takes it over for the watch session and restores the background service when watch exits. For an existing runtime or launcher env, `--repo <path> --watch --force` temporarily runs that source checkout against the env's real root, config, state, and port without changing its binding, tees foreground output to the env gateway logs, then restores a running background service when watch exits. `--onboard` runs local onboarding first and then starts the dev gateway. For a new env, `dev` uses the explicit `--repo` checkout or the checkout enclosing the current directory. Outside an OpenClaw checkout, pass `--repo`; `dev` does not select a neighboring or previously remembered repository. Existing dev envs continue to use their recorded source.
 
 Plain and watched foreground sessions support `ocm dev stop <env>` and reuse a
 matching active session. `dev status` reports backend watching separately from
@@ -314,7 +314,7 @@ ocm dev luna --watch
 ocm dev existing-env --repo ~/src/openclaw --watch --force
 ```
 
-Use `ocm dev` when you want an isolated source-run checkout with its own env root and gateway port, or when you want to temporarily run source against an existing env in watch mode without rebinding it. While a foreground dev session is running, OCM's OpenClaw-running commands for that env resolve to that source checkout, so one-shot checks use its built `openclaw.mjs`. OCM refuses background service installation, start, and restart for that env until the foreground session exits; a running service taken over with `--watch --force` is restored by the watch session after its source processes stop. Foreground output is saved under that env's `.openclaw/logs/` directory, so `ocm logs <env>` remains useful while the foreground Gateway is running. If you are already inside an OpenClaw checkout, `ocm setup` can detect that and suggest a local path automatically.
+Use `ocm dev` when you want to run your checkout with separate environment state and a gateway port, or when you want to temporarily run source against an existing env in watch mode without rebinding it. While a foreground dev session is running, OCM's OpenClaw-running commands for that env resolve to that source checkout, so one-shot checks use its built `openclaw.mjs`. OCM refuses background service installation, start, and restart for that env until the foreground session exits; a running service taken over with `--watch --force` is restored by the watch session after its source processes stop. Foreground output is saved under that env's `.openclaw/logs/` directory, so `ocm logs <env>` remains useful while the foreground Gateway is running. If you are already inside an OpenClaw checkout, `ocm setup` can detect that and suggest a local path automatically.
 
 On Unix, foreground Node commands wait until OCM records their process ownership before executing source or `NODE_OPTIONS` preload hooks. The gate preserves the command arguments, terminal input, and configured Node options after release.
 
@@ -327,7 +327,14 @@ updated OCM installation; this restarts managed gateways. Package version alone
 does not establish compatibility. A confirmed stopped or unloaded daemon does
 not require refresh, and existing session reuse and stop remain available.
 
-An existing dev env resumes its recorded worktree, preserving its uncommitted changes. If that worktree is missing or has been replaced by an unrelated checkout, `dev` reports an error instead of recreating it; restore the recorded checkout before retrying. An explicit `--repo` must still identify the env's original repository, including equivalent path aliases, and cannot rebind the env to another checkout.
+New dev environments borrow the exact selected main checkout or registered linked
+worktree, including its tracked edits and untracked files. OCM creates no Git
+worktree for them. Their environment state stays outside the source and its Git
+metadata. A borrowed environment resumes its recorded canonical source path;
+an explicit `--repo` or another enclosing checkout cannot rebind it. Restore a
+missing source, changed path alias, or invalid Git registration before retrying.
+
+An existing OCM-owned dev env resumes its recorded worktree, preserving its uncommitted changes. If that worktree is missing or has been replaced by an unrelated checkout, `dev` reports an error instead of recreating it; restore the recorded checkout before retrying. An explicit `--repo` must still identify the env's original repository, including equivalent path aliases, and cannot rebind the env to another checkout.
 
 Environment commands and Gateway resolution apply the same check when selecting
 the dev source, including routing through an active source watch. Saved service
@@ -335,7 +342,7 @@ plans also validate the recorded checkout before starting it. Restore the
 recorded checkout before retrying. Explicit runtime or launcher overrides and
 status inspection remain available. A worktree validation failure leaves config unchanged.
 
-Before starting source, `dev` checks the installed entry points for the tooling declared by that checkout. It reuses hoisted or isolated installs whose tooling resolves. Missing tooling in an OCM-owned dev worktree is prepared with `pnpm install --frozen-lockfile` and checked again. Source takeover of a runtime or launcher env only validates the borrowed checkout and fails before stopping its service if preparation is needed. OCM does not reinstall through linked dependency directories. A modules-directory environment override may select dependencies inside that checkout, including before OpenClaw creates its `node_modules` link. OCM inspects the configured tree without creating that link and rejects overrides that resolve outside the checkout. These are startup checks; OpenClaw still owns builds and validation of the running application.
+Before starting source, `dev` checks the installed entry points for the tooling declared by that checkout. It reuses hoisted or isolated installs whose tooling resolves. New borrowed environments and OCM-owned dev worktrees can prepare missing tooling with `pnpm install --frozen-lockfile` and check it again. A resumed borrowed environment reports missing tooling so you can prepare its checkout explicitly; it does not reinstall dependencies. Source takeover of a runtime or launcher env only validates the borrowed checkout and fails before stopping its service if preparation is needed. OCM does not reinstall through linked dependency directories. A modules-directory environment override may select dependencies inside that checkout, including before OpenClaw creates its `node_modules` link. OCM inspects the configured tree without creating that link and rejects overrides that resolve outside the checkout. These are startup checks; OpenClaw still owns builds and validation of the running application.
 
 Foreground dependency installation keeps build output and pnpm diagnostics readable while using lifecycle reports to check script completion. When run from a terminal, installation keeps interactive stdin while streaming that output. On Unix, interrupted or unfinished build scripts retain foreground ownership even if pnpm returns an ordinary error or an optional build lets it succeed. Completed installation errors remain retryable.
 
@@ -360,9 +367,18 @@ For new Unix foreground generations, output readers must finish before OCM clear
 
 `ocm env destroy <env> --yes` stops the recorded foreground generation and verifies shutdown before removing the environment. It rechecks the binding after stopping and preserves state if another owner or binding appears. While a watch is running, previews defer the changing process-tree inspection until after shutdown (`processInspectionDeferred` in JSON). `env remove` and `env prune` refuse active or unfinished watches; stop those sessions first. A guarded destroy with `--if-state-token` also requires `dev stop` followed by a fresh preview, so its original state guarantee remains intact. Completed watch records are removed with the env; synchronization lock files remain reusable.
 
-Environment creation, cloning, and import reject roots that overlap an already
-registered dev worktree that exists on disk, including source and destination
-path aliases. Choose a separate environment root to preserve the checkout.
+Environment creation, cloning, and import reject roots that overlap registered
+dev sources, including source and destination aliases. Missing borrowed paths
+remain reserved until their binding is removed. Removing a borrowed environment
+preserves its source, dependencies, generated output, and unrelated source workers.
+Restore and rollback also preserve borrowed source and known Git metadata;
+checkpoint exclusions must cover the affected paths, including missing source
+reservations.
+
+When a managed daemon is running, it must support new or changed borrowed
+bindings before registration. Older OCM readers refuse these records. Refresh an
+incompatible daemon with the command above; unchanged bindings and confirmed
+stopped or unloaded managers remain usable.
 
 Removal, pruning, destroy, and simulation cleanup preserve other registered dev sources and the Git metadata they need. Remove dependent dev environments before deleting their containing environment or worktree.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -96,7 +96,20 @@ ocm start luna --command 'pnpm openclaw' --cwd /path/to/openclaw --no-service
 
 Use this when you are developing OpenClaw locally or want a custom run command.
 
-For an isolated development worktree, use `ocm dev luna --repo /path/to/openclaw`.
+Use `ocm dev luna --repo /path/to/openclaw` to run that exact checkout with separate
+environment state. New dev environments borrow main or registered linked
+checkouts without creating a Git worktree. Outside a checkout, pass `--repo`;
+otherwise OCM can use the checkout enclosing the current directory. A resumed
+borrower keeps its canonical source path and refuses a different explicit or
+enclosing checkout. Existing OCM-owned environments retain their recorded
+worktrees and original repository selection.
+
+New borrowers may prepare missing tooling with `pnpm install --frozen-lockfile`.
+Resumed borrowers report missing tooling for explicit preparation; they do not
+reinstall dependencies. Removing a borrower preserves source files, dependencies,
+generated output, and unrelated source processes. Older OCM readers refuse the
+new binding records. Refresh an incompatible running daemon with
+`ocm service refresh-daemon --acknowledge-gateway-restarts` before registration.
 If an environment containing or owning the source or its required Git metadata is
 busy, retry dev creation or local upgrade simulation after its operation finishes.
 New dev environments publish a private config with a persistent Gateway token
@@ -454,9 +467,10 @@ ocm self update --check
 ## Environment lifecycle
 
 Environment creation, including `start` and migration, and `env clone` and
-`env import` require a root outside every registered dev worktree that exists
-on disk. The root must neither contain an existing registered source nor be
-inside it. OCM resolves source and destination aliases and also protects source
+`env import` require a root outside registered dev sources. Missing borrowed
+source paths remain reserved until their binding is removed; missing paths of
+OCM-owned worktrees can still be reused. The root must neither contain
+a registered source nor be inside it. OCM resolves source and destination aliases and also protects source
 symlinks that failed clone or import cleanup would remove. Choose a separate
 environment root.
 
@@ -470,7 +484,7 @@ before writing the destination. Check the recorded source with `ocm env show
 ocm env clone mira rowan
 ```
 
-Clone copies the workspace and env config into a new environment, gives the clone its own gateway port, rewrites env-scoped OpenClaw config paths under the new env root, keeps durable agent auth/settings for the same user, clears copied runtime residue like sessions, logs, and backups, and keeps the background service separate. The usual next step is:
+Clone copies the workspace and env config into a new environment, gives the clone its own gateway port, rewrites env-scoped OpenClaw config paths under the new env root, keeps durable agent auth/settings for the same user, clears copied runtime residue like sessions, logs, and backups, and keeps the background service separate. Clone does not copy dev source bindings. The usual next step is:
 
 ```bash
 ocm start rowan
@@ -520,7 +534,8 @@ not add crash recovery for an uncatchable process or machine failure.
 This policy belongs to the environment registration. Clone and import start with
 an empty list. A separately requested full snapshot, export, or clone still
 includes independent content. Full snapshot restore still rewinds unregistered
-independent content and the selected environment's own source.
+independent content and the selected environment's OCM-owned worktree when those
+paths were captured inside the environment root.
 
 Restores and required rollbacks refuse checkpoints whose recorded scope would
 replace another named environment's registered dev source or required Git
@@ -531,6 +546,11 @@ and Git identity metadata, including surviving history for a missing worktree.
 Checkpoint traversal still leaves independent content opaque; post-copy updates
 and residue cleanup leave directory links untouched. Excluding only a worktree
 is insufficient when its required Git metadata remains in scope.
+Borrowed source and its known Git metadata also remain protected from a restore
+of the borrowing environment itself. Missing borrowed paths stay reserved until
+the binding is removed; an unrelated excluded sibling does not preserve that
+reservation. Select a checkpoint whose saved exclusions cover the source and
+all affected Git metadata.
 
 ### Snapshots
 

--- a/skills/ocm-operator/references/command-cookbook.md
+++ b/skills/ocm-operator/references/command-cookbook.md
@@ -71,7 +71,7 @@ ocm start <env> --command 'pnpm openclaw' --cwd /path/to/openclaw
 ocm start <env> --command 'pnpm openclaw' --cwd /path/to/openclaw --no-service
 ```
 
-## Dev Worktree Envs
+## Dev Checkout Envs
 
 Use for source-backed development and reproductions. Do not use this as proof
 of release packaging.
@@ -86,8 +86,11 @@ ocm dev status
 ocm dev status <env>
 ```
 
-Rerun `ocm dev <env>` after pulling the source repo to refresh the worktree
-binding.
+New dev envs use the exact explicit or enclosing checkout with separate state;
+they create no Git worktree. Existing envs keep their recorded source, including
+legacy OCM-owned worktrees. Rerun `ocm dev <env>` after editing or pulling that
+source. A resumed borrower reports missing tooling for explicit preparation.
+Removing it preserves the checkout and dependencies.
 
 ## Runtime Management
 
@@ -150,6 +153,8 @@ Clone first when the test does not need sessions, logs, or backups. A clone
 retains durable auth/settings and is therefore secret-bearing. Keep its service
 stopped until credentials are replaced with mocks or dedicated test accounts,
 or the user explicitly authorizes real external access.
+
+Clone does not copy dev source bindings.
 
 ```sh
 ocm env clone <existing-env> <test-env>

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -26,8 +26,9 @@ use serde_json::Value;
 use super::Cli;
 use super::render::RenderProfile;
 use crate::env::{
-    CreateEnvironmentOptions, CreateSourceWatchOverrideOptions, EnvMeta, SourceWatchCompletion,
-    SourceWatchEndpoint, SourceWatchLease, SourceWatchMode, SourceWatchSession, SourceWatchState,
+    CreateEnvironmentOptions, CreateSourceWatchOverrideOptions, EnvDevMeta, EnvMeta,
+    SourceWatchCompletion, SourceWatchEndpoint, SourceWatchLease, SourceWatchMode,
+    SourceWatchSession, SourceWatchState,
 };
 use crate::infra::process::run_direct;
 #[cfg(unix)]
@@ -38,7 +39,7 @@ use crate::infra::terminal::{Cell, KeyValueRow, Tone, paint, render_key_value_ca
 use crate::openclaw_repo::{
     detect_openclaw_checkout, discover_enclosing_openclaw_checkout,
     ensure_source_dependency_install_target, inspect_source_dependencies,
-    inspect_source_dependencies_with_runner,
+    inspect_source_dependencies_with_runner, validate_borrowed_openclaw_checkout,
 };
 use crate::service::service_backend_support_error;
 use crate::store::{
@@ -551,8 +552,8 @@ impl Cli {
             }
         }
 
-        // Reject an already incompatible daemon before creating a new env or
-        // worktree. Lease admission rechecks after any concurrent daemon change.
+        // Reject an already incompatible daemon before creating a new env.
+        // Lease admission rechecks after any concurrent daemon change.
         self.supervisor_service().preflight_source_watch_daemon()?;
         let (meta, created) =
             self.ensure_dev_env(&name, repo_root.clone(), root.clone(), gateway_port)?;
@@ -657,13 +658,14 @@ impl Cli {
         ));
         self.stderr_lines(render_dev_external_plugin_warnings(
             &meta,
-            Path::new(&dev.worktree_root),
+            Path::new(dev.source_root()),
             stderr_profile,
         ));
 
         let preparation = self
             .prepare_dev_run(
                 &meta,
+                created,
                 onboard,
                 source_watch_lease.as_mut(),
                 watch_stop.as_deref(),
@@ -672,7 +674,7 @@ impl Cli {
                 if code == 0 && ui {
                     self.prepare_dev_ui(
                         &meta,
-                        Path::new(&dev.worktree_root),
+                        dev.execution_source_root()?,
                         source_watch_lease
                             .as_mut()
                             .ok_or_else(|| "dev UI lease is missing".to_string())?,
@@ -715,14 +717,7 @@ impl Cli {
             let current = env_service.get(&meta.name)?;
             if current.root != meta.root
                 || current.created_at != meta.created_at
-                || current
-                    .dev
-                    .as_ref()
-                    .map(|dev| (&dev.repo_root, &dev.worktree_root))
-                    != meta
-                        .dev
-                        .as_ref()
-                        .map(|dev| (&dev.repo_root, &dev.worktree_root))
+                || current.dev != meta.dev
                 || current.default_runtime != meta.default_runtime
                 || current.default_launcher != meta.default_launcher
                 || Some(crate::store::environment_service_policy_revision(
@@ -788,7 +783,7 @@ impl Cli {
                 "Watch",
                 format!(
                     "Watching {} on port {}",
-                    dev.worktree_root,
+                    dev.source_root(),
                     meta.gateway_port.unwrap_or_default()
                 ),
                 stderr_profile,
@@ -842,7 +837,7 @@ impl Cli {
                 "Starting {} on port {} from {}",
                 meta.name,
                 meta.gateway_port.unwrap_or_default(),
-                dev.worktree_root
+                dev.source_root()
             ),
             stderr_profile,
         ));
@@ -1166,9 +1161,15 @@ impl Cli {
                 existing.name
             )
         })?;
-        let existing_repo = PathBuf::from(&dev.repo_root);
-        if let Some(repo_root) = repo_root {
-            let requested = resolve_absolute_path(repo_root, &self.env, &self.cwd)?;
+        let existing_repo = PathBuf::from(dev.repo_root());
+        let selected = match repo_root {
+            Some(repo_root) => Some(resolve_absolute_path(repo_root, &self.env, &self.cwd)?),
+            None if dev.borrowed_source_root().is_some() => {
+                discover_enclosing_openclaw_checkout(&self.cwd)
+            }
+            None => None,
+        };
+        if let Some(requested) = selected {
             let requested = fs::canonicalize(&requested).map_err(|error| {
                 format!(
                     "failed to resolve OpenClaw repo {}: {error}",
@@ -1184,7 +1185,8 @@ impl Cli {
             if requested != saved_repo {
                 return Err(format!(
                     "dev cannot change the repo for existing env {}; current repo is {}",
-                    existing.name, dev.repo_root
+                    existing.name,
+                    dev.repo_root()
                 ));
             }
         }
@@ -1284,7 +1286,7 @@ impl Cli {
         }
         let expected_source = if let Some(dev) = &meta.dev {
             self.validate_existing_dev_request(meta, repo_root, root, None)?;
-            PathBuf::from(&dev.worktree_root)
+            PathBuf::from(dev.source_root())
         } else {
             if root.is_some() {
                 return Err("dev takeover uses the existing env root; remove --root".to_string());
@@ -1393,10 +1395,11 @@ impl Cli {
             return Ok((existing, false));
         }
 
-        let repo_root = self.resolve_dev_repo_root(repo_root)?;
-        let created = self.environment_service().create_dev(
-            &repo_root,
-            CreateEnvironmentOptions {
+        let source_root = self.resolve_dev_repo_root(repo_root)?;
+        validate_borrowed_openclaw_checkout(&source_root)?;
+        let created = self
+            .environment_service()
+            .create(CreateEnvironmentOptions {
                 name: name.to_string(),
                 root,
                 gateway_port,
@@ -1404,10 +1407,11 @@ impl Cli {
                 service_running: false,
                 default_runtime: None,
                 default_launcher: None,
-                dev: None,
+                dev: Some(EnvDevMeta::Borrowed {
+                    source_root: display_path(&source_root),
+                }),
                 protected: false,
-            },
-        )?;
+            })?;
 
         Ok((created, true))
     }
@@ -1440,6 +1444,7 @@ impl Cli {
     fn prepare_dev_run(
         &self,
         meta: &EnvMeta,
+        created: bool,
         onboard: bool,
         mut lease: Option<&mut SourceWatchLease>,
         stop: Option<&AtomicBool>,
@@ -1449,7 +1454,7 @@ impl Cli {
         {
             return Ok(130);
         }
-        let code = self.ensure_dev_dependencies(meta, lease.as_deref_mut(), stop)?;
+        let code = self.ensure_dev_dependencies(meta, created, lease.as_deref_mut(), stop)?;
         if code != 0 {
             return Ok(code);
         }
@@ -1460,7 +1465,7 @@ impl Cli {
                 .ok_or_else(|| "dev binding is missing".to_string())?;
             self.stderr_lines(render_dev_run_step(
                 "Onboarding",
-                format!("Running local onboarding in {}", source.worktree_root),
+                format!("Running local onboarding in {}", source.source_root()),
                 self.dev_stderr_profile(),
             ));
             return self.run_dev_onboard(meta, lease, stop);
@@ -1686,6 +1691,7 @@ impl Cli {
     fn ensure_dev_dependencies(
         &self,
         meta: &EnvMeta,
+        created: bool,
         mut lease: Option<&mut SourceWatchLease>,
         stop: Option<&AtomicBool>,
     ) -> SourceWatchResult<i32> {
@@ -1694,10 +1700,10 @@ impl Cli {
             .dev
             .as_ref()
             .ok_or_else(|| format!("environment \"{}\" is missing its dev binding", meta.name))?;
-        let worktree_root = Path::new(&dev.worktree_root);
+        let source_root = Path::new(dev.source_root());
         let process_env = build_openclaw_env(meta, &self.env);
         let inspected = self.inspect_dev_source_dependencies(
-            worktree_root,
+            source_root,
             &process_env,
             watch,
             lease.as_deref_mut(),
@@ -1708,14 +1714,17 @@ impl Cli {
         {
             return Ok(130);
         }
-        if inspected?.is_none() {
+        let Some(issue) = inspected? else {
             return Ok(0);
+        };
+        if dev.borrowed_source_root().is_some() && !created {
+            return Err(source_dependency_preparation_error(source_root, &issue).into());
         }
-        ensure_source_dependency_install_target(worktree_root, &process_env)?;
+        ensure_source_dependency_install_target(source_root, &process_env)?;
 
         self.stderr_lines(render_dev_run_step(
             "Dependencies",
-            format!("Installing dependencies in {}", dev.worktree_root),
+            format!("Installing dependencies in {}", dev.source_root()),
             self.dev_stderr_profile(),
         ));
         let code = self.run_dev_setup(
@@ -1723,7 +1732,7 @@ impl Cli {
             &["install".to_string(), "--frozen-lockfile".to_string()],
             SourcePreparationCommand::DependencyInstall,
             &process_env,
-            worktree_root,
+            source_root,
             lease.as_deref_mut(),
             stop,
         )?;
@@ -1731,14 +1740,14 @@ impl Cli {
             return Ok(code);
         }
         let inspected =
-            self.inspect_dev_source_dependencies(worktree_root, &process_env, watch, lease, stop);
+            self.inspect_dev_source_dependencies(source_root, &process_env, watch, lease, stop);
         if source_watch_allows_service_restore(&inspected)
             && stop.is_some_and(|stop| stop.load(Ordering::SeqCst))
         {
             return Ok(130);
         }
         if let Some(issue) = inspected? {
-            return Err(source_dependency_preparation_error(worktree_root, &issue).into());
+            return Err(source_dependency_preparation_error(source_root, &issue).into());
         }
         Ok(0)
     }
@@ -1795,8 +1804,8 @@ impl Cli {
             program,
             &args,
             SourcePreparationCommand::Source,
-            &build_openclaw_dev_source_env(meta, &self.env, Path::new(&dev.worktree_root)),
-            Path::new(&dev.worktree_root),
+            &build_openclaw_dev_source_env(meta, &self.env, Path::new(dev.source_root())),
+            Path::new(dev.source_root()),
             lease,
             stop,
         )
@@ -1814,7 +1823,7 @@ impl Cli {
             .ok_or_else(|| format!("environment \"{}\" is missing its dev binding", meta.name))?;
         self.run_source_gateway_watch(
             meta,
-            Path::new(&dev.worktree_root),
+            Path::new(dev.source_root()),
             true,
             source_watch_lease,
             stop_requested,
@@ -2123,9 +2132,9 @@ impl Cli {
             env_name: env_name.clone(),
             root,
             repo_root: dev
-                .map(|dev| dev.repo_root.clone())
+                .map(|dev| dev.repo_root().to_string())
                 .or_else(|| active_source.clone()),
-            worktree_root: active_source.or_else(|| dev.map(|dev| dev.worktree_root.clone())),
+            worktree_root: active_source.or_else(|| dev.map(|dev| dev.source_root().to_string())),
             gateway_port,
             gateway_url: dev_gateway_url(gateway_port),
             gateway_port_reachable: crate::service::inspect::tcp_port_reachable(gateway_port),
@@ -3519,7 +3528,7 @@ fn render_dev_status(summary: &DevStatusSummary, profile: RenderProfile) -> Vec<
         &[
             KeyValueRow::plain("Repo", summary.repo_root.as_deref().unwrap_or("unknown")),
             KeyValueRow::plain(
-                "Worktree",
+                "Source",
                 summary.worktree_root.as_deref().unwrap_or("unknown"),
             ),
         ],
@@ -3554,6 +3563,14 @@ fn dev_service_state(summary: &DevStatusSummary) -> &'static str {
     }
 }
 
+fn dev_source_labels(dev: &EnvDevMeta) -> (&'static str, &'static str) {
+    if dev.borrowed_source_root().is_some() {
+        ("source", "Source")
+    } else {
+        ("worktree", "Worktree")
+    }
+}
+
 fn render_dev_run_summary(
     meta: &EnvMeta,
     created: bool,
@@ -3565,6 +3582,7 @@ fn render_dev_run_summary(
     let Some(dev) = meta.dev.as_ref() else {
         return Vec::new();
     };
+    let (source_key, source_label) = dev_source_labels(dev);
     if !profile.pretty {
         return vec![
             format!(
@@ -3573,8 +3591,8 @@ fn render_dev_run_summary(
                 meta.name
             ),
             format!("port={}", meta.gateway_port.unwrap_or_default()),
-            format!("repo={}", dev.repo_root),
-            format!("worktree={}", dev.worktree_root),
+            format!("repo={}", dev.repo_root()),
+            format!("{source_key}={}", dev.source_root()),
             format!(
                 "mode={}",
                 if service_requested {
@@ -3610,8 +3628,8 @@ fn render_dev_run_summary(
     lines.extend(render_key_value_card(
         "Source",
         &[
-            KeyValueRow::plain("Repo", dev.repo_root.clone()),
-            KeyValueRow::plain("Worktree", dev.worktree_root.clone()),
+            KeyValueRow::plain("Repo", dev.repo_root().to_string()),
+            KeyValueRow::plain(source_label, dev.source_root().to_string()),
         ],
         profile.color,
     ));
@@ -3643,6 +3661,7 @@ fn render_dev_service_started(
     let Some(dev) = meta.dev.as_ref() else {
         return Vec::new();
     };
+    let (source_key, source_label) = dev_source_labels(dev);
 
     if !profile.pretty {
         return vec![
@@ -3652,8 +3671,8 @@ fn render_dev_service_started(
                 "url={}",
                 dev_gateway_url(meta.gateway_port.unwrap_or_default())
             ),
-            format!("repo={}", dev.repo_root),
-            format!("worktree={}", dev.worktree_root),
+            format!("repo={}", dev.repo_root()),
+            format!("{source_key}={}", dev.source_root()),
             format!("status={} service status {}", command_example, meta.name),
             format!("logs={} logs {} --follow", command_example, meta.name),
         ];
@@ -3680,8 +3699,8 @@ fn render_dev_service_started(
     lines.extend(render_key_value_card(
         "Source",
         &[
-            KeyValueRow::plain("Repo", dev.repo_root.clone()),
-            KeyValueRow::plain("Worktree", dev.worktree_root.clone()),
+            KeyValueRow::plain("Repo", dev.repo_root().to_string()),
+            KeyValueRow::plain(source_label, dev.source_root().to_string()),
         ],
         profile.color,
     ));
@@ -3714,6 +3733,7 @@ fn render_dev_service_restored(
     let Some(dev) = meta.dev.as_ref() else {
         return Vec::new();
     };
+    let (source_key, _) = dev_source_labels(dev);
 
     if !profile.pretty {
         return vec![
@@ -3723,8 +3743,8 @@ fn render_dev_service_restored(
                 "url={}",
                 dev_gateway_url(meta.gateway_port.unwrap_or_default())
             ),
-            format!("repo={}", dev.repo_root),
-            format!("worktree={}", dev.worktree_root),
+            format!("repo={}", dev.repo_root()),
+            format!("{source_key}={}", dev.source_root()),
             format!("status={} service status {}", command_example, meta.name),
             format!("logs={} logs {} --follow", command_example, meta.name),
         ];
@@ -4145,7 +4165,7 @@ fn render_dev_status_list(summaries: &[DevStatusSummary], profile: RenderProfile
             "Port",
             "Reachable",
             "Repo",
-            "Worktree",
+            "Source",
             "Session",
             "Watching",
             "Service",

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -452,7 +452,8 @@ impl Cli {
         summary.worktree_removed = env_meta
             .dev
             .as_ref()
-            .is_some_and(|dev| !Path::new(&dev.worktree_root).exists());
+            .and_then(|dev| dev.owned_worktree())
+            .is_some_and(|(_, worktree)| !Path::new(worktree).exists());
 
         // Snapshots are the recovery path if destructive cleanup fails, so
         // remove them only after the environment and worktree are gone.
@@ -1306,10 +1307,10 @@ impl Cli {
                 description: "terminate live OpenClaw processes for the env".to_string(),
             });
         }
-        if let Some(dev) = env_meta.dev.as_ref() {
+        if let Some((_, worktree)) = env_meta.dev.as_ref().and_then(|dev| dev.owned_worktree()) {
             steps.push(EnvDestroyStepSummary {
                 kind: "worktree".to_string(),
-                description: format!("remove dev worktree {}", dev.worktree_root),
+                description: format!("remove dev worktree {worktree}"),
             });
         }
         steps.push(EnvDestroyStepSummary {
@@ -1326,7 +1327,11 @@ impl Cli {
         Ok(EnvDestroySummary {
             env_name: env_meta.name,
             root: env_meta.root,
-            dev_worktree: env_meta.dev.as_ref().map(|dev| dev.worktree_root.clone()),
+            dev_worktree: env_meta
+                .dev
+                .as_ref()
+                .and_then(|dev| dev.owned_worktree())
+                .map(|(_, worktree)| worktree.to_string()),
             protected: env_meta.protected,
             apply,
             force,
@@ -2021,8 +2026,8 @@ fn process_belongs_to_env(
     .into_iter()
     .map(|value| normalize_process_path(&value))
     .collect::<Vec<_>>();
-    if let Some(dev) = meta.dev.as_ref() {
-        markers.push(normalize_process_path(&dev.worktree_root));
+    if let Some((_, worktree)) = meta.dev.as_ref().and_then(|dev| dev.owned_worktree()) {
+        markers.push(normalize_process_path(worktree));
     }
 
     let command = normalize_process_path(command);

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -102,7 +102,7 @@ pub fn root_help(cmd: &str) -> String {
             ("setup", "Guided setup for release and local-dev flows"),
             (
                 "dev",
-                "OpenClaw development envs with worktrees and watch mode",
+                "Run selected OpenClaw checkouts with isolated environment state",
             ),
             (
                 "start",
@@ -243,7 +243,7 @@ pub fn logs_help(cmd: &str) -> String {
 pub fn dev_help(cmd: &str) -> String {
     render_group(
         "Development envs",
-        "Provision OpenClaw dev envs from a checkout worktree, bootstrap the minimum local config, and run the gateway in the foreground with bundled plugins resolved from that source checkout. Existing runtime or launcher envs can also be temporarily taken over with --repo <path> --watch --force; OCM keeps their binding unchanged, routes OpenClaw commands for that env through the watched checkout while watch is active, warns for installed plugins not present in the source tree, tees the foreground output to the env gateway logs, and restores a running background service when watch exits. Background service installation, start, and restart are refused while source watch is active. New foreground sessions and service preparation require a compatible running daemon with verified process ownership; wait for startup or run service refresh-daemon --acknowledge-gateway-restarts from the updated OCM installation during a maintenance window. Confirmed stopped or unloaded daemons do not require refresh. New envs use the explicit --repo checkout or the checkout enclosing the current directory. Outside a checkout, pass --repo; neighboring and remembered repositories are not selected. Existing dev envs use their recorded source. Repeating a matching plain or --watch invocation returns the existing session status and link without setup or restart. Starting and restoring sessions report progress; they are not reported as ready. Stop the session before onboarding or changing --watch, source, root, or port. Reuse keeps the captured launch endpoint; an older watch without endpoint metadata must be stopped from its original terminal first. Add --ui to run native Vite beside a plain or watched Gateway. The controller owns both components and their initial native browser handoff. UI requires HTTP, enabled Control UI and installed UI dependencies; it cannot be combined with --service. The initial owner link is printed after both documents are ready. A pending request keeps its one helper owned, discards late grant bytes after 30 seconds, and leaves Gateway and Vite running. Matching reuse reports the captured UI address without requesting another grant. Stop before changing --ui; the address is scoped to the session.",
+        "Run the selected OpenClaw checkout with separate environment state, bootstrap the minimum local config, and run the gateway in the foreground with bundled plugins resolved from that source checkout. Existing runtime or launcher envs can also be temporarily taken over with --repo <path> --watch --force; OCM keeps their binding unchanged, routes OpenClaw commands for that env through the watched checkout while watch is active, warns for installed plugins not present in the source tree, tees the foreground output to the env gateway logs, and restores a running background service when watch exits. Background service installation, start, and restart are refused while source watch is active. Before new foreground sessions or service preparation, any running managed daemon must be compatible and have verified process ownership; wait for startup or run service refresh-daemon --acknowledge-gateway-restarts from the updated OCM installation during a maintenance window. Confirmed stopped or unloaded daemons do not require refresh. New envs borrow the exact --repo checkout or the checkout enclosing the current directory without creating a Git worktree. Main and registered linked checkouts are supported. Outside a checkout, pass --repo; neighboring and remembered repositories are not selected. Existing dev envs use their recorded source; borrowed envs refuse a different explicit or enclosing checkout. New borrowers may install missing tooling with pnpm install --frozen-lockfile; resumed borrowers require explicit preparation. Removing a borrower preserves its checkout and unrelated source workers. A running managed daemon must support new borrowed bindings; older OCM versions cannot read them. Repeating a matching plain or --watch invocation returns the existing session status and link without setup or restart. Starting and restoring sessions report progress; they are not reported as ready. Stop the session before onboarding or changing --watch, source, root, or port. Reuse keeps the captured launch endpoint; an older watch without endpoint metadata must be stopped from its original terminal first. Add --ui to run native Vite beside a plain or watched Gateway. The controller owns both components and their initial native browser handoff. UI requires HTTP, enabled Control UI and installed UI dependencies; it cannot be combined with --service. The initial owner link is printed after both documents are ready. A pending request keeps its one helper owned, discards late grant bytes after 30 seconds, and leaves Gateway and Vite running. Matching reuse reports the captured UI address without requesting another grant. Stop before changing --ui; the address is scoped to the session.",
         vec![format!(
             "{cmd} dev <env> [--repo <path>] [--root <path>] [--port <port>] [--watch] [--ui] [--force] [--service] [--onboard]"
         )],
@@ -1170,7 +1170,7 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "Environments are the main isolation unit in OCM.",
-                "The root must not overlap an existing registered dev worktree, including source and destination path aliases.",
+                "The root must not overlap registered dev sources, including aliases and missing borrowed paths.",
                 "Computed gateway ports reserve the full local OpenClaw port family and skip the machine-wide OpenClaw config when present.",
                 "Use exactly one of `--runtime`, `--version`, or `--channel`.",
             ],
@@ -1199,7 +1199,8 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
             vec![format!("{cmd} env clone mira rowan")],
             &[
                 "Clone resets environment identity while preserving the copied workspace and env config.",
-                "The destination root must not overlap an existing registered dev worktree, including source and destination path aliases.",
+                "Dev source bindings are not copied.",
+                "The destination root must not overlap registered dev sources, including aliases and missing borrowed paths.",
                 "Clone assigns a fresh gateway port to the new env to avoid collisions.",
                 "Computed gateway ports reserve the full local OpenClaw port family and skip the machine-wide OpenClaw config when present.",
                 "Clone rewrites env-scoped OpenClaw config paths inside the copied env root.",
@@ -1252,7 +1253,7 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
             )],
             &[
                 "Imported environments get a fresh identity in the central env registry.",
-                "The destination root must not overlap an existing registered dev worktree, including source and destination path aliases.",
+                "The destination root must not overlap registered dev sources, including aliases and missing borrowed paths.",
                 "Import rewrites env-scoped OpenClaw config paths for the new root.",
                 "Import removes a copied public MCP app sandbox origin unless --sandbox-origin supplies a dedicated origin for the imported env.",
                 "If the config root, mcp, mcp.apps, or mcp.apps.sandboxOrigin is owned by $include, flatten that section before importing so OCM can reset the origin without changing include ownership.",

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -2088,7 +2088,7 @@ impl Cli {
             .dev
             .as_ref()
             .ok_or_else(|| format!("environment \"{}\" is missing its dev binding", meta.name))?;
-        let worktree_root = Path::new(&dev.worktree_root);
+        let worktree_root = dev.execution_source_root()?;
         let pnpm_store = worktree_root.join("node_modules").join(".pnpm");
         let tsx_bin = worktree_root.join("node_modules").join(".bin").join("tsx");
         if pnpm_store.exists() && tsx_bin.exists() {
@@ -2163,10 +2163,14 @@ impl Cli {
                         ),
                     );
                 };
+                let source_root = match dev.execution_source_root() {
+                    Ok(root) => root,
+                    Err(error) => return UpgradeSimulationCheck::failed(name, error),
+                };
                 let mut command = Command::new("pnpm");
                 command
                     .arg(script)
-                    .current_dir(&dev.worktree_root)
+                    .current_dir(source_root)
                     .env_clear()
                     .envs(build_openclaw_env(&env_meta, &self.env))
                     .stdin(Stdio::null())

--- a/src/env/execution.rs
+++ b/src/env/execution.rs
@@ -432,8 +432,8 @@ impl<'a> EnvironmentService<'a> {
                 program_args.extend(args.clone());
                 Ok(ResolvedExecution::Dev {
                     env,
-                    repo_root: dev.repo_root,
-                    worktree_root: dev.worktree_root,
+                    repo_root: dev.repo_root().to_string(),
+                    worktree_root: dev.source_root().to_string(),
                     forwarded_args: args,
                     program: "pnpm".to_string(),
                     program_args,

--- a/src/env/inspect.rs
+++ b/src/env/inspect.rs
@@ -141,7 +141,7 @@ impl<'a> EnvironmentService<'a> {
                 if let Some(dev) = env.dev.as_ref() {
                     summary.command = Some("pnpm openclaw".to_string());
                     summary.binary_path = Some("pnpm".to_string());
-                    summary.run_dir = Some(dev.worktree_root.clone());
+                    summary.run_dir = Some(dev.source_root().to_string());
                 } else {
                     summary.issue = Some(format!(
                         "environment \"{}\" is missing its dev binding",

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -11,11 +11,11 @@ use crate::openclaw_repo::{
 use crate::runtime::RuntimeService;
 use crate::store::{
     EnvironmentOperationLock, clone_environment, clone_environment_for_simulation,
-    create_environment_with_dev_registration, create_environment_with_validated_runtime,
-    export_environment, get_environment, get_runtime_verified, import_environment,
-    list_environments, lock_environment_operation, now_utc, remove_environment_locked,
-    resolve_config_gateway_port, resolve_effective_gateway_ports, resolve_env_gateway_port,
-    save_environment, set_environment_service_policy, with_prepared_dev_source,
+    create_environment_with_validated_runtime, export_environment, get_environment,
+    get_runtime_verified, import_environment, list_environments, lock_environment_operation,
+    now_utc, remove_environment_locked, resolve_config_gateway_port,
+    resolve_effective_gateway_ports, resolve_env_gateway_port, save_environment,
+    set_environment_service_policy,
 };
 use crate::supervisor::{sync_supervisor_env_if_present, sync_supervisor_if_present};
 
@@ -31,18 +31,133 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "DevSourceRecord", into = "DevSourceRecord")]
+pub enum EnvDevMeta {
+    Owned {
+        repo_root: String,
+        worktree_root: String,
+    },
+    Borrowed {
+        source_root: String,
+    },
+}
+
+// Keep the legacy owned wire format unchanged. Borrowed records deliberately
+// omit both legacy fields, so older OCM readers cannot mistake them for an
+// owned worktree and remove the checkout.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EnvDevMeta {
-    pub repo_root: String,
-    pub worktree_root: String,
+#[serde(untagged)]
+enum DevSourceRecord {
+    Owned(OwnedDevSourceRecord),
+    Borrowed(BorrowedDevSourceRecord),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct OwnedDevSourceRecord {
+    repo_root: String,
+    worktree_root: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct BorrowedDevSourceRecord {
+    kind: BorrowedDevSourceKind,
+    source_root: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+enum BorrowedDevSourceKind {
+    #[serde(rename = "borrowed")]
+    Borrowed,
+}
+
+impl TryFrom<DevSourceRecord> for EnvDevMeta {
+    type Error = String;
+
+    fn try_from(record: DevSourceRecord) -> Result<Self, Self::Error> {
+        match record {
+            DevSourceRecord::Owned(record) => Ok(Self::Owned {
+                repo_root: record.repo_root,
+                worktree_root: record.worktree_root,
+            }),
+            DevSourceRecord::Borrowed(record) => {
+                if !Path::new(&record.source_root).is_absolute() {
+                    return Err("borrowed dev source must be an absolute checkout path".to_string());
+                }
+                Ok(Self::Borrowed {
+                    source_root: record.source_root,
+                })
+            }
+        }
+    }
+}
+
+impl From<EnvDevMeta> for DevSourceRecord {
+    fn from(meta: EnvDevMeta) -> Self {
+        match meta {
+            EnvDevMeta::Owned {
+                repo_root,
+                worktree_root,
+            } => Self::Owned(OwnedDevSourceRecord {
+                repo_root,
+                worktree_root,
+            }),
+            EnvDevMeta::Borrowed { source_root } => Self::Borrowed(BorrowedDevSourceRecord {
+                kind: BorrowedDevSourceKind::Borrowed,
+                source_root,
+            }),
+        }
+    }
 }
 
 impl EnvDevMeta {
+    pub fn repo_root(&self) -> &str {
+        match self {
+            Self::Owned { repo_root, .. } => repo_root,
+            Self::Borrowed { source_root } => source_root,
+        }
+    }
+
+    pub fn source_root(&self) -> &str {
+        match self {
+            Self::Owned { worktree_root, .. } => worktree_root,
+            Self::Borrowed { source_root } => source_root,
+        }
+    }
+
     pub(crate) fn execution_source_root(&self) -> Result<&Path, String> {
-        let source_root = Path::new(&self.worktree_root);
-        validate_openclaw_worktree(Path::new(&self.repo_root), source_root)?;
-        Ok(source_root)
+        match self {
+            Self::Owned {
+                repo_root,
+                worktree_root,
+            } => {
+                let source_root = Path::new(worktree_root);
+                validate_openclaw_worktree(Path::new(repo_root), source_root)?;
+                Ok(source_root)
+            }
+            Self::Borrowed { source_root } => {
+                crate::openclaw_repo::validate_borrowed_openclaw_checkout(Path::new(source_root))
+            }
+        }
+    }
+
+    pub fn owned_worktree(&self) -> Option<(&str, &str)> {
+        match self {
+            Self::Owned {
+                repo_root,
+                worktree_root,
+            } => Some((repo_root, worktree_root)),
+            Self::Borrowed { .. } => None,
+        }
+    }
+
+    pub fn borrowed_source_root(&self) -> Option<&str> {
+        match self {
+            Self::Borrowed { source_root } => Some(source_root),
+            Self::Owned { .. } => None,
+        }
     }
 }
 
@@ -249,22 +364,6 @@ impl<'a> EnvironmentService<'a> {
         Ok(meta)
     }
 
-    pub(crate) fn create_dev(
-        &self,
-        repo: &Path,
-        mut options: CreateEnvironmentOptions,
-    ) -> Result<EnvMeta, String> {
-        let name = options.name.clone();
-        let meta =
-            with_prepared_dev_source(repo, &name, self.env, self.cwd, |dev, registration| {
-                options.dev = Some(dev);
-                create_environment_with_dev_registration(options, registration, self.env, self.cwd)
-            })?;
-        // A sync error must preserve source whose binding was already published.
-        sync_supervisor_env_if_present(self.env, self.cwd, &meta.name)?;
-        Ok(meta)
-    }
-
     pub fn clone(&self, options: CloneEnvironmentOptions) -> Result<EnvMeta, String> {
         let meta = clone_environment(options, self.env, self.cwd)?;
         sync_supervisor_env_if_present(self.env, self.cwd, &meta.name)?;
@@ -411,10 +510,12 @@ impl<'a> EnvironmentService<'a> {
     pub(crate) fn remove_simulation(&self, name: &str) -> Result<EnvMeta, String> {
         let _lock = self.lock_operation(name)?;
         self.remove_with_cleanup_locked(name, true, |meta| {
-            if let Some(dev) = meta.dev.as_ref() {
+            if let Some((repo_root, worktree_root)) =
+                meta.dev.as_ref().and_then(EnvDevMeta::owned_worktree)
+            {
                 prepare_openclaw_simulation_worktree_cleanup(
-                    Path::new(&dev.repo_root),
-                    Path::new(&dev.worktree_root),
+                    Path::new(repo_root),
+                    Path::new(worktree_root),
                     &meta.name,
                 )?;
             }
@@ -464,5 +565,78 @@ impl<'a> EnvironmentService<'a> {
             .copied()
             .map(|port| (port, "computed"))
             .ok_or_else(|| format!("failed to resolve gateway port for env \"{}\"", target.name))
+    }
+}
+
+#[cfg(test)]
+mod dev_source_tests {
+    use super::EnvDevMeta;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    // This is the required-field decoder used by OCM before borrowed sources.
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LegacyDevMeta {
+        repo_root: String,
+        worktree_root: String,
+    }
+
+    #[test]
+    fn dev_source_records_preserve_owned_shape_and_reject_old_readers_for_borrowed_sources() {
+        let root = std::env::temp_dir()
+            .join("ocm-dev-source-record")
+            .to_string_lossy()
+            .into_owned();
+        let owned = EnvDevMeta::Owned {
+            repo_root: root.clone(),
+            worktree_root: format!("{root}/worktree"),
+        };
+        let owned_record = serde_json::to_value(&owned).unwrap();
+        assert_eq!(
+            owned_record,
+            json!({"repoRoot": root, "worktreeRoot": format!("{root}/worktree")})
+        );
+        let legacy: LegacyDevMeta = serde_json::from_value(owned_record.clone()).unwrap();
+        assert_eq!(legacy.repo_root, owned.repo_root());
+        assert_eq!(legacy.worktree_root, owned.source_root());
+        assert_eq!(
+            serde_json::from_value::<EnvDevMeta>(owned_record).unwrap(),
+            owned
+        );
+
+        let borrowed = EnvDevMeta::Borrowed {
+            source_root: root.clone(),
+        };
+        let borrowed_record = serde_json::to_value(&borrowed).unwrap();
+        assert_eq!(
+            borrowed_record,
+            json!({"kind": "borrowed", "sourceRoot": root})
+        );
+        assert!(serde_json::from_value::<LegacyDevMeta>(borrowed_record.clone()).is_err());
+        assert_eq!(
+            serde_json::from_value::<EnvDevMeta>(borrowed_record).unwrap(),
+            borrowed
+        );
+    }
+
+    #[test]
+    fn dev_source_records_reject_ambiguous_or_unknown_ownership() {
+        let root = std::env::temp_dir()
+            .join("ocm-dev-source-record")
+            .to_string_lossy()
+            .into_owned();
+        for record in [
+            json!({"kind": "borrowed", "sourceRoot": root, "repoRoot": root, "worktreeRoot": root}),
+            json!({"kind": "other", "sourceRoot": root}),
+            json!({"kind": "other", "repoRoot": root, "worktreeRoot": root}),
+            json!({"kind": "borrowed", "sourceRoot": "relative/checkout"}),
+            json!({"sourceRoot": root}),
+        ] {
+            assert!(
+                serde_json::from_value::<EnvDevMeta>(record.clone()).is_err(),
+                "accepted ambiguous dev source {record}"
+            );
+        }
     }
 }

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -10,7 +10,7 @@ use std::os::unix::ffi::OsStringExt;
 
 use serde_json::Value;
 
-use crate::store::{clean_path, display_path};
+use crate::store::{clean_path, dev_sources::path_identity, display_path};
 
 const SOURCE_DEPENDENCY_PROBE: &str = r#"import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -98,6 +98,59 @@ pub(crate) fn discover_openclaw_checkout(cwd: &Path) -> Option<PathBuf> {
 
 pub(crate) fn discover_enclosing_openclaw_checkout(cwd: &Path) -> Option<PathBuf> {
     cwd.ancestors().find_map(detect_openclaw_checkout)
+}
+
+pub(crate) fn validate_borrowed_openclaw_checkout(path: &Path) -> Result<&Path, String> {
+    if !path.is_absolute() {
+        return Err("borrowed dev source must be an absolute checkout path".to_string());
+    }
+    let checkout = fs::canonicalize(path).map_err(|error| {
+        format!(
+            "failed to resolve OpenClaw source {}: {error}; restore that checkout before retrying",
+            display_path(path)
+        )
+    })?;
+    if checkout != path {
+        return Err(format!(
+            "saved dev source {} now resolves to a different checkout; restore the recorded path before retrying",
+            display_path(path)
+        ));
+    }
+    if detect_openclaw_checkout(path).is_none() {
+        return Err(format!(
+            "OpenClaw checkout not found at {}",
+            display_path(path)
+        ));
+    }
+    let registered = registered_worktree_paths(path)?;
+    let identity = git_identity_paths(path)?
+        .ok_or_else(|| format!("Git checkout not found at {}", display_path(path)))?;
+    let private = fs::canonicalize(&identity.private_dir).map_err(|error| error.to_string())?;
+    let common = fs::canonicalize(&identity.common_dir).map_err(|error| error.to_string())?;
+    let private_identity = path_identity(&private)?;
+    let registrations = git_registration_entries(&common, path)?;
+    let registration_matches = if private_identity == path_identity(&common)? {
+        // Git lists a --separate-git-dir main checkout by its common directory.
+        // A linked slot naming this path must not be mistaken for such a main.
+        registrations.is_empty()
+    } else {
+        contains_worktree_path(&registered, path)
+            && identity.worktree_entry.as_ref().is_some_and(|backlink| {
+                normalize_git_file_path(backlink) == normalize_git_file_path(&path.join(".git"))
+            })
+            && registrations.iter().any(|slot| {
+                fs::canonicalize(slot).is_ok_and(|slot| {
+                    path_identity(&slot).is_ok_and(|slot| slot == private_identity)
+                })
+            })
+    };
+    if !git_top_level(path).is_some_and(|root| root == checkout) || !registration_matches {
+        return Err(format!(
+            "selected source is not the registered root of an OpenClaw checkout: {}",
+            display_path(path)
+        ));
+    }
+    Ok(path)
 }
 
 /// Rejects checkout dependencies that resolve through another checkout.

--- a/src/store/dev_registration.rs
+++ b/src/store/dev_registration.rs
@@ -27,7 +27,7 @@ struct SourceIdentity {
     preparation_paths: BTreeSet<PathBuf>,
 }
 
-fn registration_path(path: &Path) -> Result<(PathBuf, BTreeSet<PathBuf>), String> {
+pub(super) fn registration_path(path: &Path) -> Result<(PathBuf, BTreeSet<PathBuf>), String> {
     let mut pending = path.to_path_buf();
     let mut entries = BTreeSet::new();
     loop {
@@ -85,14 +85,14 @@ fn registration_path(path: &Path) -> Result<(PathBuf, BTreeSet<PathBuf>), String
 }
 
 fn source_identity(dev: &EnvDevMeta) -> Result<SourceIdentity, String> {
-    let repo = inspect_source_footprint(Path::new(&dev.repo_root))?;
+    let repo = inspect_source_footprint(Path::new(dev.repo_root()))?;
     let mut footprint = inspect_dev_source_footprint(dev)?;
     let mut preparation_paths = repo.entries.clone();
     preparation_paths.extend(repo.content_roots.iter().cloned());
     let mut locations = Vec::new();
     // Before worktree creation, retain the existing path through .worktrees,
     // including symlinks into another environment. This reserves no new paths.
-    for root in [&dev.repo_root, &dev.worktree_root] {
+    for root in [dev.repo_root(), dev.source_root()] {
         let (resolved, entries) = registration_path(Path::new(root))?;
         locations.push(resolved);
         preparation_paths.extend(entries.iter().cloned());
@@ -127,9 +127,12 @@ fn containing_environments(
             continue;
         }
         // Displaced roots still belong to the operation that will restore them.
-        for root in std::iter::once(meta.root.as_str())
-            .chain(meta.dev.as_ref().map(|dev| dev.worktree_root.as_str()))
-        {
+        for root in std::iter::once(meta.root.as_str()).chain(
+            meta.dev
+                .as_ref()
+                .and_then(|dev| dev.owned_worktree())
+                .map(|(_, root)| root),
+        ) {
             let (root, _) = registration_path(Path::new(root))?;
             if !root.exists()
                 && identity
@@ -145,18 +148,13 @@ fn containing_environments(
     Ok(owners)
 }
 
-fn source_tuple(dev: Option<&EnvDevMeta>) -> Option<(&str, &str)> {
-    dev.map(|dev| (dev.repo_root.as_str(), dev.worktree_root.as_str()))
-}
-
 fn source_changed(name: &str, dev: Option<&EnvDevMeta>, envs: &[EnvMeta]) -> bool {
     dev.is_some()
-        && source_tuple(dev)
-            != source_tuple(
-                envs.iter()
-                    .find(|meta| meta.name == name)
-                    .and_then(|meta| meta.dev.as_ref()),
-            )
+        && dev
+            != envs
+                .iter()
+                .find(|meta| meta.name == name)
+                .and_then(|meta| meta.dev.as_ref())
 }
 
 #[derive(Default)]
@@ -165,6 +163,7 @@ pub(crate) struct DevSourceRegistration {
     owners: BTreeSet<String>,
     _locks: Vec<EnvironmentOperationLock>,
     held_files: BTreeSet<(u64, u64)>,
+    _daemon_lifecycle: Option<super::ExclusiveFileLock>,
 }
 
 impl DevSourceRegistration {
@@ -191,12 +190,21 @@ impl DevSourceRegistration {
         env: &BTreeMap<String, String>,
         cwd: &Path,
     ) -> Result<Self, String> {
+        if dev.borrowed_source_root().is_some() {
+            dev.execution_source_root()?;
+        }
         let identity = source_identity(dev)?;
         let mut registration = Self {
             source: Some((dev.clone(), identity)),
             ..Self::default()
         };
         registration.lock_owners(envs, env, cwd)?;
+        if dev.borrowed_source_root().is_some() {
+            // The containing owner's operation may have completed since inspection.
+            dev.execution_source_root()?;
+            registration._daemon_lifecycle = crate::supervisor::SupervisorService::new(env, cwd)
+                .lock_borrowed_source_publication()?;
+        }
         Ok(registration)
     }
 
@@ -240,12 +248,13 @@ impl DevSourceRegistration {
     }
 
     fn recheck_source(&self, dev: &EnvDevMeta, envs: &[EnvMeta]) -> Result<(), String> {
+        if dev.borrowed_source_root().is_some() {
+            dev.execution_source_root()?;
+        }
         let Some((expected, identity)) = &self.source else {
             return Err(Self::changed());
         };
-        if source_tuple(Some(expected)) != source_tuple(Some(dev))
-            || source_identity(dev)? != *identity
-        {
+        if expected != dev || source_identity(dev)? != *identity {
             return Err(Self::changed());
         }
         if !containing_environments(identity, envs)?.is_subset(&self.owners) {
@@ -259,7 +268,7 @@ impl DevSourceRegistration {
             return Err(Self::changed());
         };
         let after = source_identity(dev)?;
-        if source_tuple(Some(expected)) != source_tuple(Some(dev))
+        if expected != dev
             || (!created && *before != after)
             || before.repo != after.repo
             || before.preparation_paths.iter().any(|path| {
@@ -286,7 +295,7 @@ pub(crate) fn with_prepared_dev_source<T>(
     publish: impl FnOnce(EnvDevMeta, &DevSourceRegistration) -> Result<T, String>,
 ) -> Result<T, String> {
     let name = validate_name(name, "Environment name")?;
-    let dev = EnvDevMeta {
+    let dev = EnvDevMeta::Owned {
         repo_root: display_path(repo),
         worktree_root: display_path(&default_worktree_root(repo, &name)),
     };

--- a/src/store/dev_registration_tests.rs
+++ b/src/store/dev_registration_tests.rs
@@ -58,7 +58,7 @@ fn owned_source(repo: &Path) -> EnvDevMeta {
     }
     let worktree = ensure_openclaw_worktree(repo, "child").unwrap();
     assert!(worktree.created);
-    EnvDevMeta {
+    EnvDevMeta::Owned {
         repo_root: display_path(repo),
         worktree_root: display_path(&worktree.root),
     }
@@ -83,11 +83,33 @@ fn fixture() -> (tempfile::TempDir, BTreeMap<String, String>, EnvDevMeta) {
 
 #[test]
 fn every_publisher_refuses_a_new_or_changed_source_during_its_owners_operation() {
-    let (temp, env, dev) = fixture();
+    assert_publishers_preserve_busy_source(false);
+    assert_publishers_preserve_busy_source(true);
+}
+
+fn assert_publishers_preserve_busy_source(borrowed: bool) {
+    let (temp, env, owned) = fixture();
+    let dev = if borrowed {
+        EnvDevMeta::Borrowed {
+            source_root: owned.source_root().to_string(),
+        }
+    } else {
+        owned.clone()
+    };
     let cwd = temp.path();
     let mut changed = create_environment(options("child", Some(dev.clone())), &env, cwd).unwrap();
-    let replacement = ensure_openclaw_worktree(Path::new(&dev.repo_root), "replacement").unwrap();
-    changed.dev.as_mut().unwrap().worktree_root = display_path(&replacement.root);
+    let replacement =
+        ensure_openclaw_worktree(Path::new(owned.repo_root()), "replacement").unwrap();
+    changed.dev = Some(if borrowed {
+        EnvDevMeta::Borrowed {
+            source_root: display_path(&replacement.root),
+        }
+    } else {
+        EnvDevMeta::Owned {
+            repo_root: owned.repo_root().to_string(),
+            worktree_root: display_path(&replacement.root),
+        }
+    });
     let _owner = lock_environment_operation("parent", &env, cwd).unwrap();
     for save in SAVES {
         let error = save(changed.clone(), &env, cwd).unwrap_err();
@@ -107,7 +129,7 @@ fn every_publisher_refuses_a_new_or_changed_source_during_its_owners_operation()
         );
     }
     let current = get_environment("child", &env, cwd).unwrap();
-    assert_eq!(source_tuple(current.dev.as_ref()), source_tuple(Some(&dev)));
+    assert_eq!(current.dev.as_ref(), Some(&dev));
     assert!(get_environment("new-child", &env, cwd).is_err());
 }
 
@@ -127,7 +149,7 @@ fn unchanged_source_saves_allow_locked_recovery_with_displaced_source() {
         save(child.clone(), &env, cwd).unwrap();
         let current = get_environment("child", &env, cwd).unwrap();
         assert_eq!(current.protected, child.protected);
-        assert_eq!(source_tuple(current.dev.as_ref()), source_tuple(Some(&dev)));
+        assert_eq!(current.dev.as_ref(), Some(&dev));
     }
     drop(_target);
     for save in SAVES {
@@ -168,7 +190,7 @@ fn publication_rechecks_late_owners_and_replaced_source_without_taking_locks() {
     let registration =
         DevSourceRegistration::acquire("child", child.dev.as_ref(), &env, cwd).unwrap();
     let original_root = late.root.clone();
-    late.root = dev.repo_root.clone();
+    late.root = dev.repo_root().to_string();
     save_environment(late.clone(), &env, cwd).unwrap();
     let late_lock = environment_operation_lock_path("late", &env, cwd).unwrap();
     assert!(!late_lock.exists());
@@ -181,9 +203,9 @@ fn publication_rechecks_late_owners_and_replaced_source_without_taking_locks() {
     );
     late.root = original_root;
     save_environment(late, &env, cwd).unwrap();
-    fs::rename(&dev.repo_root, temp.path().join("original-source")).unwrap();
-    let replacement = owned_source(Path::new(&dev.repo_root));
-    assert_eq!(source_tuple(Some(&replacement)), source_tuple(Some(&dev)));
+    fs::rename(dev.repo_root(), temp.path().join("original-source")).unwrap();
+    let replacement = owned_source(Path::new(dev.repo_root()));
+    assert_eq!(replacement, dev);
     let error =
         save_environment_with_dev_registration(child, &registration, &env, cwd).unwrap_err();
     assert!(error.contains("changed during registration"), "{error}");

--- a/src/store/dev_registration_tests.rs
+++ b/src/store/dev_registration_tests.rs
@@ -91,7 +91,7 @@ fn assert_publishers_preserve_busy_source(borrowed: bool) {
     let (temp, env, owned) = fixture();
     let dev = if borrowed {
         EnvDevMeta::Borrowed {
-            source_root: owned.source_root().to_string(),
+            source_root: display_path(&fs::canonicalize(owned.source_root()).unwrap()),
         }
     } else {
         owned.clone()
@@ -102,7 +102,7 @@ fn assert_publishers_preserve_busy_source(borrowed: bool) {
         ensure_openclaw_worktree(Path::new(owned.repo_root()), "replacement").unwrap();
     changed.dev = Some(if borrowed {
         EnvDevMeta::Borrowed {
-            source_root: display_path(&replacement.root),
+            source_root: display_path(&fs::canonicalize(&replacement.root).unwrap()),
         }
     } else {
         EnvDevMeta::Owned {

--- a/src/store/dev_sources.rs
+++ b/src/store/dev_sources.rs
@@ -81,6 +81,111 @@ pub(crate) fn contains_existing(root: &Path, path: &Path) -> Result<bool, String
     Ok(false)
 }
 
+// Inputs are locations projected by registration_path, or a restore's actual
+// root entry. Preserve a final symlink's identity instead of following it here.
+pub(crate) fn projected_path_contains(root: &Path, path: &Path) -> Result<bool, String> {
+    Ok(projected_path_relative(root, path)?.is_some())
+}
+
+pub(crate) fn projected_path_relative(root: &Path, path: &Path) -> Result<Option<PathBuf>, String> {
+    fn split(path: &Path) -> Result<(&Path, &Path), String> {
+        let mut existing = path;
+        loop {
+            match fs::symlink_metadata(existing) {
+                Ok(_) => {
+                    let suffix = path
+                        .strip_prefix(existing)
+                        .map_err(|error| error.to_string())?;
+                    if suffix
+                        .components()
+                        .any(|part| !matches!(part, std::path::Component::Normal(_)))
+                    {
+                        return Err(format!(
+                            "cannot resolve missing source location {}",
+                            display_path(path)
+                        ));
+                    }
+                    return Ok((existing, suffix));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    existing = existing
+                        .parent()
+                        .ok_or("source location has no existing ancestor")?;
+                }
+                Err(error) => return Err(error.to_string()),
+            }
+        }
+    }
+    let (root, root_suffix) = split(root)?;
+    let (path, path_suffix) = split(path)?;
+    if root_suffix.as_os_str().is_empty() {
+        if let Ok(relative) = path.strip_prefix(root) {
+            return Ok(Some(relative.join(path_suffix)));
+        }
+        let identity = path_identity(root)?;
+        for ancestor in path.ancestors() {
+            if path_identity(ancestor)? == identity {
+                return Ok(Some(path.strip_prefix(ancestor).unwrap().join(path_suffix)));
+            }
+        }
+        return Ok(None);
+    }
+    if path_suffix.as_os_str().is_empty() || path_identity(root)? != path_identity(path)? {
+        return Ok(None);
+    }
+    let mut actual = path_suffix.components();
+    for expected in root_suffix.components() {
+        let Some(component) = actual.next() else {
+            return Ok(None);
+        };
+        if component == expected {
+            continue;
+        }
+        let component = component
+            .as_os_str()
+            .to_str()
+            .filter(|name| name.is_ascii());
+        let expected = expected.as_os_str().to_str().filter(|name| name.is_ascii());
+        let (Some(component), Some(expected)) = (component, expected) else {
+            return Err("cannot distinguish differently encoded missing source names; restore the source before retrying".to_string());
+        };
+        #[cfg(windows)]
+        let (component, expected) = (
+            component.trim_end_matches(&['.', ' '][..]),
+            expected.trim_end_matches(&['.', ' '][..]),
+        );
+        // Missing names lack filesystem identity. Reserve possible case aliases
+        // without changing comparisons between existing entries.
+        if component.eq_ignore_ascii_case(expected) {
+            continue;
+        }
+        #[cfg(windows)]
+        if (possible_short_name(component) || possible_short_name(expected))
+            && !(plain_short_name(component) && plain_short_name(expected))
+        {
+            return Err("cannot distinguish missing Windows short-name aliases; restore the source before retrying".to_string());
+        }
+        return Ok(None);
+    }
+    Ok(Some(actual.collect()))
+}
+
+#[cfg(windows)]
+fn possible_short_name(name: &str) -> bool {
+    let mut parts = name.split('.');
+    let base = parts.next().unwrap_or_default();
+    let extension = parts.next().unwrap_or_default();
+    !base.is_empty() && base.len() <= 8 && extension.len() <= 3 && parts.next().is_none()
+}
+
+#[cfg(windows)]
+fn plain_short_name(name: &str) -> bool {
+    possible_short_name(name)
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"_-~.".contains(&byte))
+}
+
 fn existing_cleanup_path(path: &Path) -> Result<Option<PathBuf>, String> {
     match fs::canonicalize(path) {
         Ok(path) => Ok(Some(path)),
@@ -96,6 +201,9 @@ fn existing_cleanup_path(path: &Path) -> Result<Option<PathBuf>, String> {
 pub(crate) struct SourceFootprint {
     pub(crate) entries: BTreeSet<PathBuf>,
     pub(crate) content_roots: BTreeSet<PathBuf>,
+    // In-memory locations only. Existing-path identity checks must not stat an
+    // absent borrowed checkout, and legacy Owned paths remain unreserved.
+    pub(crate) reserved_roots: BTreeSet<PathBuf>,
 }
 
 fn record_path_entries(
@@ -141,21 +249,43 @@ pub(crate) fn existing_source_path_entries(path: &Path) -> Result<BTreeSet<PathB
     Ok(entries)
 }
 
+fn reserve_path(path: &Path, footprint: &mut SourceFootprint) -> Result<(), String> {
+    let (reserved, entries) = super::dev_registration::registration_path(path)?;
+    footprint.entries.extend(entries);
+    footprint.reserved_roots.insert(reserved);
+    Ok(())
+}
+
+fn record_git_path(
+    path: &Path,
+    footprint: &mut SourceFootprint,
+    reserve_missing: bool,
+    links: &mut BTreeSet<PathBuf>,
+) -> Result<Option<PathBuf>, String> {
+    if reserve_missing && existing_cleanup_path(path)?.is_none() {
+        reserve_path(path, footprint)?;
+        return Ok(None);
+    }
+    record_path_entries(path, &mut footprint.entries, links).map(Some)
+}
+
 fn append_git_footprint(
     footprint: &mut SourceFootprint,
     git: crate::openclaw_repo::GitIdentityPaths,
     include_worktree_entry: bool,
+    reserve_missing: bool,
     links: &mut BTreeSet<PathBuf>,
 ) -> Result<(), String> {
     for path in git.entries {
-        record_path_entries(&path, &mut footprint.entries, links)?;
+        record_git_path(&path, footprint, reserve_missing, links)?;
     }
     if include_worktree_entry && let Some(path) = git.worktree_entry {
-        record_path_entries(&path, &mut footprint.entries, links)?;
+        record_git_path(&path, footprint, reserve_missing, links)?;
     }
     for path in [git.private_dir, git.common_dir] {
-        let resolved = record_path_entries(&path, &mut footprint.entries, links)?;
-        footprint.content_roots.insert(resolved);
+        if let Some(resolved) = record_git_path(&path, footprint, reserve_missing, links)? {
+            footprint.content_roots.insert(resolved);
+        }
     }
     Ok(())
 }
@@ -163,25 +293,45 @@ fn append_git_footprint(
 // This primitive describes existing paths, not source eligibility. Registration
 // may retain absent/non-Git tuples; callers own that policy and path reservations.
 pub(crate) fn inspect_source_footprint(root: &Path) -> Result<SourceFootprint, String> {
+    inspect_source_footprint_paths(root, false)
+}
+
+fn inspect_source_footprint_paths(
+    root: &Path,
+    reserve_missing: bool,
+) -> Result<SourceFootprint, String> {
     let mut footprint = SourceFootprint::default();
     if existing_cleanup_path(root)?.is_none() {
         return Ok(footprint);
     }
     footprint.entries = existing_source_path_entries(root)?;
+    // Borrowed cleanup can preserve a missing Git target without accepting it
+    // for execution. Read only the known .git entry and its surviving aliases.
+    let git_entry = root.join(".git");
+    if reserve_missing && existing_cleanup_path(&git_entry)?.is_none() {
+        reserve_path(&git_entry, &mut footprint)?;
+        return Ok(footprint);
+    }
     let mut links = BTreeSet::new();
     if let Some(git) = crate::openclaw_repo::git_identity_paths(root)? {
-        let registrations = match git.worktree_entry.as_ref().and_then(|path| path.parent()) {
-            Some(worktree) => {
-                crate::openclaw_repo::git_registration_entries(&git.common_dir, worktree)?
+        let registrations = if reserve_missing && existing_cleanup_path(&git.common_dir)?.is_none()
+        {
+            Vec::new()
+        } else {
+            match git.worktree_entry.as_ref().and_then(|path| path.parent()) {
+                Some(worktree) => {
+                    crate::openclaw_repo::git_registration_entries(&git.common_dir, worktree)?
+                }
+                None => Vec::new(),
             }
-            None => Vec::new(),
         };
-        append_git_footprint(&mut footprint, git, true, &mut links)?;
+        append_git_footprint(&mut footprint, git, true, reserve_missing, &mut links)?;
         for path in registrations {
             append_git_footprint(
                 &mut footprint,
                 crate::openclaw_repo::git_registration_paths(&path)?,
                 true,
+                reserve_missing,
                 &mut links,
             )?;
         }
@@ -190,17 +340,21 @@ pub(crate) fn inspect_source_footprint(root: &Path) -> Result<SourceFootprint, S
 }
 
 pub(crate) fn inspect_dev_source_metadata(dev: &EnvDevMeta) -> Result<SourceFootprint, String> {
-    let mut footprint = inspect_source_footprint(Path::new(&dev.repo_root))?;
+    let Some((repo_root, worktree_root)) = dev.owned_worktree() else {
+        return inspect_source_footprint_paths(Path::new(dev.source_root()), true);
+    };
+    let mut footprint = inspect_source_footprint(Path::new(repo_root))?;
     let mut links = BTreeSet::new();
     for path in crate::openclaw_repo::worktree_registration_entries(
-        Path::new(&dev.repo_root),
-        Path::new(&dev.worktree_root),
+        Path::new(repo_root),
+        Path::new(worktree_root),
     )? {
         // Missing working files do not discard the slot's recoverable history.
         // Preserve existing metadata, without reserving the absent .git entry.
         append_git_footprint(
             &mut footprint,
             crate::openclaw_repo::git_registration_paths(&path)?,
+            false,
             false,
             &mut links,
         )?;
@@ -209,11 +363,14 @@ pub(crate) fn inspect_dev_source_metadata(dev: &EnvDevMeta) -> Result<SourceFoot
 }
 
 pub(crate) fn inspect_dev_source_footprint(dev: &EnvDevMeta) -> Result<SourceFootprint, String> {
+    if let Some(source) = dev.borrowed_source_root() {
+        return borrowed_source_footprint(Path::new(source));
+    }
     let mut footprint = inspect_dev_source_metadata(dev)?;
-    let worktree = inspect_source_footprint(Path::new(&dev.worktree_root))?;
+    let worktree = inspect_source_footprint(Path::new(dev.source_root()))?;
     footprint.entries.extend(worktree.entries);
     footprint.content_roots.extend(worktree.content_roots);
-    if let Some(source) = existing_cleanup_path(Path::new(&dev.worktree_root))? {
+    if let Some(source) = existing_cleanup_path(Path::new(dev.source_root()))? {
         footprint.content_roots.insert(source);
     }
     Ok(footprint)
@@ -223,15 +380,15 @@ pub(crate) fn registered_dev_source_replaced(
     meta: &EnvMeta,
     envs: &[EnvMeta],
 ) -> Result<bool, String> {
-    let Some(dev) = &meta.dev else {
+    let Some((_, worktree)) = meta.dev.as_ref().and_then(|dev| dev.owned_worktree()) else {
         return Ok(false);
     };
-    if !fs::symlink_metadata(Path::new(&dev.worktree_root).join(".git"))
+    if !fs::symlink_metadata(Path::new(worktree).join(".git"))
         .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
     {
         return Ok(false);
     }
-    let Some(source) = existing_cleanup_path(Path::new(&dev.worktree_root))? else {
+    let Some(source) = existing_cleanup_path(Path::new(worktree))? else {
         return Ok(false);
     };
     // Creation can reuse a missing worktree path for another env's state,
@@ -259,19 +416,31 @@ pub(crate) fn registered_dev_source_footprint(
         let footprint = inspect_dev_source_metadata(dev)?;
         return Ok((!footprint.entries.is_empty()).then_some(footprint));
     }
-    if existing_cleanup_path(Path::new(&dev.worktree_root))?.is_some()
+    if let Some((repo_root, worktree_root)) = dev.owned_worktree()
+        && existing_cleanup_path(Path::new(worktree_root))?.is_some()
         && !crate::openclaw_repo::has_expected_worktree_identity(
-            Path::new(&dev.repo_root),
-            Path::new(&dev.worktree_root),
+            Path::new(repo_root),
+            Path::new(worktree_root),
         )
     {
         return Err(format!(
-            "cannot verify Git identity for registered dev source {}",
-            dev.worktree_root
+            "cannot verify Git identity for registered dev source {worktree_root}"
         ));
     }
     let footprint = inspect_dev_source_footprint(dev)?;
-    Ok((!footprint.entries.is_empty()).then_some(footprint))
+    Ok(
+        (!footprint.entries.is_empty() || !footprint.reserved_roots.is_empty())
+            .then_some(footprint),
+    )
+}
+
+fn borrowed_source_footprint(source: &Path) -> Result<SourceFootprint, String> {
+    let mut footprint = inspect_source_footprint_paths(source, true)?;
+    if let Some(source) = existing_cleanup_path(source)? {
+        footprint.content_roots.insert(source);
+    }
+    reserve_path(source, &mut footprint)?;
+    Ok(footprint)
 }
 
 pub(crate) fn ensure_environment_removal_preserves_dev_sources(
@@ -279,7 +448,13 @@ pub(crate) fn ensure_environment_removal_preserves_dev_sources(
     envs: &[EnvMeta],
 ) -> Result<(), String> {
     let mut footprints = Vec::new();
-    for meta in envs.iter().filter(|meta| meta.name != target.name) {
+    for meta in envs.iter().filter(|meta| {
+        meta.name != target.name
+            || meta
+                .dev
+                .as_ref()
+                .is_some_and(|dev| dev.borrowed_source_root().is_some())
+    }) {
         if let Some(footprint) = registered_dev_source_footprint(meta, envs)? {
             footprints.push((meta.name.as_str(), footprint));
         }
@@ -324,7 +499,9 @@ fn source_removal_error(name: &str, owner: &str, path: &Path) -> String {
 pub(crate) struct DevSourceRemoval {
     root: Option<PathBuf>,
     worktree: Option<PathBuf>,
+    reserved_worktree: Option<PathBuf>,
     entry_parent: Option<PathBuf>,
+    root_link: Option<PathBuf>,
     registrations: Vec<PathBuf>,
     registration_links: Vec<PathBuf>,
 }
@@ -340,8 +517,9 @@ impl DevSourceRemoval {
 
     fn new(root_path: Option<&Path>, dev: Option<&EnvDevMeta>) -> Result<Self, String> {
         let root = root_path.map(existing_cleanup_path).transpose()?.flatten();
-        let worktree = dev
-            .map(|dev| existing_cleanup_path(Path::new(&dev.worktree_root)))
+        let owned = dev.and_then(|dev| dev.owned_worktree());
+        let worktree = owned
+            .map(|(_, worktree)| existing_cleanup_path(Path::new(worktree)))
             .transpose()?
             .flatten();
         // Removing a final symlink also changes its containing source, even when
@@ -354,12 +532,15 @@ impl DevSourceRemoval {
                 .flatten(),
             _ => None,
         };
+        let root_link = root_path
+            .zip(entry_parent.as_ref())
+            .and_then(|(path, parent)| path.file_name().map(|name| parent.join(name)));
         let mut registrations = Vec::new();
         let mut registration_links = Vec::new();
-        if let Some(dev) = dev {
+        if let Some((repo_root, worktree_root)) = owned {
             for path in crate::openclaw_repo::worktree_registration_entries(
-                Path::new(&dev.repo_root),
-                Path::new(&dev.worktree_root),
+                Path::new(repo_root),
+                Path::new(worktree_root),
             )? {
                 if fs::symlink_metadata(&path)
                     .map_err(|error| error.to_string())?
@@ -374,10 +555,25 @@ impl DevSourceRemoval {
                 }
             }
         }
+        // Missing working files can still leave a Git slot that removal deletes.
+        // Without either deletion, an Owned record reserves no missing location.
+        let reserved_worktree =
+            if worktree.is_some() || !registrations.is_empty() || !registration_links.is_empty() {
+                owned
+                    .map(|(_, worktree)| {
+                        super::dev_registration::registration_path(Path::new(worktree))
+                            .map(|(path, _)| path)
+                    })
+                    .transpose()?
+            } else {
+                None
+            };
         Ok(Self {
             root,
             worktree,
+            reserved_worktree,
             entry_parent,
+            root_link,
             registrations,
             registration_links,
         })
@@ -410,11 +606,24 @@ impl DevSourceRemoval {
             for root in &self.registrations {
                 affected |= contains_existing(root, path)?;
             }
-            for entry in &self.registration_links {
+            for entry in self.registration_links.iter().chain(self.root_link.iter()) {
                 affected |= path_identity(entry)? == path_identity(path)?;
             }
             if affected {
                 return Ok(Some(path));
+            }
+        }
+        for reserved in &footprint.reserved_roots {
+            for (path, symmetric) in [
+                (self.root.as_ref(), true),
+                (self.reserved_worktree.as_ref(), false),
+            ] {
+                let Some(path) = path else { continue };
+                if projected_path_contains(path, reserved)?
+                    || (symmetric && projected_path_contains(reserved, path)?)
+                {
+                    return Ok(Some(reserved));
+                }
             }
         }
         Ok(None)
@@ -442,7 +651,11 @@ pub(crate) fn ensure_root_outside_dev_sources(
         let Some(dev) = &meta.dev else {
             continue;
         };
-        let source = match fs::canonicalize(&dev.worktree_root) {
+        if let Some(source) = dev.borrowed_source_root() {
+            ensure_root_outside_borrowed_source(name, root, &meta.name, Path::new(source))?;
+            continue;
+        }
+        let source = match fs::canonicalize(dev.source_root()) {
             Ok(source) => source,
             // Missing source reservations belong to source registration. Its
             // existing cleanup verifies Git identity before removing a path
@@ -451,7 +664,8 @@ pub(crate) fn ensure_root_outside_dev_sources(
             Err(error) => {
                 return Err(format!(
                     "failed to resolve dev source {} for env {}: {error}",
-                    dev.worktree_root, meta.name
+                    dev.source_root(),
+                    meta.name
                 ));
             }
         };
@@ -471,6 +685,59 @@ pub(crate) fn ensure_root_outside_dev_sources(
                 meta.name
             ));
         }
+    }
+    Ok(())
+}
+
+fn ensure_root_outside_borrowed_source(
+    name: &str,
+    root: &Path,
+    source_name: &str,
+    source: &Path,
+) -> Result<(), String> {
+    let footprint = borrowed_source_footprint(source)?;
+    let (target, _) = super::dev_registration::registration_path(root)?;
+    let entry_parent = if fs::symlink_metadata(root).is_ok_and(|meta| meta.is_symlink()) {
+        let parent = root.parent().ok_or("environment root has no parent")?;
+        Some(super::dev_registration::registration_path(parent)?.0)
+    } else {
+        None
+    };
+    for (path, contents) in footprint
+        .entries
+        .iter()
+        .map(|path| (path, false))
+        .chain(footprint.content_roots.iter().map(|path| (path, true)))
+        .chain(footprint.reserved_roots.iter().map(|path| (path, true)))
+    {
+        if projected_path_contains(&target, path)?
+            || (contents && projected_path_contains(path, &target)?)
+            || (contents
+                && entry_parent
+                    .as_ref()
+                    .map(|parent| projected_path_contains(path, parent))
+                    .transpose()?
+                    .unwrap_or(false))
+        {
+            return Err(format!(
+                "environment {name} root {} overlaps borrowed source or Git metadata for env {source_name} at {}; choose a separate environment root",
+                display_path(root),
+                display_path(path)
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_borrowed_source_isolation(
+    name: &str,
+    root: &Path,
+    source_root: Option<&str>,
+    envs: &[EnvMeta],
+) -> Result<(), String> {
+    ensure_root_outside_dev_sources(name, root, envs)?;
+    if let Some(source) = source_root {
+        ensure_root_outside_borrowed_source(name, root, name, Path::new(source))?;
     }
     Ok(())
 }

--- a/src/store/dev_sources.rs
+++ b/src/store/dev_sources.rs
@@ -689,7 +689,7 @@ pub(crate) fn ensure_root_outside_dev_sources(
     Ok(())
 }
 
-fn ensure_root_outside_borrowed_source(
+pub(super) fn ensure_root_outside_borrowed_source(
     name: &str,
     root: &Path,
     source_name: &str,
@@ -735,7 +735,11 @@ pub(crate) fn ensure_borrowed_source_isolation(
     source_root: Option<&str>,
     envs: &[EnvMeta],
 ) -> Result<(), String> {
-    ensure_root_outside_dev_sources(name, root, envs)?;
+    for meta in envs {
+        if let Some(source) = meta.dev.as_ref().and_then(|dev| dev.borrowed_source_root()) {
+            ensure_root_outside_borrowed_source(name, root, &meta.name, Path::new(source))?;
+        }
+    }
     if let Some(source) = source_root {
         ensure_root_outside_borrowed_source(name, root, name, Path::new(source))?;
     }

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -199,6 +199,19 @@ fn canonicalize_launcher_binding(
 
 fn upsert_environment(registry: &mut EnvRegistry, meta: EnvMeta) -> Result<EnvMeta, String> {
     let meta = normalize_environment(meta)?;
+    if registry
+        .envs
+        .iter()
+        .find(|current| current.name == meta.name)
+        .is_none_or(|current| current.root != meta.root || current.dev != meta.dev)
+    {
+        super::dev_sources::ensure_borrowed_source_isolation(
+            &meta.name,
+            Path::new(&meta.root),
+            meta.dev.as_ref().and_then(|dev| dev.borrowed_source_root()),
+            &registry.envs,
+        )?;
+    }
     registry.envs.retain(|entry| entry.name != meta.name);
     registry.envs.push(meta.clone());
     Ok(meta)
@@ -402,7 +415,7 @@ pub fn create_environment(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
-    create_environment_with_runtime_validation(options, false, None, env, cwd)
+    create_environment_with_runtime_validation(options, false, env, cwd)
 }
 
 pub(crate) fn create_environment_with_validated_runtime(
@@ -410,34 +423,17 @@ pub(crate) fn create_environment_with_validated_runtime(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
-    create_environment_with_runtime_validation(options, true, None, env, cwd)
-}
-
-pub(crate) fn create_environment_with_dev_registration(
-    options: CreateEnvironmentOptions,
-    registration: &DevSourceRegistration,
-    env: &BTreeMap<String, String>,
-    cwd: &Path,
-) -> Result<EnvMeta, String> {
-    create_environment_with_runtime_validation(options, true, Some(registration), env, cwd)
+    create_environment_with_runtime_validation(options, true, env, cwd)
 }
 
 fn create_environment_with_runtime_validation(
     options: CreateEnvironmentOptions,
     validate_runtime: bool,
-    registration: Option<&DevSourceRegistration>,
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
     let name = validate_name(&options.name, "Environment name")?;
-    let acquired;
-    let registration = match registration {
-        Some(registration) => registration,
-        None => {
-            acquired = DevSourceRegistration::acquire(&name, options.dev.as_ref(), env, cwd)?;
-            &acquired
-        }
-    };
+    let registration = DevSourceRegistration::acquire(&name, options.dev.as_ref(), env, cwd)?;
     let service = crate::env::EnvironmentService::new(env, cwd);
     let _admission_lock = service.lock_gateway_admission(&name)?;
     if options.service_enabled && options.service_running {
@@ -472,7 +468,15 @@ fn create_environment_with_runtime_validation(
         default_env_root(&name, env, cwd)?
     };
 
-    ensure_root_outside_dev_sources(&name, &root, &registry.envs)?;
+    super::dev_sources::ensure_borrowed_source_isolation(
+        &name,
+        &root,
+        options
+            .dev
+            .as_ref()
+            .and_then(|dev| dev.borrowed_source_root()),
+        &registry.envs,
+    )?;
     let paths = derive_env_paths(&root);
     if path_exists(&paths.root) {
         let mut entries = fs::read_dir(&paths.root).map_err(|error| error.to_string())?;
@@ -1117,8 +1121,9 @@ pub(crate) fn remove_environment_locked(
     // It must not call back into registry-mutating operations.
     before_remove(&meta)?;
 
-    if let Some(dev) = meta.dev.as_ref() {
-        remove_openclaw_worktree(Path::new(&dev.repo_root), Path::new(&dev.worktree_root))?;
+    if let Some((repo_root, worktree_root)) = meta.dev.as_ref().and_then(|dev| dev.owned_worktree())
+    {
+        remove_openclaw_worktree(Path::new(repo_root), Path::new(worktree_root))?;
     }
 
     if path_exists(&paths.root) {
@@ -1185,7 +1190,7 @@ mod tests {
         for (name, dev) in [
             (
                 "dev",
-                Some(EnvDevMeta {
+                Some(EnvDevMeta::Owned {
                     repo_root: root.path().join("repo").display().to_string(),
                     worktree_root: root.path().join("worktree").display().to_string(),
                 }),

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -205,6 +205,8 @@ fn upsert_environment(registry: &mut EnvRegistry, meta: EnvMeta) -> Result<EnvMe
         .find(|current| current.name == meta.name)
         .is_none_or(|current| current.root != meta.root || current.dev != meta.dev)
     {
+        // Creation may have initialized a new root at an absent Owned path.
+        // Its pre-creation guard already checked Owned sources.
         super::dev_sources::ensure_borrowed_source_isolation(
             &meta.name,
             Path::new(&meta.root),
@@ -468,15 +470,19 @@ fn create_environment_with_runtime_validation(
         default_env_root(&name, env, cwd)?
     };
 
-    super::dev_sources::ensure_borrowed_source_isolation(
-        &name,
-        &root,
-        options
-            .dev
-            .as_ref()
-            .and_then(|dev| dev.borrowed_source_root()),
-        &registry.envs,
-    )?;
+    ensure_root_outside_dev_sources(&name, &root, &registry.envs)?;
+    if let Some(source) = options
+        .dev
+        .as_ref()
+        .and_then(|dev| dev.borrowed_source_root())
+    {
+        super::dev_sources::ensure_root_outside_borrowed_source(
+            &name,
+            &root,
+            &name,
+            Path::new(source),
+        )?;
+    }
     let paths = derive_env_paths(&root);
     if path_exists(&paths.root) {
         let mut entries = fs::read_dir(&paths.root).map_err(|error| error.to_string())?;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -42,8 +42,7 @@ pub use envs::{
 };
 pub(crate) use envs::{
     clone_environment_for_simulation, clone_environment_with_sandbox_origin,
-    create_environment_with_dev_registration, create_environment_with_validated_runtime,
-    import_environment_with_sandbox_origin,
+    create_environment_with_validated_runtime, import_environment_with_sandbox_origin,
 };
 pub(crate) use envs::{
     save_environment_with_dev_registration, save_environment_with_validated_launcher,
@@ -146,8 +145,8 @@ pub fn summarize_env(meta: &EnvMeta) -> EnvSummary {
         service_running: meta.service_running,
         default_runtime: meta.default_runtime.clone(),
         default_launcher: meta.default_launcher.clone(),
-        dev_repo_root: meta.dev.as_ref().map(|dev| dev.repo_root.clone()),
-        dev_worktree_root: meta.dev.as_ref().map(|dev| dev.worktree_root.clone()),
+        dev_repo_root: meta.dev.as_ref().map(|dev| dev.repo_root().to_string()),
+        dev_worktree_root: meta.dev.as_ref().map(|dev| dev.source_root().to_string()),
         protected: meta.protected,
         created_at: meta.created_at,
         last_used_at: meta.last_used_at,

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -19,7 +19,10 @@ use super::checkpoints::{
     prepare_scoped_tree_checkpoint_in, remove_tree_if_present,
 };
 use super::common::{copy_path_recursive, load_json_files, path_exists, read_json, write_json};
-use super::dev_sources::{contains_existing, path_identity, registered_dev_source_footprint};
+use super::dev_sources::{
+    contains_existing, path_identity, projected_path_contains, projected_path_relative,
+    registered_dev_source_footprint,
+};
 use super::layout::{
     derive_env_paths, display_path, snapshot_archive_path, snapshot_checkpoint_path,
     snapshot_env_dir, snapshot_meta_path, validate_name,
@@ -445,10 +448,12 @@ pub(crate) fn ensure_restore_preserves_dev_sources(
     cwd: &Path,
 ) -> Result<(), String> {
     super::with_locked_environments(env, cwd, |envs| {
-        if !envs
-            .iter()
-            .any(|meta| meta.name != target.name && meta.dev.is_some())
-        {
+        let protected = |meta: &EnvMeta| {
+            meta.dev
+                .as_ref()
+                .is_some_and(|dev| meta.name != target.name || dev.borrowed_source_root().is_some())
+        };
+        if !envs.iter().any(protected) {
             return Ok(());
         }
         let target_root = Path::new(&target.root);
@@ -480,15 +485,20 @@ pub(crate) fn ensure_restore_preserves_dev_sources(
             }
             Ok(None)
         };
-        for meta in envs
-            .iter()
-            .filter(|meta| meta.name != target.name && meta.dev.is_some())
-        {
+        for meta in envs.iter().filter(|meta| protected(meta)) {
             let Some(footprint) = registered_dev_source_footprint(meta, envs).map_err(|error| {
                 format!("cannot protect dev source for env {}: {error}", meta.name)
             })?
             else {
                 continue;
+            };
+            let replacement_error = |path: &Path| {
+                format!(
+                    "restoring env {} would replace registered dev source or Git metadata for env {} at {}; choose a checkpoint that preserves the complete source and Git metadata",
+                    target.name,
+                    meta.name,
+                    display_path(path)
+                )
             };
             for (path, contents) in footprint
                 .entries
@@ -513,12 +523,19 @@ pub(crate) fn ensure_restore_preserves_dev_sources(
                         )?
                 };
                 if affected {
-                    return Err(format!(
-                        "restoring env {} would replace registered dev source or Git metadata for env {} at {}; choose a checkpoint that preserves the complete source and Git metadata",
-                        target.name,
-                        meta.name,
-                        display_path(path)
-                    ));
+                    return Err(replacement_error(path));
+                }
+            }
+            for path in &footprint.reserved_roots {
+                let affected = if let Some(relative) = projected_path_relative(&root, path)? {
+                    !independent
+                        .iter()
+                        .any(|excluded| relative.starts_with(excluded))
+                } else {
+                    projected_path_contains(path, &root)?
+                };
+                if affected {
+                    return Err(replacement_error(path));
                 }
             }
         }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -48,8 +48,9 @@ const SUPERVISOR_RUNTIME_KIND: &str = "ocm-supervisor-runtime";
 // Version 9 adds service-preparation admission and running-service retention to
 // foreground-session admission and retained completion ownership.
 // Version 10 also covers UI session roles, their captured address and cleanup.
+// Version 11 adds borrowed-source decoding and ownership-aware admission.
 // Values 2 through 6 were used by incompatible development snapshots.
-const GATEWAY_ADMISSION_VERSION: u32 = 10;
+const GATEWAY_ADMISSION_VERSION: u32 = 11;
 const SUPERVISOR_POLL_INTERVAL_MS: u64 = 200;
 const SUPERVISOR_RESTART_DELAY_MS: u64 = 1_000;
 const SUPERVISOR_MAX_RESTART_DELAY_MS: u64 = 30_000;
@@ -935,6 +936,21 @@ impl<'a> SupervisorService<'a> {
     /// The caller holds daemon lifecycle and Gateway admission until its lease
     /// is published. Existing watches and stop/recovery do not use this check.
     pub(crate) fn ensure_source_watch_daemon_compatible(&self) -> Result<(), String> {
+        self.ensure_gateway_admission_compatible("start source watch")
+    }
+
+    pub(crate) fn lock_borrowed_source_publication(
+        &self,
+    ) -> Result<Option<crate::store::ExclusiveFileLock>, String> {
+        if service_manager_kind(self.env) == ServiceManagerKind::Unsupported {
+            return Ok(None);
+        }
+        let lock = self.lock_daemon_lifecycle()?;
+        self.ensure_gateway_admission_compatible("register borrowed dev source")?;
+        Ok(Some(lock))
+    }
+
+    fn ensure_gateway_admission_compatible(&self, action: &str) -> Result<(), String> {
         if service_manager_kind(self.env) == ServiceManagerKind::Unsupported {
             return Ok(());
         }
@@ -1005,7 +1021,7 @@ impl<'a> SupervisorService<'a> {
         })();
         result.map_err(|error| {
             format!(
-                "cannot start source watch: {error}; wait for daemon startup or refresh it from the updated OCM installation with \"ocm service refresh-daemon --acknowledge-gateway-restarts\" during a maintenance window"
+                "cannot {action}: {error}; wait for daemon startup or refresh it from the updated OCM installation with \"ocm service refresh-daemon --acknowledge-gateway-restarts\" during a maintenance window"
             )
         })
     }
@@ -2514,7 +2530,7 @@ fn admit_supervisor_child_start(
             .dev
             .as_ref()
             .ok_or_else(|| format!("dev binding is missing for env {}", meta.name))?;
-        let source_root = Path::new(&dev.worktree_root);
+        let source_root = Path::new(dev.source_root());
         if source_root != Path::new(&spec.run_dir) {
             return Err(format!(
                 "refusing to start env \"{}\": its saved dev source no longer matches {}; restart the service to refresh its plan",

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1986,7 +1986,7 @@ fn daemon_run_persists_live_runtime_children() {
     let cleared = wait_for_runtime_children(&runtime_path, 0, None, Duration::from_secs(5))
         .expect("daemon runtime state did not clear after shutdown");
     assert!(cleared["updatedAt"].as_str().is_some());
-    assert_eq!(gateway_admission["version"], 10);
+    assert_eq!(gateway_admission["version"], 11);
     assert_eq!(gateway_admission["process"]["pid"], daemon_pid);
     assert!(
         gateway_admission["process"]["startedAt"]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -19,14 +19,15 @@ use std::sync::{
 use std::thread;
 use std::time::{Duration, Instant};
 
+use ocm::env::EnvDevMeta;
 use ocm::store::{get_environment, now_utc, save_environment, supervisor_runtime_path};
 use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
 use serde_json::Value;
 
 use crate::support::{
-    TestDir, dev_plain, dev_watch, enable_fake_daemon_gateway_admission,
-    hold_environment_operation, install_fake_service_manager, ocm_env, path_string, run_ocm,
-    stderr, stdout, write_executable_script,
+    TestDir, create_owned_dev_env, dev_plain, dev_watch, enable_fake_daemon_gateway_admission,
+    hold_environment_operation, install_fake_service_manager, ocm_env, path_string,
+    register_owned_dev_env, run_ocm, stderr, stdout, write_executable_script,
 };
 
 fn init_openclaw_repo(root: &TestDir) -> PathBuf {
@@ -1041,6 +1042,7 @@ fn dev_ui_initial_handoff_and_owned_lifecycle() {
         assert_eq!(session["ui"]["children"]["ui"]["pid"], ui_pid);
         assert_eq!(session["ui"]["target"]["port"], ui["port"]);
         assert_eq!(gateway["cwd"], ui["cwd"]);
+        assert_eq!(ui["cwd"], path_string(&fs::canonicalize(&repo).unwrap()));
         assert!(
             ui["args"]
                 .as_array()
@@ -1323,7 +1325,7 @@ fn dev_ui_rejects_service_mode_before_creating_environment() {
 }
 
 #[test]
-fn dev_command_provisions_worktree_bootstraps_config_and_runs_gateway() {
+fn dev_command_borrows_checkout_bootstraps_config_and_runs_gateway() {
     let root = TestDir::new("dev-command-run");
     let repo = init_openclaw_repo(&root);
     let canonical_repo = fs::canonicalize(&repo).unwrap();
@@ -1331,6 +1333,7 @@ fn dev_command_provisions_worktree_bootstraps_config_and_runs_gateway() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    let registered = git_worktree_paths(&repo);
 
     let run = run_ocm(&cwd, &env, &["dev", "demo", "--repo", &path_string(&repo)]);
     assert!(run.status.success(), "{}", stderr(&run));
@@ -1343,7 +1346,13 @@ fn dev_command_provisions_worktree_bootstraps_config_and_runs_gateway() {
     let workspace_dir = PathBuf::from(show_json["workspaceDir"].as_str().unwrap());
 
     assert_eq!(show_json["devRepoRoot"], path_string(&canonical_repo));
-    assert!(worktree_root.starts_with(canonical_repo.join(".worktrees")));
+    assert_eq!(worktree_root, canonical_repo);
+    assert_eq!(git_worktree_paths(&repo), registered);
+    assert!(!repo.join(".worktrees").exists());
+    assert!(matches!(
+        get_environment("demo", &env, &cwd).unwrap().dev,
+        Some(EnvDevMeta::Borrowed { .. })
+    ));
     assert!(worktree_root.join(".git").exists());
 
     let config: Value = serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
@@ -1449,6 +1458,7 @@ fn dev_registration_rejects_a_busy_containing_environment_before_preparing_sourc
     );
     assert!(allowed.status.success(), "{}", stderr(&allowed));
     drop(lock);
+    create_owned_dev_env(&source, "child", &env, &cwd);
     let created = run_ocm(
         &cwd,
         &env,
@@ -1457,17 +1467,17 @@ fn dev_registration_rejects_a_busy_containing_environment_before_preparing_sourc
     assert!(created.status.success(), "{}", stderr(&created));
     let dev = get_environment("child", &env, &cwd).unwrap().dev.unwrap();
     assert_eq!(
-        dev.repo_root,
+        dev.repo_root(),
         path_string(&fs::canonicalize(&source).unwrap())
     );
-    assert!(Path::new(&dev.worktree_root).join(".git").exists());
+    assert!(Path::new(dev.source_root()).join(".git").exists());
     let _child_operation = hold_environment_operation(&root, "child");
     let before_nested = fs::read(&registry).unwrap();
     let mut nested = DevWatchFixture::spawn(
         &root,
         &cwd,
         &env,
-        &dev_plain(&["grandchild", "--repo", &dev.worktree_root]),
+        &dev_plain(&["grandchild", "--repo", dev.source_root()]),
     );
     let rejected = nested.wait_without_release();
     assert!(!rejected.status.success());
@@ -1478,7 +1488,7 @@ fn dev_registration_rejects_a_busy_containing_environment_before_preparing_sourc
     );
     assert_eq!(fs::read(&registry).unwrap(), before_nested);
     assert!(
-        !Path::new(&dev.worktree_root)
+        !Path::new(dev.source_root())
             .join(".worktrees/grandchild")
             .exists()
     );
@@ -1492,7 +1502,7 @@ fn dev_registration_rejects_a_busy_containing_environment_before_preparing_sourc
 }
 
 #[test]
-fn dev_registration_cleanup_preserves_reused_and_published_worktrees() {
+fn dev_registration_failures_preserve_source_and_existing_worktrees() {
     let root = TestDir::new("dev-registration-cleanup");
     let repo = init_openclaw_repo(&root);
     let cwd = root.child("workspace");
@@ -1554,7 +1564,11 @@ fn dev_registration_cleanup_preserves_reused_and_published_worktrees() {
         .unwrap()
         .dev
         .unwrap();
-    assert!(Path::new(&published.worktree_root).join(".git").is_file());
+    assert_eq!(
+        published.source_root(),
+        path_string(&fs::canonicalize(&repo).unwrap())
+    );
+    assert!(!repo.join(".worktrees/published").exists());
     assert!(state.is_dir());
     #[cfg(unix)]
     assert!(
@@ -1573,6 +1587,7 @@ fn dev_command_rejects_an_unregistered_clone_at_the_managed_path() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    register_owned_dev_env(&repo, &worktree_root, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -1592,6 +1607,244 @@ fn dev_command_rejects_an_unregistered_clone_at_the_managed_path() {
 }
 
 #[test]
+fn dev_borrowed_linked_checkout_uses_explicit_and_enclosing_source() {
+    let root = TestDir::new("dev-borrowed-linked");
+    let repo = init_openclaw_repo(&root);
+    for destination in [".worktrees/input", ".worktrees/other"] {
+        let linked = Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(["worktree", "add", "--detach", destination])
+            .output()
+            .unwrap();
+        assert!(linked.status.success(), "{}", stderr(&linked));
+    }
+    let source = fs::canonicalize(repo.join(".worktrees/input")).unwrap();
+    let source_arg = path_string(&source);
+    fs::write(source.join("scripts/run-node.mjs"), "// current edits\n").unwrap();
+    let legacy_path = source.join(".worktrees/demo");
+    fs::create_dir_all(&legacy_path).unwrap();
+    fs::write(legacy_path.join("SENTINEL"), "untracked source\n").unwrap();
+    fs::create_dir_all(source.join("node_modules/local")).unwrap();
+    fs::write(
+        source.join("node_modules/local/entry.js"),
+        "// retained dependency\n",
+    )
+    .unwrap();
+    let registered = git_worktree_paths(&repo);
+    let nested = source.join("scripts");
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+
+    for (name, cwd, args) in [
+        ("demo", &repo, dev_plain(&["demo", "--repo", &source_arg])),
+        ("enclosing", &nested, dev_plain(&["enclosing"])),
+    ] {
+        let created = run_ocm(cwd, &env, &args);
+        assert!(created.status.success(), "{}", stderr(&created));
+        let meta = get_environment(name, &env, cwd).unwrap();
+        assert_eq!(
+            meta.dev.unwrap().borrowed_source_root(),
+            Some(source_arg.as_str())
+        );
+    }
+    let resumed = run_ocm(&nested, &env, &dev_plain(&["demo"]));
+    assert!(resumed.status.success(), "{}", stderr(&resumed));
+    let node_before = fs::read(root.child("node.log")).unwrap();
+    let repo_arg = path_string(&repo);
+    for args in [
+        dev_plain(&["demo"]),
+        dev_plain(&["demo", "--repo", &repo_arg]),
+    ] {
+        let changed = run_ocm(&repo, &env, &args);
+        assert!(!changed.status.success());
+        assert!(stderr(&changed).contains("cannot change the repo"));
+    }
+    let git_path = source.join(".git");
+    let original_git = fs::read(&git_path).unwrap();
+    fs::copy(repo.join(".worktrees/other/.git"), &git_path).unwrap();
+    let wrong_backlink = run_ocm(&nested, &env, &dev_plain(&["demo"]));
+    fs::write(&git_path, &original_git).unwrap();
+    assert!(!wrong_backlink.status.success());
+    assert!(
+        stderr(&wrong_backlink).contains("not the registered root"),
+        "{}",
+        stderr(&wrong_backlink)
+    );
+    let common = Command::new("git")
+        .arg("-C")
+        .arg(&source)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .unwrap();
+    assert!(common.status.success(), "{}", stderr(&common));
+    fs::write(&git_path, format!("gitdir: {}\n", stdout(&common).trim())).unwrap();
+    let stale_slot = run_ocm(&nested, &env, &dev_plain(&["demo"]));
+    fs::write(&git_path, original_git).unwrap();
+    assert!(!stale_slot.status.success());
+    assert!(
+        stderr(&stale_slot).contains("not the registered root"),
+        "{}",
+        stderr(&stale_slot)
+    );
+    assert_eq!(fs::read(root.child("node.log")).unwrap(), node_before);
+    let prefix = format!("{source_arg}|");
+    assert!(
+        String::from_utf8(node_before)
+            .unwrap()
+            .lines()
+            .all(|line| line.starts_with(&prefix))
+    );
+    for name in ["demo", "enclosing"] {
+        let removed = run_ocm(&repo, &env, &["env", "remove", name]);
+        assert!(removed.status.success(), "{}", stderr(&removed));
+    }
+    assert_eq!(git_worktree_paths(&repo), registered);
+    assert_eq!(
+        fs::read_to_string(source.join("scripts/run-node.mjs")).unwrap(),
+        "// current edits\n"
+    );
+    assert_eq!(
+        fs::read_to_string(legacy_path.join("SENTINEL")).unwrap(),
+        "untracked source\n"
+    );
+    assert_eq!(
+        fs::read_to_string(source.join("node_modules/local/entry.js")).unwrap(),
+        "// retained dependency\n"
+    );
+}
+
+#[test]
+fn dev_borrowed_missing_or_redirected_source_is_not_recreated() {
+    let root = TestDir::new("dev-borrowed-missing");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+    let created = run_ocm(
+        &cwd,
+        &env,
+        &dev_plain(&["demo", "--repo", &path_string(&repo)]),
+    );
+    assert!(created.status.success(), "{}", stderr(&created));
+    let meta = get_environment("demo", &env, &cwd).unwrap();
+    let binding = meta.dev;
+    let retained = root.child("retained-source");
+    fs::rename(&repo, &retained).unwrap();
+    fs::remove_file(root.child("node.log")).unwrap();
+    for args in [
+        dev_plain(&["demo"]),
+        vec!["env", "resolve", "demo", "--json"],
+    ] {
+        let missing = run_ocm(&cwd, &env, &args);
+        assert!(!missing.status.success());
+        assert!(
+            stderr(&missing).contains("restore that checkout"),
+            "{}",
+            stderr(&missing)
+        );
+    }
+    assert!(!repo.exists());
+    let watch_path = source_watch_override_path(&root, "demo");
+    let metadata = [
+        ocm::store::env_registry_path(&env, &cwd).unwrap(),
+        Path::new(&meta.root).join(".openclaw/openclaw.json"),
+        watch_path.with_extension("session"),
+        watch_path,
+        root.child("pnpm.log"),
+    ];
+    let metadata_before = metadata.each_ref().map(|path| fs::read(path).ok());
+    let status = run_ocm(&cwd, &env, &["dev", "status", "demo", "--json"]);
+    assert!(status.status.success(), "{}", stderr(&status));
+    let status: Value = serde_json::from_str(&stdout(&status)).unwrap();
+    let source = binding.as_ref().unwrap().source_root();
+    assert_eq!(status["repoRoot"].as_str(), Some(source));
+    assert_eq!(status["worktreeRoot"].as_str(), Some(source));
+    assert_eq!(
+        metadata.each_ref().map(|path| fs::read(path).ok()),
+        metadata_before
+    );
+    assert!(
+        !repo.exists(),
+        "passive status recreated the borrowed source"
+    );
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&retained, &repo).unwrap();
+        let redirected = run_ocm(&cwd, &env, &dev_plain(&["demo"]));
+        assert!(!redirected.status.success());
+        assert!(stderr(&redirected).contains("now resolves to a different checkout"));
+        fs::remove_file(&repo).unwrap();
+    }
+    assert!(!root.child("node.log").exists());
+    assert_eq!(get_environment("demo", &env, &cwd).unwrap().dev, binding);
+    let removed = run_ocm(&cwd, &env, &["env", "remove", "demo"]);
+    assert!(removed.status.success(), "{}", stderr(&removed));
+    assert!(retained.join("scripts/run-node.mjs").exists());
+    assert!(!repo.exists());
+}
+
+#[test]
+fn dev_borrowed_dependencies_are_prepared_only_on_first_creation() {
+    for mode in [None, Some("--watch"), Some("--service")] {
+        let root = TestDir::new("dev-borrowed-dependencies");
+        let repo = init_openclaw_repo(&root);
+        declare_source_tooling(&repo);
+        fs::write(repo.join("pnpm-lock.yaml"), "frozen fixture\n").unwrap();
+        let cwd = root.child("workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let mut env = service_env_with_gateway_admission(&root);
+        install_probe_aware_fake_dev_runners(&root, &mut env);
+        install_frozen_source_dependency_runner(&root);
+        let repo_arg = path_string(&repo);
+        let mut args = vec!["dev", "demo", "--repo", &repo_arg];
+        args.extend(mode);
+        let created = run_ocm(&cwd, &env, &args);
+        assert!(created.status.success(), "{mode:?}: {}", stderr(&created));
+        let install_log = fs::read(root.child("pnpm.log")).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&install_log)
+                .lines()
+                .filter(|line| line.contains("|install --frozen-lockfile"))
+                .count(),
+            1
+        );
+        assert!(repo.join("node_modules/tsx/entry.mjs").is_file());
+        fs::remove_file(repo.join("node_modules/tsx/entry.mjs")).unwrap();
+        let before = serde_json::to_value(get_environment("demo", &env, &cwd).unwrap()).unwrap();
+        let node_before = fs::read(root.child("node.log")).ok();
+        let mut attempts = vec![args.clone()];
+        if mode.is_none() {
+            attempts.extend([
+                vec!["dev", "demo", "--ui"],
+                vec!["dev", "demo", "--watch", "--ui"],
+            ]);
+        }
+        for args in attempts {
+            let refused = run_ocm(&cwd, &env, &args);
+            assert!(!refused.status.success());
+            assert!(
+                stderr(&refused).contains("pnpm install --frozen-lockfile"),
+                "{}",
+                stderr(&refused)
+            );
+            assert_eq!(fs::read(root.child("pnpm.log")).unwrap(), install_log);
+            assert_eq!(fs::read(root.child("node.log")).ok(), node_before);
+            assert_eq!(
+                serde_json::to_value(get_environment("demo", &env, &cwd).unwrap()).unwrap(),
+                before
+            );
+        }
+        assert!(!repo.join("node_modules/tsx/entry.mjs").exists());
+        assert_eq!(
+            fs::read_to_string(repo.join("pnpm-lock.yaml")).unwrap(),
+            "frozen fixture\n"
+        );
+    }
+}
+
+#[test]
 fn dev_dependencies_reuse_flat_source_tooling_without_running_it() {
     let root = TestDir::new("dev-dependencies-reuse");
     let repo = init_openclaw_repo(&root);
@@ -1606,7 +1859,7 @@ fn dev_dependencies_reuse_flat_source_tooling_without_running_it() {
     );
     assert!(created.status.success(), "{}", stderr(&created));
     let meta = get_environment("demo", &env, &cwd).unwrap();
-    let worktree = PathBuf::from(meta.dev.unwrap().worktree_root);
+    let worktree = PathBuf::from(meta.dev.unwrap().source_root());
     declare_source_tooling(&worktree);
     // The normal source runner does not require the watch-only package.
     write_resolvable_source_tool(&worktree, "tsx");
@@ -1791,6 +2044,7 @@ fn dev_dependencies_bootstrap_with_a_frozen_lockfile_and_retry_after_failure() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_probe_aware_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
     install_frozen_source_dependency_runner(&root);
     env.insert("OCM_TEST_INSTALL_EXIT_CODE".to_string(), "42".to_string());
 
@@ -1801,7 +2055,7 @@ fn dev_dependencies_bootstrap_with_a_frozen_lockfile_and_retry_after_failure() {
     );
     assert_eq!(failed.status.code(), Some(42), "{}", stderr(&failed));
     let meta = get_environment("demo", &env, &cwd).unwrap();
-    let worktree = PathBuf::from(meta.dev.unwrap().worktree_root);
+    let worktree = PathBuf::from(meta.dev.unwrap().source_root());
     assert!(!root.child("node.log").exists());
     assert!(!source_watch_override_path(&root, "demo").exists());
     assert_eq!(
@@ -1875,6 +2129,7 @@ fn dev_dependencies_preserve_reported_lifecycle_uncertainty() {
         fs::create_dir_all(&cwd).unwrap();
         let mut env = ocm_env(&root);
         install_probe_aware_fake_dev_runners(&root, &mut env);
+        create_owned_dev_env(&repo, "demo", &env, &cwd);
         let created = run_ocm(
             &cwd,
             &env,
@@ -1883,7 +2138,7 @@ fn dev_dependencies_preserve_reported_lifecycle_uncertainty() {
         assert!(created.status.success(), "{label}: {}", stderr(&created));
         fs::remove_file(root.child("node.log")).unwrap();
         let meta = get_environment("demo", &env, &cwd).unwrap();
-        let source = Path::new(&meta.dev.as_ref().unwrap().worktree_root);
+        let source = Path::new(meta.dev.as_ref().unwrap().source_root());
         declare_source_tooling(source);
         fs::write(source.join("pnpm-lock.yaml"), "retained frozen lock\n").unwrap();
 
@@ -2136,11 +2391,12 @@ fn dev_dependencies_reject_unready_borrowed_source_before_service_changes() {
 #[cfg(unix)]
 #[test]
 fn dev_dependencies_do_not_repair_through_linked_install_targets() {
-    for (relative, configured) in [
-        ("node_modules", false),
-        ("node_modules/.pnpm", false),
-        ("installed-modules", true),
-        ("installed-modules/.pnpm", true),
+    for (relative, configured, borrowed) in [
+        ("node_modules", false, false),
+        ("node_modules/.pnpm", false, false),
+        ("installed-modules", true, false),
+        ("installed-modules/.pnpm", true, false),
+        ("node_modules/.pnpm", false, true),
     ] {
         let root = TestDir::new("dev-dependencies-linked-install");
         let repo = init_openclaw_repo(&root);
@@ -2148,19 +2404,11 @@ fn dev_dependencies_do_not_repair_through_linked_install_targets() {
         fs::create_dir_all(&cwd).unwrap();
         let mut env = ocm_env(&root);
         install_probe_aware_fake_dev_runners(&root, &mut env);
-        let created = run_ocm(
-            &cwd,
-            &env,
-            &dev_plain(&["demo", "--repo", &path_string(&repo)]),
-        );
-        assert!(created.status.success(), "{}", stderr(&created));
-        let worktree = PathBuf::from(
-            get_environment("demo", &env, &cwd)
-                .unwrap()
-                .dev
-                .unwrap()
-                .worktree_root,
-        );
+        let worktree = if borrowed {
+            repo.clone()
+        } else {
+            create_owned_dev_env(&repo, "demo", &env, &cwd)
+        };
         declare_source_tooling(&worktree);
         if configured {
             env.insert(
@@ -2173,9 +2421,11 @@ fn dev_dependencies_do_not_repair_through_linked_install_targets() {
         let target = worktree.join("borrowed-modules");
         fs::create_dir_all(&target).unwrap();
         std::os::unix::fs::symlink(&target, &link).unwrap();
-        fs::remove_file(root.child("node.log")).unwrap();
-
-        let failed = run_ocm(&cwd, &env, &dev_plain(&["demo"]));
+        let failed = run_ocm(
+            &cwd,
+            &env,
+            &dev_plain(&["demo", "--repo", &path_string(&repo)]),
+        );
         assert!(!failed.status.success());
         assert!(stderr(&failed).contains("refusing to install"));
         assert_eq!(fs::read_link(&link).unwrap(), target);
@@ -2192,6 +2442,7 @@ fn dev_command_does_not_recreate_a_missing_saved_worktree() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let first = run_ocm(
         &cwd,
@@ -2213,7 +2464,7 @@ fn dev_command_does_not_recreate_a_missing_saved_worktree() {
     assert_eq!(git_worktree_paths(&repo), registered);
     assert!(!root.child("node.log").exists());
     let meta = get_environment("demo", &env, &cwd).unwrap();
-    assert_eq!(meta.dev.unwrap().worktree_root, path_string(&worktree_root));
+    assert_eq!(meta.dev.unwrap().source_root(), path_string(&worktree_root));
 
     let resolve = run_ocm(&cwd, &env, &["env", "resolve", "demo", "--json"]);
     assert!(!resolve.status.success());
@@ -2291,6 +2542,7 @@ fn dev_command_resumes_the_recorded_worktree_without_recreating_the_default() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let first = run_ocm(
         &cwd,
@@ -2300,7 +2552,7 @@ fn dev_command_resumes_the_recorded_worktree_without_recreating_the_default() {
     assert!(first.status.success(), "{}", stderr(&first));
     let mut meta = get_environment("demo", &env, &cwd).unwrap();
     let dev = meta.dev.as_mut().unwrap();
-    let original_worktree = PathBuf::from(&dev.worktree_root);
+    let original_worktree = PathBuf::from(dev.source_root());
     let recorded_worktree = repo.join(".worktrees/recorded-source");
     let moved = Command::new("git")
         .arg("-C")
@@ -2311,7 +2563,10 @@ fn dev_command_resumes_the_recorded_worktree_without_recreating_the_default() {
         .output()
         .unwrap();
     assert!(moved.status.success(), "{}", stderr(&moved));
-    dev.worktree_root = path_string(&recorded_worktree);
+    *dev = EnvDevMeta::Owned {
+        repo_root: dev.repo_root().to_string(),
+        worktree_root: path_string(&recorded_worktree),
+    };
     save_environment(meta, &env, &cwd).unwrap();
     fs::write(recorded_worktree.join("SENTINEL"), "keep my edits\n").unwrap();
     fs::write(
@@ -2366,6 +2621,7 @@ fn dev_command_rejects_an_unrelated_recorded_worktree_before_running_source() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let first = run_ocm(
         &cwd,
@@ -2376,7 +2632,10 @@ fn dev_command_rejects_an_unrelated_recorded_worktree_before_running_source() {
     let unrelated_worktree = root.child("unrelated-source");
     init_nested_openclaw_repo(&unrelated_worktree);
     let mut meta = get_environment("demo", &env, &cwd).unwrap();
-    meta.dev.as_mut().unwrap().worktree_root = path_string(&unrelated_worktree);
+    meta.dev = Some(EnvDevMeta::Owned {
+        repo_root: meta.dev.as_ref().unwrap().repo_root().to_string(),
+        worktree_root: path_string(&unrelated_worktree),
+    });
     save_environment(meta, &env, &cwd).unwrap();
     fs::remove_file(root.child("node.log")).unwrap();
 
@@ -2399,6 +2658,7 @@ fn dev_command_accepts_a_repo_alias_without_rebinding_the_env() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let first = run_ocm(
         &cwd,
@@ -2417,8 +2677,7 @@ fn dev_command_accepts_a_repo_alias_without_rebinding_the_env() {
     );
     assert!(resumed.status.success(), "{}", stderr(&resumed));
     let after = get_environment("demo", &env, &cwd).unwrap().dev.unwrap();
-    assert_eq!(after.repo_root, before.repo_root);
-    assert_eq!(after.worktree_root, before.worktree_root);
+    assert_eq!(after, before);
 
     let unrelated_repo = root.child("unrelated-repo");
     init_nested_openclaw_repo(&unrelated_repo);
@@ -2431,9 +2690,13 @@ fn dev_command_accepts_a_repo_alias_without_rebinding_the_env() {
     );
     assert!(!changed.status.success());
     assert!(stderr(&changed).contains("dev cannot change the repo for existing env"));
+    let worktree_cwd = Path::new(before.source_root()).join("scripts");
+    for cwd in [&unrelated_repo, &worktree_cwd] {
+        let resumed = run_ocm(cwd, &env, &dev_plain(&["demo"]));
+        assert!(resumed.status.success(), "{}", stderr(&resumed));
+    }
     let after = get_environment("demo", &env, &cwd).unwrap().dev.unwrap();
-    assert_eq!(after.repo_root, before.repo_root);
-    assert_eq!(after.worktree_root, before.worktree_root);
+    assert_eq!(after, before);
 }
 
 #[test]
@@ -2444,6 +2707,7 @@ fn dev_command_rejects_a_stale_registration_replaced_by_an_unrelated_clone() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let first = run_ocm(
         &cwd,
@@ -2537,6 +2801,7 @@ fn dev_command_rejects_a_symlink_alias_to_another_registered_worktree() {
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let env = ocm_env(&root);
+    register_owned_dev_env(&repo, &repo.join(".worktrees/demo"), "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2563,6 +2828,7 @@ fn env_remove_preserves_an_untracked_dev_worktree() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2613,6 +2879,7 @@ fn env_remove_preserves_ignored_local_files() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2642,6 +2909,7 @@ fn env_remove_discards_installed_node_modules() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2668,6 +2936,7 @@ fn dev_command_rejects_another_worktrees_git_backlink() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let first = run_ocm(
         &cwd,
@@ -2734,6 +3003,7 @@ fn env_remove_accepts_a_clean_worktree_with_an_initialized_submodule() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
     let run = run_ocm(
         &cwd,
         &env,
@@ -2758,6 +3028,7 @@ fn env_remove_accepts_a_missing_worktree_with_a_non_git_repo_path() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2787,6 +3058,7 @@ fn env_remove_accepts_a_clean_registered_worktree_without_openclaw_markers() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2837,6 +3109,7 @@ fn env_remove_preserves_ignored_files_inside_initialized_submodules() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2884,6 +3157,7 @@ fn dev_command_supports_relative_worktree_links() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2904,6 +3178,7 @@ fn env_remove_refuses_an_unrelated_replacement_checkout() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -2952,6 +3227,7 @@ fn env_remove_refuses_a_clean_replacement_at_a_stale_registered_path() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
     install_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let run = run_ocm(
         &cwd,
@@ -3039,12 +3315,7 @@ fn dev_status_reports_dev_envs() {
     assert_eq!(summary["serviceRunning"], false);
     assert_eq!(summary["sourceWatch"]["state"], "inactive");
     assert_eq!(summary["repoRoot"], path_string(&canonical_repo));
-    assert!(
-        summary["worktreeRoot"]
-            .as_str()
-            .unwrap()
-            .contains("/.worktrees/demo")
-    );
+    assert_eq!(summary["worktreeRoot"], path_string(&canonical_repo));
     assert!(summary["gatewayPort"].as_u64().unwrap() > 0);
     assert_eq!(
         summary["gatewayUrl"],
@@ -3345,6 +3616,7 @@ fn dev_command_discovers_the_enclosing_checkout_from_a_deep_directory() {
         show_json["devRepoRoot"],
         path_string(&fs::canonicalize(&repo).unwrap())
     );
+    assert_eq!(show_json["devWorktreeRoot"], show_json["devRepoRoot"]);
 }
 
 #[test]
@@ -3361,13 +3633,27 @@ fn dev_command_does_not_select_a_neighboring_checkout() {
     assert!(!repo.join(".worktrees/demo").exists());
 }
 
-#[cfg(unix)]
 #[test]
 fn dev_command_records_the_canonical_explicit_source() {
     let root = TestDir::new("dev-command-canonical-source");
     let repo = init_openclaw_repo(&root);
-    let alias = root.child("source-alias");
-    std::os::unix::fs::symlink(&repo, &alias).unwrap();
+    let separate = Command::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["init", "--quiet", "--separate-git-dir"])
+        .arg(root.child("external-git-dir"))
+        .output()
+        .unwrap();
+    assert!(separate.status.success(), "{}", stderr(&separate));
+    assert!(repo.join(".git").is_file());
+    #[cfg(unix)]
+    let alias = {
+        let alias = root.child("source-alias");
+        std::os::unix::fs::symlink(&repo, &alias).unwrap();
+        alias
+    };
+    #[cfg(not(unix))]
+    let alias = repo.clone();
     let cwd = root.child("workspace");
     fs::create_dir_all(&cwd).unwrap();
     let mut env = ocm_env(&root);
@@ -3906,7 +4192,7 @@ fn dev_destroy_stops_the_recorded_watch_before_removing_state() {
         assert!(source_watch_lock_path(&root, "demo").exists());
         assert!(repo.exists());
         if let Some(dev) = before.dev {
-            assert!(!Path::new(&dev.worktree_root).exists());
+            assert!(Path::new(dev.source_root()).exists());
         }
     }
 }
@@ -4165,7 +4451,7 @@ fn dev_foreground_reuses_plain_mode_and_named_stop_preserves_source() {
     assert_eq!(session["kind"], "ocm-source-foreground-session-v1");
     assert_eq!(session["watching"], false);
     let meta = get_environment("demo", &env, &cwd).unwrap();
-    let source = Path::new(&meta.dev.as_ref().unwrap().worktree_root);
+    let source = Path::new(meta.dev.as_ref().unwrap().source_root());
     let config_path = Path::new(&meta.root).join(".openclaw/openclaw.json");
     let mut config: Value = serde_json::from_slice(&fs::read(&config_path).unwrap()).unwrap();
     config["gateway"].as_object_mut().unwrap().remove("mode");
@@ -4257,7 +4543,7 @@ fn dev_watch_retains_unverified_worker_ownership_across_retries() {
                     .unwrap()
                     .dev
                     .unwrap()
-                    .worktree_root,
+                    .source_root(),
             )
         };
         let entry = source.join(if watching {
@@ -4583,15 +4869,7 @@ fn dev_service_preparation_cancellation_preserves_its_running_service() {
     assert_eq!(completed["restoreService"], false);
     let after = get_environment("demo", &env, &cwd).unwrap();
     assert!(after.service_running && after.service_enabled);
-    assert_eq!(
-        after
-            .dev
-            .as_ref()
-            .map(|dev| (&dev.repo_root, &dev.worktree_root)),
-        meta.dev
-            .as_ref()
-            .map(|dev| (&dev.repo_root, &dev.worktree_root))
-    );
+    assert_eq!(after.dev, meta.dev);
     assert_eq!(fs::read(&config_path).unwrap(), edited_config);
     let after_state: Value = serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
     assert_eq!(after_state["children"], initial_state["children"]);
@@ -4653,6 +4931,7 @@ fn dev_stop_cancels_owned_preparation_before_gateway_start() {
         fs::create_dir_all(&cwd).unwrap();
         let mut env = service_env_with_gateway_admission(&root);
         install_probe_aware_fake_dev_runners(&root, &mut env);
+        create_owned_dev_env(&repo, "demo", &env, &cwd);
         let prepare = run_ocm(
             &cwd,
             &env,
@@ -4660,7 +4939,7 @@ fn dev_stop_cancels_owned_preparation_before_gateway_start() {
         );
         assert!(prepare.status.success(), "{}", stderr(&prepare));
         let meta = get_environment("demo", &env, &cwd).unwrap();
-        let worktree = Path::new(&meta.dev.as_ref().unwrap().worktree_root);
+        let worktree = Path::new(meta.dev.as_ref().unwrap().source_root());
         if phase != "onboard" {
             declare_source_tooling(worktree);
         }
@@ -4917,6 +5196,7 @@ fn dev_watch_reuses_active_session_and_reclaims_the_released_lock() {
     fs::create_dir_all(&cwd).unwrap();
     let mut env = service_env(&root);
     let (started, release, watch_log) = install_blocking_fake_dev_runners(&root, &mut env);
+    create_owned_dev_env(&repo, "demo", &env, &cwd);
 
     let mut first = Command::new(env!("CARGO_BIN_EXE_ocm"));
     first
@@ -4944,7 +5224,7 @@ fn dev_watch_reuses_active_session_and_reclaims_the_released_lock() {
     config["gateway"].as_object_mut().unwrap().remove("bind");
     let config_before = serde_json::to_vec(&config).unwrap();
     fs::write(&config_path, &config_before).unwrap();
-    let worktree = Path::new(&meta.dev.as_ref().unwrap().worktree_root);
+    let worktree = Path::new(meta.dev.as_ref().unwrap().source_root());
     let manifest_before = fs::read(worktree.join("package.json")).unwrap();
     declare_source_tooling(worktree);
     let pnpm_before = fs::read(root.child("pnpm.log")).ok();

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -3388,6 +3388,17 @@ fn dev_status_reports_dev_envs() {
     assert_eq!(stale["serviceRunning"], false);
     assert_eq!(fs::read(&runtime_path).unwrap(), runtime_bytes);
 
+    // Seed the foreign store before the status-only fake daemon is loaded.
+    let mut other_env = env.clone();
+    let other_home = root.child("other-ocm-home");
+    other_env.insert("OCM_HOME".to_string(), path_string(&other_home));
+    save_environment(
+        get_environment("demo", &env, &cwd).unwrap(),
+        &other_env,
+        &cwd,
+    )
+    .unwrap();
+
     let started = run_ocm(&cwd, &env, &["service", "start", "demo"]);
     assert!(started.status.success(), "{}", stderr(&started));
     let live = run_ocm(&cwd, &env, &["dev", "status", "demo", "--json"]);
@@ -3410,15 +3421,6 @@ fn dev_status_reports_dev_envs() {
         assert_eq!(fs::read(&runtime_path).unwrap(), runtime_bytes);
     }
 
-    let mut other_env = env.clone();
-    let other_home = root.child("other-ocm-home");
-    other_env.insert("OCM_HOME".to_string(), path_string(&other_home));
-    save_environment(
-        get_environment("demo", &env, &cwd).unwrap(),
-        &other_env,
-        &cwd,
-    )
-    .unwrap();
     let mut other_runtime = runtime.clone();
     other_runtime.ocm_home = path_string(&other_home);
     let other_runtime_path = supervisor_runtime_path(&other_env, &cwd).unwrap();

--- a/tests/dev_source_isolation_tests.rs
+++ b/tests/dev_source_isolation_tests.rs
@@ -2,12 +2,13 @@ mod support;
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use ocm::env::{CreateEnvironmentOptions, EnvDevMeta, EnvMeta};
-use ocm::store::{create_environment, env_registry_path};
+use ocm::store::{create_environment, env_registry_path, save_environment};
 
-use support::{TestDir, ocm_env, path_string, run_ocm, stderr, write_text};
+use support::{TestDir, ocm_env, path_string, run_ocm, stderr, stdout, write_text};
 
 fn create(
     name: &str,
@@ -15,7 +16,7 @@ fn create(
     dev: Option<EnvDevMeta>,
     env: &BTreeMap<String, String>,
     cwd: &Path,
-) -> EnvMeta {
+) -> Result<EnvMeta, String> {
     create_environment(
         CreateEnvironmentOptions {
             name: name.to_string(),
@@ -31,11 +32,10 @@ fn create(
         env,
         cwd,
     )
-    .unwrap()
 }
 
 fn dev_binding(source: &Path) -> EnvDevMeta {
-    EnvDevMeta {
+    EnvDevMeta::Owned {
         repo_root: path_string(source.parent().unwrap()),
         worktree_root: path_string(source),
     }
@@ -48,8 +48,8 @@ fn create_clone_and_import_reject_registered_dev_source_destinations() {
     let env = ocm_env(&fixture);
     let source = fixture.child("repo/worktree");
     write_text(&source.join("authored.txt"), "preserve source\n");
-    create("developer", None, Some(dev_binding(&source)), &env, cwd);
-    let template = create("template", None, None, &env, cwd);
+    create("developer", None, Some(dev_binding(&source)), &env, cwd).unwrap();
+    let template = create("template", None, None, &env, cwd).unwrap();
     let archive = fixture.child("template.tar");
     let export = run_ocm(
         cwd,
@@ -179,4 +179,223 @@ fn create_clone_and_import_reject_registered_dev_source_destinations() {
         ],
     );
     assert!(imported.status.success(), "{}", stderr(&imported));
+}
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    stdout(&output).trim().to_string()
+}
+
+fn init_checkout(path: &Path) -> PathBuf {
+    write_text(&path.join("package.json"), r#"{"name":"openclaw"}"#);
+    write_text(&path.join("scripts/run-node.mjs"), "// retained source\n");
+    git(path, &["init"]);
+    git(path, &["add", "."]);
+    git(
+        path,
+        &[
+            "-c",
+            "user.name=OCM Tests",
+            "-c",
+            "user.email=tests@example.com",
+            "commit",
+            "-m",
+            "init",
+        ],
+    );
+    fs::canonicalize(path).unwrap()
+}
+
+fn borrowed(source: &Path) -> EnvDevMeta {
+    EnvDevMeta::Borrowed {
+        source_root: path_string(source),
+    }
+}
+
+#[test]
+fn missing_borrowed_sources_remain_reserved_until_the_binding_is_removed() {
+    let fixture = TestDir::new("missing-borrowed-reservations");
+    let cwd = fixture.path();
+    let env = ocm_env(&fixture);
+    let source = init_checkout(&fixture.child("projects/openclaw"));
+    let mut developer = create("developer", None, Some(borrowed(&source)), &env, cwd).unwrap();
+    let template = create("template", None, None, &env, cwd).unwrap();
+    let archive = fixture.child("template.tar");
+    let exported = run_ocm(
+        cwd,
+        &env,
+        &[
+            "env",
+            "export",
+            "template",
+            "--output",
+            &path_string(&archive),
+        ],
+    );
+    assert!(exported.status.success(), "{}", stderr(&exported));
+    let retained = fixture.child("retained");
+    fs::rename(&source, &retained).unwrap();
+    // Recovery writes retain an unchanged binding while its source is displaced.
+    developer.protected = true;
+    save_environment(developer, &env, cwd).unwrap();
+    let registry = env_registry_path(&env, cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+    let mut destinations = vec![
+        source.clone(),
+        source.join("new/state"),
+        source.parent().unwrap().to_path_buf(),
+        source.with_file_name("OPENCLAW").join("state"),
+    ];
+    #[cfg(unix)]
+    {
+        let alias = fixture.child("projects-alias");
+        std::os::unix::fs::symlink(source.parent().unwrap(), &alias).unwrap();
+        destinations.push(alias.join("openclaw/state"));
+    }
+    for destination in &destinations {
+        let destination = path_string(destination);
+        let archive = path_string(&archive);
+        for action in ["create", "clone", "import"] {
+            let mut args = match action {
+                "create" => vec!["env", "create", "blocked"],
+                "clone" => vec!["env", "clone", "template", "blocked"],
+                _ => vec!["env", "import", &archive, "--name", "blocked"],
+            };
+            args.extend(["--root", &destination]);
+            let rejected = run_ocm(cwd, &env, &args);
+            assert!(!rejected.status.success());
+            assert!(
+                stderr(&rejected).contains("overlaps borrowed source"),
+                "{}",
+                stderr(&rejected)
+            );
+            assert_eq!(fs::read(&registry).unwrap(), before);
+            assert!(!source.exists());
+        }
+    }
+    for (name, destination) in [
+        ("sibling", source.with_file_name("sibling")),
+        ("nested", Path::new(&template.root).join("nested")),
+    ] {
+        create(name, Some(&destination), None, &env, cwd).unwrap();
+    }
+    let removed = run_ocm(cwd, &env, &["env", "remove", "developer", "--force"]);
+    assert!(removed.status.success(), "{}", stderr(&removed));
+    create("reused", Some(&source), None, &env, cwd).unwrap();
+    assert!(!source.join(".git").exists());
+    assert_eq!(
+        fs::read_to_string(retained.join("scripts/run-node.mjs")).unwrap(),
+        "// retained source\n"
+    );
+
+    for dangling_link in [false, true] {
+        #[cfg(not(unix))]
+        if dangling_link {
+            continue;
+        }
+        let fixture = TestDir::new("missing-borrowed-git-target");
+        let cwd = fixture.path();
+        let env = ocm_env(&fixture);
+        let source = init_checkout(&fixture.child("openclaw"));
+        let metadata = fixture.child("metadata");
+        git(
+            &source,
+            &["init", "--separate-git-dir", &path_string(&metadata)],
+        );
+        let git_entry = source.join(".git");
+        #[cfg(unix)]
+        if dangling_link {
+            fs::remove_file(&git_entry).unwrap();
+            std::os::unix::fs::symlink(&metadata, &git_entry).unwrap();
+        }
+        create("developer", None, Some(borrowed(&source)), &env, cwd).unwrap();
+        let registry = env_registry_path(&env, cwd).unwrap();
+        let before = fs::read(&registry).unwrap();
+        if !dangling_link {
+            let pointer = fs::read(&git_entry).unwrap();
+            fs::write(&git_entry, "malformed Git pointer\n").unwrap();
+            let rejected = create("invalid", None, None, &env, cwd).unwrap_err();
+            assert!(
+                rejected.contains("invalid Git identity pointer"),
+                "{rejected}"
+            );
+            assert_eq!(fs::read(&registry).unwrap(), before);
+            fs::write(&git_entry, pointer).unwrap();
+        }
+        let retained = fixture.child("retained-git");
+        let head = fs::read(metadata.join("HEAD")).unwrap();
+        fs::rename(&metadata, &retained).unwrap();
+        for destination in [metadata.clone(), metadata.join("new-state")] {
+            let rejected = create("blocked", Some(&destination), None, &env, cwd).unwrap_err();
+            assert!(rejected.contains("overlaps borrowed source"), "{rejected}");
+            assert_eq!(fs::read(&registry).unwrap(), before);
+            assert!(!metadata.exists());
+        }
+        create("unrelated", None, None, &env, cwd).unwrap();
+        let removed = run_ocm(cwd, &env, &["env", "remove", "developer"]);
+        assert!(removed.status.success(), "{}", stderr(&removed));
+        assert!(!metadata.exists());
+        assert!(fs::symlink_metadata(&git_entry).is_ok());
+        assert_eq!(fs::read(retained.join("HEAD")).unwrap(), head);
+        assert_eq!(
+            fs::read_to_string(source.join("scripts/run-node.mjs")).unwrap(),
+            "// retained source\n"
+        );
+        create("reused", Some(&metadata), None, &env, cwd).unwrap();
+    }
+}
+
+#[test]
+fn borrowed_state_roots_cannot_overlap_the_source_or_its_git_metadata() {
+    let fixture = TestDir::new("borrowed-source-state-isolation");
+    let cwd = fixture.path();
+    let env = ocm_env(&fixture);
+    let repo = init_checkout(&fixture.child("openclaw"));
+    git(&repo, &["worktree", "add", "--detach", "../linked"]);
+    let linked = fs::canonicalize(fixture.child("linked")).unwrap();
+    // Another existing state root inside the selected repo is still supported.
+    create("contained", Some(&repo.join("state")), None, &env, cwd).unwrap();
+    let registry = env_registry_path(&env, cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+    for source in [&repo, &linked] {
+        let common = PathBuf::from(git(
+            source,
+            &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        ));
+        let private = PathBuf::from(git(source, &["rev-parse", "--absolute-git-dir"]));
+        for destination in [
+            source.to_path_buf(),
+            source.join("new-state"),
+            common.join("new-state"),
+            private.join("new-state"),
+        ] {
+            let rejected = create(
+                "blocked",
+                Some(&destination),
+                Some(borrowed(source)),
+                &env,
+                cwd,
+            )
+            .unwrap_err();
+            assert!(rejected.contains("overlaps borrowed source"), "{rejected}");
+            assert_eq!(fs::read(&registry).unwrap(), before);
+            if destination != *source {
+                assert!(!destination.exists());
+            }
+        }
+    }
+    let mut developer = create("developer", None, Some(borrowed(&linked)), &env, cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+    developer.root = path_string(&repo.join(".git/new-state"));
+    let rejected = save_environment(developer, &env, cwd).unwrap_err();
+    assert!(rejected.contains("overlaps borrowed source"), "{rejected}");
+    assert_eq!(fs::read(&registry).unwrap(), before);
+    assert!(!repo.join(".git/new-state").exists());
+    create("main-source", None, Some(borrowed(&repo)), &env, cwd).unwrap();
 }

--- a/tests/env_destroy_tests.rs
+++ b/tests/env_destroy_tests.rs
@@ -17,8 +17,9 @@ use ocm::env::{EnvDevMeta, EnvMeta};
 use ocm::store::{get_environment, save_environment};
 
 use crate::support::{
-    TestDir, dev_plain, managed_service_definition_path, ocm_env, path_string, run_ocm, stderr,
-    stdout, write_executable_script,
+    TestDir, create_owned_dev_env, create_owned_dev_env_at_root, dev_plain,
+    managed_service_definition_path, ocm_env, path_string, run_ocm, stderr, stdout,
+    write_executable_script,
 };
 
 fn install_fake_launchctl(root: &TestDir, env: &mut BTreeMap<String, String>) {
@@ -190,8 +191,7 @@ fn create_dev_source(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> EnvMeta {
-    let created = run_ocm(cwd, env, &dev_plain(&[name, "--repo", &path_string(repo)]));
-    assert!(created.status.success(), "{}", stderr(&created));
+    create_owned_dev_env(repo, name, env, cwd);
     get_environment(name, env, cwd).unwrap()
 }
 
@@ -572,6 +572,7 @@ fn env_destroy_yes_removes_dev_worktree() {
     install_fake_launchctl(&root, &mut env);
     install_fake_dev_runners(&root, &mut env);
 
+    let worktree = create_owned_dev_env(&repo, "demo", &env, &cwd);
     let run = run_ocm(
         &cwd,
         &env,
@@ -579,12 +580,174 @@ fn env_destroy_yes_removes_dev_worktree() {
     );
     assert!(run.status.success(), "{}", stderr(&run));
 
-    let worktree = repo.join(".worktrees/demo");
     assert!(worktree.exists());
 
     let destroy = run_ocm(&cwd, &env, &["env", "destroy", "demo", "--yes"]);
     assert!(destroy.status.success(), "{}", stderr(&destroy));
     assert!(!worktree.exists(), "dev worktree should be removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn env_destroy_borrower_preserves_shared_source_and_its_worker() {
+    let root = TestDir::new("env-destroy-borrowed-source");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.path();
+    let mut env = ocm_launchd_env(&root);
+    install_fake_launchctl(&root, &mut env);
+    install_fake_dev_runners(&root, &mut env);
+    let source = create_owned_dev_env(&repo, "owner", &env, cwd);
+    let created = run_ocm(
+        cwd,
+        &env,
+        &dev_plain(&["borrower", "--repo", &path_string(&source)]),
+    );
+    assert!(created.status.success(), "{}", stderr(&created));
+    let borrower = get_environment("borrower", &env, cwd).unwrap();
+    assert!(borrower.dev.as_ref().unwrap().owned_worktree().is_none());
+    fs::write(source.join("retained.txt"), "uncommitted source\n").unwrap();
+    let registrations = git(&repo, &["worktree", "list", "--porcelain"]);
+    let registry = ocm::store::env_registry_path(&env, cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+    let mut worker = Command::new("python3")
+        .current_dir(&source)
+        .args(["-c", "import time; time.sleep(60)"])
+        .env_clear()
+        .envs(&env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let owner = run_ocm(
+        cwd,
+        &env,
+        &["env", "destroy", "owner", "--yes", "--force", "--json"],
+    );
+    let owner_preserved = fs::read(&registry).unwrap() == before;
+    let owner_worker_alive = worker.try_wait().unwrap().is_none();
+    let destroyed = run_ocm(
+        cwd,
+        &env,
+        &["env", "destroy", "borrower", "--yes", "--force", "--json"],
+    );
+    let borrower_worker_alive = worker.try_wait().unwrap().is_none();
+    if borrower_worker_alive {
+        let _ = worker.kill();
+    }
+    let _ = worker.wait();
+    assert!(!owner.status.success(), "{}", stdout(&owner));
+    assert!(
+        stdout(&owner).contains("registered dev source"),
+        "{}",
+        stdout(&owner)
+    );
+    assert!(owner_preserved && owner_worker_alive);
+    assert!(
+        destroyed.status.success(),
+        "{} {}",
+        stdout(&destroyed),
+        stderr(&destroyed)
+    );
+    assert!(
+        borrower_worker_alive,
+        "borrowed source CWD did not grant process ownership"
+    );
+    let summary: serde_json::Value = serde_json::from_str(&stdout(&destroyed)).unwrap();
+    assert_eq!(summary["worktreeRemoved"], false);
+    assert!(summary["devWorktree"].is_null());
+    assert_eq!(summary["processesTerminated"], 0);
+    assert!(
+        summary["steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|step| step["kind"] != "worktree")
+    );
+    assert!(!Path::new(&borrower.root).exists());
+    assert_eq!(
+        git(&repo, &["worktree", "list", "--porcelain"]),
+        registrations
+    );
+    assert_eq!(
+        fs::read_to_string(source.join("retained.txt")).unwrap(),
+        "uncommitted source\n"
+    );
+    assert!(get_environment("owner", &env, cwd).is_ok());
+
+    let created = run_ocm(
+        cwd,
+        &env,
+        &dev_plain(&["borrower", "--repo", &path_string(&source)]),
+    );
+    assert!(created.status.success(), "{}", stderr(&created));
+    let retained = root.child("retained-worktree");
+    fs::rename(&source, &retained).unwrap();
+    let registrations = git(&repo, &["worktree", "list", "--porcelain"]);
+    let before = fs::read(&registry).unwrap();
+    let owner = run_ocm(
+        cwd,
+        &env,
+        &["env", "destroy", "owner", "--yes", "--force", "--json"],
+    );
+    assert!(!owner.status.success(), "{}", stdout(&owner));
+    assert!(stdout(&owner).contains("registered dev source"));
+    assert_eq!(fs::read(&registry).unwrap(), before);
+    assert_eq!(
+        git(&repo, &["worktree", "list", "--porcelain"]),
+        registrations
+    );
+    assert!(!source.exists());
+    // Once an external prune removes the slot too, owner cleanup no longer
+    // mutates this missing source and may remove its separate environment state.
+    git(&repo, &["worktree", "prune", "--expire", "now"]);
+    for name in ["owner", "borrower"] {
+        let removed = run_ocm(cwd, &env, &["env", "remove", name, "--force"]);
+        assert!(removed.status.success(), "{name}: {}", stderr(&removed));
+    }
+    assert_eq!(
+        fs::read_to_string(retained.join("retained.txt")).unwrap(),
+        "uncommitted source\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn env_remove_preserves_a_dangling_root_link_used_by_a_borrowed_source() {
+    let root = TestDir::new("env-remove-borrowed-root-link");
+    let cwd = root.path();
+    let mut env = ocm_launchd_env(&root);
+    install_fake_launchctl(&root, &mut env);
+    install_fake_dev_runners(&root, &mut env);
+    let created = run_ocm(cwd, &env, &["env", "create", "parent"]);
+    assert!(created.status.success(), "{}", stderr(&created));
+    let parent = get_environment("parent", &env, cwd).unwrap();
+    let source = Path::new(&parent.root).join("project");
+    fs::rename(init_openclaw_repo(&root), &source).unwrap();
+    let created = run_ocm(
+        cwd,
+        &env,
+        &dev_plain(&["borrower", "--repo", &path_string(&source)]),
+    );
+    assert!(created.status.success(), "{}", stderr(&created));
+    let retained = root.child("retained-parent");
+    fs::rename(&parent.root, &retained).unwrap();
+    let missing = root.child("missing-parent");
+    std::os::unix::fs::symlink(&missing, &parent.root).unwrap();
+    let registry = ocm::store::env_registry_path(&env, cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+    let rejected = ocm::store::remove_environment("parent", true, &env, cwd).unwrap_err();
+    assert!(rejected.contains("registered dev source"), "{rejected}");
+    assert_eq!(fs::read(&registry).unwrap(), before);
+    assert_eq!(fs::read_link(&parent.root).unwrap(), missing);
+    assert!(retained.join("project/scripts/run-node.mjs").is_file());
+    ocm::store::remove_environment("borrower", true, &env, cwd).unwrap();
+    ocm::store::remove_environment("parent", true, &env, cwd).unwrap();
+    assert!(get_environment("borrower", &env, cwd).is_err());
+    assert!(get_environment("parent", &env, cwd).is_err());
+    // Removing registry records preserves an already dangling environment link.
+    assert_eq!(fs::read_link(&parent.root).unwrap(), missing);
+    assert!(retained.join("project/scripts/run-node.mjs").is_file());
 }
 
 #[cfg(unix)]
@@ -602,7 +765,7 @@ fn env_destroy_preserves_nested_registered_dev_source_and_worker() {
     fs::create_dir_all(repo.parent().unwrap()).unwrap();
     fs::rename(init_openclaw_repo(&root), &repo).unwrap();
     let child = create_dev_source(&repo, "child", &env, cwd);
-    let worktree = Path::new(&child.dev.as_ref().unwrap().worktree_root);
+    let worktree = Path::new(child.dev.as_ref().unwrap().source_root());
     let parent_root = fs::canonicalize(&parent.root).unwrap();
     assert!(
         fs::canonicalize(worktree)
@@ -737,7 +900,7 @@ fn env_cleanup_preserves_registered_dev_identity_paths() {
             symlink(&bridge, repo.join(".git")).unwrap();
         }
         let child = create_dev_source(&repo, "child", &env, cwd);
-        let worktree = Path::new(&child.dev.as_ref().unwrap().worktree_root);
+        let worktree = Path::new(child.dev.as_ref().unwrap().source_root());
         let entrypoint = if layout == "repo-private" {
             repo.as_path()
         } else {
@@ -824,7 +987,7 @@ fn env_remove_keeps_independent_owned_children_removable() {
     install_fake_launchctl(&root, &mut env);
     install_fake_dev_runners(&root, &mut env);
     let parent = create_dev_source(&repo, "parent", &env, root.path());
-    let source = Path::new(&parent.dev.as_ref().unwrap().worktree_root);
+    let source = Path::new(parent.dev.as_ref().unwrap().source_root());
     create_dev_source(source, "child", &env, root.path());
     let refused = run_ocm(root.path(), &env, &["env", "remove", "parent"]);
     assert!(!refused.status.success());
@@ -887,7 +1050,7 @@ fn env_remove_preserves_missing_owned_worktree_recovery() {
             repo = contained;
         }
         let child = create_dev_source(&repo, "child", &env, root.path());
-        let worktree = Path::new(&child.dev.as_ref().unwrap().worktree_root);
+        let worktree = Path::new(child.dev.as_ref().unwrap().source_root());
         fs::write(worktree.join("retained.txt"), "unique detached work\n").unwrap();
         git(worktree, &["add", "retained.txt"]);
         git(worktree, &["commit", "-m", "retain detached dev history"]);
@@ -929,20 +1092,16 @@ fn env_remove_preserves_missing_owned_worktree_recovery() {
         } else {
             worktree.to_path_buf()
         };
-        let replacement = if dev_replacement {
-            run_ocm(
-                root.path(),
+        if dev_replacement {
+            create_owned_dev_env_at_root(
+                &repo,
+                "replacement",
+                &replacement_root,
                 &env,
-                &dev_plain(&[
-                    "replacement",
-                    "--repo",
-                    &path_string(&repo),
-                    "--root",
-                    &path_string(&replacement_root),
-                ]),
-            )
+                root.path(),
+            );
         } else {
-            run_ocm(
+            let replacement = run_ocm(
                 root.path(),
                 &env,
                 &[
@@ -952,9 +1111,9 @@ fn env_remove_preserves_missing_owned_worktree_recovery() {
                     "--root",
                     &path_string(&replacement_root),
                 ],
-            )
-        };
-        assert!(replacement.status.success(), "{}", stderr(&replacement));
+            );
+            assert!(replacement.status.success(), "{}", stderr(&replacement));
+        }
         let replacement = get_environment("replacement", &env, root.path()).unwrap();
         let replacement_before = serde_json::to_value(&replacement).unwrap();
         let retained_state = Path::new(&replacement.root).join("retained-state.txt");
@@ -1008,7 +1167,7 @@ fn env_remove_preserves_source_inside_owned_git_registration() {
         install_fake_launchctl(&root, &mut env);
         install_fake_dev_runners(&root, &mut env);
         let owner = create_dev_source(&repo, "owner", &env, root.path());
-        let worktree = Path::new(&owner.dev.as_ref().unwrap().worktree_root);
+        let worktree = Path::new(owner.dev.as_ref().unwrap().source_root());
         let registration = PathBuf::from(git(worktree, &["rev-parse", "--absolute-git-dir"]));
         let child_repo = registration.join("project");
         git(
@@ -1022,7 +1181,7 @@ fn env_remove_preserves_source_inside_owned_git_registration() {
             ],
         );
         let child = create_dev_source(&child_repo, "child", &env, root.path());
-        let child_source = Path::new(&child.dev.as_ref().unwrap().worktree_root);
+        let child_source = Path::new(child.dev.as_ref().unwrap().source_root());
         // Missing target files still leave a registration slot that Git removes.
         fs::remove_dir_all(worktree).unwrap();
         fs::remove_dir_all(&owner.root).unwrap();
@@ -1056,7 +1215,7 @@ fn env_destroy_preserves_recovery_data_when_worktree_removal_fails() {
     let invalid_worktree = root.child("invalid-worktree");
     fs::write(&invalid_worktree, "not a directory").unwrap();
     let mut meta = get_environment("demo", &env, &cwd).unwrap();
-    meta.dev = Some(EnvDevMeta {
+    meta.dev = Some(EnvDevMeta::Owned {
         repo_root: path_string(&root.child("missing-repo")),
         worktree_root: path_string(&invalid_worktree),
     });

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -393,12 +393,12 @@ fn env_snapshot_restore_preserves_the_current_complete_dev_binding() {
 
         let mut current = get_environment("source", &env, &cwd).unwrap();
         if binding != "ordinary" {
-            current.dev = Some(EnvDevMeta {
+            current.dev = Some(EnvDevMeta::Owned {
                 repo_root: path_string(&root.child("saved-repo")),
                 worktree_root: path_string(&root.child("saved-worktree")),
             });
             if binding == "dev" {
-                let repo = Path::new(&current.dev.as_ref().unwrap().repo_root);
+                let repo = Path::new(current.dev.as_ref().unwrap().repo_root());
                 write_text(&repo.join("package.json"), r#"{"name":"openclaw"}"#);
                 write_text(&repo.join("scripts/run-node.mjs"), "");
                 for args in [
@@ -490,7 +490,7 @@ fn env_snapshot_restore_preserves_the_current_complete_dev_binding() {
         if binding == "dev" {
             assert_eq!(
                 resolved.run_dir,
-                current.dev.as_ref().unwrap().worktree_root
+                current.dev.as_ref().unwrap().source_root()
             );
         }
     }
@@ -1131,7 +1131,7 @@ fn env_snapshot_restore_remains_compatible_with_legacy_tar_metadata() {
     assert_eq!(fs::read_to_string(&notes).unwrap(), "legacy-snapshot\n");
 
     let mut current = get_environment("source", &env, &cwd).unwrap();
-    current.dev = Some(EnvDevMeta {
+    current.dev = Some(EnvDevMeta::Owned {
         repo_root: path_string(&root.child("saved-repo")),
         worktree_root: path_string(&root.child("saved-worktree")),
     });

--- a/tests/execution_tests.rs
+++ b/tests/execution_tests.rs
@@ -120,7 +120,7 @@ fn resolve_execution_binding_falls_back_to_launcher_default() {
 #[test]
 fn resolve_execution_binding_falls_back_to_dev_binding() {
     let mut env = sample_env(None, None);
-    env.dev = Some(EnvDevMeta {
+    env.dev = Some(EnvDevMeta::Owned {
         repo_root: "/tmp/openclaw".to_string(),
         worktree_root: "/tmp/openclaw/.worktrees/demo".to_string(),
     });

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -20,7 +20,7 @@ fn top_level_help_is_clean_and_points_to_topics() {
     ));
     assert!(output.contains("ocm [--color <mode>] <command> [args]"));
     assert!(output.contains("Fast path: create or reuse an env and keep it running"));
-    assert!(output.contains("OpenClaw development envs with worktrees and watch mode"));
+    assert!(output.contains("Run selected OpenClaw checkouts with isolated environment state"));
     assert!(output.contains("Guided setup for release and local-dev flows"));
     assert!(output.contains("Safely update one env or all envs and restart services when needed"));
     assert!(output.contains("Check host software for release and feature readiness"));

--- a/tests/source_watch_daemon_admission_tests.rs
+++ b/tests/source_watch_daemon_admission_tests.rs
@@ -9,7 +9,8 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use ocm::env::{CreateEnvironmentOptions, EnvDevMeta, EnvironmentService};
+use fs2::FileExt;
+use ocm::env::{CreateEnvironmentOptions, EnvDevMeta, EnvMeta, EnvironmentService};
 use ocm::store::{env_registry_path, supervisor_runtime_path, supervisor_state_path};
 use serde_json::{Value, json};
 
@@ -132,6 +133,43 @@ impl AdmissionFixture {
         }
     }
 
+    fn prepare_borrowed_repo(&mut self) {
+        let initialized = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&self.repo)
+            .output()
+            .unwrap();
+        assert!(
+            initialized.status.success(),
+            "{}",
+            String::from_utf8_lossy(&initialized.stderr)
+        );
+        self.repo = fs::canonicalize(&self.repo).unwrap();
+        write_executable_script(
+            &self.root.child("fake-bin/pnpm"),
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n",
+                path_string(&self.root.child("pnpm.log"))
+            ),
+        );
+    }
+
+    fn create_borrowed(&self, name: &str) -> Result<EnvMeta, String> {
+        EnvironmentService::new(&self.env, &self.cwd).create(CreateEnvironmentOptions {
+            name: name.to_string(),
+            root: Some(path_string(&self.root.child(name))),
+            gateway_port: None,
+            service_enabled: false,
+            service_running: false,
+            default_runtime: None,
+            default_launcher: None,
+            dev: Some(EnvDevMeta::Borrowed {
+                source_root: path_string(&self.repo),
+            }),
+            protected: false,
+        })
+    }
+
     fn start_daemon(&mut self) -> Value {
         // No services are desired running, so the owned daemon has no child
         // processes. Its real native identity supplies the capability fixture.
@@ -155,7 +193,7 @@ impl AdmissionFixture {
                 && runtime["gatewayAdmission"]["process"]["pid"] == pid
             {
                 assert_eq!(runtime["children"], json!([]));
-                assert_eq!(runtime["gatewayAdmission"]["version"], 10);
+                assert_eq!(runtime["gatewayAdmission"]["version"], 11);
                 assert!(
                     runtime["gatewayAdmission"]["process"]["startedAt"]
                         .as_str()
@@ -428,6 +466,11 @@ fn dev_watch_allows_confirmed_stopped_and_unloaded_daemons() {
 
 #[test]
 fn saved_dev_plan_revalidates_source_and_binding_before_launch() {
+    assert_saved_dev_plan_revalidation(false);
+    assert_saved_dev_plan_revalidation(true);
+}
+
+fn assert_saved_dev_plan_revalidation(borrowed: bool) {
     let mut fixture = AdmissionFixture::new("dev-daemon-saved-plan");
     fixture.set_manager_state("stopped", 0);
     fixture.repo = fs::canonicalize(&fixture.repo).unwrap();
@@ -478,9 +521,15 @@ fn saved_dev_plan_revalidates_source_and_binding_before_launch() {
             service_running: true,
             default_runtime: None,
             default_launcher: None,
-            dev: Some(EnvDevMeta {
-                repo_root: path_string(&fixture.repo),
-                worktree_root: worktree_path.clone(),
+            dev: Some(if borrowed {
+                EnvDevMeta::Borrowed {
+                    source_root: worktree_path.clone(),
+                }
+            } else {
+                EnvDevMeta::Owned {
+                    repo_root: path_string(&fixture.repo),
+                    worktree_root: worktree_path.clone(),
+                }
             }),
             protected: false,
         })
@@ -500,22 +549,30 @@ fn saved_dev_plan_revalidates_source_and_binding_before_launch() {
     let worktree_git = worktree.join(".git");
     let git_link = fs::read(&worktree_git).unwrap();
 
-    for case in [
-        "replaced-worktree",
-        "saved-source",
-        "binding-name",
-        "runtime",
-        "launcher",
-    ] {
+    let cases: &[&str] = if borrowed {
+        &["saved-source", "missing-source"]
+    } else {
+        &[
+            "replaced-worktree",
+            "saved-source",
+            "binding-name",
+            "runtime",
+            "launcher",
+        ]
+    };
+    for &case in cases {
         let mut stale = plan.clone();
         let mut changed = source.clone();
         let expected = if case == "replaced-worktree" {
             "registered worktree is not a valid OpenClaw checkout"
         } else if case == "saved-source" {
             "saved dev source no longer matches"
+        } else if case == "missing-source" {
+            "restore that checkout"
         } else {
             "saved dev plan no longer matches the registered binding"
         };
+        let retained_source = fixture.root.child("retained-source");
         match case {
             "replaced-worktree" => {
                 fs::remove_file(&worktree_git).unwrap();
@@ -532,6 +589,7 @@ fn saved_dev_plan_revalidates_source_and_binding_before_launch() {
             "binding-name" => stale["children"][0]["bindingName"] = json!("old-dev"),
             "runtime" => changed.default_runtime = Some("stable".to_string()),
             "launcher" => changed.default_launcher = Some("custom".to_string()),
+            "missing-source" => fs::rename(&worktree, &retained_source).unwrap(),
             _ => unreachable!(),
         }
         ocm::store::save_environment(changed, &fixture.env, &fixture.cwd).unwrap();
@@ -596,5 +654,232 @@ fn saved_dev_plan_revalidates_source_and_binding_before_launch() {
         );
         assert!(!command_log.exists(), "{case} launched the stale command");
         assert!(!fixture.root.child("node.log").exists(), "{case}");
+        if case == "missing-source" {
+            fs::rename(&retained_source, &worktree).unwrap();
+        }
+    }
+}
+
+#[test]
+fn borrowed_dev_requires_decoder_capability_before_plain_watch_or_service_creation() {
+    let mut fixture = AdmissionFixture::new("borrowed-daemon-create");
+    fixture.prepare_borrowed_repo();
+    let current = fixture.start_daemon();
+    let mut legacy = current.clone();
+    legacy["gatewayAdmission"]["version"] = json!(10);
+    write_json_replacing_path(&fixture.runtime, &legacy);
+    let registry = env_registry_path(&fixture.env, &fixture.cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+    let config_path = fixture
+        .root
+        .child("ocm-home/envs/demo/.openclaw/openclaw.json");
+    let config_before = fs::read(&config_path).ok();
+    let source_before = fs::read(fixture.repo.join("package.json")).unwrap();
+    let runtime_before = fs::read(&fixture.runtime).unwrap();
+    let repo = path_string(&fixture.repo);
+    for (name, mode) in [
+        ("plain", None),
+        ("watch", Some("--watch")),
+        ("service", Some("--service")),
+    ] {
+        let root = fixture.root.child(format!("{name}-env"));
+        let root_arg = path_string(&root);
+        let mut args = vec!["dev", name, "--repo", &repo, "--root", &root_arg];
+        if let Some(mode) = mode {
+            args.push(mode);
+        }
+        let rejected = run_ocm(&fixture.cwd, &fixture.env, &args);
+        assert!(!rejected.status.success(), "{name}");
+        assert!(
+            stderr(&rejected).contains("unsupported Gateway admission version"),
+            "{name}: {}",
+            stderr(&rejected)
+        );
+        assert!(
+            stderr(&rejected).contains("service refresh-daemon --acknowledge-gateway-restarts")
+        );
+        assert!(
+            !root.exists(),
+            "{name} created its environment before admission"
+        );
+        assert_eq!(fs::read(&registry).unwrap(), before, "{name}");
+        assert_eq!(
+            fs::read(&fixture.runtime).unwrap(),
+            runtime_before,
+            "{name}"
+        );
+        assert_eq!(
+            fs::read(fixture.repo.join("package.json")).unwrap(),
+            source_before,
+            "{name}"
+        );
+        assert_eq!(fs::read(&config_path).ok(), config_before, "{name}");
+        assert!(!fixture.root.child("node.log").exists(), "{name}");
+        assert!(!fixture.root.child("pnpm.log").exists(), "{name}");
+        assert!(!fixture.repo.join(".worktrees").exists(), "{name}");
+        assert!(!fixture.repo.join("node_modules").exists(), "{name}");
+    }
+    let rejected = fixture.create_borrowed("direct").unwrap_err();
+    assert!(
+        rejected.contains("unsupported Gateway admission version"),
+        "{rejected}"
+    );
+    assert_eq!(fs::read(&registry).unwrap(), before);
+    assert!(!fixture.root.child("direct").exists());
+    write_json_replacing_path(&fixture.runtime, &current);
+    let accepted = fixture.create_borrowed("accepted").unwrap();
+    assert!(matches!(accepted.dev, Some(EnvDevMeta::Borrowed { .. })));
+    fixture.stop_daemon();
+    fixture.set_manager_state("stopped", 0);
+    write_json_replacing_path(&fixture.runtime, &legacy);
+    let stopped = fixture.create_borrowed("stopped").unwrap();
+    assert!(matches!(stopped.dev, Some(EnvDevMeta::Borrowed { .. })));
+}
+
+#[test]
+fn borrowed_new_saved_binding_requires_decoder_capability_but_unchanged_binding_does_not() {
+    let mut fixture = AdmissionFixture::new("borrowed-daemon-saved-binding");
+    fixture.prepare_borrowed_repo();
+    let mut current = fixture.start_daemon();
+    let source = fixture.create_borrowed("source-env").unwrap();
+    current["gatewayAdmission"]["version"] = json!(10);
+    write_json_replacing_path(&fixture.runtime, &current);
+    let registry = env_registry_path(&fixture.env, &fixture.cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+
+    let mut invalid = source.clone();
+    invalid.name = "relative-source".to_string();
+    invalid.dev = Some(EnvDevMeta::Borrowed {
+        source_root: "relative".to_string(),
+    });
+    let rejected = ocm::store::save_environment(invalid, &fixture.env, &fixture.cwd).unwrap_err();
+    assert!(rejected.contains("absolute checkout path"), "{rejected}");
+    assert_eq!(fs::read(&registry).unwrap(), before);
+
+    let mut replacement = ocm::store::get_environment("demo", &fixture.env, &fixture.cwd).unwrap();
+    replacement.dev = source.dev.clone();
+    let rejected =
+        ocm::store::save_environment(replacement, &fixture.env, &fixture.cwd).unwrap_err();
+    assert!(
+        rejected.contains("unsupported Gateway admission version"),
+        "{rejected}"
+    );
+    assert_eq!(fs::read(&registry).unwrap(), before);
+
+    let retained = EnvironmentService::new(&fixture.env, &fixture.cwd)
+        .set_protected(&source.name, true)
+        .unwrap();
+    assert_eq!(retained.dev, source.dev);
+    assert!(retained.protected);
+    let ordinary = EnvironmentService::new(&fixture.env, &fixture.cwd)
+        .set_protected("demo", true)
+        .unwrap();
+    assert!(ordinary.dev.is_none());
+}
+
+#[test]
+fn borrowed_publication_holds_daemon_lifecycle_until_registry_write() {
+    for source_removed in [false, true] {
+        let mut fixture = AdmissionFixture::new("borrowed-daemon-publication-lock");
+        fixture.prepare_borrowed_repo();
+        fixture.start_daemon();
+        let registry = env_registry_path(&fixture.env, &fixture.cwd).unwrap();
+        let registry_before = fs::read(&registry).unwrap();
+        let registry_lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(registry.with_extension("lock"))
+            .unwrap();
+        registry_lock.lock_exclusive().unwrap();
+        let lifecycle = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(fixture.definition.with_extension("lifecycle.lock"))
+            .unwrap();
+        let target = fixture.root.child("queued-env");
+        let target_root = path_string(&target);
+        let source_root = path_string(&fixture.repo);
+        let env = fixture.env.clone();
+        let cwd = fixture.cwd.clone();
+        let (published_tx, published_rx) = std::sync::mpsc::channel();
+        // Exercise the registry producer directly: a foreground CLI command also
+        // briefly takes lifecycle for preflight, before it reaches publication.
+        let publisher = thread::spawn(move || {
+            let result = EnvironmentService::new(&env, &cwd).create(CreateEnvironmentOptions {
+                name: "queued".to_string(),
+                root: Some(target_root),
+                gateway_port: None,
+                service_enabled: false,
+                service_running: false,
+                default_runtime: None,
+                default_launcher: None,
+                dev: Some(EnvDevMeta::Borrowed { source_root }),
+                protected: false,
+            });
+            let _ = published_tx.send(result);
+        });
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match lifecycle.try_lock_exclusive() {
+                Ok(()) => FileExt::unlock(&lifecycle).unwrap(),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(error) => panic!("cannot inspect lifecycle lock: {error}"),
+            }
+            assert!(
+                Instant::now() < deadline,
+                "publisher never acquired lifecycle before the registry"
+            );
+            assert!(
+                matches!(
+                    published_rx.try_recv(),
+                    Err(std::sync::mpsc::TryRecvError::Empty)
+                ),
+                "publisher exited while waiting for registry"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            !target.exists(),
+            "publisher changed the root before acquiring the registry"
+        );
+        let retained_source = fixture.root.child("retained-source");
+        if source_removed {
+            fs::rename(&fixture.repo, &retained_source).unwrap();
+        }
+        FileExt::unlock(&registry_lock).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match lifecycle.try_lock_exclusive() {
+                Ok(()) => break,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "publisher did not release lifecycle"
+                    );
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(error) => panic!("cannot inspect lifecycle release: {error}"),
+            }
+        }
+        let published = ocm::store::get_environment("queued", &fixture.env, &fixture.cwd);
+        FileExt::unlock(&lifecycle).unwrap();
+        let result = published_rx.recv_timeout(Duration::from_secs(15)).unwrap();
+        publisher.join().unwrap();
+        if source_removed {
+            let error = result.unwrap_err();
+            assert!(error.contains("restore that checkout"), "{error}");
+            assert!(published.is_err(), "invalidated source was published");
+            assert!(
+                !target.exists(),
+                "invalidated source created environment state"
+            );
+            assert_eq!(fs::read(&registry).unwrap(), registry_before);
+            assert!(retained_source.join("package.json").exists());
+        } else {
+            let published =
+                published.expect("daemon lifecycle was released before borrowed registration");
+            assert!(matches!(published.dev, Some(EnvDevMeta::Borrowed { .. })));
+            assert!(result.is_ok(), "{}", result.unwrap_err());
+        }
     }
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -69,6 +69,82 @@ impl Drop for TestDir {
     }
 }
 
+pub fn register_owned_dev_env(
+    repo: &Path,
+    worktree: &Path,
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> ocm::env::EnvMeta {
+    register_owned_dev_env_with_root(repo, worktree, name, None, env, cwd)
+}
+
+fn register_owned_dev_env_with_root(
+    repo: &Path,
+    worktree: &Path,
+    name: &str,
+    root: Option<&Path>,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> ocm::env::EnvMeta {
+    ocm::env::EnvironmentService::new(env, cwd)
+        .create(ocm::env::CreateEnvironmentOptions {
+            name: name.to_string(),
+            root: root.map(path_string),
+            gateway_port: None,
+            service_enabled: false,
+            service_running: false,
+            default_runtime: None,
+            default_launcher: None,
+            dev: Some(ocm::env::EnvDevMeta::Owned {
+                repo_root: path_string(&fs::canonicalize(repo).unwrap()),
+                worktree_root: path_string(worktree),
+            }),
+            protected: false,
+        })
+        .unwrap()
+}
+
+pub fn create_owned_dev_env(
+    repo: &Path,
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> PathBuf {
+    create_owned_dev_env_with_root(repo, name, None, env, cwd)
+}
+
+pub fn create_owned_dev_env_at_root(
+    repo: &Path,
+    name: &str,
+    root: &Path,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> PathBuf {
+    create_owned_dev_env_with_root(repo, name, Some(root), env, cwd)
+}
+
+fn create_owned_dev_env_with_root(
+    repo: &Path,
+    name: &str,
+    root: Option<&Path>,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> PathBuf {
+    let relative = Path::new(".worktrees").join(name);
+    let created = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["worktree", "add", "--detach"])
+        .arg(&relative)
+        .output()
+        .unwrap();
+    assert!(created.status.success(), "{}", stderr(&created));
+    let worktree = fs::canonicalize(repo).unwrap().join(relative);
+    register_owned_dev_env_with_root(repo, &worktree, name, root, env, cwd);
+    worktree
+}
+
 impl TestHttpServer {
     pub fn serve_bytes(path: &str, content_type: &str, body: &[u8]) -> Self {
         Self::serve_bytes_times(path, content_type, body, 1)
@@ -423,7 +499,7 @@ pub fn enable_fake_daemon_gateway_admission(
     let (started_at, process_scope) = fixture_process_ownership();
     let capability =
         serde_json::from_value::<ocm::supervisor::SupervisorGatewayAdmission>(serde_json::json!({
-            "version": 10,
+            "version": 11,
             "process": { "pid": std::process::id(), "startedAt": started_at },
             "processScope": process_scope,
         }))

--- a/tests/upgrade_checkpoint_scope_tests.rs
+++ b/tests/upgrade_checkpoint_scope_tests.rs
@@ -11,7 +11,10 @@ use std::time::{Duration, Instant};
 
 use rusqlite::Connection;
 use serde_json::Value;
-use support::{TestDir, ocm_env, run_ocm, stderr, stdout, write_executable_script, write_text};
+use support::{
+    TestDir, create_owned_dev_env, dev_plain, ocm_env, run_ocm, stderr, stdout,
+    write_executable_script, write_text,
+};
 
 struct Fixture {
     root: TestDir,
@@ -553,8 +556,19 @@ impl Fixture {
         self.run_ok(&args);
     }
 
-    fn register_child(&self) {
-        self.run_ok(&["dev", "child", "--repo", self.project.to_str().unwrap()]);
+    fn register_child(&self, borrowed: bool) {
+        let source = self.project.join(".worktrees/child");
+        let repo = if borrowed {
+            source_test_git(
+                &self.project,
+                &["worktree", "add", "--detach", ".worktrees/child"],
+            );
+            &source
+        } else {
+            create_owned_dev_env(&self.project, "child", &self.env, self.root.path());
+            &self.project
+        };
+        self.run_ok(&dev_plain(&["child", "--repo", repo.to_str().unwrap()]));
         write_text(
             &self.project.join(".worktrees/child/authored"),
             "current child work\n",
@@ -590,13 +604,15 @@ impl Fixture {
 #[test]
 fn restore_and_explicit_rollback_preserve_registered_source_and_git_identity() {
     // capture_git is irrelevant for the separately requested full snapshot.
-    for (action, capture_git, current_git, allowed) in [
-        ("full", false, true, false),
-        ("restore", false, true, false),
-        ("restore", true, false, true),
-        ("rollback", false, true, false),
-        ("rollback", true, false, false),
-        ("rollback", true, true, true),
+    for (action, capture_git, current_git, allowed, borrowed) in [
+        ("full", false, true, false, false),
+        ("restore", false, true, false, false),
+        ("restore", true, false, true, false),
+        ("rollback", false, true, false, false),
+        ("rollback", true, false, false, false),
+        ("rollback", true, true, true, false),
+        ("full", false, true, false, true),
+        ("restore", true, false, true, true),
     ] {
         let fixture = Fixture::with_dev_repo();
         fixture.source_scope(capture_git);
@@ -609,7 +625,7 @@ fn restore_and_explicit_rollback_preserve_registered_source_and_git_identity() {
         let id = capture[if action == "full" { "id" } else { "snapshotId" }]
             .as_str()
             .unwrap();
-        fixture.register_child();
+        fixture.register_child(borrowed);
         fixture.source_scope(current_git);
         if action == "full" {
             let mut meta =
@@ -631,7 +647,7 @@ fn restore_and_explicit_rollback_preserve_registered_source_and_git_identity() {
         assert_eq!(
             result.status.success(),
             allowed,
-            "{action}, captured Git={capture_git}, current Git={current_git}: {} {}",
+            "{action}, borrowed={borrowed}, captured Git={capture_git}, current Git={current_git}: {} {}",
             stdout(&result),
             stderr(&result)
         );
@@ -661,8 +677,103 @@ fn restore_and_explicit_rollback_preserve_registered_source_and_git_identity() {
             assert_eq!(stdout(&fixture.run_ok(&snapshots)), snapshots_before);
         }
         assert_eq!(fixture.child_witness(), child_before);
-        fixture.run_ok(&["dev", "child"]);
+        fixture.run_ok(&dev_plain(&["child"]));
     }
+}
+
+#[test]
+fn restore_keeps_a_missing_borrowed_checkout_reserved() {
+    let fixture = Fixture::with_dev_repo();
+    let source = fixture.project.join(".worktrees/child");
+    write_text(&source.join("captured-state"), "old environment content\n");
+    fixture.run_ok(&[
+        "env",
+        "set-independent-paths",
+        "demo",
+        ".openclaw/workspace/projects/example/.worktrees/other",
+        ".openclaw/workspace/projects/example/.git",
+    ]);
+    let capture = fixture.run_ok(&["upgrade", "demo", "--runtime", "new", "--json"]);
+    let capture: Value = serde_json::from_str(&stdout(&capture)).unwrap();
+    let id = capture["snapshotId"].as_str().unwrap();
+    fs::remove_dir_all(&source).unwrap();
+    fixture.register_child(true);
+    let child_before = fixture.child_witness();
+    let retained = fixture.root.child("retained-child");
+    fs::rename(&source, &retained).unwrap();
+    let registry = ocm::store::env_registry_path(&fixture.env, fixture.root.path()).unwrap();
+    let registry_before = fs::read(&registry).unwrap();
+    let snapshots = ["env", "snapshot", "list", "demo", "--json"];
+    let snapshots_before = stdout(&fixture.run_ok(&snapshots));
+    let restored = fixture.run(&["env", "snapshot", "restore", "demo", id]);
+    assert!(!restored.status.success());
+    assert!(
+        stderr(&restored).contains("registered dev source"),
+        "{}",
+        stderr(&restored)
+    );
+    assert!(
+        !source.exists(),
+        "restore recreated the missing borrowed checkout"
+    );
+    assert_eq!(fs::read(&registry).unwrap(), registry_before);
+    assert_eq!(stdout(&fixture.run_ok(&snapshots)), snapshots_before);
+    fs::rename(&retained, &source).unwrap();
+    assert_eq!(fixture.child_witness(), child_before);
+}
+
+#[test]
+fn restore_protects_its_own_borrowed_git_metadata() {
+    let fixture = Fixture::with_dev_repo();
+    fixture.register_child(true);
+    let source = fixture.project.join(".worktrees/child");
+    let capture = fixture.run_ok(&["env", "snapshot", "create", "child", "--json"]);
+    let capture: Value = serde_json::from_str(&stdout(&capture)).unwrap();
+    let args = [
+        "env",
+        "snapshot",
+        "restore",
+        "child",
+        capture["id"].as_str().unwrap(),
+    ];
+    let child = ocm::store::get_environment("child", &fixture.env, fixture.root.path()).unwrap();
+    fixture.run_ok(&args);
+    assert_eq!(
+        ocm::store::get_environment("child", &fixture.env, fixture.root.path())
+            .unwrap()
+            .dev,
+        child.dev
+    );
+    let identity = source_test_git(
+        &source,
+        &[
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-dir",
+            "--git-common-dir",
+        ],
+    );
+    let identity = String::from_utf8(identity).unwrap();
+    let mut identity = identity.lines();
+    let private = PathBuf::from(identity.next().unwrap());
+    let common = identity.next().unwrap();
+    let moved = PathBuf::from(child.root).join(".openclaw/workspace/projects/git-private");
+    fs::create_dir_all(moved.parent().unwrap()).unwrap();
+    fs::rename(&private, &moved).unwrap();
+    fs::write(moved.join("commondir"), format!("{common}\n")).unwrap();
+    symlink(&moved, &private).unwrap();
+    let child_before = fixture.child_witness();
+    let registry = ocm::store::env_registry_path(&fixture.env, fixture.root.path()).unwrap();
+    let registry_before = fs::read(&registry).unwrap();
+    let restored = fixture.run(&args);
+    assert!(!restored.status.success());
+    assert!(
+        stderr(&restored).contains("registered dev source"),
+        "{}",
+        stderr(&restored)
+    );
+    assert_eq!(fs::read(&registry).unwrap(), registry_before);
+    assert_eq!(fixture.child_witness(), child_before);
 }
 
 #[test]
@@ -671,7 +782,7 @@ fn upgrade_requires_safe_rollback_but_respects_no_rollback() {
     fixture
         .env
         .insert("OCM_PROOF_FAIL".to_string(), "1".to_string());
-    fixture.register_child();
+    fixture.register_child(false);
     fixture.source_scope(false);
     let child_before = fixture.child_witness();
     let registry = ocm::store::env_registry_path(&fixture.env, fixture.root.path()).unwrap();
@@ -717,9 +828,9 @@ fn upgrade_requires_safe_rollback_but_respects_no_rollback() {
     assert_eq!(fixture.child_witness(), child_before);
 }
 
-fn check_snapshot_residue_preserves_source(root_link: bool) {
+fn check_snapshot_residue_preserves_source(root_link: bool, borrowed: bool) {
     let fixture = Fixture::with_dev_repo();
-    fixture.register_child();
+    fixture.register_child(borrowed);
     fixture.run_ok(&["env", "create", "linked"]);
     let source = fixture.project.join(".worktrees/child");
     let linked = fixture.root.child("ocm-home/envs/linked");
@@ -760,12 +871,14 @@ fn check_snapshot_residue_preserves_source(root_link: bool) {
 
 #[test]
 fn snapshot_residue_cleanup_preserves_state_directory_links() {
-    check_snapshot_residue_preserves_source(false);
+    check_snapshot_residue_preserves_source(false, false);
 }
 
 #[test]
 fn snapshot_residue_cleanup_preserves_root_directory_links() {
-    check_snapshot_residue_preserves_source(true);
+    for borrowed in [false, true] {
+        check_snapshot_residue_preserves_source(true, borrowed);
+    }
 }
 
 #[test]
@@ -776,7 +889,7 @@ fn legacy_snapshot_restore_preserves_linked_registered_source() {
     };
 
     let fixture = Fixture::with_dev_repo();
-    fixture.register_child();
+    fixture.register_child(false);
     fixture.run_ok(&["env", "create", "linked"]);
     let source = fixture.project.join(".worktrees/child");
     let linked = fixture.root.child("ocm-home/envs/linked");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -3267,14 +3267,7 @@ fi
             );
             None
         } else {
-            let created = run_ocm(
-                cwd,
-                &env,
-                &support::dev_plain(&["dependency", "--repo", &path_string(&repo)]),
-            );
-            assert!(created.status.success(), "{}", stderr(&created));
-            let peer = ocm::store::get_environment("dependency", &env, cwd).unwrap();
-            let source = PathBuf::from(peer.dev.unwrap().worktree_root);
+            let source = support::create_owned_dev_env(&repo, "dependency", &env, cwd);
             fs::create_dir_all(source.join("dist")).unwrap();
             fs::write(source.join("dist/sentinel"), "retained peer output\n").unwrap();
             Some(source)
@@ -3337,13 +3330,13 @@ fi
             );
             let child = ocm::store::get_environment("dependency", &env, cwd).unwrap();
             assert!(
-                Path::new(&child.dev.unwrap().worktree_root)
+                Path::new(child.dev.unwrap().source_root())
                     .join("package.json")
                     .is_file()
             );
             let simulation = ocm::store::get_environment(simulation_name, &env, cwd).unwrap();
             assert!(
-                Path::new(&simulation.dev.unwrap().worktree_root)
+                Path::new(simulation.dev.unwrap().source_root())
                     .join(".artifacts/build.json")
                     .is_file()
             );
@@ -4010,7 +4003,7 @@ fn upgrade_rollback_refuses_a_broken_source_launcher_before_mutation() {
 
     fs::create_dir_all(&project_dir).unwrap();
     let mut current = ocm::store::get_environment("hacking", &env, &cwd).unwrap();
-    current.dev = Some(ocm::env::EnvDevMeta {
+    current.dev = Some(ocm::env::EnvDevMeta::Owned {
         repo_root: path_string(&project_dir),
         worktree_root: path_string(&root.child("saved-worktree")),
     });
@@ -4564,7 +4557,7 @@ fn upgrade_rollback_restores_and_reverses_a_runtime_switch() {
     fs::write(&marker, "after-upgrade").unwrap();
 
     let mut current = ocm::store::get_environment("demo", &env, &cwd).unwrap();
-    current.dev = Some(ocm::env::EnvDevMeta {
+    current.dev = Some(ocm::env::EnvDevMeta::Owned {
         repo_root: path_string(&root.child("saved-repo")),
         worktree_root: path_string(&root.child("saved-worktree")),
     });
@@ -5900,7 +5893,7 @@ fn upgrade_rolls_back_runtime_binding_when_update_finalization_fails() {
     fs::write(&secondary_skill, "skill before upgrade\n").unwrap();
 
     let mut current = ocm::store::get_environment("demo", &env, &cwd).unwrap();
-    current.dev = Some(ocm::env::EnvDevMeta {
+    current.dev = Some(ocm::env::EnvDevMeta::Owned {
         repo_root: path_string(&root.child("saved-repo")),
         worktree_root: path_string(&root.child("saved-worktree")),
     });


### PR DESCRIPTION
## What Problem This Solves

`ocm dev <env> --repo <checkout>` creates a separate worktree, so edits in the selected checkout can be absent from the running environment.

## Why This Change Was Made

New dev environments borrow the canonical explicit or enclosing OpenClaw checkout, with environment state kept outside its source and Git metadata. Execution, cleanup, and restore distinguish borrowed source from OCM-owned worktrees.

## User Impact

- Main and registered linked checkouts run directly, including tracked edits and untracked files. Existing OCM-owned environments retain their worktrees, legacy metadata encoding, and lifecycle behavior, including supported reuse of a missing worktree path.
- Borrowed resumes keep the recorded canonical path and check current Git registration. A different explicit or enclosing checkout is refused; a valid replacement at the same path can satisfy the check.
- Fresh borrowers may prepare missing tooling with `pnpm install --frozen-lockfile`; resumed borrowers report missing tooling for explicit preparation.
- Removing a borrower preserves its source, dependencies, generated output, and unrelated source processes. Cleanup and restore refuse to replace protected borrowed paths or their known Git metadata; missing borrowed paths remain reserved.
- When a managed daemon is running, new or changed borrowed bindings require decoder support. Older OCM readers reject the new records; refresh an incompatible daemon with `ocm service refresh-daemon --acknowledge-gateway-restarts`.

## Evidence

- Remote formatting, a fresh correction CLI build, and the planned affected suite passed: 74 retained executions plus 231 on the corrected source. The existing missing-worktree replacement test passes with its assertions unchanged. The canonical-path and foreign-store status fixture corrections each passed their existing targeted case; all original assertions remain.
- Native OpenClaw comparison captured at `30d4d9dd`: with explicit `--watch --ui`, the selected-checkout edit appears in the borrowed run and remains absent from the OCM-owned baseline. Both runs completed named/repeated stop, destroy, and guarded source restoration. The later publication guard correction preserves the demonstrated flow under reviewed control-flow equivalence.
- On an integrated verification build, seven compatibility predicates passed using real old/new binaries, including old-reader refusal and admission after an explicit daemon refresh.

## Visual evidence

| Before | After |
| --- | --- |
| ![Owned worktree remains unaffected by the selected checkout stylesheet edit](https://github.com/user-attachments/assets/d34fa9c4-006f-401d-b3fd-a70810d01b72) | ![Borrowed checkout shows the edited stylesheet in the running UI](https://github.com/user-attachments/assets/b55934e0-7953-4a45-930d-e56698dc298e) |

### Selected checkout edit appears without a document reload

https://github.com/user-attachments/assets/c68304ed-e286-4174-ba27-cf056b5cbb18

### Visual verification

- Baseline: abda3cbfebb2277711eec303355b30139b7901ce
- Reviewed head: `7fa4cb3349132c5a7bda5625a939ec58632e8381`
- Media capture head: `30d4d9dd50990250da813cf18d1ec7a07dd8b71d`
- Scenario: Run explicit watch and UI modes, then edit ui/src/styles.css in the selected checkout. Compare the old separate Owned worktree with the new Borrowed binding.
- Runtime/build: Native Linux; captured OCM 30d4d9dd/source 2c3d3f26, binary c15f502cf5cd; OpenClaw 61f76146412c; Chrome 151.0.7922.71; current head retains the demonstrated behavior under reviewed control-flow equivalence; production files match the qualified correction
- Selected stylesheet served by the UI: Owned false; Borrowed true
- Rendered edit marker: Owned absent; Borrowed visible inside 1280x900 viewport
- Main-frame navigations during edit: 0 in both runs
- Source and lifecycle preservation: Exact edit retained through named stop and destroy, then restored by fixture; no fallback or remaining processes
- Both independent helper and recorder reviews closed on exact hashes
- Source snapshot tree independently reconstructs qualified source fingerprint
- All four source stills and 238 decoded frames manually reviewed
- After-edit comparison uses matching settled settings views
- Native owner verified source restoration, Git/worktree preservation and complete fixture cleanup

