### PR TITLE
feat: add initial native UI to foreground dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ If you are developing OpenClaw itself, use the dev path:
 ocm dev shaks
 ocm dev shaks --root /tmp/shaks
 ocm dev shaks --watch
+ocm dev shaks --watch --ui
 ocm dev shaks --watch --force
 ocm dev stop shaks
 ocm dev shaks --repo /path/to/openclaw --watch --force
@@ -141,6 +142,20 @@ the environment is registered. The token remains stable through restarts and
 source rebuilds, so paired clients can reconnect. Initialization never replaces an
 existing config or its auth/SecretRefs. Repeating minimum setup leaves an unchanged
 config untouched.
+
+Add `--ui` to run OpenClaw's native Vite server beside either foreground mode.
+OCM prints the session's UI address, then its initial native owner link after
+both Vite and the Gateway Control UI document are ready. The native handoff keeps
+the Gateway identity and credentials; only the browser document moves to Vite.
+UI requires a local HTTP Gateway with Control UI enabled and installed UI dependencies.
+It cannot be combined with `--service`.
+
+The controller owns Gateway, Vite and the initial dashboard helper. A component
+exit stops its sibling; `dev stop` stops both and gives a running helper only the
+remainder of its original 30-second budget. A late link is discarded, and uncertain
+cleanup retains ownership. Repeating the matching command reports the current
+address without starting another helper. The address belongs to this session;
+stop the session before changing UI mode or requesting a new initial owner link.
 
 If you already have a plain `~/.openclaw` home you care about, use `ocm migrate <env>` instead of starting fresh. `setup` and `start` now point that out when they detect an existing plain OpenClaw home.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -104,6 +104,17 @@ before registration, so paired clients can reconnect after a restart or source
 rebuild. Initialization preserves existing config files, including authored auth
 and SecretRefs. Repeating minimum setup preserves unchanged config bytes.
 
+For live Control UI edits, run `ocm dev luna --watch --ui` (or `--ui` with a plain
+foreground Gateway). OCM owns the native Vite process and prints its initial
+native browser handoff once both documents are ready. The UI uses a captured
+loopback address for that session. `ocm dev status luna` and matching repeated
+starts report the address; repeated starts do not issue another browser grant.
+`ocm dev stop luna` stops the components together. A pending initial request gets
+30 seconds and retains its helper until completion; late grant bytes are discarded.
+An unfinished or interrupted cleanup keeps its recorded ownership.
+UI requires HTTP, enabled Control UI and installed source UI dependencies, and
+cannot run with `--service`. Existing authentication settings remain in effect.
+
 If you run `ocm setup` from inside an OpenClaw checkout, local mode can detect that and fill in sensible defaults.
 
 ### 5. Test a local checkout as a release-shaped runtime

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -1,4 +1,5 @@
 mod pnpm;
