### PR TITLE
fix: preserve dev bindings during snapshot restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ safety snapshot and a linked history transaction before it stops a managed
 service or replaces runtime bytes. If restore or verification fails, OCM puts
 the pre-rollback runtime and environment state back. Rolling back the linked
 transaction safely reverses the rollback.
+Dev environments retain their current source binding during restore.
+Manual snapshot restore also keeps their current runtime/launcher binding;
+upgrade rollback restores the recorded runtime/launcher instead.
 Once an environment is bound to a runtime, direct `runtime update`,
 `runtime install --force`, `runtime build-local --force`, and `runtime remove`
 operations reject that runtime. Use `ocm upgrade <env>` so the environment gets

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -515,6 +515,11 @@ operator recovery: preserve the environment
 and check the watch processes and service policy before recovering its ownership
 record. Refusal preserves the current state and service policy.
 
+Manual restore of a dev environment keeps its current source binding and
+runtime/launcher binding while restoring saved state. Upgrade rollback keeps
+that dev identity but restores the recorded runtime/launcher. Ordinary runtime
+and launcher environments still restore their captured bindings.
+
 Snapshot create and restore stop a running OCM-managed gateway before copying or
 replacing its root, then restore the recorded service policy. New snapshots are
 verified whole-root checkpoints: they include secrets, browser state, SQLite

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1785,6 +1785,7 @@ pub fn env_snapshot_command_help(cmd: &str, action: &str) -> Option<String> {
             &[
                 "Restore uses an exclusive same-filesystem namespace and retains the displaced root through service acceptance.",
                 "Restore requires a completed source-watch session. Request shutdown of recorded ownership with dev stop. Older watches without an unfinished ownership record require their original dev terminal; unreadable or unverified ownership requires verified operator recovery.",
+                "Manual restore keeps a dev environment's current source binding and runtime/launcher binding. Upgrade rollback retains its dev identity while restoring the recorded runtime/launcher.",
             ],
         ),
         "remove" => render_leaf(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -1414,12 +1414,12 @@ impl Cli {
             }
         }
 
