### PR TITLE
fix: block restores and upgrades during dev watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ ocm upgrade simulate mira --to beta --scenario all
 ocm upgrade simulate mira --to ./openclaw
 ```
 
+Live upgrades and rollbacks require a completed source-watch session. Run
+`ocm dev stop <env>` first; OCM refuses active or unfinished ownership before
+changing environment state, runtime files, or upgrade history.
+
 `upgrade` stages the target runtime, validates the checkpoint source, and
 prepares runtime recovery while the current managed gateway remains available.
 Preparation failures leave the source environment and service unchanged. OCM

--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ ocm upgrade simulate mira --to beta --scenario all
 ocm upgrade simulate mira --to ./openclaw
 ```
 
-Live upgrades and rollbacks require a completed source-watch session. Run
-`ocm dev stop <env>` first; OCM refuses active or unfinished ownership before
-changing environment state, runtime files, or upgrade history.
+Live upgrades and rollbacks require a completed source-watch session. Stop a
+known owned watch with `ocm dev stop <env>`. Unreadable or unverified ownership
+requires verified operator recovery, including checking the watch processes and
+service policy. OCM preserves environment state, runtime files, and upgrade
+history while refusing those operations.
 
 `upgrade` stages the target runtime, validates the checkpoint source, and
 prepares runtime recovery while the current managed gateway remains available.