+mod ui;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
@@ -154,6 +155,8 @@ struct DevStatusSummary {
     gateway_port: u32,
     gateway_url: String,
     gateway_port_reachable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ui_url: Option<String>,
     config_path: String,
     workspace_dir: String,
     service_enabled: bool,
@@ -183,6 +186,7 @@ struct ExistingEnvSourceWatchOptions {
     watch: bool,
     force: bool,
     onboard: bool,
+    ui: bool,
 }
 
 #[derive(Serialize)]
@@ -442,10 +446,31 @@ impl Cli {
         Ok(0)
     }
 
+    fn acquire_dev_lease(
+        &self,
+        name: &str,
+        force: bool,
+        mode: SourceWatchMode,
+        ui: bool,
+    ) -> Result<SourceWatchLease, String> {
+        match (mode, ui) {
+            (SourceWatchMode::Foreground { watching }, true) => self
+                .environment_service()
+                .acquire_source_ui_lease(name, force, watching),
+            (_, false) => self
+                .environment_service()
+                .acquire_source_watch_lease(name, force, mode),
+            (SourceWatchMode::ServicePreparation, true) => {
+                Err("dev cannot combine --ui with --service".to_string())
+            }
+        }
+    }
+
     fn handle_dev_run(&self, args: Vec<String>) -> Result<i32, String> {
         let (args, force) = Self::consume_flag(args, "--force");
         let (args, service_requested) = Self::consume_flag(args, "--service");
         let (args, watch) = Self::consume_flag(args, "--watch");
+        let (args, ui) = Self::consume_flag(args, "--ui");
         let (args, onboard) = Self::consume_flag(args, "--onboard");
         let (args, repo_root) = Self::consume_option(args, "--repo")?;
         let repo_root = Self::require_option_value(repo_root, "--repo")?;
@@ -466,6 +491,13 @@ impl Cli {
         if watch && service_requested {
             return Err("dev cannot combine --watch with --service".to_string());
         }
+        if ui && service_requested {
+            return Err("dev cannot combine --ui with --service".to_string());
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+        if ui {
+            return Err("native dev UI sessions are unsupported on this platform".to_string());
+        }
         if service_requested && let Some(error) = service_backend_support_error(&self.env) {
             return Err(error);
         }
@@ -485,6 +517,7 @@ impl Cli {
                     gateway_port,
                     onboard,
                     watch,
+                    ui,
                 )?
             {
                 return Ok(0);
@@ -499,6 +532,7 @@ impl Cli {
                         watch,
                         force,
                         onboard,
+                        ui,
                     },
                 );
             }
@@ -526,11 +560,8 @@ impl Cli {
         } else {
             SourceWatchMode::Foreground { watching: watch }
         };
-        let mut source_watch_lease = Some(
-            match self
-                .environment_service()
-                .acquire_source_watch_lease(&meta.name, force, mode)
-            {
+        let mut source_watch_lease =
+            Some(match self.acquire_dev_lease(&meta.name, force, mode, ui) {
                 Ok(lease) => lease,
                 Err(error) => {
                     // A competing invocation may have claimed the lease after the first lookup.
@@ -543,14 +574,14 @@ impl Cli {
                             gateway_port,
                             onboard,
                             watch,
+                            ui,
                         )?
                     {
                         return Ok(0);
                     }
                     return Err(error);
                 }
-            },
-        );
+            });
         // Preparation belongs to the lease owner, including a newly created env.
         // A losing invocation must not rewrite config before returning the winner's status.
         let prepared = (|| {
@@ -564,6 +595,12 @@ impl Cli {
             let prepared = self
                 .environment_service()
                 .apply_effective_gateway_port(current)?;
+            if ui {
+                crate::store::dev_ui_gateway_url(
+                    &derive_env_paths(Path::new(&prepared.root)),
+                    prepared.gateway_port.unwrap_or_default(),
+                )?;
+            }
             self.bootstrap_dev_env(&prepared)?;
             Ok::<_, String>(prepared)
         })();
@@ -611,12 +648,28 @@ impl Cli {
             stderr_profile,
         ));
 
-        let preparation = self.prepare_dev_run(
-            &meta,
-            onboard,
-            source_watch_lease.as_mut(),
-            watch_stop.as_deref(),
-        );
+        let preparation = self
+            .prepare_dev_run(
+                &meta,
+                onboard,
+                source_watch_lease.as_mut(),
+                watch_stop.as_deref(),
+            )
+            .and_then(|code| {
+                if code == 0 && ui {
+                    self.prepare_dev_ui(
+                        &meta,
+                        Path::new(&dev.worktree_root),
+                        source_watch_lease
+                            .as_mut()
+                            .ok_or_else(|| "dev UI lease is missing".to_string())?,
+                        watch_stop
+                            .as_deref()
+                            .ok_or_else(|| "dev UI cancellation state is missing".to_string())?,
+                    )?;
+                }
+                Ok(code)
+            });
         if !matches!(&preparation, Ok(0)) {
             return match source_watch_lease.as_mut() {
                 Some(lease) => {
@@ -805,6 +858,7 @@ impl Cli {
             watch,
             force,
             onboard,
+            ui,
         } = options;
         if !watch || !force {
             return Err(format!(
@@ -840,10 +894,11 @@ impl Cli {
         let meta = existing;
         let watch_stop = install_source_watch_signal_handler()?;
         let mut source_watch_lease = Some(
-            match self.environment_service().acquire_source_watch_lease(
+            match self.acquire_dev_lease(
                 &meta.name,
                 true,
                 SourceWatchMode::Foreground { watching: true },
+                ui,
             ) {
                 Ok(lease) => lease,
                 Err(error) => {
@@ -854,6 +909,7 @@ impl Cli {
                         None,
                         false,
                         true,
+                        ui,
                     )? {
                         return Ok(0);
                     }
@@ -904,6 +960,9 @@ impl Cli {
         };
         if !matches!(&preparation, Ok(0)) {
             return finish_source_watch_session(&meta.name, lease, preparation, Ok(()), false);
+        }
+        if ui && let Err(error) = self.prepare_dev_ui(&meta, &repo_root, lease, &watch_stop) {
+            return finish_source_watch_session(&meta.name, lease, Err(error), Ok(()), false);
         }
         let stderr_profile = self.dev_stderr_profile();
         self.stderr_lines(render_source_watch_takeover_summary(
@@ -1150,6 +1209,7 @@ impl Cli {
         gateway_port: Option<u32>,
         onboard: bool,
         watching: bool,
+        ui: bool,
     ) -> Result<bool, String> {
         let env_service = self.environment_service();
         let _operation = env_service.lock_operation(&meta.name)?;
@@ -1162,6 +1222,15 @@ impl Cli {
             SourceWatchState::Active(_) => "active",
             SourceWatchState::Restoring => "restoring",
         };
+        let actual_ui = env_service
+            .source_watch_session(&meta.name)?
+            .is_some_and(|session| !session.closed && session.ui.is_some());
+        if actual_ui != ui {
+            return Err(format!(
+                "dev env {} is running in a different UI mode; stop it before changing --ui",
+                meta.name
+            ));
+        }
         let actual_watching = match &observation {
             SourceWatchState::Active(active) => Some(active.watching.unwrap_or(true)),
             _ => {
@@ -1747,6 +1816,9 @@ impl Cli {
         lease: &mut SourceWatchLease,
         stop_requested: &AtomicBool,
     ) -> SourceWatchResult<i32> {
+        if lease.has_ui() {
+            return self.run_source_gateway_ui(meta, repo_root, lease, stop_requested);
+        }
         let args = [
             if lease.is_watching() {
                 "scripts/watch-node.mjs"
@@ -1980,6 +2052,7 @@ impl Cli {
             issue: None,
         };
         let mut active_endpoint = None;
+        let mut ui_url = None;
         let active_source = match observation {
             Ok(SourceWatchState::Inactive) => None,
             Ok(SourceWatchState::Starting) => {
@@ -1999,6 +2072,10 @@ impl Cli {
                     source_watch.issue = Some("This watch has no recorded launch endpoint; the displayed URL comes from current configuration.".to_string());
                 }
                 active_endpoint = watch.endpoint;
+                ui_url = watch
+                    .ui
+                    .as_ref()
+                    .map(|ui| format!("http://127.0.0.1:{}/", ui.port));
                 Some(watch.repo_root)
             }
             Err(error) => {
@@ -2038,6 +2115,7 @@ impl Cli {
             gateway_port,
             gateway_url: dev_gateway_url(gateway_port),
             gateway_port_reachable: crate::service::inspect::tcp_port_reachable(gateway_port),
+            ui_url,
             config_path: display_path(&paths.config_path),
             workspace_dir: display_path(&paths.workspace_dir),
             service_enabled: meta.service_enabled,
@@ -2252,12 +2330,23 @@ fn stop_orphaned_source_watch(session: &SourceWatchSession) -> Result<(), String
         return Err("source watch process scope changed; no processes were signaled".to_string());
     }
     #[cfg(windows)]
-    if session.child_spawn_pending {
+    if session.child_pending() {
         return Err("source watch controller exited before publishing child ownership; Windows crash cleanup cannot be verified, so the unfinished session was retained".to_string());
     }
-    let Some(child) = &session.child else {
-        return Ok(());
-    };
+    let mut errors = Vec::new();
+    for (_, child) in session.recorded_children() {
+        if let Err(error) = stop_orphaned_source_child(&child, session.is_legacy_watch()) {
+            errors.push(error);
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
+fn stop_orphaned_source_child(child: &ProcessIdentity, legacy: bool) -> Result<(), String> {
     #[cfg(unix)]
     {
         let process = observe_process(child.pid)?;
@@ -2265,7 +2354,7 @@ fn stop_orphaned_source_watch(session: &SourceWatchSession) -> Result<(), String
             .as_ref()
             .is_some_and(|process| process.running && process.identity == *child)
         {
-            if session.is_legacy_watch() && process_group_members(child.pid)?.is_empty() {
+            if legacy && process_group_members(child.pid)?.is_empty() {
                 return Ok(());
             }
             return Err("recorded source child no longer matches a live group owner; cleanup cannot be verified from an empty process group, so its session was retained and no processes were signaled".to_string());
@@ -2355,6 +2444,7 @@ fn stop_orphaned_source_watch(session: &SourceWatchSession) -> Result<(), String
     }
     #[cfg(windows)]
     {
+        let _ = legacy;
         // The existing kill-on-close job contains all children when its
         // controller exits. Never replace that authority with a PID tree scan.
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
@@ -3321,6 +3411,9 @@ fn render_dev_status(summary: &DevStatusSummary, profile: RenderProfile) -> Vec<
         if let Some(issue) = &summary.source_watch.issue {
             lines.push(format!("watch_issue={issue}"));
         }
+        if let Some(url) = &summary.ui_url {
+            lines.push(format!("ui_url={url}"));
+        }
         return lines;
     }
 
@@ -3369,6 +3462,9 @@ fn render_dev_status(summary: &DevStatusSummary, profile: RenderProfile) -> Vec<
     ));
     if let Some(issue) = &summary.source_watch.issue {
         lines.push(paint(issue, Tone::Warning, profile.color));
+    }
+    if let Some(url) = &summary.ui_url {
+        lines.push(format!("UI address: {url}"));
     }
     lines
 }
@@ -4322,6 +4418,7 @@ fs.writeFileSync('source-ran', JSON.stringify({
             gateway_port: 18789,
             gateway_url: "http://127.0.0.1:18789".to_string(),
             gateway_port_reachable: true,
+            ui_url: None,
             config_path: "/tmp/demo/.openclaw/openclaw.json".to_string(),
             workspace_dir: "/tmp/demo/.openclaw/workspace".to_string(),
             service_enabled: true,

--- a/src/cli/dev/ui.rs
+++ b/src/cli/dev/ui.rs
@@ -1,0 +1,894 @@
+use std::net::{Ipv4Addr, SocketAddrV4, TcpStream};
+use url::Url;
+
+use super::*;
+use crate::env::{DevUiChildRole, SourceUiTarget};
+
+#[derive(Clone, Debug)]
+struct DevUiTarget {
+    port: u32,
+    gateway_url: String,
+}
+
+impl DevUiTarget {
+    fn validate(&self, gateway_port: u32) -> Result<(), String> {
+        let url = Url::parse(&self.gateway_url)
+            .map_err(|_| "the saved UI Gateway URL is invalid".to_string())?;
+        if !(1..=u16::MAX as u32).contains(&self.port)
+            || !(1..=u16::MAX as u32).contains(&gateway_port)
+            || url.scheme() != "http"
+            || url.host_str() != Some("127.0.0.1")
+            || url.port_or_known_default() != Some(gateway_port as u16)
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(
+                "the saved UI target does not match the dev session's loopback Gateway".to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    fn documents_ready(&self) -> bool {
+        let Ok(gateway) = Url::parse(&self.gateway_url) else {
+            return false;
+        };
+        let Some(port) = gateway.port_or_known_default() else {
+            return false;
+        };
+        http_ready(u32::from(port), "/health", false)
+            && http_ready(u32::from(port), gateway.path(), true)
+            && http_ready(self.port, "/", true)
+    }
+
+    fn command(&self, meta: &EnvMeta, source: &Path, env: &BTreeMap<String, String>) -> Command {
+        let args = [
+            "scripts/ui.js",
+            "dev",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &self.port.to_string(),
+            "--strictPort",
+            "--logLevel",
+            "error",
+            "--clearScreen",
+            "false",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let mut command = gated_dev_command("node", &args);
+        command
+            .stdin(Stdio::null())
+            .env_clear()
+            .envs(build_openclaw_dev_source_env(meta, env, source))
+            .env("OPENCLAW_UI_DEV_GATEWAY_URL", &self.gateway_url)
+            .env("OPENCLAW_CONTROL_UI_BASE_PATH", "/")
+            .current_dir(source);
+        command
+    }
+
+    fn dashboard_command(
+        &self,
+        meta: &EnvMeta,
+        source: &Path,
+        env: &BTreeMap<String, String>,
+    ) -> Command {
+        let args = vec![
+            display_path(&source.join("openclaw.mjs")),
+            "dashboard".to_string(),
+            "--json".to_string(),
+        ];
+        let mut command = gated_dev_command("node", &args);
+        command
+            .stdin(Stdio::null())
+            .env_clear()
+            .envs(build_openclaw_dev_source_env(meta, env, source))
+            .current_dir(source);
+        command
+    }
+
+    fn handoff_url(&self, output: &[u8]) -> Result<String, String> {
+        let payload: Value = serde_json::from_slice(output)
+            .map_err(|_| "the native dashboard did not return valid JSON".to_string())?;
+        if payload.get("ok").and_then(Value::as_bool) != Some(true) {
+            return Err("the native dashboard did not produce a browser handoff".to_string());
+        }
+        let now_ms = time::OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000;
+        if payload
+            .get("browserBootstrapExpiresAtMs")
+            .and_then(Value::as_i64)
+            .is_none_or(|expires| i128::from(expires) <= now_ms)
+        {
+            return Err(
+                "the native dashboard handoff is missing or expired; restart dev to request a fresh link"
+                    .to_string(),
+            );
+        }
+        let mut link = payload
+            .get("browserUrl")
+            .and_then(Value::as_str)
+            .and_then(|value| Url::parse(value).ok())
+            .ok_or_else(|| {
+                "the native dashboard did not produce a valid browser URL".to_string()
+            })?;
+        let expected = Url::parse(&self.gateway_url)
+            .map_err(|_| "the dev Gateway URL is invalid".to_string())?;
+        if link.origin() != expected.origin()
+            || link.path().trim_end_matches('/') != expected.path().trim_end_matches('/')
+            || !link.username().is_empty()
+            || link.password().is_some()
+            || link.query().is_some()
+        {
+            return Err("the native dashboard targets a different Gateway; stop the dev session before changing its address".to_string());
+        }
+        let fragment = link.fragment().ok_or_else(|| {
+            "the native dashboard did not provide its normal owner handoff".to_string()
+        })?;
+        let fields = url::form_urlencoded::parse(fragment.as_bytes()).collect::<Vec<_>>();
+        let gateways = fields
+            .iter()
+            .filter(|(key, _)| key == "gatewayUrl")
+            .collect::<Vec<_>>();
+        let grants = fields
+            .iter()
+            .filter(|(key, _)| key == "bootstrapToken")
+            .collect::<Vec<_>>();
+        if gateways.len() != 1 || grants.len() != 1 || grants[0].1.trim().is_empty() {
+            return Err(
+                "the native dashboard did not provide an unambiguous Gateway owner handoff"
+                    .to_string(),
+            );
+        }
+        let mut gateway = Url::parse(&gateways[0].1)
+            .map_err(|_| "the native dashboard Gateway URL is invalid".to_string())?;
+        if gateway.scheme() != "ws"
+            || !gateway.username().is_empty()
+            || gateway.password().is_some()
+            || gateway.query().is_some()
+            || gateway.fragment().is_some()
+        {
+            return Err(
+                "the native dashboard Gateway URL does not match this dev session".to_string(),
+            );
+        }
+        gateway
+            .set_scheme("http")
+            .map_err(|_| "the native dashboard Gateway URL is invalid".to_string())?;
+        if gateway.as_str().trim_end_matches('/') != expected.as_str().trim_end_matches('/') {
+            return Err("the native dashboard targets a different Gateway; stop the dev session before changing its address".to_string());
+        }
+        // Preserve the native grant and logical Gateway identity exactly. Only the
+        // document moves to Vite, whose transport is owned by OpenClaw.
+        link.set_port(Some(self.port as u16))
+            .map_err(|_| "the session UI port is invalid".to_string())?;
+        link.set_path("/");
+        Ok(link.to_string())
+    }
+}
+
+fn http_ready(port: u32, path: &str, html: bool) -> bool {
+    if !(1..=u16::MAX as u32).contains(&port) {
+        return false;
+    }
+    let deadline = std::time::Instant::now() + Duration::from_millis(350);
+    let address = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port as u16);
+    let Ok(mut stream) = TcpStream::connect_timeout(&address.into(), Duration::from_millis(100))
+    else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(200)));
+    if stream
+        .write_all(
+            format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n")
+                .as_bytes(),
+        )
+        .is_err()
+    {
+        return false;
+    }
+    let mut response = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    while response.len() < 8192 {
+        let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+            return false;
+        };
+        let _ = stream.set_read_timeout(Some(remaining));
+        let Ok(count) = stream.read(&mut chunk) else {
+            return false;
+        };
+        if count == 0 {
+            break;
+        }
+        response.extend_from_slice(&chunk[..count]);
+        if response.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+            break;
+        }
+    }
+    if !response.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+        return false;
+    }
+    let headers = String::from_utf8_lossy(&response).to_ascii_lowercase();
+    (headers.starts_with("http/1.1 200 ") || headers.starts_with("http/1.0 200 "))
+        && (!html
+            || headers
+                .lines()
+                .any(|line| line.starts_with("content-type:") && line.contains("text/html")))
+}
+
+const DASHBOARD_TIMEOUT: Duration = Duration::from_secs(30);
+const DASHBOARD_ATTEMPTS: usize = 3;
+
+enum UiChildOutput {
+    Capture,
+    Logs(SourceWatchLogFiles),
+}
+
+struct OwnedUiChild {
+    role: DevUiChildRole,
+    child: std::process::Child,
+    guard: SourceWatchProcessGuard,
+    identity: ProcessIdentity,
+    started: Option<std::time::Instant>,
+    completion: Option<SourceWatchResult<std::process::ExitStatus>>,
+    stdout: Option<JoinHandle<SourceWatchResult<Vec<u8>>>>,
+    stderr: Option<JoinHandle<SourceWatchResult<Vec<u8>>>>,
+    tees: Vec<JoinHandle<SourceWatchResult<()>>>,
+    drained_output: Option<SourceWatchResult<(Vec<u8>, Vec<u8>)>>,
+}
+
+fn gated_dev_command(program: &str, args: &[String]) -> Command {
+    #[cfg(unix)]
+    {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", SOURCE_WATCH_SETUP_SHIM, "ocm-dev", program]);
+        command.args(args);
+        command
+    }
+    #[cfg(not(unix))]
+    {
+        let mut command = Command::new(program);
+        command.args(args);
+        command
+    }
+}
+
+fn spawn_ui_child(
+    mut command: Command,
+    role: DevUiChildRole,
+    terminal: bool,
+    output: UiChildOutput,
+    lease: &mut SourceWatchLease,
+) -> SourceWatchResult<OwnedUiChild> {
+    lease.configure_child(&mut command);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut guard = SourceWatchProcessGuard::new_with_terminal(terminal)?;
+    guard.configure_command(&mut command)?;
+    lease.begin_ui_child_spawn(role)?;
+    let mut child = command.spawn().map_err(|error| {
+        let message = format!(
+            "failed to run {:?} for dev {role:?}: {error}",
+            command.get_program()
+        );
+        match lease.clear_ui_child(role, None) {
+            Ok(()) => SourceWatchError::from(message),
+            Err(error) => SourceWatchError::unverified(format!("{message}; {error}")),
+        }
+    })?;
+    let ownership = (|| {
+        guard.assign_child(&child)?;
+        lease.attach_to_child(&child)?;
+        lease.record_ui_child(role, child.id())
+    })();
+    let identity = match ownership {
+        Ok(identity) => identity,
+        Err(error) => {
+            #[cfg(windows)]
+            let stopped = stop_suspended_source_watch_after_error(&mut child, &guard, error);
+            #[cfg(not(windows))]
+            let stopped = stop_source_watch_after_error(&mut child, &guard, error);
+            if stopped.cleanup_verified {
+                let expected = lease
+                    .session()
+                    .and_then(|session| session.ui.as_ref())
+                    .and_then(|ui| ui.children.get(role))
+                    .cloned();
+                lease.clear_ui_child(role, expected.as_ref())?;
+            }
+            return Err(stopped);
+        }
+    };
+    let stdout = child
+        .stdout
+        .take()
+        .expect("dev stdout was configured as a pipe");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("dev stderr was configured as a pipe");
+    let (stdout, stderr, tees) = match output {
+        UiChildOutput::Capture => (
+            Some(spawn_source_capture(stdout, "stdout", false)),
+            Some(spawn_source_capture(stderr, "stderr", false)),
+            Vec::new(),
+        ),
+        UiChildOutput::Logs(logs) => (
+            None,
+            None,
+            vec![
+                spawn_tee_thread(stdout, io::stdout(), logs.stdout, "stdout"),
+                spawn_tee_thread(stderr, io::stderr(), logs.stderr, "stderr"),
+            ],
+        ),
+    };
+    Ok(OwnedUiChild {
+        role,
+        child,
+        guard,
+        identity,
+        started: None,
+        completion: None,
+        stdout,
+        stderr,
+        tees,
+        drained_output: None,
+    })
+}
+
+impl OwnedUiChild {
+    fn start(&mut self) -> SourceWatchResult<()> {
+        self.guard.start_child(&self.child)?;
+        self.started = Some(std::time::Instant::now());
+        Ok(())
+    }
+
+    fn poll(&mut self) -> SourceWatchResult<Option<std::process::ExitStatus>> {
+        if self.completion.is_some() {
+            return Ok(None);
+        }
+        let result = poll_source_watch_child(&mut self.child, &self.guard)?;
+        if let Some(status) = result {
+            self.completion = Some(self.guard.classify_completion(Ok(status), true, false));
+        }
+        Ok(result)
+    }
+
+    fn stop(&mut self) -> SourceWatchResult<()> {
+        if self.completion.is_some() {
+            return Ok(());
+        }
+        if self.role == DevUiChildRole::Command
+            && let Some(started) = self.started
+        {
+            // The original request budget also bounds stop-time grace. Native
+            // dashboard reads can finish normally after the Gateway stops.
+            while started.elapsed() < DASHBOARD_TIMEOUT {
+                if self.poll()?.is_some() {
+                    return Ok(());
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+        }
+        let status = if self.started.is_some() {
+            stop_source_watch_child(&mut self.child, &self.guard)?
+        } else {
+            // Startup did not complete. The guard retains whether release was
+            // attempted while we terminate the assigned scope directly.
+            self.guard
+                .stop_remaining(self.child.id())
+                .map_err(SourceWatchError::unverified)?;
+            self.child
+                .wait()
+                .map_err(|error| SourceWatchError::unverified(error.to_string()))?
+        };
+        // Every role owns both output pipes. Keep the raw completion separate
+        // from their EOF result, including a partially released startup gate.
+        self.completion = Some(self.guard.classify_completion(Ok(status), true, true));
+        Ok(())
+    }
+
+    fn finish(&mut self, lease: &mut SourceWatchLease) -> SourceWatchResult<()> {
+        let Some(completion) = self.completion.as_ref() else {
+            return Err(SourceWatchError::unverified(
+                "dev child cleanup has not been verified",
+            ));
+        };
+        let terminal = self.guard.restore_terminal();
+        if self.drained_output.is_none() {
+            let captures = collect_source_captures(self.stdout.take(), self.stderr.take());
+            let tees = wait_for_tee_threads(std::mem::take(&mut self.tees));
+            let drained = match (captures, tees) {
+                (Ok(output), Ok(())) => Ok(output),
+                (Err(capture), Err(tee)) => Err(capture.combine(tee)),
+                (Err(error), _) | (_, Err(error)) => Err(error),
+            };
+            // A later cleanup pass must not turn a consumed failed reader into
+            // successful EOF and erase this child's retained ownership.
+            self.drained_output = Some(drained);
+        }
+        let drained = match self.drained_output.as_ref().expect("output was drained") {
+            Ok(_) => Ok(()),
+            // A bounded reporting failure after verified EOF is delivered as
+            // a pending handoff through output(); it is not a component exit.
+            Err(error) if self.role == DevUiChildRole::Command && error.cleanup_verified => Ok(()),
+            Err(error) => Err(error.clone()),
+        };
+        let mut result =
+            combine_source_watch_cleanup_results(completion.clone(), drained, Ok(())).map(|_| ());
+        if source_watch_allows_service_restore(&result)
+            && let Err(error) = lease.clear_ui_child(self.role, Some(&self.identity))
+        {
+            result = Err(match result {
+                Ok(()) => error.into(),
+                Err(prior) => prior.combine(error.into()),
+            });
+        }
+        match (result, terminal) {
+            (result, Ok(())) => result,
+            (Ok(()), Err(error)) => Err(error.into()),
+            (Err(prior), Err(error)) => Err(prior.combine(error.into())),
+        }
+    }
+
+    fn output(&mut self) -> Result<(Vec<u8>, Vec<u8>), String> {
+        match &mut self.drained_output {
+            Some(Ok((stdout, stderr))) => Ok((std::mem::take(stdout), std::mem::take(stderr))),
+            Some(Err(error)) => Err(error.message.clone()),
+            None => Err("dev output has not completed cleanup verification".to_string()),
+        }
+    }
+}
+
+impl Cli {
+    pub(super) fn prepare_dev_ui(
+        &self,
+        meta: &EnvMeta,
+        source: &Path,
+        lease: &mut SourceWatchLease,
+        stop: &AtomicBool,
+    ) -> SourceWatchResult<()> {
+        if source_watch_cancelled(lease, stop)? {
+            return Err("dev UI setup was cancelled".to_string().into());
+        }
+        let gateway_url = crate::store::dev_ui_gateway_url(
+            &derive_env_paths(Path::new(&meta.root)),
+            meta.gateway_port.unwrap_or_default(),
+        )?;
+        if !source.join("scripts/ui.js").is_file() || !source.join("ui/index.html").is_file() {
+            return Err("the selected source does not contain the native Control UI development entry point".to_string().into());
+        }
+        const PROBE: &str = r#"const fs = require('node:fs');
+const path = require('node:path');
+const {createRequire} = require('node:module');
+const root = fs.realpathSync(process.cwd());
+const uiRequire = createRequire(path.join(root, 'ui', 'package.json'));
+for (const name of ['vite', 'dompurify']) {
+  const entry = fs.realpathSync(uiRequire.resolve(name));
+  const relative = path.relative(root, entry);
+  if (path.isAbsolute(relative) || relative === '..' || relative.startsWith('..' + path.sep)) {
+    throw new Error(name + ' resolves outside the selected OpenClaw checkout');
+  }
+}"#;
+        let mut env = build_openclaw_dev_source_env(meta, &self.env, source);
+        for key in ["NODE_OPTIONS", "NODE_PATH", "NODE_COMPILE_CACHE"] {
+            env.remove(key);
+        }
+        let mut probe = gated_dev_command(
+            "node",
+            &[
+                "--input-type=commonjs".to_string(),
+                "--eval".to_string(),
+                PROBE.to_string(),
+            ],
+        );
+        probe
+            .env_clear()
+            .envs(env)
+            .current_dir(source)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let output = self
+            .run_owned_source_watch_command(
+                probe,
+                lease,
+                stop,
+                SourcePreparationCommand::DependencyProbe,
+            )?
+            .ok_or_else(|| SourceWatchError::from("dev UI setup was cancelled".to_string()))?;
+        if !output.status.success() {
+            return Err("Control UI dependencies are not ready; run pnpm install --frozen-lockfile in the selected checkout before retrying --ui".to_string().into());
+        }
+        let service = self.environment_service();
+        let _operation = service.lock_operation(&meta.name)?;
+        // Only startup reads other live session claims. The registry lock joins
+        // simultaneous selections until this lease publishes its chosen address.
+        crate::store::with_locked_environments(&self.env, &self.cwd, |metas| {
+            if source_watch_cancelled(lease, stop)? {
+                return Err("dev UI setup was cancelled".to_string());
+            }
+            if !metas.iter().any(|current| {
+                lease
+                    .session()
+                    .is_some_and(|session| session.restore_target_matches(current))
+            }) {
+                return Err("dev environment changed before UI startup".to_string());
+            }
+            let mut claimed = Vec::new();
+            for other in metas {
+                if other.name == meta.name {
+                    continue;
+                }
+                if let Some(session) = service.source_watch_session(&other.name)?
+                    && !session.closed
+                    && let Some(target) = session.ui.as_ref().and_then(|ui| ui.target.as_ref())
+                {
+                    claimed.push(target.port);
+                }
+            }
+            let port = crate::store::choose_source_ui_port(metas, &claimed, &self.env)?;
+            let target = DevUiTarget {
+                port,
+                gateway_url: gateway_url.clone(),
+            };
+            target.validate(meta.gateway_port.unwrap_or_default())?;
+            lease.claim_ui_target(SourceUiTarget {
+                port,
+                gateway_url: gateway_url.clone(),
+            })
+        })?;
+        Ok(())
+    }
+
+    pub(super) fn run_source_gateway_ui(
+        &self,
+        meta: &EnvMeta,
+        source: &Path,
+        lease: &mut SourceWatchLease,
+        stop: &AtomicBool,
+    ) -> SourceWatchResult<i32> {
+        if source_watch_cancelled(lease, stop)? {
+            return Ok(130);
+        }
+        let captured = lease
+            .session()
+            .and_then(|session| session.ui.as_ref())
+            .and_then(|ui| ui.target.as_ref())
+            .ok_or_else(|| "dev UI target was not captured".to_string())?;
+        let target = DevUiTarget {
+            port: captured.port,
+            gateway_url: captured.gateway_url.clone(),
+        };
+        target.validate(meta.gateway_port.unwrap_or_default())?;
+        let mut children: Vec<OwnedUiChild> = Vec::new();
+        let mut override_token = None;
+        let result = (|| {
+            let args = vec![
+                "gateway".to_string(),
+                "run".to_string(),
+                "--port".to_string(),
+                meta.gateway_port.unwrap_or_default().to_string(),
+            ];
+            let mut gateway = source_watch_node_command(
+                if lease.is_watching() {
+                    "scripts/watch-node.mjs"
+                } else {
+                    "scripts/run-node.mjs"
+                },
+                &args,
+            );
+            gateway
+                .stdin(Stdio::inherit())
+                .env_clear()
+                .envs(build_openclaw_dev_source_env(meta, &self.env, source))
+                .current_dir(source);
+            children.push(spawn_ui_child(
+                gateway,
+                DevUiChildRole::Gateway,
+                true,
+                UiChildOutput::Logs(open_source_watch_log_files(meta)?),
+                lease,
+            )?);
+            children.push(spawn_ui_child(
+                target.command(meta, source, &self.env),
+                DevUiChildRole::Ui,
+                false,
+                UiChildOutput::Logs(open_source_watch_log_files(meta)?),
+                lease,
+            )?);
+            let active = self
+                .environment_service()
+                .create_source_watch_override_with_lease(
+                    CreateSourceWatchOverrideOptions {
+                        env_name: meta.name.clone(),
+                        repo_root: source.to_path_buf(),
+                        endpoint: SourceWatchEndpoint {
+                            env_root: meta.root.clone(),
+                            gateway_port: meta.gateway_port.unwrap_or_default(),
+                        },
+                        watch_pid: children[0].identity.pid,
+                    },
+                    lease,
+                )?;
+            override_token = Some(active.token.clone());
+            for child in &mut children {
+                if source_watch_cancelled(lease, stop)? {
+                    return Ok(130);
+                }
+                child.start()?;
+            }
+            self.stdout_line(format!("UI address: http://127.0.0.1:{}/", target.port));
+            let began = std::time::Instant::now();
+            let mut last_probe = began - Duration::from_secs(1);
+            let mut attempts = 0;
+            let mut handoff_started: Option<std::time::Instant> = None;
+            let mut discarded = false;
+            let mut delivered = false;
+            let mut pending_reported = false;
+            let mut handoff_failure = None;
+            loop {
+                if source_watch_cancelled(lease, stop)? {
+                    return Ok(130);
+                }
+                let mut index = 0;
+                while index < children.len() {
+                    let Some(status) = children[index].poll()? else {
+                        index += 1;
+                        continue;
+                    };
+                    children[index].finish(lease)?;
+                    let mut child = children.remove(index);
+                    if child.role != DevUiChildRole::Command {
+                        self.stderr_line(format!(
+                            "Dev {:?} exited; stopping the remaining dev processes.",
+                            child.role
+                        ));
+                        return Ok(source_watch_status_code(
+                            &status,
+                            stop.load(Ordering::SeqCst),
+                        ));
+                    }
+                    let expired = handoff_started
+                        .is_some_and(|started| started.elapsed() >= DASHBOARD_TIMEOUT);
+                    handoff_started = None;
+                    last_probe = std::time::Instant::now();
+                    let output = child.output();
+                    if std::mem::take(&mut discarded) || expired {
+                        attempts = DASHBOARD_ATTEMPTS;
+                        if !pending_reported {
+                            self.report_initial_ui_pending("the native dashboard request exceeded 30 seconds; no browser link was delivered");
+                            pending_reported = true;
+                        }
+                        continue;
+                    }
+                    let link = if status.success() {
+                        output.and_then(|(stdout, _)| target.handoff_url(&stdout))
+                    } else {
+                        Err("the native dashboard did not produce a browser handoff".to_string())
+                    };
+                    match link {
+                        Ok(link) => {
+                            if source_watch_cancelled(lease, stop)? {
+                                return Ok(130);
+                            }
+                            self.stdout_line(format!("UI: {link}"));
+                            delivered = true;
+                        }
+                        Err(error) => handoff_failure = Some(error),
+                    }
+                }
+                if handoff_started.is_some_and(|started| started.elapsed() >= DASHBOARD_TIMEOUT)
+                    && !discarded
+                {
+                    discarded = true;
+                    attempts = DASHBOARD_ATTEMPTS;
+                    self.report_initial_ui_pending("the native dashboard request exceeded 30 seconds; its helper remains owned until completion");
+                    pending_reported = true;
+                }
+                if !delivered
+                    && handoff_started.is_none()
+                    && attempts < DASHBOARD_ATTEMPTS
+                    && last_probe.elapsed() >= Duration::from_secs(1)
+                {
+                    last_probe = std::time::Instant::now();
+                    if target.documents_ready() {
+                        attempts += 1;
+                        let service = self.environment_service();
+                        let current = service.get(&meta.name)?;
+                        if !lease
+                            .session()
+                            .is_some_and(|session| session.restore_target_matches(&current))
+                        {
+                            return Err("dev environment changed before the browser handoff"
+                                .to_string()
+                                .into());
+                        }
+                        let current = service.source_watch_environment(current, &active)?;
+                        match spawn_ui_child(
+                            target.dashboard_command(&current, source, &self.env),
+                            DevUiChildRole::Command,
+                            false,
+                            UiChildOutput::Capture,
+                            lease,
+                        ) {
+                            Ok(child) => {
+                                children.push(child);
+                                let child =
+                                    children.last_mut().expect("dashboard child was recorded");
+                                child.start()?;
+                                handoff_started = child.started;
+                                discarded = false;
+                            }
+                            Err(error) if error.cleanup_verified => {
+                                handoff_failure = Some(error.message)
+                            }
+                            Err(error) => return Err(error),
+                        }
+                    }
+                }
+                if !delivered
+                    && !pending_reported
+                    && ((attempts == DASHBOARD_ATTEMPTS && handoff_started.is_none())
+                        || began.elapsed() >= Duration::from_secs(10))
+                {
+                    self.report_initial_ui_pending(handoff_failure.as_deref().unwrap_or(
+                        "waiting for the Gateway document, Vite and the native browser handoff",
+                    ));
+                    pending_reported = true;
+                }
+                #[cfg(unix)]
+                if let Some(gateway) = children
+                    .iter()
+                    .find(|child| child.role == DevUiChildRole::Gateway)
+                    && observe_process(gateway.identity.pid)?.is_some_and(|process| process.stopped)
+                {
+                    gateway
+                        .guard
+                        .suspend_with_child(gateway.identity.pid, lease, stop)?;
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+        })();
+        let mut verified = source_watch_allows_service_restore(&result);
+        let mut errors = Vec::new();
+        // Persistent components precede Command, whose stop grace is limited to
+        // the remaining original request budget. Every error still stops siblings.
+        for child in &mut children {
+            if let Err(error) = child.stop().and_then(|()| child.finish(lease)) {
+                verified &= error.cleanup_verified;
+                errors.push(error.message);
+            }
+        }
+        if verified
+            && let Some(token) = override_token
+            && let Err(error) = self
+                .environment_service()
+                .clear_source_watch_override(&meta.name, &token)
+        {
+            errors.push(error);
+        }
+        match result {
+            Ok(code) if errors.is_empty() => Ok(code),
+            Ok(_) => Err(SourceWatchError {
+                message: errors.join("; "),
+                cleanup_verified: verified,
+            }),
+            Err(error) => {
+                errors.insert(0, error.message);
+                Err(SourceWatchError {
+                    message: errors.join("; "),
+                    cleanup_verified: verified,
+                })
+            }
+        }
+    }
+
+    fn report_initial_ui_pending(&self, reason: &str) {
+        self.stderr_line(format!(
+            "UI link pending: {reason}. Gateway and Vite remain running."
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn handoff(target: &DevUiTarget) -> Value {
+        let mut browser = Url::parse(&target.gateway_url).unwrap();
+        let mut gateway = browser.clone();
+        gateway.set_scheme("ws").unwrap();
+        let fragment = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("bootstrapToken", "synthetic-owner-grant")
+            .append_pair("bootstrapProfile", "control-ui-owner")
+            .append_pair("gatewayUrl", gateway.as_str())
+            .finish();
+        browser.set_fragment(Some(&fragment));
+        json!({
+            "ok": true,
+            "browserUrl": browser.as_str(),
+            "browserBootstrapExpiresAtMs": (time::OffsetDateTime::now_utc().unix_timestamp() + 60) * 1000,
+            "url": "http://127.0.0.1:18789/#token=synthetic-legacy-token",
+            "gatewayPassword": "synthetic-legacy-password",
+        })
+    }
+
+    #[test]
+    fn dev_ui_handoff_retains_native_auth_and_logical_gateway_for_each_mount() {
+        for base in ["/", "/console/", "/nested/control-ui/"] {
+            let target = DevUiTarget {
+                port: 5173,
+                gateway_url: format!("http://127.0.0.1:18789{base}"),
+            };
+            let payload = handoff(&target);
+            let before = Url::parse(payload["browserUrl"].as_str().unwrap()).unwrap();
+            let output = target
+                .handoff_url(&serde_json::to_vec(&payload).unwrap())
+                .unwrap();
+            let after = Url::parse(&output).unwrap();
+            assert_eq!(
+                after.origin().ascii_serialization(),
+                "http://127.0.0.1:5173"
+            );
+            assert_eq!(after.path(), "/");
+            assert_eq!(after.fragment(), before.fragment());
+            assert!(!output.contains("synthetic-legacy"));
+        }
+    }
+
+    #[test]
+    fn dev_ui_handoff_rejects_foreign_or_ambiguous_auth_without_echoing_it() {
+        let target = DevUiTarget {
+            port: 5173,
+            gateway_url: "http://127.0.0.1:18789/console/".to_string(),
+        };
+        let valid = handoff(&target);
+        let valid_link = valid["browserUrl"].as_str().unwrap();
+        let mut cases = vec![json!({"ok": false})];
+        for (from, to) in [
+            ("127.0.0.1:18789", "foreign.example:18789"),
+            ("127.0.0.1:18789", "127.0.0.1:18790"),
+            ("/console/#", "/other/#"),
+            ("http://", "http://synthetic-private@"),
+            ("/console/#", "/console/?secret=synthetic-private#"),
+            ("bootstrapToken=", "unrecognizedToken="),
+            ("bootstrapToken=synthetic-owner-grant", "bootstrapToken="),
+            ("ws%3A", "wss%3A"),
+            ("%2Fconsole%2F", "%2Fforeign%2F"),
+        ] {
+            assert!(valid_link.contains(from));
+            let mut payload = valid.clone();
+            payload["browserUrl"] = valid_link.replacen(from, to, 1).into();
+            cases.push(payload);
+        }
+        for field in [
+            "bootstrapToken=synthetic-private",
+            "gatewayUrl=ws%3A%2F%2Fforeign.example",
+        ] {
+            let mut payload = valid.clone();
+            payload["browserUrl"] = format!("{valid_link}&{field}").into();
+            cases.push(payload);
+        }
+        for expires in [Value::Null, json!(0)] {
+            let mut payload = valid.clone();
+            payload["browserBootstrapExpiresAtMs"] = expires;
+            cases.push(payload);
+        }
+        for payload in cases {
+            let error = target
+                .handoff_url(&serde_json::to_vec(&payload).unwrap())
+                .unwrap_err();
+            assert!(!error.contains("synthetic-"), "{error}");
+        }
+        assert!(
+            target
+                .handoff_url(b"synthetic-private malformed JSON")
+                .is_err()
+        );
+    }
+}

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -151,6 +151,7 @@ pub fn root_help(cmd: &str) -> String {
         format_examples(&[
             format!("{cmd} dev shaks"),
             format!("{cmd} dev shaks --watch"),
+            format!("{cmd} dev shaks --watch --ui"),
             format!("{cmd} start mira"),
             format!("{cmd} migrate mira"),
             format!("{cmd} adopt inspect"),
@@ -242,9 +243,9 @@ pub fn logs_help(cmd: &str) -> String {
 pub fn dev_help(cmd: &str) -> String {
     render_group(
         "Development envs",
-        "Provision OpenClaw dev envs from a checkout worktree, bootstrap the minimum local config, and run the gateway in the foreground with bundled plugins resolved from that source checkout. Existing runtime or launcher envs can also be temporarily taken over with --repo <path> --watch --force; OCM keeps their binding unchanged, routes OpenClaw commands for that env through the watched checkout while watch is active, warns for installed plugins not present in the source tree, tees the foreground output to the env gateway logs, and restores a running background service when watch exits. Background service installation, start, and restart are refused while source watch is active. New foreground sessions and service preparation require a compatible running daemon with verified process ownership; wait for startup or run service refresh-daemon --acknowledge-gateway-restarts from the updated OCM installation during a maintenance window. Confirmed stopped or unloaded daemons do not require refresh. New envs use the explicit --repo checkout or the checkout enclosing the current directory. Outside a checkout, pass --repo; neighboring and remembered repositories are not selected. Existing dev envs use their recorded source. Repeating a matching plain or --watch invocation returns the existing session status and link without setup or restart. Starting and restoring sessions report progress; they are not reported as ready. Stop the session before onboarding or changing --watch, source, root, or port. Reuse keeps the captured launch endpoint; an older watch without endpoint metadata must be stopped from its original terminal first.",
+        "Provision OpenClaw dev envs from a checkout worktree, bootstrap the minimum local config, and run the gateway in the foreground with bundled plugins resolved from that source checkout. Existing runtime or launcher envs can also be temporarily taken over with --repo <path> --watch --force; OCM keeps their binding unchanged, routes OpenClaw commands for that env through the watched checkout while watch is active, warns for installed plugins not present in the source tree, tees the foreground output to the env gateway logs, and restores a running background service when watch exits. Background service installation, start, and restart are refused while source watch is active. New foreground sessions and service preparation require a compatible running daemon with verified process ownership; wait for startup or run service refresh-daemon --acknowledge-gateway-restarts from the updated OCM installation during a maintenance window. Confirmed stopped or unloaded daemons do not require refresh. New envs use the explicit --repo checkout or the checkout enclosing the current directory. Outside a checkout, pass --repo; neighboring and remembered repositories are not selected. Existing dev envs use their recorded source. Repeating a matching plain or --watch invocation returns the existing session status and link without setup or restart. Starting and restoring sessions report progress; they are not reported as ready. Stop the session before onboarding or changing --watch, source, root, or port. Reuse keeps the captured launch endpoint; an older watch without endpoint metadata must be stopped from its original terminal first. Add --ui to run native Vite beside a plain or watched Gateway. The controller owns both components and their initial native browser handoff. UI requires HTTP, enabled Control UI and installed UI dependencies; it cannot be combined with --service. The initial owner link is printed after both documents are ready. A pending request keeps its one helper owned, discards late grant bytes after 30 seconds, and leaves Gateway and Vite running. Matching reuse reports the captured UI address without requesting another grant. Stop before changing --ui; the address is scoped to the session.",
         vec![format!(
-            "{cmd} dev <env> [--repo <path>] [--root <path>] [--port <port>] [--watch] [--force] [--service] [--onboard]"
+            "{cmd} dev <env> [--repo <path>] [--root <path>] [--port <port>] [--watch] [--ui] [--force] [--service] [--onboard]"
         )],
         &[(
             "Commands",
@@ -260,6 +261,7 @@ pub fn dev_help(cmd: &str) -> String {
             format!("{cmd} dev shaks"),
             format!("{cmd} dev shaks --root /tmp/shaks"),
             format!("{cmd} dev shaks --watch"),
+            format!("{cmd} dev shaks --watch --ui"),
             format!("{cmd} dev shaks --watch --force"),
             format!("{cmd} dev shaks --repo /path/to/openclaw --watch --force"),
             format!("{cmd} dev shaks --service"),
@@ -280,7 +282,7 @@ pub fn dev_command_help(cmd: &str, action: &str) -> Option<String> {
     match action {
         "stop" => Some(render_leaf(
             "Stop foreground dev session",
-            "Ask the recorded dev controller to stop its setup or gateway processes, including --service preparation. Preserve the env, source checkout, dependencies, and configuration; report unverified completion without discarding ownership.",
+            "Ask the recorded dev controller to stop its setup, Gateway and optional UI processes, including --service preparation. Preserve the env, source checkout, dependencies, and configuration; report unverified completion without discarding ownership.",
             vec![format!("{cmd} dev stop <env> [--raw] [--json]")],
             &[
                 (
@@ -299,7 +301,8 @@ pub fn dev_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "Waits for the owned source processes to stop before restoring a background service taken over by --watch --force.",
-                "Stops plain and watched foreground dev sessions, including setup. Also cancels --service preparation while preserving an already-running managed Gateway; explicit service stop or uninstall still takes effect.",
+                "Stops plain and watched foreground dev sessions, including setup and optional UI. Also cancels --service preparation while preserving an already-running managed Gateway; explicit service stop or uninstall still takes effect.",
+                "For UI sessions, persistent components stop first; an initial dashboard helper can use only the remaining original 30-second request budget. Unverified cleanup keeps ownership.",
                 "For new Unix foreground generations, a lost controller, raw termination signal, or incomplete output retains unfinished ownership even if the recorded process group stops. Stop/reuse/service-start/destroy cannot erase that uncertainty. Released legacy records keep their recovery rules.",
                 "Ordinary acknowledged errors remain retryable after output completes. Onboarding keeps real terminal output; cancellation or failure without observed output retains ownership, while successful onboarding remains supported.",
                 "During Unix foreground preparation, pnpm lifecycle reports distinguish completed install errors from interrupted or unfinished build scripts; uncertain script cleanup retains ownership even if pnpm returns an ordinary error or succeeds after an optional build. Installer stdin stays interactive when run from a terminal; human output is streamed.",

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -33,8 +33,10 @@ pub use snapshots::{
 pub(crate) use source_watch::{
     CreateSourceWatchOverrideOptions, SourceWatchLease, SourceWatchMode, SourceWatchState,
 };
-pub use source_watch::{SourceWatchEndpoint, SourceWatchOverride};
-pub(crate) use source_watch_session::{SourceWatchCompletion, SourceWatchSession};
+pub use source_watch::{SourceWatchEndpoint, SourceWatchOverride, SourceWatchUiEndpoint};
+pub(crate) use source_watch_session::{
+    DevUiChildRole, SourceUiTarget, SourceWatchCompletion, SourceWatchSession,
+};
 
 pub struct EnvironmentService<'a> {
     env: &'a BTreeMap<String, String>,

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -20,8 +20,12 @@ use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 
 use super::EnvironmentService;
-use super::source_watch_session::{SourceWatchSession, SourceWatchSessionPaths};
-use crate::infra::process_identity::{current_process_identity, observe_process, process_scope_id};
+use super::source_watch_session::{
+    DevUiChildRole, SourceUiTarget, SourceWatchSession, SourceWatchSessionPaths,
+};
+use crate::infra::process_identity::{
+    ProcessIdentity, current_process_identity, observe_process, process_scope_id,
+};
 use crate::service::platform::{ServiceManagerKind, service_manager_kind};
 use crate::store::{
     ExclusiveFileLock, display_path, ensure_dir, lock_file, now_utc, read_json,
@@ -51,9 +55,19 @@ pub struct SourceWatchOverride {
     pub watch_pid: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub watching: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ui: Option<SourceWatchUiEndpoint>,
     pub token: String,
     #[serde(with = "time::serde::rfc3339")]
     pub started_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SourceWatchUiEndpoint {
+    pub port: u32,
+    pub pid: u32,
+    pub gateway_url: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -119,6 +133,12 @@ impl SourceWatchLease {
         self.watching
     }
 
+    pub(crate) fn has_ui(&self) -> bool {
+        self.session
+            .as_ref()
+            .is_some_and(|session| session.ui.is_some())
+    }
+
     pub(crate) fn service_was_running(&self) -> bool {
         self.service_was_running
     }
@@ -143,6 +163,9 @@ impl SourceWatchLease {
     }
 
     pub(crate) fn begin_child_spawn(&mut self) -> Result<(), String> {
+        if self.has_ui() {
+            return self.begin_ui_child_spawn(DevUiChildRole::Command);
+        }
         if let Some(session) = &mut self.session {
             session.child = None;
             session.child_spawn_pending = true;
@@ -152,6 +175,11 @@ impl SourceWatchLease {
     }
 
     pub(crate) fn record_child(&mut self, pid: u32) -> Result<(), String> {
+        if self.has_ui() {
+            return self
+                .record_ui_child(DevUiChildRole::Command, pid)
+                .map(|_| ());
+        }
         if let Some(session) = &mut self.session {
             let process = observe_process(pid)?.ok_or_else(|| {
                 format!("failed to inspect source watch child identity for pid {pid}")
@@ -164,12 +192,111 @@ impl SourceWatchLease {
     }
 
     pub(crate) fn clear_child(&mut self) -> Result<(), String> {
+        if self.has_ui() {
+            let expected = self
+                .session
+                .as_ref()
+                .and_then(|session| session.ui.as_ref())
+                .and_then(|ui| ui.children.get(DevUiChildRole::Command))
+                .cloned();
+            return self.clear_ui_child(DevUiChildRole::Command, expected.as_ref());
+        }
         if let Some(session) = &mut self.session {
             session.child = None;
             session.child_spawn_pending = false;
             self.session_paths.save_session(session)?;
         }
         Ok(())
+    }
+
+    pub(crate) fn claim_ui_target(&mut self, target: SourceUiTarget) -> Result<(), String> {
+        if !target.valid() {
+            return Err("the dev UI target is invalid".to_string());
+        }
+        let session = self.session.as_mut().ok_or("dev UI session is missing")?;
+        if session.closed || session.has_child_ownership() {
+            return Err("dev UI target cannot change while a child is owned".to_string());
+        }
+        let ui = session
+            .ui
+            .as_mut()
+            .ok_or("dev session did not request a UI")?;
+        if ui.target.as_ref().is_some_and(|current| current != &target) {
+            return Err("dev UI target was already captured".to_string());
+        }
+        ui.target = Some(target);
+        self.session_paths.save_session(session)
+    }
+
+    pub(crate) fn begin_ui_child_spawn(&mut self, role: DevUiChildRole) -> Result<(), String> {
+        let session = self.session.as_mut().ok_or("dev UI session is missing")?;
+        let ui = session
+            .ui
+            .as_mut()
+            .ok_or("dev session did not request a UI")?;
+        if session.closed
+            || ui.pending.is_some()
+            || ui.children.get(role).is_some()
+            || (role != DevUiChildRole::Command && ui.target.is_none())
+        {
+            return Err("dev UI child cannot replace existing ownership".to_string());
+        }
+        ui.pending = Some(role);
+        self.session_paths.save_session(session)
+    }
+
+    pub(crate) fn record_ui_child(
+        &mut self,
+        role: DevUiChildRole,
+        pid: u32,
+    ) -> Result<ProcessIdentity, String> {
+        let process =
+            observe_process(pid)?.ok_or_else(|| format!("failed to inspect dev UI child {pid}"))?;
+        let session = self.session.as_mut().ok_or("dev UI session is missing")?;
+        if session
+            .recorded_children()
+            .iter()
+            .any(|(_, child)| child.pid == pid)
+            || session.controller.pid == pid
+        {
+            return Err("dev UI child identity is already owned".to_string());
+        }
+        let ui = session
+            .ui
+            .as_mut()
+            .ok_or("dev session did not request a UI")?;
+        if ui.pending != Some(role) || ui.children.get(role).is_some() {
+            return Err("dev UI child has no matching pending spawn".to_string());
+        }
+        *ui.children.get_mut(role) = Some(process.identity.clone());
+        ui.pending = None;
+        self.session_paths.save_session(session)?;
+        Ok(process.identity)
+    }
+
+    pub(crate) fn clear_ui_child(
+        &mut self,
+        role: DevUiChildRole,
+        expected: Option<&ProcessIdentity>,
+    ) -> Result<(), String> {
+        let session = self.session.as_mut().ok_or("dev UI session is missing")?;
+        let ui = session
+            .ui
+            .as_mut()
+            .ok_or("dev session did not request a UI")?;
+        if ui
+            .children
+            .get(role)
+            .is_some_and(|child| Some(child) != expected)
+            || (expected.is_some() && ui.pending == Some(role))
+        {
+            return Err("dev UI child changed; refusing stale cleanup".to_string());
+        }
+        *ui.children.get_mut(role) = None;
+        if ui.pending == Some(role) {
+            ui.pending = None;
+        }
+        self.session_paths.save_session(session)
     }
 
     pub(crate) fn begin_service_takeover(&mut self) -> Result<(), String> {
@@ -346,6 +473,10 @@ impl<'a> EnvironmentService<'a> {
         session.process_scope = process_scope_id()?;
         session.child = None;
         session.child_spawn_pending = false;
+        if let Some(ui) = &mut session.ui {
+            ui.children = Default::default();
+            ui.pending = None;
+        }
         session.closed = false;
         session.completion = None;
         session_paths.save_session(&session)?;
@@ -448,7 +579,7 @@ impl<'a> EnvironmentService<'a> {
                 return Err(error.to_string());
             }
             if !session.closed
-                && (session.child.is_some() || session.child_spawn_pending)
+                && session.has_child_ownership()
                 && !session.controller_is_running()?
             {
                 return Err(format!(
@@ -469,6 +600,30 @@ impl<'a> EnvironmentService<'a> {
         env_name: &str,
         allow_service_takeover: bool,
         mode: SourceWatchMode,
+    ) -> Result<SourceWatchLease, String> {
+        self.acquire_foreground_lease(env_name, allow_service_takeover, mode, false)
+    }
+
+    pub(crate) fn acquire_source_ui_lease(
+        &self,
+        env_name: &str,
+        allow_service_takeover: bool,
+        watching: bool,
+    ) -> Result<SourceWatchLease, String> {
+        self.acquire_foreground_lease(
+            env_name,
+            allow_service_takeover,
+            SourceWatchMode::Foreground { watching },
+            true,
+        )
+    }
+
+    fn acquire_foreground_lease(
+        &self,
+        env_name: &str,
+        allow_service_takeover: bool,
+        mode: SourceWatchMode,
+        ui: bool,
     ) -> Result<SourceWatchLease, String> {
         let env_name = validate_name(env_name, "Environment name")?;
         // Match service updates: operation, daemon lifecycle, then Gateway
@@ -561,7 +716,11 @@ impl<'a> EnvironmentService<'a> {
         // lease, even if its child PID has since been reused by another process.
         remove_file_if_present(&override_path)?;
         #[cfg(any(target_os = "linux", target_os = "macos", windows))]
-        let session = Some(session_paths.create_session(&meta, &lease_id, mode)?);
+        let session = Some(if ui {
+            session_paths.create_ui_session(&meta, &lease_id, mode.is_watching())?
+        } else {
+            session_paths.create_session(&meta, &lease_id, mode)?
+        });
         #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
         let session = None;
         Ok(SourceWatchLease {
@@ -589,7 +748,29 @@ impl<'a> EnvironmentService<'a> {
                 lease.env_name, options.env_name
             ));
         }
-        self.write_source_watch_override(options, &lease.lease_id, lease.watching)
+        let ui = if let Some(ui) = lease.session().and_then(|session| session.ui.as_ref()) {
+            let target = ui.target.as_ref().ok_or("dev UI target was not captured")?;
+            if ui
+                .children
+                .get(DevUiChildRole::Gateway)
+                .map(|child| child.pid)
+                != Some(options.watch_pid)
+            {
+                return Err("dev Gateway does not match its recorded UI session".to_string());
+            }
+            Some(SourceWatchUiEndpoint {
+                port: target.port,
+                pid: ui
+                    .children
+                    .get(DevUiChildRole::Ui)
+                    .ok_or("dev UI child was not recorded")?
+                    .pid,
+                gateway_url: target.gateway_url.clone(),
+            })
+        } else {
+            None
+        };
+        self.write_source_watch_override(options, &lease.lease_id, lease.watching, ui)
     }
 
     fn write_source_watch_override(
@@ -597,6 +778,7 @@ impl<'a> EnvironmentService<'a> {
         options: CreateSourceWatchOverrideOptions,
         lease_id: &str,
         watching: bool,
+        ui: Option<SourceWatchUiEndpoint>,
     ) -> Result<SourceWatchOverride, String> {
         let env_name = validate_name(&options.env_name, "Environment name")?;
         let path = source_watch_override_path(&env_name, self.env, self.cwd)?;
@@ -615,6 +797,7 @@ impl<'a> EnvironmentService<'a> {
             endpoint: Some(options.endpoint),
             watch_pid: options.watch_pid,
             watching: Some(watching),
+            ui,
             token,
             started_at: now_utc(),
         };
@@ -665,7 +848,8 @@ impl<'a> EnvironmentService<'a> {
         cleanup_stale: bool,
     ) -> Result<SourceWatchState, String> {
         let env_name = validate_name(env_name, "Environment name")?;
-        if let Some(session) = self.source_watch_session(&env_name)? {
+        let session = self.source_watch_session(&env_name)?;
+        if let Some(session) = &session {
             if let Some(error) = session.unsafe_cleanup_error() {
                 return Err(error.to_string());
             }
@@ -706,7 +890,13 @@ impl<'a> EnvironmentService<'a> {
 
         #[cfg(windows)]
         if let Some(_lease_event) = open_windows_source_watch_event(&lock_path)? {
-            return read_leased_source_watch_state(&path, &lock_path, &env_name, cleanup_stale);
+            return read_leased_source_watch_state(
+                &path,
+                &lock_path,
+                &env_name,
+                cleanup_stale,
+                session.as_ref(),
+            );
         }
 
         match try_lock_source_watch_file(&lock_file, false) {
@@ -733,7 +923,13 @@ impl<'a> EnvironmentService<'a> {
                     .unwrap_or(SourceWatchState::Inactive))
             }
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                read_leased_source_watch_state(&path, &lock_path, &env_name, cleanup_stale)
+                read_leased_source_watch_state(
+                    &path,
+                    &lock_path,
+                    &env_name,
+                    cleanup_stale,
+                    session.as_ref(),
+                )
             }
             Err(error) => Err(format!(
                 "failed checking source watch lock {}: {error}",
@@ -772,6 +968,7 @@ fn read_leased_source_watch_state(
     lock_path: &Path,
     env_name: &str,
     cleanup_stale: bool,
+    session: Option<&SourceWatchSession>,
 ) -> Result<SourceWatchState, String> {
     let lock_lease_id = File::open(lock_path)
         .and_then(|mut file| read_source_watch_lock(&mut file))
@@ -800,6 +997,34 @@ fn read_leased_source_watch_state(
     if source_watch_matches_lease(&meta, &lock_lease_id)
         && is_valid_source_watch_structure(&meta, env_name)
     {
+        if meta.ui.is_some() || session.is_some_and(|session| session.ui.is_some()) {
+            let matched = session.is_some_and(|session| {
+                let Some(ui) = &session.ui else { return false };
+                let Some(target) = &ui.target else {
+                    return false;
+                };
+                let Some(endpoint) = &meta.ui else {
+                    return false;
+                };
+                !session.closed
+                    && session.lease_id == lock_lease_id
+                    && meta.watching == session.watching
+                    && target.port == endpoint.port
+                    && target.gateway_url == endpoint.gateway_url
+                    && ui
+                        .children
+                        .get(DevUiChildRole::Gateway)
+                        .map(|child| child.pid)
+                        == Some(meta.watch_pid)
+                    && ui.children.get(DevUiChildRole::Ui).map(|child| child.pid)
+                        == Some(endpoint.pid)
+            });
+            if !matched {
+                return Err(
+                    "dev UI metadata does not match its recorded children and target".to_string(),
+                );
+            }
+        }
         Ok(SourceWatchState::Active(meta))
     } else {
         Err(format!(
@@ -1205,6 +1430,7 @@ mod tests {
             endpoint: None,
             watch_pid: 123,
             watching: None,
+            ui: None,
             token: "123-token".to_string(),
             started_at: OffsetDateTime::UNIX_EPOCH,
         };

--- a/src/env/source_watch_session.rs
+++ b/src/env/source_watch_session.rs
@@ -16,7 +16,77 @@ const LEGACY_SESSION_KIND: &str = "ocm-source-watch-session";
 const WATCH_V2_SESSION_KIND: &str = "ocm-source-watch-session-v2";
 const SESSION_KIND: &str = "ocm-source-foreground-session-v1";
 const SERVICE_PREPARATION_SESSION_KIND: &str = "ocm-source-service-preparation-session-v1";
+const UI_SESSION_KIND: &str = "ocm-source-ui-session-v1";
 const STOP_KIND: &str = "ocm-source-watch-stop";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DevUiChildRole {
+    Gateway,
+    Ui,
+    Command,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SourceUiTarget {
+    pub(crate) port: u32,
+    pub(crate) gateway_url: String,
+}
+
+impl SourceUiTarget {
+    pub(super) fn valid(&self) -> bool {
+        (1..=u16::MAX as u32).contains(&self.port)
+            && url::Url::parse(&self.gateway_url).is_ok_and(|url| {
+                url.scheme() == "http"
+                    && url.host_str() == Some("127.0.0.1")
+                    && url.port_or_known_default().is_some_and(|port| port > 0)
+                    && url.username().is_empty()
+                    && url.password().is_none()
+                    && url.query().is_none()
+                    && url.fragment().is_none()
+            })
+    }
+}
+
+// Fixed fields reject unknown or duplicate roles while keeping the older
+// single-child representation unchanged for sessions without a UI.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SourceUiChildren {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    gateway: Option<ProcessIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ui: Option<ProcessIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    command: Option<ProcessIdentity>,
+}
+
+impl SourceUiChildren {
+    pub(crate) fn get(&self, role: DevUiChildRole) -> Option<&ProcessIdentity> {
+        match role {
+            DevUiChildRole::Gateway => self.gateway.as_ref(),
+            DevUiChildRole::Ui => self.ui.as_ref(),
+            DevUiChildRole::Command => self.command.as_ref(),
+        }
+    }
+
+    pub(super) fn get_mut(&mut self, role: DevUiChildRole) -> &mut Option<ProcessIdentity> {
+        match role {
+            DevUiChildRole::Gateway => &mut self.gateway,
+            DevUiChildRole::Ui => &mut self.ui,
+            DevUiChildRole::Command => &mut self.command,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SourceUiSession {
+    pub(crate) target: Option<SourceUiTarget>,
+    pub(crate) children: SourceUiChildren,
+    pub(crate) pending: Option<DevUiChildRole>,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -35,6 +105,8 @@ pub(crate) struct SourceWatchSession {
     pub(crate) watching: Option<bool>,
     #[serde(default)]
     pub(crate) service_preparation: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) ui: Option<SourceUiSession>,
     pub(crate) restore_service: bool,
     #[serde(default)]
     pub(crate) closed: bool,
@@ -92,8 +164,34 @@ impl SourceWatchSessionPaths {
         lease_id: &str,
         mode: super::SourceWatchMode,
     ) -> Result<SourceWatchSession, String> {
+        self.create_session_with_mode(meta, lease_id, mode, false)
+    }
+
+    pub(super) fn create_ui_session(
+        &self,
+        meta: &EnvMeta,
+        lease_id: &str,
+        watching: bool,
+    ) -> Result<SourceWatchSession, String> {
+        self.create_session_with_mode(
+            meta,
+            lease_id,
+            super::SourceWatchMode::Foreground { watching },
+            true,
+        )
+    }
+
+    fn create_session_with_mode(
+        &self,
+        meta: &EnvMeta,
+        lease_id: &str,
+        mode: super::SourceWatchMode,
+        ui: bool,
+    ) -> Result<SourceWatchSession, String> {
         let session = SourceWatchSession {
-            kind: if mode.is_service_preparation() {
+            kind: if ui {
+                UI_SESSION_KIND
+            } else if mode.is_service_preparation() {
                 SERVICE_PREPARATION_SESSION_KIND
             } else {
                 SESSION_KIND
@@ -109,6 +207,7 @@ impl SourceWatchSessionPaths {
             child_spawn_pending: false,
             watching: Some(mode.is_watching()),
             service_preparation: mode.is_service_preparation(),
+            ui: ui.then(SourceUiSession::default),
             restore_service: false,
             closed: false,
             completion: None,
@@ -129,14 +228,18 @@ impl SourceWatchSessionPaths {
             session.kind.as_str(),
             SESSION_KIND
                 | SERVICE_PREPARATION_SESSION_KIND
+                | UI_SESSION_KIND
                 | WATCH_V2_SESSION_KIND
                 | LEGACY_SESSION_KIND
-        ) || (session.kind == SESSION_KIND && session.watching.is_none())
+        ) || (matches!(session.kind.as_str(), SESSION_KIND | UI_SESSION_KIND)
+            && session.watching.is_none())
             || (session.kind == SERVICE_PREPARATION_SESSION_KIND
                 && (!session.service_preparation
                     || session.watching != Some(false)
                     || session.restore_service))
             || (session.service_preparation && session.kind != SERVICE_PREPARATION_SESSION_KIND)
+            || (session.kind == UI_SESSION_KIND) != session.ui.is_some()
+            || (session.ui.is_some() && (session.child.is_some() || session.child_spawn_pending))
             || session.env_name != env_name
             || session.lease_id.trim().is_empty()
             || session.controller.pid == 0
@@ -151,12 +254,33 @@ impl SourceWatchSessionPaths {
                 "source watch ownership metadata for env \"{env_name}\" is invalid"
             ));
         }
+        let children = session.recorded_children();
+        if session.ui.as_ref().is_some_and(|ui| {
+            children.iter().any(|(_, child)| {
+                child.pid == 0 || child.started_at.is_empty() || child.pid == session.controller.pid
+            }) || children.iter().enumerate().any(|(index, (_, child))| {
+                children[..index]
+                    .iter()
+                    .any(|(_, prior)| prior.pid == child.pid)
+            }) || ui.target.as_ref().is_some_and(|target| !target.valid())
+                || ui
+                    .pending
+                    .is_some_and(|role| ui.children.get(role).is_some())
+                || (ui.target.is_none()
+                    && (ui.children.get(DevUiChildRole::Gateway).is_some()
+                        || ui.children.get(DevUiChildRole::Ui).is_some()
+                        || ui
+                            .pending
+                            .is_some_and(|role| role != DevUiChildRole::Command)))
+                || (session.closed && session.has_child_ownership())
+        }) {
+            return Err("dev UI ownership metadata is invalid".to_string());
+        }
         #[cfg(unix)]
         if session.controller.pid > i32::MAX as u32
-            || session
-                .child
-                .as_ref()
-                .is_some_and(|child| child.pid <= 1 || child.pid > i32::MAX as u32)
+            || children
+                .iter()
+                .any(|(_, child)| child.pid <= 1 || child.pid > i32::MAX as u32)
         {
             return Err("source watch ownership contains an invalid process range".to_string());
         }
@@ -175,6 +299,20 @@ impl SourceWatchSessionPaths {
                 "source watch session for env \"{}\" changed; refusing to replace its ownership metadata",
                 session.env_name
             ));
+        }
+        if current.kind != session.kind
+            || current.watching != session.watching
+            || current.service_preparation != session.service_preparation
+            || current.ui.is_some() != session.ui.is_some()
+            || current
+                .ui
+                .as_ref()
+                .and_then(|ui| ui.target.as_ref())
+                .is_some_and(|target| {
+                    session.ui.as_ref().and_then(|ui| ui.target.as_ref()) != Some(target)
+                })
+        {
+            return Err("dev session mode or captured UI target changed".to_string());
         }
         write_json(&self.session, session)
     }
@@ -243,6 +381,9 @@ impl SourceWatchSessionPaths {
                 session.env_name
             ));
         }
+        if session.ui.is_some() && !preserve_session && session.has_child_ownership() {
+            return Err("dev UI cleanup still owns a child; refusing session closure".to_string());
+        }
         let mut completed = session.clone();
         completed.closed = !preserve_session;
         completed.completion = Some(SourceWatchCompletion {
@@ -278,6 +419,38 @@ impl SourceWatchSession {
         ) || self.watching.unwrap_or(true)
     }
 
+    pub(crate) fn recorded_children(&self) -> Vec<(DevUiChildRole, ProcessIdentity)> {
+        if let Some(ui) = &self.ui {
+            [
+                DevUiChildRole::Gateway,
+                DevUiChildRole::Ui,
+                DevUiChildRole::Command,
+            ]
+            .into_iter()
+            .filter_map(|role| ui.children.get(role).cloned().map(|child| (role, child)))
+            .collect()
+        } else {
+            self.child
+                .clone()
+                .map(|child| vec![(DevUiChildRole::Gateway, child)])
+                .unwrap_or_default()
+        }
+    }
+
+    pub(crate) fn child_pending(&self) -> bool {
+        self.child_spawn_pending || self.ui.as_ref().is_some_and(|ui| ui.pending.is_some())
+    }
+
+    pub(crate) fn has_child_ownership(&self) -> bool {
+        self.child.is_some()
+            || self.child_pending()
+            || self.ui.as_ref().is_some_and(|ui| {
+                ui.children.gateway.is_some()
+                    || ui.children.ui.is_some()
+                    || ui.children.command.is_some()
+            })
+    }
+
     pub(crate) fn is_legacy_watch(&self) -> bool {
         self.kind == LEGACY_SESSION_KIND
     }
@@ -300,16 +473,11 @@ impl SourceWatchSession {
 
     #[cfg(unix)]
     pub(crate) fn requires_controller_completion(&self) -> bool {
-        !self.is_legacy_watch()
-            && !self.closed
-            && (self.child.is_some() || self.child_spawn_pending)
+        !self.is_legacy_watch() && !self.closed && self.has_child_ownership()
     }
 
     pub(crate) fn unsafe_cleanup_error(&self) -> Option<&str> {
-        if !self.is_legacy_watch()
-            && !self.closed
-            && (self.child.is_some() || self.child_spawn_pending)
-        {
+        if !self.is_legacy_watch() && !self.closed && self.has_child_ownership() {
             self.completion
                 .as_ref()
                 .and_then(|completion| completion.error.as_deref())
@@ -327,7 +495,7 @@ impl SourceWatchSession {
             return Ok(false);
         }
         #[cfg(windows)]
-        if self.child_spawn_pending {
+        if self.child_pending() {
             return Ok(false);
         }
         // A current Unix source session can own native descendants outside its
@@ -337,9 +505,9 @@ impl SourceWatchSession {
         if self.requires_controller_completion() {
             return Ok(false);
         }
-        if let Some(child) = &self.child {
+        for (_, child) in self.recorded_children() {
             if observe_process(child.pid)?
-                .is_some_and(|process| process.running && process.identity == *child)
+                .is_some_and(|process| process.running && process.identity == child)
             {
                 return Ok(false);
             }
@@ -514,6 +682,86 @@ mod tests {
     use super::*;
 
     #[test]
+    fn ui_session_keeps_child_ownership_and_rejects_ambiguous_records() {
+        let root = tempfile::tempdir().unwrap();
+        let env = BTreeMap::from([("OCM_HOME".to_string(), display_path(root.path()))]);
+        let meta = crate::store::create_environment(
+            super::super::CreateEnvironmentOptions {
+                name: "demo".to_string(),
+                root: None,
+                gateway_port: Some(19789),
+                service_enabled: false,
+                service_running: false,
+                default_runtime: None,
+                default_launcher: None,
+                dev: None,
+                protected: false,
+            },
+            &env,
+            root.path(),
+        )
+        .unwrap();
+        let paths = EnvironmentService::new(&env, root.path())
+            .source_watch_session_paths("demo")
+            .unwrap();
+        let mut session = paths
+            .create_ui_session(&meta, "ui-generation", false)
+            .unwrap();
+        assert!(!session.is_watching());
+        assert!(!session.service_preparation);
+        let gateway = ProcessIdentity {
+            pid: session.controller.pid + 10000,
+            started_at: "gateway".to_string(),
+        };
+        let ui_child = ProcessIdentity {
+            pid: gateway.pid + 1,
+            started_at: "ui".to_string(),
+        };
+        let ui = session.ui.as_mut().unwrap();
+        ui.target = Some(SourceUiTarget {
+            port: 5173,
+            gateway_url: "http://127.0.0.1:19789/".to_string(),
+        });
+        ui.children.gateway = Some(gateway);
+        ui.children.ui = Some(ui_child);
+        paths.save_session(&session).unwrap();
+        assert!(paths.finish(&session, false, None, false).is_err());
+        assert!(!paths.load_session("demo").unwrap().unwrap().closed);
+        paths
+            .finish(
+                &session,
+                false,
+                Some("unverified UI cleanup".to_string()),
+                true,
+            )
+            .unwrap();
+        let retained = paths.load_session("demo").unwrap().unwrap();
+        assert_eq!(retained.recorded_children().len(), 2);
+        assert!(paths.request_stop(&retained).is_err());
+        assert!(paths.ensure_previous_session_finished("demo").is_err());
+
+        let mut mixed = session.clone();
+        mixed.kind = SESSION_KIND.to_string();
+        write_json(&paths.session, &mixed).unwrap();
+        assert!(paths.load_session("demo").is_err());
+        let mut mixed = session.clone();
+        mixed.service_preparation = true;
+        write_json(&paths.session, &mixed).unwrap();
+        assert!(paths.load_session("demo").is_err());
+        let mut unknown = serde_json::to_value(&session).unwrap();
+        unknown["ui"]["children"]["unowned"] = serde_json::json!({"pid": 1, "startedAt": "other"});
+        write_json(&paths.session, &unknown).unwrap();
+        assert!(paths.load_session("demo").is_err());
+        let duplicate = serde_json::to_string(&session).unwrap().replacen(
+            "\"gateway\":",
+            "\"gateway\":{\"pid\":1,\"startedAt\":\"other\"},\"gateway\":",
+            1,
+        );
+        fs::write(&paths.session, duplicate).unwrap();
+        assert!(paths.load_session("demo").is_err());
+    }
+
+    #[test]
     fn unverified_completion_survives_bad_stop_metadata_and_reclaim() {
         let root = tempfile::tempdir().unwrap();
         let env = BTreeMap::from([("OCM_HOME".to_string(), display_path(root.path()))]);
@@ -535,6 +783,7 @@ mod tests {
             child_spawn_pending: false,
             watching: Some(false),
             service_preparation: false,
+            ui: None,
             restore_service: false,
             closed: false,
             completion: None,
@@ -647,6 +896,7 @@ mod tests {
             child_spawn_pending: false,
             watching: Some(false),
             service_preparation: false,
+            ui: None,
             restore_service: false,
             closed: false,
             completion: None,

--- a/src/store/gateway_ports.rs
+++ b/src/store/gateway_ports.rs
@@ -85,6 +85,24 @@ fn reserve_foreign_openclaw_port_family(
     }
 }
 
+pub(crate) fn choose_source_ui_port(
+    envs: &[EnvMeta],
+    active_ui_ports: &[u32],
+    env: &BTreeMap<String, String>,
+) -> Result<u32, String> {
+    let mut claimed = BTreeSet::new();
+    reserve_foreign_openclaw_port_family(env, &mut claimed);
+    for port in resolve_effective_gateway_ports(envs, env).values().copied() {
+        reserve_openclaw_port_family(port, &mut claimed);
+    }
+    claimed.extend(active_ui_ports);
+    (5173..=u16::MAX as u32)
+        .find(|port| {
+            !claimed.contains(port) && TcpListener::bind(("127.0.0.1", *port as u16)).is_ok()
+        })
+        .ok_or_else(|| "no unreserved loopback port is available for the dev UI".to_string())
+}
+
 fn next_available_gateway_port(start: u32, claimed: &BTreeSet<u32>) -> u32 {
     let mut port = start.max(DEFAULT_GATEWAY_PORT);
     while openclaw_port_family_conflicts(port, claimed) || !openclaw_port_family_available(port) {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -50,8 +50,8 @@ pub(crate) use envs::{
     save_environment_with_validated_runtime, with_locked_environments,
 };
 pub(crate) use gateway_ports::{
-    openclaw_port_family_available, openclaw_port_family_range, resolve_config_gateway_port,
-    resolve_effective_gateway_ports, resolve_env_gateway_port,
+    choose_source_ui_port, openclaw_port_family_available, openclaw_port_family_range,
+    resolve_config_gateway_port, resolve_effective_gateway_ports, resolve_env_gateway_port,
 };
 pub use launchers::{add_launcher, get_launcher, list_launchers, remove_launcher};
 pub use layout::{
@@ -65,10 +65,11 @@ pub use layout::{
 };
 pub(crate) use openclaw_config::{
     OpenClawConfigAudit, audit_openclaw_config, clear_skip_bootstrap_for_openclaw_onboarding,
-    ensure_minimum_local_openclaw_config, normalize_new_environment_sandbox_origin,
-    openclaw_config_include_paths, openclaw_config_uses_includes,
-    reject_include_owned_agent_workspaces, reject_include_owned_sandbox_origin,
-    repair_openclaw_config, rewrite_external_workspace_paths_for_migration,
+    dev_ui_gateway_url, ensure_minimum_local_openclaw_config,
+    normalize_new_environment_sandbox_origin, openclaw_config_include_paths,
+    openclaw_config_uses_includes, reject_include_owned_agent_workspaces,
+    reject_include_owned_sandbox_origin, repair_openclaw_config,
+    rewrite_external_workspace_paths_for_migration,
     rewrite_identity_bound_workspace_paths_for_target, rewrite_openclaw_config_for_migration,
     rewrite_openclaw_config_for_new_environment, rewrite_openclaw_config_for_simulation,
     rewrite_openclaw_config_for_target, rewrite_openclaw_config_includes_for_target,

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -602,6 +602,49 @@ fn minimum_local_config_value(
     Ok(value)
 }
 
+pub(crate) fn dev_ui_gateway_url(paths: &EnvPaths, port: u32) -> Result<String, String> {
+    let config = load_effective_openclaw_config(&paths.config_path)?
+        .map(|config| config.value)
+        .unwrap_or_else(|| json!({}));
+    let gateway = config.get("gateway");
+    if gateway
+        .and_then(|value| value.get("tls"))
+        .and_then(|value| value.get("enabled"))
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        return Err(
+            "--ui currently requires a local HTTP Gateway; this environment enables Gateway TLS. Omit --ui to keep using its configured Gateway"
+                .to_string(),
+        );
+    }
+    let control_ui = gateway.and_then(|value| value.get("controlUi"));
+    if control_ui
+        .and_then(|value| value.get("enabled"))
+        .and_then(Value::as_bool)
+        == Some(false)
+    {
+        return Err(
+            "the environment disables the Control UI; omit --ui to keep using its configured Gateway"
+                .to_string(),
+        );
+    }
+    let base = match control_ui.and_then(|value| value.get("basePath")) {
+        None | Some(Value::Null) => "",
+        Some(Value::String(value)) => value.trim().trim_matches('/'),
+        Some(_) => return Err("gateway.controlUi.basePath must be a URL path".to_string()),
+    };
+    if base.contains(['?', '#', '\\']) || base.split('/').any(|part| matches!(part, "." | "..")) {
+        return Err("gateway.controlUi.basePath must be a URL path without a query, fragment, or dot segments".to_string());
+    }
+    let mut url =
+        Url::parse(&format!("http://127.0.0.1:{port}/")).map_err(|error| error.to_string())?;
+    if !base.is_empty() {
+        url.set_path(&format!("/{base}/"));
+    }
+    Ok(url.to_string())
+}
+
 pub(crate) fn clear_skip_bootstrap_for_openclaw_onboarding(
     target_paths: &EnvPaths,
 ) -> Result<bool, String> {

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -47,8 +47,9 @@ const SUPERVISOR_RUNTIME_KIND: &str = "ocm-supervisor-runtime";
 // This capability covers the current admission filename through child publication.
 // Version 9 adds service-preparation admission and running-service retention to
 // foreground-session admission and retained completion ownership.
+// Version 10 also covers UI session roles, their captured address and cleanup.
 // Values 2 through 6 were used by incompatible development snapshots.
-const GATEWAY_ADMISSION_VERSION: u32 = 9;
+const GATEWAY_ADMISSION_VERSION: u32 = 10;
 const SUPERVISOR_POLL_INTERVAL_MS: u64 = 200;
 const SUPERVISOR_RESTART_DELAY_MS: u64 = 1_000;
 const SUPERVISOR_MAX_RESTART_DELAY_MS: u64 = 30_000;

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1986,7 +1986,7 @@ fn daemon_run_persists_live_runtime_children() {
     let cleared = wait_for_runtime_children(&runtime_path, 0, None, Duration::from_secs(5))
         .expect("daemon runtime state did not clear after shutdown");
     assert!(cleared["updatedAt"].as_str().is_some());
-    assert_eq!(gateway_admission["version"], 9);
+    assert_eq!(gateway_admission["version"], 10);
     assert_eq!(gateway_admission["process"]["pid"], daemon_pid);
     assert!(
         gateway_admission["process"]["startedAt"]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -944,12 +944,51 @@ exec '{node}' "$@"
 }
 
 #[cfg(unix)]
-fn initial_ui_process(root: &TestDir, role: &str) -> Value {
+fn initial_ui_process(root: &TestDir, role: &str, owner: &mut DevWatchFixture) -> Value {
     let file = root.child(format!("{role}.json"));
-    assert!(
-        wait_for_path(&file, Duration::from_secs(10)),
-        "{role} did not start"
-    );
+    if !wait_for_path(&file, Duration::from_secs(10)) {
+        // Read only bytes already in this fixture's stderr pipe; diagnosing a
+        // failed startup must not block on EOF or release/stop its processes.
+        let mut diagnostic = String::new();
+        let mut controller = None;
+        let mut status = None;
+        if let Some(child) = owner.child.as_mut() {
+            controller = Some(child.id());
+            status = Some(child.try_wait());
+            if let Some(stderr) = child.stderr.as_mut() {
+                let mut available: libc::c_int = 0;
+                if unsafe { libc::ioctl(stderr.as_raw_fd(), libc::FIONREAD, &mut available) } == 0
+                    && available > 0
+                {
+                    let mut bytes = vec![0; (available as usize).min(64 * 1024)];
+                    if stderr.read_exact(&mut bytes).is_ok() {
+                        diagnostic = String::from_utf8_lossy(&bytes).into_owned();
+                    }
+                }
+            }
+        }
+        let recorded = fs::read_to_string(&owner.session).unwrap_or_default();
+        let source = owner
+            .session
+            .parent()
+            .and_then(Path::parent)
+            .and_then(|store| fs::read(store.join("envs.json")).ok())
+            .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+            .and_then(|registry| {
+                registry["envs"].as_array().and_then(|envs| {
+                    envs.iter()
+                        .find(|meta| {
+                            meta["name"].as_str()
+                                == owner.session.file_stem().and_then(|name| name.to_str())
+                        })
+                        .map(|meta| meta["dev"].clone())
+                })
+            });
+        panic!(
+            "{role} did not start at {}; controller={controller:?}, status={status:?}, source={source:?}, session={recorded}, stderr={diagnostic}",
+            file.display()
+        );
+    }
     serde_json::from_slice(&fs::read(file).unwrap()).unwrap()
 }
 
@@ -980,8 +1019,8 @@ fn dev_ui_initial_handoff_and_owned_lifecycle() {
             fs::write(root.child("dashboard-hold"), "hold").unwrap();
         }
         let mut controller = DevWatchFixture::spawn(&root, &repo, &env, &args);
-        let gateway = initial_ui_process(&root, "gateway");
-        let ui = initial_ui_process(&root, "ui");
+        let gateway = initial_ui_process(&root, "gateway", &mut controller);
+        let ui = initial_ui_process(&root, "ui", &mut controller);
         let gateway_pid = gateway["pid"].as_u64().unwrap() as u32;
         let ui_pid = ui["pid"].as_u64().unwrap() as u32;
         let session = read_source_watch_session(&root);
@@ -1119,15 +1158,49 @@ fn dev_ui_claims_an_address_before_the_listener_starts() {
     let mut env = ocm_env(&root);
     let repo = prepare_initial_ui_repo(&root, &mut env);
     fs::write(root.child("ui-start-hold"), "hold").unwrap();
+    fs::write(root.child("gateway-start-hold"), "hold").unwrap();
     let mut first = DevWatchFixture::spawn(
         &root,
         &repo,
         &env,
         &["dev", "first", "--repo", &path_string(&repo), "--ui"],
     );
-    let first_gateway = initial_ui_process(&root, "gateway");
+    assert!(wait_for_path(
+        &source_watch_override_path(&root, "first"),
+        Duration::from_secs(10)
+    ));
     let session_file = source_watch_override_path(&root, "first").with_extension("session");
     let session: Value = serde_json::from_slice(&fs::read(&session_file).unwrap()).unwrap();
+    let gateway_port = url::Url::parse(session["ui"]["target"]["gatewayUrl"].as_str().unwrap())
+        .unwrap()
+        .port()
+        .unwrap();
+    // Other tests' isolated stores probe this same OS port after selection.
+    // Hold one such transient conflict until the fake actually observes it.
+    let until = Instant::now() + Duration::from_secs(5);
+    let probe = loop {
+        match std::net::TcpListener::bind(("127.0.0.1", gateway_port)) {
+            Ok(probe) => break probe,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::AddrInUse && Instant::now() < until =>
+            {
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(error) => panic!("failed to hold the selected Gateway port: {error}"),
+        }
+    };
+    fs::remove_file(root.child("gateway-start-hold")).unwrap();
+    assert!(wait_for_path(
+        &root.child("gateway-listen-error"),
+        Duration::from_secs(5)
+    ));
+    assert_eq!(
+        fs::read_to_string(root.child("gateway-listen-error")).unwrap(),
+        "EADDRINUSE"
+    );
+    assert!(!root.child("gateway.json").exists());
+    drop(probe);
+    let first_gateway = initial_ui_process(&root, "gateway", &mut first);
     let port = session["ui"]["target"]["port"].as_u64().unwrap() as u16;
     assert!(
         std::net::TcpListener::bind(("127.0.0.1", port)).is_ok(),
@@ -1149,11 +1222,11 @@ fn dev_ui_claims_an_address_before_the_listener_starts() {
             "--ui",
         ],
     );
-    let second_gateway = initial_ui_process(&second_root, "gateway");
-    let second_ui = initial_ui_process(&second_root, "ui");
+    let second_gateway = initial_ui_process(&second_root, "gateway", &mut second);
+    let second_ui = initial_ui_process(&second_root, "ui", &mut second);
     assert_ne!(second_ui["port"].as_u64().unwrap(), u64::from(port));
     fs::remove_file(root.child("ui-start-hold")).unwrap();
-    let first_ui = initial_ui_process(&root, "ui");
+    let first_ui = initial_ui_process(&root, "ui", &mut first);
     for name in ["first", "second"] {
         let stopped = run_named_dev_stop(&repo, &env, name);
         assert!(stopped.status.success(), "{}", stderr(&stopped));

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -445,7 +445,9 @@ impl DevWatchFixture {
         Self {
             child: Some(child),
             release: root.child("source-watch.release"),
-            session: source_watch_override_path(root, args[1]).with_extension("session"),
+            session: PathBuf::from(&env["OCM_HOME"])
+                .join("source-watch")
+                .join(format!("{}.session", args[1])),
         }
     }
 
@@ -500,6 +502,17 @@ impl Drop for DevWatchFixture {
             .and_then(|session| session["child"]["pid"].as_u64())
         {
             let _ = wait_for_process_exit(pid as u32, Duration::from_secs(2));
+        }
+        if let Some(children) = fs::read(&self.session)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+            .and_then(|session| session["ui"]["children"].as_object().cloned())
+        {
+            for child in children.values() {
+                if let Some(pid) = child["pid"].as_u64() {
+                    let _ = wait_for_process_exit(pid as u32, Duration::from_secs(3));
+                }
+            }
         }
     }
 }
@@ -835,6 +848,339 @@ fn service_env_with_gateway_admission(
     let mut env = service_env(root);
     enable_fake_daemon_gateway_admission(root, &mut env);
     env
+}
+
+#[cfg(unix)]
+static INITIAL_UI_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(unix)]
+fn prepare_initial_ui_repo(
+    root: &TestDir,
+    env: &mut std::collections::BTreeMap<String, String>,
+) -> PathBuf {
+    let repo = init_openclaw_repo(root);
+    let node = Command::new("node")
+        .args(["-p", "process.execPath"])
+        .env_clear()
+        .envs(&*env)
+        .output()
+        .unwrap();
+    assert!(node.status.success(), "{}", stderr(&node));
+    let node = stdout(&node).trim().replace('\'', "'\\''");
+    let bin = root.child("initial-ui-bin");
+    fs::create_dir_all(&bin).unwrap();
+    // Root dependency inspection is covered by its own owner. The UI probe
+    // executes real resolution against these deliberately nonexecutable stubs.
+    write_executable_script(
+        &bin.join("node"),
+        &format!(
+            r#"#!/bin/sh
+case "${{3:-}}" in
+  *uiRequire*) exec '{node}' "$@";;
+  *createRequire*|*ocm-source-dependencies*)
+    if [ -n "$OCM_SOURCE_WATCH_START_FD" ]; then
+      IFS= read -r start < "/dev/fd/$OCM_SOURCE_WATCH_START_FD" || exit 1
+      unset OCM_SOURCE_WATCH_START_FD
+    fi
+    exit 0;;
+esac
+exec '{node}' "$@"
+"#
+        ),
+    );
+    prepend_fake_bin(env, &bin);
+    env.insert("OCM_TEST_DEV_UI_DIR".to_string(), path_string(root.path()));
+    fs::create_dir_all(repo.join("ui")).unwrap();
+    fs::write(
+        repo.join("ui/index.html"),
+        "<!doctype html><title>UI fixture</title>",
+    )
+    .unwrap();
+    fs::write(repo.join("ui/package.json"), r#"{"name":"ui-fixture"}"#).unwrap();
+    fs::write(
+        repo.join("scripts/dev-ui-fixture.cjs"),
+        include_str!("support/dev_ui.cjs"),
+    )
+    .unwrap();
+    fs::write(
+        repo.join("scripts/ui.js"),
+        "require('./dev-ui-fixture.cjs');\n",
+    )
+    .unwrap();
+    for entry in ["watch-node.mjs", "run-node.mjs"] {
+        fs::write(
+            repo.join("scripts").join(entry),
+            "import './dev-ui-fixture.cjs';\n",
+        )
+        .unwrap();
+    }
+    fs::write(
+        repo.join("openclaw.mjs"),
+        "import './scripts/dev-ui-fixture.cjs';\n",
+    )
+    .unwrap();
+    for name in ["vite", "dompurify"] {
+        let directory = repo.join("node_modules").join(name);
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(
+            directory.join("package.json"),
+            format!(r#"{{"name":"{name}","main":"index.js"}}"#),
+        )
+        .unwrap();
+        fs::write(
+            directory.join("index.js"),
+            "throw new Error('UI inspection must not execute package code');\n",
+        )
+        .unwrap();
+    }
+    // These are tiny synthetic resolution fixtures, not copied dependencies.
+    let added = Command::new("git")
+        .args(["-C", &path_string(&repo), "add", "-f", "node_modules"])
+        .output()
+        .unwrap();
+    assert!(added.status.success(), "{}", stderr(&added));
+    commit_nested_openclaw_repo(&repo);
+    repo
+}
+
+#[cfg(unix)]
+fn initial_ui_process(root: &TestDir, role: &str) -> Value {
+    let file = root.child(format!("{role}.json"));
+    assert!(
+        wait_for_path(&file, Duration::from_secs(10)),
+        "{role} did not start"
+    );
+    serde_json::from_slice(&fs::read(file).unwrap()).unwrap()
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_ui_initial_handoff_and_owned_lifecycle() {
+    let _serial = INITIAL_UI_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (watch, outcome) in [
+        (false, "stop"),
+        (true, "sibling"),
+        (false, "deadline"),
+        (true, "raw"),
+        (true, "crash"),
+    ] {
+        let root = TestDir::new("initial-ui-owner");
+        let mut env = ocm_env(&root);
+        let repo = prepare_initial_ui_repo(&root, &mut env);
+        let repo_arg = path_string(&repo);
+        let mut args = if watch {
+            dev_watch(&["demo", "--repo", &repo_arg, "--watch"])
+        } else {
+            dev_plain(&["demo", "--repo", &repo_arg])
+        };
+        args.push("--ui");
+        if outcome == "deadline" {
+            fs::write(root.child("dashboard-hold"), "hold").unwrap();
+        }
+        let mut controller = DevWatchFixture::spawn(&root, &repo, &env, &args);
+        let gateway = initial_ui_process(&root, "gateway");
+        let ui = initial_ui_process(&root, "ui");
+        let gateway_pid = gateway["pid"].as_u64().unwrap() as u32;
+        let ui_pid = ui["pid"].as_u64().unwrap() as u32;
+        let session = read_source_watch_session(&root);
+        assert_eq!(session["watching"], watch);
+        assert_eq!(session["ui"]["children"]["gateway"]["pid"], gateway_pid);
+        assert_eq!(session["ui"]["children"]["ui"]["pid"], ui_pid);
+        assert_eq!(session["ui"]["target"]["port"], ui["port"]);
+        assert_eq!(gateway["cwd"], ui["cwd"]);
+        assert!(
+            ui["args"]
+                .as_array()
+                .unwrap()
+                .contains(&Value::String("--strictPort".to_string()))
+        );
+        let until = Instant::now() + Duration::from_secs(3);
+        while !root.child("gateway-requests").exists() && Instant::now() < until {
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert!(
+            !root.child("dashboard-attempts").exists(),
+            "Gateway health alone started a handoff"
+        );
+        fs::write(root.child("gateway-document-ready"), "ready").unwrap();
+        assert!(wait_for_path(
+            &root.child("dashboard-attempt-1"),
+            Duration::from_secs(5)
+        ));
+        if outcome == "deadline" {
+            let helper = fs::read_to_string(root.child("dashboard-attempt-1"))
+                .unwrap()
+                .trim()
+                .parse::<u32>()
+                .unwrap();
+            thread::sleep(Duration::from_secs(31));
+            assert!(
+                process_is_alive(helper)
+                    && process_is_alive(gateway_pid)
+                    && process_is_alive(ui_pid)
+            );
+            let reused = run_ocm(&repo, &env, &args);
+            assert!(reused.status.success(), "{}", stderr(&reused));
+            assert!(stdout(&reused).contains("ui_url="));
+            assert!(!stdout(&reused).contains("bootstrapToken"));
+            assert_eq!(
+                fs::read_to_string(root.child("dashboard-attempts"))
+                    .unwrap()
+                    .lines()
+                    .count(),
+                1
+            );
+            fs::remove_file(root.child("dashboard-hold")).unwrap();
+            assert!(wait_for_process_exit(helper, Duration::from_secs(3)));
+        }
+        let until = Instant::now() + Duration::from_secs(3);
+        while read_source_watch_session(&root)["ui"]["children"]
+            .get("command")
+            .is_some()
+            && Instant::now() < until
+        {
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert!(
+            read_source_watch_session(&root)["ui"]["children"]
+                .get("command")
+                .is_none()
+        );
+        let mismatch = run_ocm(
+            &repo,
+            &env,
+            &if watch {
+                dev_watch(&["demo", "--watch"])
+            } else {
+                dev_plain(&["demo"])
+            },
+        );
+        assert!(!mismatch.status.success());
+        assert!(stderr(&mismatch).contains("different UI mode"));
+        if outcome == "raw" || outcome == "crash" {
+            if outcome == "crash" {
+                controller.crash_controller();
+            } else {
+                assert_eq!(
+                    unsafe { libc::kill(ui_pid as libc::pid_t, libc::SIGKILL) },
+                    0
+                );
+                let output = controller.wait_without_release();
+                assert!(!output.status.success());
+                assert!(stderr(&output).contains("terminated by signal"));
+                let retained = read_source_watch_session(&root);
+                assert_eq!(retained["ui"]["children"]["ui"]["pid"], ui_pid);
+                assert!(retained["ui"]["children"].get("gateway").is_none());
+            }
+            let stopped = run_dev_stop(&repo, &env);
+            assert!(!stopped.status.success());
+            assert!(stderr(&stopped).contains(if outcome == "crash" {
+                "source controller exited"
+            } else {
+                "terminated by signal"
+            }));
+            assert_eq!(read_source_watch_session(&root)["closed"], false);
+            let session_path = source_watch_override_path(&root, "demo").with_extension("session");
+            let retained = fs::read(&session_path).unwrap();
+            let removed = run_ocm(&repo, &env, &["env", "destroy", "demo", "--yes"]);
+            assert!(!removed.status.success());
+            assert!(stderr(&removed).contains("unverified"));
+            assert!(fs::read(session_path).unwrap() == retained);
+        } else if outcome == "sibling" {
+            fs::write(root.child("ui.exit"), "exit").unwrap();
+            let output = controller.wait_without_release();
+            assert_eq!(output.status.code(), Some(17));
+            assert!(stdout(&output).contains("UI: http://127.0.0.1:"));
+        } else {
+            let stopped = run_dev_stop(&repo, &env);
+            assert!(stopped.status.success(), "{}", stderr(&stopped));
+            let output = controller.wait_without_release();
+            assert_eq!(output.status.code(), Some(130));
+            assert_eq!(
+                stdout(&output).contains("UI: http://127.0.0.1:"),
+                outcome != "deadline"
+            );
+            assert!(!stdout(&output).contains("synthetic-legacy"));
+        }
+        assert!(wait_for_process_exit(gateway_pid, Duration::from_secs(3)));
+        assert!(wait_for_process_exit(ui_pid, Duration::from_secs(3)));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_ui_claims_an_address_before_the_listener_starts() {
+    let _serial = INITIAL_UI_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let root = TestDir::new("initial-ui-first-claim");
+    let mut env = ocm_env(&root);
+    let repo = prepare_initial_ui_repo(&root, &mut env);
+    fs::write(root.child("ui-start-hold"), "hold").unwrap();
+    let mut first = DevWatchFixture::spawn(
+        &root,
+        &repo,
+        &env,
+        &["dev", "first", "--repo", &path_string(&repo), "--ui"],
+    );
+    let first_gateway = initial_ui_process(&root, "gateway");
+    let session_file = source_watch_override_path(&root, "first").with_extension("session");
+    let session: Value = serde_json::from_slice(&fs::read(&session_file).unwrap()).unwrap();
+    let port = session["ui"]["target"]["port"].as_u64().unwrap() as u16;
+    assert!(
+        std::net::TcpListener::bind(("127.0.0.1", port)).is_ok(),
+        "held UI already listened"
+    );
+    let second_root = TestDir::new("initial-ui-second-claim");
+    let mut second_env = ocm_env(&second_root);
+    let second_repo = prepare_initial_ui_repo(&second_root, &mut second_env);
+    second_env.insert("OCM_HOME".to_string(), env["OCM_HOME"].clone());
+    let mut second = DevWatchFixture::spawn(
+        &second_root,
+        &second_repo,
+        &second_env,
+        &[
+            "dev",
+            "second",
+            "--repo",
+            &path_string(&second_repo),
+            "--ui",
+        ],
+    );
+    let second_gateway = initial_ui_process(&second_root, "gateway");
+    let second_ui = initial_ui_process(&second_root, "ui");
+    assert_ne!(second_ui["port"].as_u64().unwrap(), u64::from(port));
+    fs::remove_file(root.child("ui-start-hold")).unwrap();
+    let first_ui = initial_ui_process(&root, "ui");
+    for name in ["first", "second"] {
+        let stopped = run_named_dev_stop(&repo, &env, name);
+        assert!(stopped.status.success(), "{}", stderr(&stopped));
+    }
+    assert_eq!(first.wait_without_release().status.code(), Some(130));
+    assert_eq!(second.wait_without_release().status.code(), Some(130));
+    for process in [first_gateway, first_ui, second_gateway, second_ui] {
+        assert!(wait_for_process_exit(
+            process["pid"].as_u64().unwrap() as u32,
+            Duration::from_secs(3)
+        ));
+    }
+}
+
+#[test]
+fn dev_ui_rejects_service_mode_before_creating_environment() {
+    let root = TestDir::new("initial-ui-service-conflict");
+    let env = ocm_env(&root);
+    let result = run_ocm(root.path(), &env, &["dev", "demo", "--ui", "--service"]);
+    assert!(!result.status.success());
+    assert!(stderr(&result).contains("cannot combine --ui with --service"));
+    let listed = run_ocm(root.path(), &env, &["env", "list", "--json"]);
+    assert!(listed.status.success(), "{}", stderr(&listed));
+    assert_eq!(
+        serde_json::from_str::<Value>(&stdout(&listed)).unwrap(),
+        serde_json::json!([])
+    );
 }
 
 #[test]

--- a/tests/launcher_help_tests.rs
+++ b/tests/launcher_help_tests.rs
@@ -112,11 +112,13 @@ fn dev_help_is_available_from_help_and_bare_group() {
     assert_eq!(output, stdout(&bare));
     assert!(output.contains("Development envs"));
     assert!(output.contains(
-        "ocm dev <env> [--repo <path>] [--root <path>] [--port <port>] [--watch] [--force] [--service] [--onboard]"
+        "ocm dev <env> [--repo <path>] [--root <path>] [--port <port>] [--watch] [--ui] [--force] [--service] [--onboard]"
     ));
     assert!(output.contains("ocm dev shaks --root /tmp/shaks"));
     assert!(output.contains("ocm dev shaks --watch"));
     assert!(output.contains("ocm dev shaks --watch --force"));
+    assert!(output.contains("ocm dev shaks --watch --ui"));
+    assert!(output.contains("initial native browser handoff"));
     assert!(output.contains("ocm dev shaks --repo /path/to/openclaw --watch --force"));
     assert!(output.contains("ocm dev shaks --service"));
     assert!(output.contains("ocm help dev status"));

--- a/tests/source_watch_daemon_admission_tests.rs
+++ b/tests/source_watch_daemon_admission_tests.rs
@@ -155,7 +155,7 @@ impl AdmissionFixture {
                 && runtime["gatewayAdmission"]["process"]["pid"] == pid
             {
                 assert_eq!(runtime["children"], json!([]));
-                assert_eq!(runtime["gatewayAdmission"]["version"], 9);
+                assert_eq!(runtime["gatewayAdmission"]["version"], 10);
                 assert!(
                     runtime["gatewayAdmission"]["process"]["startedAt"]
                         .as_str()
@@ -340,7 +340,7 @@ fn dev_watch_requires_the_current_managed_daemon_capability() {
 fn dev_foreground_rejects_unknown_daemon_before_creating_an_environment() {
     let mut fixture = AdmissionFixture::new("dev-daemon-preflight");
     let mut old_runtime = fixture.start_daemon();
-    old_runtime["gatewayAdmission"]["version"] = json!(8);
+    old_runtime["gatewayAdmission"]["version"] = json!(9);
     write_json_replacing_path(&fixture.runtime, &old_runtime);
     let registry = env_registry_path(&fixture.env, &fixture.cwd).unwrap();
     let before = fs::read(&registry).unwrap();
@@ -353,12 +353,17 @@ fn dev_foreground_rejects_unknown_daemon_before_creating_an_environment() {
         ("plain", "running"),
         ("service", "starting"),
         ("service", "running"),
+        ("ui", "starting"),
+        ("ui", "running"),
+        ("ui-watch", "running"),
     ] {
         fixture.set_manager_state(state, fixture.daemon.as_ref().unwrap().id());
         let mut args = vec!["dev", "fresh", "--repo", &repo_arg, "--root", &root_arg];
         match mode {
             "watch" => args.push("--watch"),
             "service" => args.push("--service"),
+            "ui" => args.push("--ui"),
+            "ui-watch" => args.extend(["--watch", "--ui"]),
             _ => {}
         }
         let rejected = run_ocm(&fixture.cwd, &fixture.env, &args);

--- a/tests/support/dev_ui.cjs
+++ b/tests/support/dev_ui.cjs
@@ -1,0 +1,95 @@
+const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+const {spawn} = require("node:child_process");
+
+const root = process.env.OCM_TEST_DEV_UI_DIR;
+const file = (name) => path.join(root, name);
+const exists = (name) => fs.existsSync(file(name));
+const config = JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8"));
+const gatewayPort = Number(process.env.OPENCLAW_GATEWAY_PORT);
+const base = String(config.gateway.controlUi?.basePath ?? "").replace(/^\/+|\/+$/g, "");
+const documentPath = base ? `/${base}/` : "/";
+const gatewayUrl = `http://127.0.0.1:${gatewayPort}${documentPath}`;
+const role = process.argv.includes("dashboard")
+  ? "dashboard"
+  : process.argv[1].endsWith("ui.js")
+    ? "ui"
+    : "gateway";
+
+if (role === "dashboard") {
+  const attempts = file("dashboard-attempts");
+  fs.appendFileSync(attempts, `${process.pid}\n`);
+  const count = fs.readFileSync(attempts, "utf8").trim().split("\n").length;
+  fs.writeFileSync(file(`dashboard-attempt-${count}`), String(process.pid));
+  const deliver = () => {
+    if (exists("dashboard-pending")) {
+      console.log(JSON.stringify({ ok: false, reason: "fixture Gateway is pending" }));
+      process.exit(1);
+    }
+    const link = new URL(gatewayUrl);
+    link.hash = new URLSearchParams({
+      bootstrapToken: `synthetic-owner-grant-${count}`,
+      bootstrapProfile: "control-ui-owner",
+      gatewayUrl: gatewayUrl.replace(/^http:/, "ws:"),
+    }).toString();
+    console.log(JSON.stringify({
+      ok: true,
+      browserUrl: link.toString(),
+      browserBootstrapExpiresAtMs: Date.now() + 60000,
+      url: `${gatewayUrl}#token=synthetic-legacy-token`,
+      gatewayPassword: "synthetic-legacy-password",
+    }));
+    process.exit(0);
+  };
+  const timer = setInterval(() => {
+    if (exists("source-watch.release")) process.exit(0);
+    if (!exists("dashboard-hold")) {
+      clearInterval(timer);
+      deliver();
+    }
+  }, 20);
+} else {
+  const port = role === "ui"
+    ? Number(process.argv[process.argv.indexOf("--port") + 1])
+    : gatewayPort;
+  const descendant = process.env.OCM_TEST_DEV_UI_DESCENDANTS === "1"
+    ? spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], {stdio:"ignore", windowsHide:true})
+    : undefined;
+  const server = http.createServer((request, response) => {
+    fs.appendFileSync(file(`${role}-requests`), `${request.url}\n`);
+    const ready = role === "ui"
+      || request.url === "/health"
+      || (request.url === documentPath && exists("gateway-document-ready"));
+    const health = request.url === "/health";
+    response.writeHead(ready ? 200 : 503, {
+      "content-type": health || !ready ? "application/json" : "text/html; charset=utf-8",
+    });
+    response.end(health ? '{"ok":true}' : ready ? "<!doctype html><title>OCM UI fixture</title>" : '{"pending":true}');
+  });
+  // Ordinary native owners acknowledge a handled stop after their resources close.
+  process.once("SIGTERM", () => server.close(() => process.exit(143)));
+  const listen = () => server.listen(port, "127.0.0.1", () => {
+    const temporary = file(`${role}.${process.pid}.tmp`);
+    fs.writeFileSync(temporary, JSON.stringify({
+      pid: process.pid,
+      descendantPid: descendant?.pid,
+      port,
+      cwd: fs.realpathSync(process.cwd()),
+      gatewayUrl: process.env.OPENCLAW_UI_DEV_GATEWAY_URL,
+      uiBasePath: process.env.OPENCLAW_CONTROL_UI_BASE_PATH,
+      args: process.argv.slice(2),
+    }));
+    fs.renameSync(temporary, file(`${role}.json`));
+  });
+  const start = setInterval(() => {
+    if (role !== "ui" || !exists("ui-start-hold")) {
+      clearInterval(start);
+      listen();
+    }
+  }, 20);
+  setInterval(() => {
+    if (exists("source-watch.release")) process.exit(0);
+    if (exists(`${role}.exit`)) process.exit(17);
+  }, 20);
+}

--- a/tests/support/dev_ui.cjs
+++ b/tests/support/dev_ui.cjs
@@ -68,22 +68,49 @@ if (role === "dashboard") {
     response.end(health ? '{"ok":true}' : ready ? "<!doctype html><title>OCM UI fixture</title>" : '{"pending":true}');
   });
   // Ordinary native owners acknowledge a handled stop after their resources close.
-  process.once("SIGTERM", () => server.close(() => process.exit(143)));
-  const listen = () => server.listen(port, "127.0.0.1", () => {
-    const temporary = file(`${role}.${process.pid}.tmp`);
-    fs.writeFileSync(temporary, JSON.stringify({
-      pid: process.pid,
-      descendantPid: descendant?.pid,
-      port,
-      cwd: fs.realpathSync(process.cwd()),
-      gatewayUrl: process.env.OPENCLAW_UI_DEV_GATEWAY_URL,
-      uiBasePath: process.env.OPENCLAW_CONTROL_UI_BASE_PATH,
-      args: process.argv.slice(2),
-    }));
-    fs.renameSync(temporary, file(`${role}.json`));
+  let stopping = false;
+  process.once("SIGTERM", () => {
+    stopping = true;
+    server.close(() => process.exit(143));
   });
+  let listenDeadline;
+  const listen = () => {
+    if (stopping) return;
+    listenDeadline ??= Date.now() + 5000;
+    const onListening = () => {
+      server.off("error", onError);
+      const temporary = file(`${role}.${process.pid}.tmp`);
+      fs.writeFileSync(temporary, JSON.stringify({
+        pid: process.pid,
+        descendantPid: descendant?.pid,
+        port,
+        cwd: fs.realpathSync(process.cwd()),
+        gatewayUrl: process.env.OPENCLAW_UI_DEV_GATEWAY_URL,
+        uiBasePath: process.env.OPENCLAW_CONTROL_UI_BASE_PATH,
+        args: process.argv.slice(2),
+      }));
+      fs.renameSync(temporary, file(`${role}.json`));
+    };
+    const onError = (error) => {
+      server.off("listening", onListening);
+      const temporary = file(`${role}.error.${process.pid}.tmp`);
+      fs.writeFileSync(temporary, error.code ?? "UNKNOWN");
+      fs.renameSync(temporary, file(`${role}-listen-error`));
+      // The native Gateway retries transient EADDRINUSE from other processes'
+      // availability probes. Keep this fake's retry inside its 10s startup
+      // budget; Vite's --strictPort behavior and other errors remain immediate.
+      if (role === "gateway" && error.code === "EADDRINUSE" && Date.now() < listenDeadline) {
+        server.close(() => setTimeout(listen, 20));
+        return;
+      }
+      throw error;
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, "127.0.0.1");
+  };
   const start = setInterval(() => {
-    if (role !== "ui" || !exists("ui-start-hold")) {
+    if (!exists(`${role}-start-hold`)) {
       clearInterval(start);
       listen();
     }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -423,7 +423,7 @@ pub fn enable_fake_daemon_gateway_admission(
     let (started_at, process_scope) = fixture_process_ownership();
     let capability =
         serde_json::from_value::<ocm::supervisor::SupervisorGatewayAdmission>(serde_json::json!({
-            "version": 9,
+            "version": 10,
             "process": { "pid": std::process::id(), "startedAt": started_at },
             "processScope": process_scope,
         }))

--- a/tests/support/windows_dev_stop.cjs
+++ b/tests/support/windows_dev_stop.cjs
@@ -98,7 +98,7 @@ function capture(child) {
 }
 function sessionPath(name) { return path.join(env.OCM_HOME, 'source-watch', name + '.session'); }
 function session(name) { return JSON.parse(fs.readFileSync(sessionPath(name), 'utf8')); }
-async function start(name, watching = true) {
+async function start(name, watching = true, withUi = false) {
   const directory = path.join(root, name);
   const repo = path.join(directory, 'repo');
   fs.mkdirSync(path.join(repo, 'scripts'), {recursive:true});
@@ -119,6 +119,24 @@ async function start(name, watching = true) {
   ].join('\n');
   fs.writeFileSync(path.join(repo, 'scripts', 'watch-node.mjs'), watch);
   fs.writeFileSync(path.join(repo, 'scripts', 'run-node.mjs'), watch);
+  if (withUi) {
+    fs.mkdirSync(path.join(repo, 'ui'), {recursive:true});
+    fs.writeFileSync(path.join(repo, 'ui', 'package.json'), '{"name":"ui-fixture"}');
+    fs.writeFileSync(path.join(repo, 'ui', 'index.html'), '<!doctype html><title>UI fixture</title>');
+    fs.copyFileSync(path.join(__dirname, 'dev_ui.cjs'), path.join(repo, 'scripts', 'dev-ui-fixture.cjs'));
+    fs.writeFileSync(path.join(repo, 'scripts', 'ui.js'), "require('./dev-ui-fixture.cjs');\n");
+    for (const entry of ['watch-node.mjs', 'run-node.mjs']) {
+      fs.writeFileSync(path.join(repo, 'scripts', entry), "import './dev-ui-fixture.cjs';\n");
+    }
+    fs.writeFileSync(path.join(repo, 'openclaw.mjs'), "import './scripts/dev-ui-fixture.cjs';\n");
+    for (const name of ['vite', 'dompurify']) {
+      const module = path.join(repo, 'node_modules', name);
+      fs.mkdirSync(module, {recursive:true});
+      fs.writeFileSync(path.join(module, 'package.json'), JSON.stringify({name, main:'index.js'}));
+      fs.writeFileSync(path.join(module, 'index.js'), "throw new Error('UI inspection must not execute package code');\n");
+    }
+    fs.writeFileSync(path.join(directory, 'dashboard-hold'), 'hold');
+  }
   fs.writeFileSync(path.join(repo, 'SENTINEL'), 'preserve source');
   const init = cp.spawnSync('git', ['init','--quiet',repo], {env, encoding:'utf8', timeout:15000});
   if (init.error) throw init.error;
@@ -134,30 +152,64 @@ async function start(name, watching = true) {
       assert.equal(saved.status, 0, saved.stderr);
     }
   }
-  const args = ['dev',name,'--repo',repo,...(watching ? ['--watch','--force'] : ['--root',envRoot,'--port',port])];
-  const controller = cp.spawn(binary, args, {cwd:root, env, stdio:['ignore','pipe','pipe'], windowsHide:true});
+  if (withUi) {
+    fs.mkdirSync(path.join(envRoot, '.openclaw'), {recursive:true});
+    fs.writeFileSync(path.join(envRoot, '.openclaw', 'openclaw.json'), JSON.stringify({
+      gateway:{controlUi:{basePath:'/console'}, auth:{mode:'token', token:'synthetic-fixture-auth'}},
+    }));
+  }
+  const args = ['dev',name,'--repo',repo,...(watching ? ['--watch','--force'] : ['--root',envRoot,'--port',port]), ...(withUi ? ['--ui'] : [])];
+  const sourceEnv = withUi ? {...env, OCM_TEST_DEV_UI_DIR:directory, OCM_TEST_DEV_UI_DESCENDANTS:'1'} : env;
+  const controller = cp.spawn(binary, args, {cwd:root, env:sourceEnv, stdio:['ignore','pipe','pipe'], windowsHide:true});
   const output = capture(controller);
   const record = {name, directory, repo, controller, output, identities:[]};
   tracked.push(record);
   assert.ok(controller.pid, 'Controller did not spawn');
   const controllerIdentity = {pid:controller.pid, startedAt:startIdentity(controller.pid)};
   record.identities.push(controllerIdentity);
-  await waitFor(() => fs.existsSync(ready), () => 'Source process did not start: ' + name + '\n' + output());
-  assert.equal(path.basename(fs.readFileSync(ready, 'utf8')), watching ? 'watch-node.mjs' : 'run-node.mjs');
+  const gatewayFile = path.join(directory, 'gateway.json');
+  const uiFile = path.join(directory, 'ui.json');
+  await waitFor(() => withUi ? fs.existsSync(gatewayFile) && fs.existsSync(uiFile) : fs.existsSync(ready),
+    () => 'Source process did not start: ' + name + '\n' + output());
   const owner = session(name);
-  const watcher = Number(fs.readFileSync(rootPid,'utf8'));
-  const descendant = Number(fs.readFileSync(descendantPid,'utf8'));
+  const gateway = withUi ? JSON.parse(fs.readFileSync(gatewayFile)) : {
+    pid:Number(fs.readFileSync(rootPid,'utf8')), descendantPid:Number(fs.readFileSync(descendantPid,'utf8')),
+  };
+  if (!withUi) assert.equal(path.basename(fs.readFileSync(ready, 'utf8')), watching ? 'watch-node.mjs' : 'run-node.mjs');
+  const watcher = gateway.pid;
+  const descendant = gateway.descendantPid;
   assert.equal(owner.controller.pid, controller.pid);
-  assert.equal(owner.child.pid, watcher);
-  assert.equal(owner.childSpawnPending, false);
-  assert.equal(owner.kind, 'ocm-source-foreground-session-v1');
+  assert.equal(owner.kind, withUi ? 'ocm-source-ui-session-v1' : 'ocm-source-foreground-session-v1');
   assert.equal(owner.watching, watching);
   assert.deepEqual(owner.controller, controllerIdentity);
   const childIdentity = {pid:watcher, startedAt:startIdentity(watcher)};
-  assert.deepEqual(owner.child, childIdentity);
+  assert.deepEqual(withUi ? owner.ui.children.gateway : owner.child, childIdentity);
+  assert.equal(owner.childSpawnPending, false);
   record.identities.push(childIdentity, {pid:descendant, startedAt:startIdentity(descendant)});
+  record.sourcePids = [watcher, descendant];
+  if (withUi) {
+    const ui = JSON.parse(fs.readFileSync(uiFile));
+    const uiIdentity = {pid:ui.pid, startedAt:startIdentity(ui.pid)};
+    assert.deepEqual(owner.ui.children.ui, uiIdentity);
+    assert.equal(owner.ui.pending, null);
+    assert.equal(owner.ui.target.port, ui.port);
+    assert.equal(gateway.cwd, ui.cwd);
+    assert.ok(ui.args.includes('--strictPort'));
+    record.identities.push(uiIdentity, {pid:ui.descendantPid, startedAt:startIdentity(ui.descendantPid)});
+    record.sourcePids.push(ui.pid, ui.descendantPid);
+    assert.ok(!fs.existsSync(path.join(directory, 'dashboard-attempts')), 'Gateway document readiness was bypassed');
+    fs.writeFileSync(path.join(directory, 'gateway-document-ready'), 'ready');
+    const helperFile = path.join(directory, 'dashboard-attempt-1');
+    await waitFor(() => fs.existsSync(helperFile), () => 'Native handoff did not start\n' + output());
+    const pid = Number(fs.readFileSync(helperFile));
+    const helperIdentity = {pid, startedAt:startIdentity(pid)};
+    assert.deepEqual(session(name).ui.children.command, helperIdentity);
+    record.identities.push(helperIdentity);
+    record.sourcePids.push(pid);
+    record.helperPid = pid;
+  }
   assert.ok(record.identities.every(identity => /^\d+$/.test(identity.startedAt)));
-  assert.ok(alive(watcher) && alive(descendant));
+  assert.ok(record.sourcePids.every(alive));
   record.original = fs.readFileSync(sessionPath(name));
   record.watcher = watcher;
   record.descendant = descendant;
@@ -176,7 +228,7 @@ async function stop(name) {
 async function crash(record) {
   assert.ok(killRecordedProcess(record.controller.pid, record.identities[0].startedAt), 'Controller was not running before the crash');
   await waitFor(() => record.controller.exitCode !== null || record.controller.signalCode !== null, 'Controller did not exit');
-  await waitFor(() => !alive(record.watcher) && !alive(record.descendant), 'Kill-on-close job did not stop both source processes');
+  await waitFor(() => record.sourcePids.every(pid => !alive(pid)), 'Kill-on-close jobs left an owned source process running');
 }
 async function checkPreserved(record) {
   assert.equal(fs.readFileSync(path.join(record.directory,'env','SENTINEL'),'utf8'), 'preserve environment');
@@ -212,17 +264,22 @@ for (const [signal, code] of [['SIGINT',130],['SIGTERM',143]]) process.once(sign
     // No subprocess may be created before this handshake completes.
     assert.equal(native('ready').ready, true);
     run(['runtime','add','proof-node','--path',process.execPath]);
-    const normal = await start('normal.stop');
+    const normal = await start('normal.stop', true, true);
+    fs.rmSync(path.join(normal.directory, 'dashboard-hold'));
+    await waitFor(() => !alive(normal.helperPid) && !session(normal.name).ui.children.command && normal.output().includes('UI: '),
+      'Completed initial handoff was not acknowledged');
+    assert.match(normal.output(), /UI: http:\/\/127\.0\.0\.1:\d+\/#bootstrapToken=synthetic-owner-grant-1/);
+    assert.ok(!normal.output().includes('synthetic-legacy'));
     const active = JSON.parse(run(['dev','status',normal.name,'--json']).stdout);
     assert.equal(active.sourceWatch.state, 'active', 'Held watch lease was not readable by dev status');
     assert.equal(active.sourceWatch.watching, true);
     await stop(normal.name);
-    await waitFor(() => !alive(normal.watcher) && !alive(normal.descendant), 'Named stop left its source tree running');
+    await waitFor(() => normal.sourcePids.every(pid => !alive(pid)), 'Named stop left a Gateway/UI tree running');
     await waitFor(() => normal.controller.exitCode !== null, 'Controller did not acknowledge named stop');
     await checkPreserved(normal);
     const again = JSON.parse(run(['dev','stop',normal.name,'--json']).stdout);
     assert.equal(again.stopped, false);
-    results.push('native named stop, descendant cleanup, repeat stop, env/source preservation');
+    results.push('native initial UI handoff, both component trees stopped, repeat stop, env/source preservation');
 
     const plain = await start('plain.stop', false);
     const plainStatus = JSON.parse(run(['dev','status',plain.name,'--json']).stdout);
@@ -234,11 +291,11 @@ for (const [signal, code] of [['SIGINT',130],['SIGTERM',143]]) process.once(sign
     await checkPreserved(plain);
     results.push('native plain named stop, descendant cleanup, env/source preservation');
 
-    const crashed = await start('crashed');
+    const crashed = await start('crashed', true, true);
     await crash(crashed);
     await stop(crashed.name);
     await checkPreserved(crashed);
-    results.push('controller crash, kill-on-close job cleanup, closed recovery');
+    results.push('controller crash, Gateway/UI/helper job cleanup, closed recovery');
 
     const reused = await start('reused');
     await crash(reused);


### PR DESCRIPTION
## What Problem This Solves

Control UI edits do not appear in the static dashboard used alongside foreground dev. Starting Vite separately leaves its process, address and initial sign-in link outside the dev session.

## Why This Change Was Made

Add `--ui` to run OpenClaw's native Vite entry beside a plain or watched Gateway. One controller owns both components and the initial native dashboard helper. It captures a loopback address for the session and prints the native owner link after both documents are ready, preserving the Gateway identity and authentication.

## User Impact

- Run `ocm dev demo --ui` or `ocm dev demo --watch --ui`, then edit the dev worktree shown by `ocm dev status demo`.
- Repeat a matching command to inspect the current address. A new initial browser grant requires stopping and restarting the session.
- `ocm dev stop demo` stops the components together. A native request has a 30-second reply deadline; its helper stays owned, late links are discarded, and stopping dev uses only the remaining budget before strict cleanup.
- Use a local HTTP Gateway with Control UI enabled and installed UI dependencies. Existing authentication settings remain in effect. Unverified cleanup retains ownership.
- An older running daemon must be refreshed before a new foreground session or service preparation: `ocm service refresh-daemon --acknowledge-gateway-restarts`. Run this during a maintenance window; managed Gateways restart from their preserved desired state.

## Evidence

The UI source passed remote formatting, workspace/all-target compilation, a fresh CLI build and 235 affected tests across dev, source isolation, cleanup, snapshots, services, daemon behavior, resolution, status and output. The final source-registration/restore composition passed three existing CLI cases covering concurrent UI registration, owned startup/stop and worktree removal. Controlled socket conflicts verify Gateway retry, persistent conflict refusal and strict UI behavior. Source, controller, fixture and integration reviews are independently clean.

Actual OpenClaw at `61f7614` proof passed fresh Owned-worktree preparation, initial native pairing, authenticated Vite transport, paired reload, matching address reuse, normal stop and ordinary environment/worktree removal. Normal stop took 0.529 seconds with zero fallback signals or remaining scoped processes. A separate real empty-daemon upgrade from version 9 to 10 passed admission refusal, acknowledged refresh, older-client refusal to alter the live UI session, and new-client cleanup.

The previously qualified UI head passed all nine Linux/macOS/Windows CI jobs, including the five-case native Windows lifecycle wrapper, and exact-head Platinum review. CI and review are being refreshed for the final main-based head. The unchanged refresh owner also has existing populated native-daemon and direct/npm restart proof; the UI-specific version-9-to-10 experiment remains explicitly an empty-daemon check.

This PR targets main and contains only the initial UI slice; retained addresses, fresh grants on reuse and default-mode changes are separate follow-ups.

## Visual evidence

| Before | After |
| --- | --- |
| ![Fresh browser asks for Gateway credentials before the native handoff](https://github.com/user-attachments/assets/26c9d7f0-fc76-4ee5-91d4-7bcd7115c7dd) | ![Authenticated Model Setup remains accessible after reloading without another grant](https://github.com/user-attachments/assets/eda16e14-3219-40d5-bdb7-c4bda60e6697) |

### Native handoff and paired reload, 7.4 seconds

https://github.com/user-attachments/assets/44084c62-58b1-470d-b55d-5e7db9253f40

### Visual verification

- Baseline: abda3cb: fresh unpaired browser before consuming the native grant; OpenClaw 61f76146412c
- Exact head: `674731adbbdf7680b824f5236b68682d5700a1ae`
- Scenario: Open the Vite UI in a fresh unpaired browser, consume the initial native owner handoff, then reload without another grant.
- Runtime/build: OCM source 3fb6ccbd / native binary 0408541c; OpenClaw 61f76146412c (tree d555a6ff); Chromium 151.0.7922.71
- Authentication states: stopped/unpaired → connected with hello → connected after clean reload
- Gateway identity and transport: same logical Gateway; native same-origin Vite WebSocket route observed in each stage
- Grant handling: bootstrap cleared; grant absent from storage and visible text; no new grant on reload
- Normal stop: 0.529 seconds; zero scoped processes and zero fallback signals
- Before and after use the same 1280×900 viewport, light theme, route and fresh environment.
- All three full screenshots and all 185 recorded frames were reviewed; no visible secrets or private user data were found.
- The after image shows the settled paired reload. The visible Server updated banner is retained; model configuration and full capability refresh were not exercised.
- Source/config were preserved, and OCM removed the task-owned environment/worktree with no remaining scoped processes.
- The current head retains the recorded UI/controller/session code unchanged. Its source-registration and restore composition passed the CLI/cleanup integration gate; the native recording remains tied to source 3fb6ccbd.