-        let restore = match self.environment_service().prepare_snapshot_restore_locked(
-            RestoreEnvSnapshotOptions {
+        let restore = match self
+            .environment_service()
+            .prepare_upgrade_snapshot_restore_locked(RestoreEnvSnapshotOptions {
                 env_name: env_name.to_string(),
                 snapshot_id: plan.record.snapshot_id.clone(),
-            },
-        ) {
+            }) {
             Ok(restore) => restore,
             Err(error) => {
                 return Ok(self.fail_upgrade_rollback_locked(
@@ -4865,12 +4865,12 @@ impl Cli {
         }) {
             self.restore_runtime_backup(runtime_backup)?;
         }
-        let restore = self.environment_service().prepare_snapshot_restore_locked(
-            RestoreEnvSnapshotOptions {
+        let restore = self
+            .environment_service()
+            .prepare_upgrade_snapshot_restore_locked(RestoreEnvSnapshotOptions {
                 env_name: env_name.to_string(),
                 snapshot_id: transaction.snapshot_id.clone(),
-            },
-        )?;
+            })?;
         // Keep displaced state until the restored service has recovered. Slow or
         // failed discard-only cleanup must not extend the outage.
         let acceptance = (|| {

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -8,8 +8,9 @@ use crate::store::{
     EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
     create_env_snapshot, create_env_snapshot_from_preparation, get_env_snapshot,
     list_all_env_snapshots, list_env_snapshots, now_utc, prepare_env_snapshot_capture,
-    prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture, remove_env_snapshot,
-    rollback_env_snapshot_restore, summarize_snapshot,
+    prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture,
+    prepare_upgrade_snapshot_restore, remove_env_snapshot, rollback_env_snapshot_restore,
+    summarize_snapshot,
 };
 use crate::supervisor::sync_supervisor_env_if_present;
 
@@ -224,6 +225,16 @@ impl<'a> EnvironmentService<'a> {
     ) -> Result<EnvSnapshotRestoreTransaction, String> {
         let env_name = options.env_name.clone();
         let transaction = prepare_env_snapshot_restore(options, self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, &env_name)?;
+        Ok(transaction)
+    }
+
+    pub(crate) fn prepare_upgrade_snapshot_restore_locked(
+        &self,
+        options: RestoreEnvSnapshotOptions,
+    ) -> Result<EnvSnapshotRestoreTransaction, String> {
+        let env_name = options.env_name.clone();
+        let transaction = prepare_upgrade_snapshot_restore(options, self.env, self.cwd)?;
         sync_supervisor_env_if_present(self.env, self.cwd, &env_name)?;
         Ok(transaction)
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -92,7 +92,8 @@ pub(crate) use snapshots::{
     EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
     create_env_snapshot_from_preparation, prepare_env_snapshot_capture,
     prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture,
-    rollback_env_snapshot_restore, validate_upgrade_independent_paths,
+    prepare_upgrade_snapshot_restore, rollback_env_snapshot_restore,
+    validate_upgrade_independent_paths,
 };
 pub use snapshots::{
     create_env_snapshot, get_env_snapshot, list_all_env_snapshots, list_env_snapshots,

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -454,6 +454,23 @@ pub(crate) fn prepare_env_snapshot_restore(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvSnapshotRestoreTransaction, String> {
+    prepare_env_snapshot_restore_with_binding(options, true, env, cwd)
+}
+
+pub(crate) fn prepare_upgrade_snapshot_restore(
+    options: RestoreEnvSnapshotOptions,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvSnapshotRestoreTransaction, String> {
+    prepare_env_snapshot_restore_with_binding(options, false, env, cwd)
+}
+
+fn prepare_env_snapshot_restore_with_binding(
+    options: RestoreEnvSnapshotOptions,
+    preserve_current_dev_execution: bool,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvSnapshotRestoreTransaction, String> {
     let env_name = validate_name(&options.env_name, "Environment name")?;
     let snapshot = get_env_snapshot(&env_name, &options.snapshot_id, env, cwd)?;
     crate::env::EnvironmentService::new(env, cwd)
@@ -511,7 +528,7 @@ pub(crate) fn prepare_env_snapshot_restore(
                     service_running: archived.service_running,
                     default_runtime: archived.default_runtime,
                     default_launcher: archived.default_launcher,
-                    dev: None,
+                    dev: current.dev.clone(),
                     protected: archived.protected,
                     created_at: current.created_at,
                     updated_at: current.updated_at,
@@ -534,7 +551,7 @@ pub(crate) fn prepare_env_snapshot_restore(
                     service_running: snapshot.service_running,
                     default_runtime: snapshot.default_runtime.clone(),
                     default_launcher: snapshot.default_launcher.clone(),
-                    dev: None,
+                    dev: current.dev.clone(),
                     protected: snapshot.protected,
                     created_at: current.created_at,
                     updated_at: current.updated_at,
@@ -543,6 +560,11 @@ pub(crate) fn prepare_env_snapshot_restore(
                 false,
             )
         };
+
+        if preserve_current_dev_execution && current.dev.is_some() {
+            restored.default_runtime = current.default_runtime.clone();
+            restored.default_launcher = current.default_launcher.clone();
+        }
 
         let mut renamed = false;
         if !independent.is_empty() {

--- a/tests/env_snapshot_tests.rs
+++ b/tests/env_snapshot_tests.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use fs2::FileExt;
+use ocm::env::{EnvDevMeta, EnvironmentService};
 use ocm::store::{
     env_registry_path, get_environment, now_utc, save_environment, source_watch_override_path,
     supervisor_runtime_path,
@@ -347,6 +348,123 @@ fn env_snapshot_restore_reverts_state_from_the_selected_snapshot() {
             .unwrap(),
         "before restore"
     );
+}
+
+#[test]
+fn env_snapshot_restore_preserves_the_current_complete_dev_binding() {
+    for binding in ["runtime", "launcher", "dev", "ordinary"] {
+        let root = TestDir::new("env-snapshot-dev-binding");
+        let cwd = root.child("workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let env = ocm_env(&root);
+        let created = run_ocm(&cwd, &env, &["env", "create", "source"]);
+        assert!(created.status.success(), "{}", stderr(&created));
+        for name in ["captured", "current"] {
+            let binary = root.child(format!("{name}-openclaw"));
+            write_executable_script(&binary, "#!/bin/sh\nexit 0\n");
+            let runtime = run_ocm(
+                &cwd,
+                &env,
+                &["runtime", "add", name, "--path", &path_string(&binary)],
+            );
+            assert!(runtime.status.success(), "{}", stderr(&runtime));
+            let launcher = run_ocm(
+                &cwd,
+                &env,
+                &["launcher", "add", name, "--command", "printf retained"],
+            );
+            assert!(launcher.status.success(), "{}", stderr(&launcher));
+        }
+        let mut meta = get_environment("source", &env, &cwd).unwrap();
+        meta.service_enabled = false;
+        meta.service_running = false;
+        meta.default_runtime = Some("captured".to_string());
+        meta.default_launcher = Some("captured".to_string());
+        save_environment(meta, &env, &cwd).unwrap();
+        let notes = root.child("ocm-home/envs/source/.openclaw/workspace/notes.txt");
+        write_text(&notes, "snapshot state\n");
+        let snapshot = run_ocm(
+            &cwd,
+            &env,
+            &["env", "snapshot", "create", "source", "--json"],
+        );
+        assert!(snapshot.status.success(), "{}", stderr(&snapshot));
+        let snapshot: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+
+        let mut current = get_environment("source", &env, &cwd).unwrap();
+        if binding != "ordinary" {
+            current.dev = Some(EnvDevMeta {
+                repo_root: path_string(&root.child("saved-repo")),
+                worktree_root: path_string(&root.child("saved-worktree")),
+            });
+        }
+        current.default_runtime =
+            matches!(binding, "runtime" | "ordinary").then(|| "current".to_string());
+        current.default_launcher = (binding != "dev").then(|| "current".to_string());
+        save_environment(current.clone(), &env, &cwd).unwrap();
+        write_text(&notes, "current state\n");
+        let restored = run_ocm(
+            &cwd,
+            &env,
+            &[
+                "env",
+                "snapshot",
+                "restore",
+                "source",
+                snapshot["id"].as_str().unwrap(),
+            ],
+        );
+        assert!(
+            restored.status.success(),
+            "{binding}: {}",
+            stderr(&restored)
+        );
+        let restored = get_environment("source", &env, &cwd).unwrap();
+        assert_eq!(
+            serde_json::to_value(&restored.dev).unwrap(),
+            serde_json::to_value(&current.dev).unwrap()
+        );
+        let expected = if binding == "ordinary" {
+            "captured"
+        } else {
+            "current"
+        };
+        assert_eq!(
+            restored.default_runtime.as_deref(),
+            if matches!(binding, "runtime" | "ordinary") {
+                Some(expected)
+            } else {
+                None
+            }
+        );
+        assert_eq!(
+            restored.default_launcher.as_deref(),
+            (binding != "dev").then_some(expected)
+        );
+        assert_eq!(fs::read_to_string(&notes).unwrap(), "snapshot state\n");
+        let resolved = EnvironmentService::new(&env, &cwd)
+            .resolve("source", None, None, &["status".to_string()])
+            .unwrap()
+            .into_summary();
+        assert_eq!(
+            resolved.binding_kind,
+            if binding == "ordinary" {
+                "runtime"
+            } else {
+                binding
+            }
+        );
+        assert_eq!(
+            resolved.binding_name,
+            if binding == "dev" { "dev" } else { expected }
+        );
+        if binding == "dev" {
+            assert_eq!(
+                resolved.run_dir,
+                current.dev.as_ref().unwrap().worktree_root
+            );
+        }
+    }
 }
 
 #[test]
@@ -982,6 +1100,26 @@ fn env_snapshot_restore_remains_compatible_with_legacy_tar_metadata() {
     );
     assert!(restore.status.success(), "{}", stderr(&restore));
     assert_eq!(fs::read_to_string(&notes).unwrap(), "legacy-snapshot\n");
+
+    let mut current = get_environment("source", &env, &cwd).unwrap();
+    current.dev = Some(EnvDevMeta {
+        repo_root: path_string(&root.child("saved-repo")),
+        worktree_root: path_string(&root.child("saved-worktree")),
+    });
+    let saved_dev = serde_json::to_value(&current.dev).unwrap();
+    save_environment(current, &env, &cwd).unwrap();
+    write_text(&notes, "current dev state\n");
+    let restore = run_ocm(
+        &cwd,
+        &env,
+        &["env", "snapshot", "restore", "source", snapshot_id],
+    );
+    assert!(restore.status.success(), "{}", stderr(&restore));
+    assert_eq!(fs::read_to_string(&notes).unwrap(), "legacy-snapshot\n");
+    assert_eq!(
+        serde_json::to_value(get_environment("source", &env, &cwd).unwrap().dev).unwrap(),
+        saved_dev
+    );
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -3856,6 +3856,24 @@ fn upgrade_rollback_refuses_a_broken_source_launcher_before_mutation() {
     assert!(history.status.success(), "{}", stderr(&history));
     let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
     assert_eq!(history_json.as_array().unwrap().len(), 1);
+
+    fs::create_dir_all(&project_dir).unwrap();
+    let mut current = ocm::store::get_environment("hacking", &env, &cwd).unwrap();
+    current.dev = Some(ocm::env::EnvDevMeta {
+        repo_root: path_string(&project_dir),
+        worktree_root: path_string(&root.child("saved-worktree")),
+    });
+    let saved_dev = serde_json::to_value(&current.dev).unwrap();
+    ocm::store::save_environment(current, &env, &cwd).unwrap();
+    let rollback = run_ocm(&cwd, &env, &["upgrade", "rollback", "hacking", "--json"]);
+    assert!(rollback.status.success(), "{}", stderr(&rollback));
+    let restored = ocm::store::get_environment("hacking", &env, &cwd).unwrap();
+    assert!(restored.default_runtime.is_none());
+    assert_eq!(restored.default_launcher.as_deref(), Some("hacking.local"));
+    assert_eq!(serde_json::to_value(restored.dev).unwrap(), saved_dev);
+    let version = run_ocm(&cwd, &env, &["@hacking", "--", "--version"]);
+    assert!(version.status.success(), "{}", stderr(&version));
+    assert_eq!(stdout(&version).trim(), "2026.3.23");
 }
 
 #[test]
@@ -4394,6 +4412,14 @@ fn upgrade_rollback_restores_and_reverses_a_runtime_switch() {
     assert!(stdout(&upgrade).contains("outcome=switched"));
     fs::write(&marker, "after-upgrade").unwrap();
 
+    let mut current = ocm::store::get_environment("demo", &env, &cwd).unwrap();
+    current.dev = Some(ocm::env::EnvDevMeta {
+        repo_root: path_string(&root.child("saved-repo")),
+        worktree_root: path_string(&root.child("saved-worktree")),
+    });
+    let saved_dev = serde_json::to_value(&current.dev).unwrap();
+    ocm::store::save_environment(current, &env, &cwd).unwrap();
+
     let history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
     assert!(history.status.success(), "{}", stderr(&history));
     let history_json: Value = serde_json::from_str(&stdout(&history)).unwrap();
@@ -4438,6 +4464,10 @@ fn upgrade_rollback_restores_and_reverses_a_runtime_switch() {
     let version = run_ocm(&cwd, &env, &["@demo", "--", "--version"]);
     assert!(version.status.success(), "{}", stderr(&version));
     assert_eq!(stdout(&version).trim(), "2026.6.11");
+    assert_eq!(
+        serde_json::to_value(ocm::store::get_environment("demo", &env, &cwd).unwrap().dev).unwrap(),
+        saved_dev
+    );
 
     let rollback_history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
     assert!(
@@ -4461,6 +4491,10 @@ fn upgrade_rollback_restores_and_reverses_a_runtime_switch() {
     let version = run_ocm(&cwd, &env, &["@demo", "--", "--version"]);
     assert!(version.status.success(), "{}", stderr(&version));
     assert_eq!(stdout(&version).trim(), "2026.6.33");
+    assert_eq!(
+        serde_json::to_value(ocm::store::get_environment("demo", &env, &cwd).unwrap().dev).unwrap(),
+        saved_dev
+    );
 
     let final_history = run_ocm(&cwd, &env, &["upgrade", "history", "demo", "--json"]);
     assert!(final_history.status.success(), "{}", stderr(&final_history));
@@ -5714,6 +5748,14 @@ fn upgrade_rolls_back_runtime_binding_when_update_finalization_fails() {
     fs::create_dir_all(secondary_skill.parent().unwrap()).unwrap();
     fs::write(&secondary_skill, "skill before upgrade\n").unwrap();
 
+    let mut current = ocm::store::get_environment("demo", &env, &cwd).unwrap();
+    current.dev = Some(ocm::env::EnvDevMeta {
+        repo_root: path_string(&root.child("saved-repo")),
+        worktree_root: path_string(&root.child("saved-worktree")),
+    });
+    let saved_dev = serde_json::to_value(&current.dev).unwrap();
+    ocm::store::save_environment(current, &env, &cwd).unwrap();
+
     env.insert("OCM_TEST_FAIL_UPDATE_FINALIZE".to_string(), "1".to_string());
     let upgrade = run_ocm(&cwd, &env, &["upgrade", "demo", "--runtime", "new-local"]);
     assert!(!upgrade.status.success(), "{}", stdout(&upgrade));
@@ -5729,6 +5771,10 @@ fn upgrade_rolls_back_runtime_binding_when_update_finalization_fails() {
     assert!(show.status.success(), "{}", stderr(&show));
     let env_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     assert_eq!(env_json["defaultRuntime"], "old-local");
+    assert_eq!(
+        serde_json::to_value(ocm::store::get_environment("demo", &env, &cwd).unwrap().dev).unwrap(),
+        saved_dev
+    );
     assert_eq!(
         fs::read_to_string(secondary_skill).unwrap(),
         "skill before upgrade\n"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users restoring a snapshot of a dev environment would lose its source binding or revert the runtime or launcher they selected after the snapshot.

## Why This Change Was Made

Manual restore retains the dev environment's current source binding and runtime/launcher selection while restoring saved state. Upgrade rollback retains the dev identity while restoring the recorded runtime/launcher selection. Both checkpoint and legacy archive restores use the same policy.

## User Impact

Restoring dev state preserves the selected source checkout and execution binding. Ordinary runtime and launcher environments keep their existing snapshot restore behavior.

## Evidence

CLI cases cover source-only, runtime and launcher dev bindings; ordinary and legacy snapshot restore; active-watch refusal; failed restore acceptance; runtime rollback and reversal; launcher rollback; and automatic failed-upgrade recovery. Formatting, all-target compilation and the affected snapshot/upgrade integration checks passed on current main. Hosted platform checks remain the final validation step.