--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ ocm upgrade simulate mira --to beta --scenario all
 ocm upgrade simulate mira --to ./openclaw
 ```
 
-Live upgrades and rollbacks require a completed source-watch session. Stop a
-known owned watch with `ocm dev stop <env>`. Unreadable or unverified ownership
+Live upgrades and rollbacks require a completed source-watch session. Request
+shutdown of recorded ownership with `ocm dev stop <env>`. Older watches without
+an unfinished ownership record must be stopped from their original dev terminal.
+Unreadable or unverified ownership
 requires verified operator recovery, including checking the watch processes and
 service policy. OCM preserves environment state, runtime files, and upgrade
 history while refusing those operations.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -485,8 +485,10 @@ includes independent content. Full snapshot restore still rewinds that content.
 ### Snapshots
 
 Snapshot restore and live upgrade or rollback require a completed dev session.
-Stop a known owned watch with `ocm dev stop <env>` before retrying. Unreadable or
-unverified ownership requires verified operator recovery: preserve the environment
+Request shutdown of recorded ownership with `ocm dev stop <env>` before retrying.
+Older watches without an unfinished ownership record must be stopped from their
+original dev terminal. Unreadable or unverified ownership requires verified
+operator recovery: preserve the environment
 and check the watch processes and service policy before recovering its ownership
 record. Refusal preserves the current state and service policy.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -485,10 +485,10 @@ includes independent content. Full snapshot restore still rewinds that content.
 ### Snapshots
 
 Snapshot restore and live upgrade or rollback require a completed dev session.
-If a watch is active, starting,
-restoring its service, or has unfinished or unreadable ownership, run
-`ocm dev stop <env>` before retrying. Refusal preserves the current state and
-service policy.
+Stop a known owned watch with `ocm dev stop <env>` before retrying. Unreadable or
+unverified ownership requires verified operator recovery: preserve the environment
+and check the watch processes and service policy before recovering its ownership
+record. Refusal preserves the current state and service policy.
 
 Snapshot create and restore stop a running OCM-managed gateway before copying or
 replacing its root, then restore the recorded service policy. New snapshots are

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -484,7 +484,8 @@ includes independent content. Full snapshot restore still rewinds that content.
 
 ### Snapshots
 
-Snapshot restore requires a completed dev session. If a watch is active, starting,
+Snapshot restore and live upgrade or rollback require a completed dev session.
+If a watch is active, starting,
 restoring its service, or has unfinished or unreadable ownership, run
 `ocm dev stop <env>` before retrying. Refusal preserves the current state and
 service policy.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -484,6 +484,11 @@ includes independent content. Full snapshot restore still rewinds that content.
 
 ### Snapshots
 
+Snapshot restore requires a completed dev session. If a watch is active, starting,
+restoring its service, or has unfinished or unreadable ownership, run
+`ocm dev stop <env>` before retrying. Refusal preserves the current state and
+service policy.
+
 Snapshot create and restore stop a running OCM-managed gateway before copying or
 replacing its root, then restore the recorded service policy. New snapshots are
 verified whole-root checkpoints: they include secrets, browser state, SQLite

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -990,6 +990,7 @@ impl Cli {
                 let selected_snapshot = self
                     .environment_service()
                     .get_snapshot(name, snapshot_id)?;
+                self.environment_service().ensure_snapshot_restore_allowed_locked(name)?;
                 let service_state = self
                     .service_service()
                     .quiesce_for_snapshot_locked(name)?;

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -990,7 +990,7 @@ impl Cli {
                 let selected_snapshot = self
                     .environment_service()
                     .get_snapshot(name, snapshot_id)?;
-                self.environment_service().ensure_snapshot_restore_allowed_locked(name)?;
+                self.environment_service().ensure_source_watch_allows_state_mutation_locked(name)?;
                 let service_state = self
                     .service_service()
                     .quiesce_for_snapshot_locked(name)?;

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -644,7 +644,7 @@ pub fn upgrade_help(cmd: &str) -> String {
         &[
             "Simulations clone the source env, leave the real env untouched, and clean temporary envs and runtimes by default.",
             "Upgrade history lists completed transaction records newest first without reading config contents or credentials.",
-            "Stop a known owned watch with dev stop <env> before upgrading or rolling back. Unreadable or unverified ownership requires verified operator recovery before mutation.",
+            "Request shutdown of recorded ownership with dev stop <env> before upgrading or rolling back. Older watches without an unfinished ownership record require their original dev terminal; unreadable or unverified ownership requires verified operator recovery before mutation.",
             "Upgrade rollback restores the latest completed transition by default; use --transaction to select a specific unconsumed transaction.",
             "Rollback refuses before mutation when the current binding, OpenClaw version, service policy, source binding, snapshot, or retained runtime recovery no longer matches the selected transaction.",
             "Rollback creates a pre-rollback safety snapshot and linked history transaction. Rolling back that linked transaction safely reverses the rollback.",
@@ -696,7 +696,7 @@ pub fn upgrade_rollback_help(cmd: &str) -> String {
         &[
             "Without --transaction, OCM selects the newest completed upgrade or rollback transition that has not already been reversed.",
             "Preflight requires the current binding, OpenClaw version, and service policy to match the selected transaction target.",
-            "Live rollback requires a completed source-watch session. Stop known ownership with dev stop; unreadable or unverified ownership requires verified operator recovery.",
+            "Live rollback requires a completed source-watch session. Request shutdown of recorded ownership with dev stop. Older watches without an unfinished ownership record require their original dev terminal; unreadable or unverified ownership requires verified operator recovery.",
             "The recorded pre-upgrade snapshot and source runtime or launcher must still be available. Same-name runtime updates also require healthy retained runtime recovery.",
             "Rollback creates a pre-rollback safety snapshot and linked history transaction before stopping a managed service or replacing runtime bytes.",
             "If restore or verification fails, OCM restores the pre-rollback runtime and environment state.",
@@ -1781,7 +1781,7 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
             )],
             &[
                 "Restore uses an exclusive same-filesystem namespace and retains the displaced root through service acceptance.",
-                "Restore requires a completed source-watch session. Stop known ownership with dev stop; unreadable or unverified ownership requires verified operator recovery.",
+                "Restore requires a completed source-watch session. Request shutdown of recorded ownership with dev stop. Older watches without an unfinished ownership record require their original dev terminal; unreadable or unverified ownership requires verified operator recovery.",
             ],
         ),
         "remove" => render_leaf(

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -644,7 +644,7 @@ pub fn upgrade_help(cmd: &str) -> String {
         &[
             "Simulations clone the source env, leave the real env untouched, and clean temporary envs and runtimes by default.",
             "Upgrade history lists completed transaction records newest first without reading config contents or credentials.",
-            "Stop an owned source-watch session with dev stop <env> before upgrading or rolling back. Active, unfinished, or unreadable ownership is refused before mutation.",
+            "Stop a known owned watch with dev stop <env> before upgrading or rolling back. Unreadable or unverified ownership requires verified operator recovery before mutation.",
             "Upgrade rollback restores the latest completed transition by default; use --transaction to select a specific unconsumed transaction.",
             "Rollback refuses before mutation when the current binding, OpenClaw version, service policy, source binding, snapshot, or retained runtime recovery no longer matches the selected transaction.",
             "Rollback creates a pre-rollback safety snapshot and linked history transaction. Rolling back that linked transaction safely reverses the rollback.",
@@ -696,7 +696,7 @@ pub fn upgrade_rollback_help(cmd: &str) -> String {
         &[
             "Without --transaction, OCM selects the newest completed upgrade or rollback transition that has not already been reversed.",
             "Preflight requires the current binding, OpenClaw version, and service policy to match the selected transaction target.",
-            "Live rollback requires a completed source-watch session; run dev stop <env> before retrying.",
+            "Live rollback requires a completed source-watch session. Stop known ownership with dev stop; unreadable or unverified ownership requires verified operator recovery.",
             "The recorded pre-upgrade snapshot and source runtime or launcher must still be available. Same-name runtime updates also require healthy retained runtime recovery.",
             "Rollback creates a pre-rollback safety snapshot and linked history transaction before stopping a managed service or replacing runtime bytes.",
             "If restore or verification fails, OCM restores the pre-rollback runtime and environment state.",
@@ -1781,7 +1781,7 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
             )],
             &[
                 "Restore uses an exclusive same-filesystem namespace and retains the displaced root through service acceptance.",
-                "Restore requires a completed source-watch session; run dev stop <env> before retrying.",
+                "Restore requires a completed source-watch session. Stop known ownership with dev stop; unreadable or unverified ownership requires verified operator recovery.",
             ],
         ),
         "remove" => render_leaf(

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -644,6 +644,7 @@ pub fn upgrade_help(cmd: &str) -> String {
         &[
             "Simulations clone the source env, leave the real env untouched, and clean temporary envs and runtimes by default.",
             "Upgrade history lists completed transaction records newest first without reading config contents or credentials.",
+            "Stop an owned source-watch session with dev stop <env> before upgrading or rolling back. Active, unfinished, or unreadable ownership is refused before mutation.",
             "Upgrade rollback restores the latest completed transition by default; use --transaction to select a specific unconsumed transaction.",
             "Rollback refuses before mutation when the current binding, OpenClaw version, service policy, source binding, snapshot, or retained runtime recovery no longer matches the selected transaction.",
             "Rollback creates a pre-rollback safety snapshot and linked history transaction. Rolling back that linked transaction safely reverses the rollback.",
@@ -695,6 +696,7 @@ pub fn upgrade_rollback_help(cmd: &str) -> String {
         &[
             "Without --transaction, OCM selects the newest completed upgrade or rollback transition that has not already been reversed.",
             "Preflight requires the current binding, OpenClaw version, and service policy to match the selected transaction target.",
+            "Live rollback requires a completed source-watch session; run dev stop <env> before retrying.",
             "The recorded pre-upgrade snapshot and source runtime or launcher must still be available. Same-name runtime updates also require healthy retained runtime recovery.",
             "Rollback creates a pre-rollback safety snapshot and linked history transaction before stopping a managed service or replacing runtime bytes.",
             "If restore or verification fails, OCM restores the pre-rollback runtime and environment state.",
@@ -1779,6 +1781,7 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
             )],
             &[
                 "Restore uses an exclusive same-filesystem namespace and retains the displaced root through service acceptance.",
+                "Restore requires a completed source-watch session; run dev stop <env> before retrying.",
             ],
         ),
         "remove" => render_leaf(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -712,6 +712,10 @@ impl Cli {
         for env_name in &lock_names {
             transaction_locks.push(lock_upgrade_transaction(env_name, &self.env, &self.cwd)?);
             operation_locks.push(self.environment_service().lock_operation(env_name)?);
+            if !options.dry_run {
+                self.environment_service()
+                    .ensure_source_watch_allows_state_mutation_locked(env_name)?;
+            }
         }
         let target = UpgradeTarget {
             version: None,
@@ -1099,6 +1103,20 @@ impl Cli {
         transaction_id: Option<&str>,
         dry_run: bool,
     ) -> Result<UpgradeRollbackSummary, String> {
+        let _transaction_lock = if dry_run {
+            None
+        } else {
+            Some(lock_upgrade_transaction(env_name, &self.env, &self.cwd)?)
+        };
+        let _operation_lock = if dry_run {
+            None
+        } else {
+            Some(self.environment_service().lock_operation(env_name)?)
+        };
+        if !dry_run {
+            self.environment_service()
+                .ensure_source_watch_allows_state_mutation_locked(env_name)?;
+        }
         let plan = self.prepare_upgrade_rollback(env_name, transaction_id)?;
         if dry_run {
             return Ok(UpgradeRollbackSummary {
@@ -1120,9 +1138,6 @@ impl Cli {
             });
         }
 
-        let _transaction_lock = lock_upgrade_transaction(env_name, &self.env, &self.cwd)?;
-        let _operation_lock = self.environment_service().lock_operation(env_name)?;
-        let plan = self.prepare_upgrade_rollback(env_name, Some(&plan.record.id))?;
         self.execute_upgrade_rollback_locked(env_name, plan)
     }
 
@@ -2344,6 +2359,10 @@ impl Cli {
         target: &UpgradeTarget,
         options: UpgradeOptions,
     ) -> Result<UpgradeEnvSummary, String> {
+        if !options.dry_run {
+            self.environment_service()
+                .ensure_source_watch_allows_state_mutation_locked(name)?;
+        }
         let env = self.environment_service().get(name)?;
 
         if let Some(runtime_name) = env.default_runtime.as_deref() {

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
 
-use super::{EnvironmentService, SourceWatchState};
+use super::EnvironmentService;
 use crate::store::{
     EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
     create_env_snapshot, create_env_snapshot_from_preparation, get_env_snapshot,
@@ -216,30 +216,6 @@ impl<'a> EnvironmentService<'a> {
         let summary = commit_env_snapshot_restore(transaction);
         sync_supervisor_env_if_present(self.env, self.cwd, &env_name)?;
         Ok(summary)
-    }
-
-    pub(crate) fn ensure_snapshot_restore_allowed_locked(&self, name: &str) -> Result<(), String> {
-        let state = match self.observe_source_watch(name) {
-            Ok(SourceWatchState::Inactive) => None,
-            Ok(SourceWatchState::Starting) => Some("starting".to_string()),
-            Ok(SourceWatchState::Active(_)) => Some("active".to_string()),
-            Ok(SourceWatchState::Restoring) => Some("restoring".to_string()),
-            Err(error) => Some(format!("unknown ({error})")),
-        };
-        if let Some(state) = state {
-            return Err(format!(
-                "cannot restore env {name} while its dev session is {state}; stop it with ocm dev stop {name} first"
-            ));
-        }
-        let session = self.source_watch_session(name).map_err(|error| {
-            format!("cannot verify the dev session for env {name}: {error}; stop it with ocm dev stop {name} before restoring")
-        })?;
-        if session.is_some_and(|session| !session.closed) {
-            return Err(format!(
-                "cannot restore env {name} while its dev session is unfinished; stop it with ocm dev stop {name} first"
-            ));
-        }
-        Ok(())
     }
 
     pub(crate) fn prepare_snapshot_restore_locked(

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -3,13 +3,13 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
 
-use super::EnvironmentService;
+use super::{EnvironmentService, SourceWatchState};
 use crate::store::{
     EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
     create_env_snapshot, create_env_snapshot_from_preparation, get_env_snapshot,
     list_all_env_snapshots, list_env_snapshots, now_utc, prepare_env_snapshot_capture,
     prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture, remove_env_snapshot,
-    restore_env_snapshot, rollback_env_snapshot_restore, summarize_snapshot,
+    rollback_env_snapshot_restore, summarize_snapshot,
 };
 use crate::supervisor::sync_supervisor_env_if_present;
 
@@ -212,9 +212,34 @@ impl<'a> EnvironmentService<'a> {
         options: RestoreEnvSnapshotOptions,
     ) -> Result<EnvSnapshotRestoreSummary, String> {
         let env_name = options.env_name.clone();
-        let summary = restore_env_snapshot(options, self.env, self.cwd)?;
+        let transaction = prepare_env_snapshot_restore(options, self.env, self.cwd)?;
+        let summary = commit_env_snapshot_restore(transaction);
         sync_supervisor_env_if_present(self.env, self.cwd, &env_name)?;
         Ok(summary)
+    }
+
+    pub(crate) fn ensure_snapshot_restore_allowed_locked(&self, name: &str) -> Result<(), String> {
+        let state = match self.observe_source_watch(name) {
+            Ok(SourceWatchState::Inactive) => None,
+            Ok(SourceWatchState::Starting) => Some("starting".to_string()),
+            Ok(SourceWatchState::Active(_)) => Some("active".to_string()),
+            Ok(SourceWatchState::Restoring) => Some("restoring".to_string()),
+            Err(error) => Some(format!("unknown ({error})")),
+        };
+        if let Some(state) = state {
+            return Err(format!(
+                "cannot restore env {name} while its dev session is {state}; stop it with ocm dev stop {name} first"
+            ));
+        }
+        let session = self.source_watch_session(name).map_err(|error| {
+            format!("cannot verify the dev session for env {name}: {error}; stop it with ocm dev stop {name} before restoring")
+        })?;
+        if session.is_some_and(|session| !session.closed) {
+            return Err(format!(
+                "cannot restore env {name} while its dev session is unfinished; stop it with ocm dev stop {name} first"
+            ));
+        }
+        Ok(())
     }
 
     pub(crate) fn prepare_snapshot_restore_locked(

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -379,21 +379,23 @@ impl<'a> EnvironmentService<'a> {
         &self,
         name: &str,
     ) -> Result<(), String> {
-        let state = match self.observe_source_watch(name) {
-            Ok(SourceWatchState::Inactive) => None,
-            Ok(SourceWatchState::Starting) => Some("starting".to_string()),
-            Ok(SourceWatchState::Active(_)) => Some("active".to_string()),
-            Ok(SourceWatchState::Restoring) => Some("restoring".to_string()),
-            Err(error) => Some(format!("unknown ({error})")),
+        let unverified = |error: String| {
+            format!(
+                "cannot verify dev ownership for env {name}: {error}; verified operator recovery is required before changing env state; preserve the environment and verify the watch processes and service policy before retrying"
+            )
+        };
+        let state = match self.observe_source_watch(name).map_err(&unverified)? {
+            SourceWatchState::Inactive => None,
+            SourceWatchState::Starting => Some("starting"),
+            SourceWatchState::Active(_) => Some("active"),
+            SourceWatchState::Restoring => Some("restoring"),
         };
         if let Some(state) = state {
             return Err(format!(
                 "cannot change env {name} while its dev session is {state}; stop it with ocm dev stop {name} first"
             ));
         }
-        let session = self.source_watch_session(name).map_err(|error| {
-            format!("cannot verify the dev session for env {name}: {error}; stop it with ocm dev stop {name} before changing env state")
-        })?;
+        let session = self.source_watch_session(name).map_err(unverified)?;
         if session.is_some_and(|session| !session.closed) {
             return Err(format!(
                 "cannot change env {name} while its dev session is unfinished; stop it with ocm dev stop {name} first"

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -384,6 +384,8 @@ impl<'a> EnvironmentService<'a> {
                 "cannot verify dev ownership for env {name}: {error}; verified operator recovery is required before changing env state; preserve the environment and verify the watch processes and service policy before retrying"
             )
         };
+        let session = self.source_watch_session(name).map_err(&unverified)?;
+        let unfinished = session.is_some_and(|session| !session.closed);
         let state = match self.observe_source_watch(name).map_err(&unverified)? {
             SourceWatchState::Inactive => None,
             SourceWatchState::Starting => Some("starting"),
@@ -391,14 +393,20 @@ impl<'a> EnvironmentService<'a> {
             SourceWatchState::Restoring => Some("restoring"),
         };
         if let Some(state) = state {
+            let recovery = if unfinished {
+                format!(
+                    "request shutdown with ocm dev stop {name}; if ownership cannot be verified, verified operator recovery is required"
+                )
+            } else {
+                "stop it from its original dev terminal; if that is unavailable, verified operator recovery is required".to_string()
+            };
             return Err(format!(
-                "cannot change env {name} while its dev session is {state}; stop it with ocm dev stop {name} first"
+                "cannot change env {name} while its dev session is {state}; {recovery}"
             ));
         }
-        let session = self.source_watch_session(name).map_err(unverified)?;
-        if session.is_some_and(|session| !session.closed) {
+        if unfinished {
             return Err(format!(
-                "cannot change env {name} while its dev session is unfinished; stop it with ocm dev stop {name} first"
+                "cannot change env {name} while its dev session is unfinished; request shutdown with ocm dev stop {name}; if ownership cannot be verified, verified operator recovery is required"
             ));
         }
         Ok(())

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -375,6 +375,33 @@ impl<'a> EnvironmentService<'a> {
         Ok(source_watch_override_path(&env_name, self.env, self.cwd)?.with_extension("admission"))
     }
 
+    pub(crate) fn ensure_source_watch_allows_state_mutation_locked(
+        &self,
+        name: &str,
+    ) -> Result<(), String> {
+        let state = match self.observe_source_watch(name) {
+            Ok(SourceWatchState::Inactive) => None,
+            Ok(SourceWatchState::Starting) => Some("starting".to_string()),
+            Ok(SourceWatchState::Active(_)) => Some("active".to_string()),
+            Ok(SourceWatchState::Restoring) => Some("restoring".to_string()),
+            Err(error) => Some(format!("unknown ({error})")),
+        };
+        if let Some(state) = state {
+            return Err(format!(
+                "cannot change env {name} while its dev session is {state}; stop it with ocm dev stop {name} first"
+            ));
+        }
+        let session = self.source_watch_session(name).map_err(|error| {
+            format!("cannot verify the dev session for env {name}: {error}; stop it with ocm dev stop {name} before changing env state")
+        })?;
+        if session.is_some_and(|session| !session.closed) {
+            return Err(format!(
+                "cannot change env {name} while its dev session is unfinished; stop it with ocm dev stop {name} first"
+            ));
+        }
+        Ok(())
+    }
+
     pub(crate) fn ensure_source_watch_allows_service(&self, env_name: &str) -> Result<(), String> {
         if let Some(session) = self.source_watch_session(env_name)? {
             if let Some(error) = session.unsafe_cleanup_error() {

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -444,6 +444,7 @@ pub fn restore_env_snapshot(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvSnapshotRestoreSummary, String> {
+    let _operation_lock = super::lock_environment_operation(&options.env_name, env, cwd)?;
     let transaction = prepare_env_snapshot_restore(options, env, cwd)?;
     Ok(commit_env_snapshot_restore(transaction))
 }
@@ -455,6 +456,8 @@ pub(crate) fn prepare_env_snapshot_restore(
 ) -> Result<EnvSnapshotRestoreTransaction, String> {
     let env_name = validate_name(&options.env_name, "Environment name")?;
     let snapshot = get_env_snapshot(&env_name, &options.snapshot_id, env, cwd)?;
+    crate::env::EnvironmentService::new(env, cwd)
+        .ensure_snapshot_restore_allowed_locked(&env_name)?;
     let current = get_environment(&env_name, env, cwd)?;
     let current_paths = derive_env_paths(Path::new(&current.root));
     let root_exists = path_exists(&current_paths.root);

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -457,7 +457,7 @@ pub(crate) fn prepare_env_snapshot_restore(
     let env_name = validate_name(&options.env_name, "Environment name")?;
     let snapshot = get_env_snapshot(&env_name, &options.snapshot_id, env, cwd)?;
     crate::env::EnvironmentService::new(env, cwd)
-        .ensure_snapshot_restore_allowed_locked(&env_name)?;
+        .ensure_source_watch_allows_state_mutation_locked(&env_name)?;
     let current = get_environment(&env_name, env, cwd)?;
     let current_paths = derive_env_paths(Path::new(&current.root));
     let root_exists = path_exists(&current_paths.root);

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -377,6 +377,25 @@ fn env_snapshot_restore_refuses_active_transitional_and_unknown_dev_ownership() 
     fs::write(checkout.join("openclaw.mjs"), "fixture\n").unwrap();
     let override_path = source_watch_override_path("source", &env, &cwd).unwrap();
     fs::create_dir_all(override_path.parent().unwrap()).unwrap();
+    let session_path = override_path.with_extension("session");
+    let unfinished = serde_json::json!({
+        "kind": "ocm-source-watch-session", "envName": "source",
+        "leaseId": "snapshot-fixture", "envRoot": meta.root,
+        "envCreatedAt": serde_json::to_value(&meta).unwrap()["createdAt"],
+        "processScope": null, "controller": {"pid": std::process::id(), "startedAt": "fixture"},
+        "child": null, "childSpawnPending": false, "restoreService": false, "closed": false
+    });
+    let unfinished_record = serde_json::to_string(&unfinished).unwrap();
+    let mut closed = unfinished.clone();
+    closed["closed"] = serde_json::json!(true);
+    let closed_record = serde_json::to_string(&closed).unwrap();
+    let mut unverified = unfinished.clone();
+    unverified["kind"] = serde_json::json!("ocm-source-watch-session-v2");
+    unverified["childSpawnPending"] = serde_json::json!(true);
+    unverified["completion"] = serde_json::json!({
+        "serviceRestored": false, "error": "source shutdown is unverified"
+    });
+    let unverified_record = serde_json::to_string(&unverified).unwrap();
     let mut lease = fs::OpenOptions::new()
         .read(true)
         .write(true)
@@ -385,7 +404,45 @@ fn env_snapshot_restore_refuses_active_transitional_and_unknown_dev_ownership() 
         .open(override_path.with_extension("lock"))
         .unwrap();
     lease.lock_exclusive().unwrap();
-    for state in ["starting", "active", "restoring", "unknown"] {
+    for (state, record, advice) in [
+        (
+            "starting",
+            Some(unfinished_record.as_str()),
+            "dev stop source",
+        ),
+        (
+            "active",
+            Some(unfinished_record.as_str()),
+            "dev stop source",
+        ),
+        (
+            "restoring",
+            Some(unfinished_record.as_str()),
+            "dev stop source",
+        ),
+        (
+            "unknown",
+            Some(unfinished_record.as_str()),
+            "operator recovery",
+        ),
+        ("active", None, "original dev terminal"),
+        (
+            "active",
+            Some(closed_record.as_str()),
+            "original dev terminal",
+        ),
+        ("active", Some("{"), "operator recovery"),
+        (
+            "active",
+            Some(unverified_record.as_str()),
+            "operator recovery",
+        ),
+    ] {
+        if let Some(record) = record {
+            fs::write(&session_path, record).unwrap();
+        } else {
+            fs::remove_file(&session_path).unwrap();
+        }
         lease.set_len(0).unwrap();
         lease.seek(SeekFrom::Start(0)).unwrap();
         writeln!(
@@ -426,17 +483,12 @@ fn env_snapshot_restore_refuses_active_transitional_and_unknown_dev_ownership() 
             ],
         );
         assert!(!restored.status.success(), "accepted {state}");
-        let advice = if state == "unknown" {
-            "operator recovery"
-        } else {
-            "dev stop source"
-        };
         assert!(
             stderr(&restored).contains(advice),
             "{state}: {}",
             stderr(&restored)
         );
-        if state == "unknown" {
+        if advice != "dev stop source" {
             assert!(!stderr(&restored).contains("dev stop"));
         }
         assert_eq!(fs::read_to_string(&notes).unwrap(), "current state\n");
@@ -447,15 +499,7 @@ fn env_snapshot_restore_refuses_active_transitional_and_unknown_dev_ownership() 
     }
     fs::remove_file(&override_path).unwrap();
     drop(lease);
-    let session_path = override_path.with_extension("session");
-    let unfinished = serde_json::json!({
-        "kind": "ocm-source-watch-session", "envName": "source",
-        "leaseId": "snapshot-fixture", "envRoot": meta.root,
-        "envCreatedAt": serde_json::to_value(&meta).unwrap()["createdAt"],
-        "processScope": null, "controller": {"pid": std::process::id(), "startedAt": "fixture"},
-        "child": null, "childSpawnPending": false, "restoreService": false, "closed": false
-    });
-    for record in [serde_json::to_string(&unfinished).unwrap(), "{".to_string()] {
+    for record in [unfinished_record, "{".to_string()] {
         fs::write(&session_path, &record).unwrap();
         let refused = run_ocm(
             &cwd,

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -1,5 +1,7 @@
 mod support;
 
+use std::io::{Seek, SeekFrom, Write};
+
 use std::process::{Command, Stdio};
 use std::sync::{
     Arc,
@@ -12,7 +14,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ocm::store::{env_registry_path, now_utc, supervisor_runtime_path};
+use fs2::FileExt;
+use ocm::store::{
+    env_registry_path, get_environment, now_utc, save_environment, source_watch_override_path,
+    supervisor_runtime_path,
+};
 use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeService, SupervisorRuntimeState};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
@@ -341,6 +347,151 @@ fn env_snapshot_restore_reverts_state_from_the_selected_snapshot() {
             .unwrap(),
         "before restore"
     );
+}
+
+#[test]
+fn env_snapshot_restore_refuses_active_transitional_and_unknown_dev_ownership() {
+    let root = TestDir::new("env-snapshot-watch-ownership");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let env = ocm_env(&root);
+    let created = run_ocm(&cwd, &env, &["env", "create", "source"]);
+    assert!(created.status.success(), "{}", stderr(&created));
+    let mut meta = get_environment("source", &env, &cwd).unwrap();
+    meta.service_enabled = false;
+    meta.service_running = false;
+    save_environment(meta.clone(), &env, &cwd).unwrap();
+    let notes = root.child("ocm-home/envs/source/.openclaw/workspace/notes.txt");
+    write_text(&notes, "snapshot state\n");
+    let snapshot = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "create", "source", "--json"],
+    );
+    assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+    let snapshot: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    write_text(&notes, "current state\n");
+    let registry_before = fs::read(env_registry_path(&env, &cwd).unwrap()).unwrap();
+    let checkout = root.child("watched-source");
+    fs::create_dir_all(checkout.join("extensions")).unwrap();
+    fs::write(checkout.join("openclaw.mjs"), "fixture\n").unwrap();
+    let override_path = source_watch_override_path("source", &env, &cwd).unwrap();
+    fs::create_dir_all(override_path.parent().unwrap()).unwrap();
+    let mut lease = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(override_path.with_extension("lock"))
+        .unwrap();
+    lease.lock_exclusive().unwrap();
+    for state in ["starting", "active", "restoring", "unknown"] {
+        lease.set_len(0).unwrap();
+        lease.seek(SeekFrom::Start(0)).unwrap();
+        writeln!(
+            lease,
+            "{}snapshot-fixture",
+            if state == "restoring" {
+                "restoring:"
+            } else {
+                ""
+            }
+        )
+        .unwrap();
+        match state {
+            "active" => fs::write(
+                &override_path,
+                serde_json::to_vec(&serde_json::json!({
+                    "kind": "ocm-source-watch-override", "envName": "source", "repoRoot": checkout,
+                    "watchPid": std::process::id(), "token": "lease:snapshot-fixture:fixture",
+                    "startedAt": "2026-06-17T00:00:00Z"
+                }))
+                .unwrap(),
+            )
+            .unwrap(),
+            "unknown" => fs::write(&override_path, "{").unwrap(),
+            _ => {
+                let _ = fs::remove_file(&override_path);
+            }
+        }
+        let restored = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "env",
+                "snapshot",
+                "restore",
+                "source",
+                snapshot["id"].as_str().unwrap(),
+            ],
+        );
+        assert!(!restored.status.success(), "accepted {state}");
+        assert!(
+            stderr(&restored).contains("dev stop source"),
+            "{state}: {}",
+            stderr(&restored)
+        );
+        assert_eq!(fs::read_to_string(&notes).unwrap(), "current state\n");
+        assert_eq!(
+            fs::read(env_registry_path(&env, &cwd).unwrap()).unwrap(),
+            registry_before
+        );
+    }
+    fs::remove_file(&override_path).unwrap();
+    drop(lease);
+    let session_path = override_path.with_extension("session");
+    let unfinished = serde_json::json!({
+        "kind": "ocm-source-watch-session", "envName": "source",
+        "leaseId": "snapshot-fixture", "envRoot": meta.root,
+        "envCreatedAt": serde_json::to_value(&meta).unwrap()["createdAt"],
+        "processScope": null, "controller": {"pid": std::process::id(), "startedAt": "fixture"},
+        "child": null, "childSpawnPending": false, "restoreService": false, "closed": false
+    });
+    for record in [serde_json::to_string(&unfinished).unwrap(), "{".to_string()] {
+        fs::write(&session_path, record).unwrap();
+        let refused = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "env",
+                "snapshot",
+                "restore",
+                "source",
+                snapshot["id"].as_str().unwrap(),
+            ],
+        );
+        assert!(!refused.status.success());
+        assert!(
+            stderr(&refused).contains("dev stop source"),
+            "{}",
+            stderr(&refused)
+        );
+        assert_eq!(fs::read_to_string(&notes).unwrap(), "current state\n");
+        assert_eq!(
+            fs::read(env_registry_path(&env, &cwd).unwrap()).unwrap(),
+            registry_before
+        );
+    }
+    fs::remove_file(&session_path).unwrap();
+    let restored = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "env",
+            "snapshot",
+            "restore",
+            "source",
+            snapshot["id"].as_str().unwrap(),
+        ],
+    );
+    assert!(restored.status.success(), "{}", stderr(&restored));
+    assert_eq!(fs::read_to_string(notes).unwrap(), "snapshot state\n");
+    ocm::env::EnvironmentService::new(&env, &cwd)
+        .restore_snapshot(ocm::env::RestoreEnvSnapshotOptions {
+            env_name: "source".to_string(),
+            snapshot_id: snapshot["id"].as_str().unwrap().to_string(),
+        })
+        .unwrap();
 }
 
 #[cfg(target_os = "macos")]

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -426,11 +426,19 @@ fn env_snapshot_restore_refuses_active_transitional_and_unknown_dev_ownership() 
             ],
         );
         assert!(!restored.status.success(), "accepted {state}");
+        let advice = if state == "unknown" {
+            "operator recovery"
+        } else {
+            "dev stop source"
+        };
         assert!(
-            stderr(&restored).contains("dev stop source"),
+            stderr(&restored).contains(advice),
             "{state}: {}",
             stderr(&restored)
         );
+        if state == "unknown" {
+            assert!(!stderr(&restored).contains("dev stop"));
+        }
         assert_eq!(fs::read_to_string(&notes).unwrap(), "current state\n");
         assert_eq!(
             fs::read(env_registry_path(&env, &cwd).unwrap()).unwrap(),
@@ -448,7 +456,7 @@ fn env_snapshot_restore_refuses_active_transitional_and_unknown_dev_ownership() 
         "child": null, "childSpawnPending": false, "restoreService": false, "closed": false
     });
     for record in [serde_json::to_string(&unfinished).unwrap(), "{".to_string()] {
-        fs::write(&session_path, record).unwrap();
+        fs::write(&session_path, &record).unwrap();
         let refused = run_ocm(
             &cwd,
             &env,
@@ -461,11 +469,15 @@ fn env_snapshot_restore_refuses_active_transitional_and_unknown_dev_ownership() 
             ],
         );
         assert!(!refused.status.success());
-        assert!(
-            stderr(&refused).contains("dev stop source"),
-            "{}",
-            stderr(&refused)
-        );
+        let advice = if record == "{" {
+            "operator recovery"
+        } else {
+            "dev stop source"
+        };
+        assert!(stderr(&refused).contains(advice), "{}", stderr(&refused));
+        if record == "{" {
+            assert!(!stderr(&refused).contains("dev stop"));
+        }
         assert_eq!(fs::read_to_string(&notes).unwrap(), "current state\n");
         assert_eq!(
             fs::read(env_registry_path(&env, &cwd).unwrap()).unwrap(),

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -4567,10 +4567,11 @@ fn upgrade_refuses_a_live_watch_before_state_or_runtime_mutation() {
         assert!(!refused.status.success(), "accepted {args:?}");
         assert!(
             stderr(&refused).contains("dev session is active")
-                && stderr(&refused).contains("dev stop demo"),
+                && stderr(&refused).contains("original dev terminal"),
             "{args:?}: {}",
             stderr(&refused)
         );
+        assert!(!stderr(&refused).contains("dev stop"));
         assert_eq!(fs::read(&registry_path).unwrap(), registry_before);
         assert_eq!(fs::read(&next).unwrap(), next_before);
         assert_eq!(

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -4472,6 +4472,117 @@ fn upgrade_rollback_restores_and_reverses_a_runtime_switch() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn upgrade_refuses_a_live_watch_before_state_or_runtime_mutation() {
+    use fs2::FileExt;
+
+    fn inventory(path: &Path) -> BTreeMap<PathBuf, Option<Vec<u8>>> {
+        let mut entries = BTreeMap::new();
+        if path.is_dir() {
+            entries.insert(path.to_path_buf(), None);
+            for entry in fs::read_dir(path).unwrap() {
+                entries.extend(inventory(&entry.unwrap().path()));
+            }
+        } else if path.exists() {
+            entries.insert(path.to_path_buf(), Some(fs::read(path).unwrap()));
+        }
+        entries
+    }
+
+    let root = TestDir::new("upgrade-live-watch-refusal");
+    let mut fixture = seed_in_place_rollback(&root, "2026.6.11");
+    let next = root.child("next-openclaw");
+    write_executable_script(&next, &recording_openclaw_script("2026.6.44"));
+    let added = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["runtime", "add", "next", "--path", &path_string(&next)],
+    );
+    assert!(added.status.success(), "{}", stderr(&added));
+    let sibling = run_ocm(
+        &fixture.cwd,
+        &fixture.env,
+        &["env", "create", "sibling", "--runtime", "next"],
+    );
+    assert!(sibling.status.success(), "{}", stderr(&sibling));
+    let command_log = root.child("refused-commands.log");
+    fixture.env.insert(
+        "OCM_TEST_COMMAND_LOG".to_string(),
+        path_string(&command_log),
+    );
+    let home = PathBuf::from(fixture.env.get("OCM_HOME").unwrap());
+    write_text(
+        &home.join("envs/demo/.openclaw/openclaw.json"),
+        "{\"gateway\":{\"port\":19001}}\n",
+    );
+    let checkout = root.child("watched-source");
+    fs::create_dir_all(checkout.join("extensions")).unwrap();
+    write_text(
+        &checkout.join("openclaw.mjs"),
+        "console.log('2026.6.33');\n",
+    );
+    let watch = ocm::store::source_watch_override_path("demo", &fixture.env, &fixture.cwd).unwrap();
+    fs::create_dir_all(watch.parent().unwrap()).unwrap();
+    let mut lease = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(watch.with_extension("lock"))
+        .unwrap();
+    lease.lock_exclusive().unwrap();
+    writeln!(lease, "upgrade-refusal").unwrap();
+    let watch_bytes = serde_json::to_vec(&serde_json::json!({
+        "kind": "ocm-source-watch-override", "envName": "demo", "repoRoot": checkout,
+        "watchPid": std::process::id(), "token": "lease:upgrade-refusal:fixture",
+        "startedAt": "2026-06-17T00:00:00Z"
+    }))
+    .unwrap();
+    fs::write(&watch, &watch_bytes).unwrap();
+    let registry_path = env_registry_path(&fixture.env, &fixture.cwd).unwrap();
+    let registry_before = fs::read(&registry_path).unwrap();
+    let next_before = fs::read(&next).unwrap();
+    let owned_paths = [
+        "envs",
+        "runtimes",
+        "snapshots",
+        "upgrade-history",
+        "upgrade-batches",
+    ];
+    let before = owned_paths.map(|path| inventory(&home.join(path)));
+    for args in [
+        vec!["upgrade", "demo", "--runtime", "next"],
+        vec!["upgrade", "rollback", "demo"],
+        vec![
+            "upgrade",
+            "batch",
+            "--envs",
+            "demo,sibling",
+            "--runtime",
+            "next",
+            "--accept-fleet-outage",
+        ],
+    ] {
+        let refused = run_ocm(&fixture.cwd, &fixture.env, &args);
+        assert!(!refused.status.success(), "accepted {args:?}");
+        assert!(
+            stderr(&refused).contains("dev session is active")
+                && stderr(&refused).contains("dev stop demo"),
+            "{args:?}: {}",
+            stderr(&refused)
+        );
+        assert_eq!(fs::read(&registry_path).unwrap(), registry_before);
+        assert_eq!(fs::read(&next).unwrap(), next_before);
+        assert_eq!(
+            owned_paths.map(|path| inventory(&home.join(path))),
+            before,
+            "mutated state for {args:?}"
+        );
+        assert_eq!(fs::read(&watch).unwrap(), watch_bytes);
+        assert!(!command_log.exists(), "invoked OpenClaw for {args:?}");
+    }
+}
+
 #[test]
 fn upgrade_rollback_restores_retained_in_place_runtime_bytes() {
     let root = TestDir::new("upgrade-explicit-rollback-in-place");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where snapshot restoration or an upgrade could replace environment state while a watched development session still owned it. An upgrade could also change runtime files before discovering that rollback could not safely restore the live environment.

## Why This Change Was Made

Use one source-watch admission check before snapshot restoration, ordinary upgrades, batch preparation, and explicit rollback verification. The existing operation locks prevent a new watch from starting between the check and the transaction.

## User Impact

Active, transitional, unfinished, or unreadable watches leave environment state and service policy intact. Request shutdown of recorded ownership with `ocm dev stop <env>`. Older watches without an unfinished ownership record require their original dev terminal. Unreadable or unverified ownership requires verified operator recovery, including checking the watch processes and service policy before retrying.

## Evidence

- The snapshot regression reproduces on main: restore previously succeeded during a starting watch.
- Recovery guidance covers active ownership with valid, missing, closed, and malformed session records; the full command-help suite passes.
- The upgrade refusal table verifies no OpenClaw invocation, registry/config/runtime mutation, or snapshot/history creation for single, batch, and explicit rollback commands.
- Remote Crabbox formatting and locked all-target compilation pass. Refusal/retry, direct environment/storage restore, normal rollback, failed-upgrade recovery, batch ordering, and dry-run controls pass.
- Independent source and caller review found no remaining blocker in the corrected patch.
