### PR TITLE
fix: preserve private access on Windows config updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Check Windows targets
         run: cargo check --workspace --all-targets --locked
+      - name: Prove private config replacement
+        run: cargo test --locked --lib private_config_
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.15.0'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_IO",
     "Win32_System_JobObjects",
+    "Win32_System_SystemServices",
     "Win32_System_Threading",
 ] }
 

--- a/README.md
+++ b/README.md
@@ -391,9 +391,9 @@ Use `ocm` when you want:
 
 Manual setup works. `ocm` is what makes it feel organized.
 
-On Unix, updates to an already-private OpenClaw config preserve its private
-access. OCM creates the replacement privately and verifies protection before
-writing data; files with other authored access rules keep the existing writer.
+On Unix and Windows, updates to an already-private OpenClaw config preserve its
+private access. OCM creates the replacement privately and verifies protection
+before writing data; files with other authored access rules keep the existing writer.
 
 ## Learn more
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -743,10 +743,11 @@ Windows service support is not implemented yet.
 `ocm` keeps safety checks around destructive actions.
 
 On Unix, updating an already-private OpenClaw config preserves its file mode.
-Private replacements exclude inherited macOS access at creation, and protection
-is verified before any config data is written. Other authored access rules
-retain the existing writer. Config values, including auth and SecretRefs,
-follow the existing command's update rules.
+On Windows, this preserves a protected ACL owned by and granting access only to
+the current user. Private replacements exclude inherited macOS and Windows access
+at creation, and protection is verified before any config data is written. Other
+authored access rules retain the existing writer. Config values, including auth
+and SecretRefs, follow the existing command's update rules.
 
 Examples:
 

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -10,3 +10,5 @@ pub mod shell;
 mod sqlite_snapshot;
 pub mod terminal;
 pub(crate) mod tree_digest;
+#[cfg(windows)]
+pub(crate) mod windows_security;

--- a/src/infra/windows_security.rs
+++ b/src/infra/windows_security.rs
@@ -1,0 +1,323 @@
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::mem::{MaybeUninit, size_of};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::path::Path;
+use std::ptr;
+
+use windows_sys::Win32::Foundation::{
+    ERROR_INSUFFICIENT_BUFFER, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::Security::{
+    ACCESS_ALLOWED_ACE, ACE_HEADER, ACL, ACL_REVISION, AddAccessAllowedAce,
+    DACL_SECURITY_INFORMATION, EqualSid, GetAce, GetKernelObjectSecurity, GetLengthSid,
+    GetSecurityDescriptorControl, GetSecurityDescriptorDacl, GetSecurityDescriptorOwner,
+    GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor, IsValidSid,
+    OWNER_SECURITY_INFORMATION, PSID, SE_DACL_PROTECTED, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR,
+    SetSecurityDescriptorControl, SetSecurityDescriptorDacl, SetSecurityDescriptorOwner,
+    TOKEN_QUERY, TOKEN_USER, TokenUser,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CREATE_NEW, CreateFileW, FILE_ALL_ACCESS, FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_REPARSE_POINT,
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+    FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, READ_CONTROL,
+};
+use windows_sys::Win32::System::SystemServices::{
+    ACCESS_ALLOWED_ACE_TYPE, SECURITY_DESCRIPTOR_REVISION,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+const MAX_SECURITY_BYTES: usize = 64 * 1024;
+
+fn with_user_only_security_attributes<T>(
+    user: &UserSid,
+    action: impl FnOnce(&SECURITY_ATTRIBUTES) -> io::Result<T>,
+) -> io::Result<T> {
+    let sid_bytes = unsafe { GetLengthSid(user.as_sid()) } as usize;
+    let acl_bytes =
+        size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + sid_bytes;
+    let mut acl_storage = vec![0_usize; acl_bytes.div_ceil(size_of::<usize>())];
+    let acl = acl_storage.as_mut_ptr().cast::<ACL>();
+    let mut descriptor = SECURITY_DESCRIPTOR::default();
+    let descriptor_ptr = ptr::from_mut(&mut descriptor).cast();
+    if unsafe { InitializeAcl(acl, acl_bytes as u32, ACL_REVISION) } == 0
+        || unsafe { AddAccessAllowedAce(acl, ACL_REVISION, FILE_ALL_ACCESS, user.as_sid()) } == 0
+        || unsafe { InitializeSecurityDescriptor(descriptor_ptr, SECURITY_DESCRIPTOR_REVISION) }
+            == 0
+        || unsafe { SetSecurityDescriptorOwner(descriptor_ptr, user.as_sid(), 0) } == 0
+        || unsafe { SetSecurityDescriptorDacl(descriptor_ptr, 1, acl, 0) } == 0
+        || unsafe {
+            SetSecurityDescriptorControl(descriptor_ptr, SE_DACL_PROTECTED, SE_DACL_PROTECTED)
+        } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    // Protected DACLs exclude inheritable permissions on custom parent roots.
+    // Keep the SID, ACL, and descriptor alive until the creation call returns.
+    action(&SECURITY_ATTRIBUTES {
+        nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: descriptor_ptr,
+        bInheritHandle: 0,
+    })
+}
+
+pub(crate) fn create_private_file_new(path: &Path) -> io::Result<File> {
+    let mut path = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    if path.contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid private file path",
+        ));
+    }
+    path.push(0);
+    let user = UserSid::current()?;
+    with_user_only_security_attributes(&user, |attributes| {
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                attributes,
+                CREATE_NEW,
+                FILE_ATTRIBUTE_NORMAL,
+                ptr::null_mut(),
+            )
+        };
+        owned_handle(handle).map(File::from)
+    })
+}
+
+fn owned_handle(raw: HANDLE) -> io::Result<OwnedHandle> {
+    if raw.is_null() || raw == INVALID_HANDLE_VALUE {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { OwnedHandle::from_raw_handle(raw) })
+    }
+}
+
+struct UserSid {
+    // TOKEN_USER contains a pointer into this allocation. Keep its alignment
+    // and allocation stable until all SID comparisons have completed.
+    storage: Vec<usize>,
+}
+
+impl UserSid {
+    fn current() -> io::Result<Self> {
+        let mut token = ptr::null_mut();
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let token = owned_handle(token)?;
+        let mut needed = 0;
+        let result = unsafe {
+            GetTokenInformation(
+                token.as_raw_handle(),
+                TokenUser,
+                ptr::null_mut(),
+                0,
+                &mut needed,
+            )
+        };
+        if result != 0
+            || io::Error::last_os_error().raw_os_error() != Some(ERROR_INSUFFICIENT_BUFFER as i32)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "could not size the process user identity",
+            ));
+        }
+        if !(size_of::<TOKEN_USER>()..=MAX_SECURITY_BYTES).contains(&(needed as usize)) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid process user identity size",
+            ));
+        }
+        let mut storage = vec![0_usize; (needed as usize).div_ceil(size_of::<usize>())];
+        let mut returned = 0;
+        if unsafe {
+            GetTokenInformation(
+                token.as_raw_handle(),
+                TokenUser,
+                storage.as_mut_ptr().cast(),
+                needed,
+                &mut returned,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        if returned < size_of::<TOKEN_USER>() as u32 || returned > needed {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid process user identity data",
+            ));
+        }
+        let user = Self { storage };
+        if user.as_sid().is_null() || unsafe { IsValidSid(user.as_sid()) } == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid process user SID",
+            ));
+        }
+        Ok(user)
+    }
+
+    fn as_sid(&self) -> PSID {
+        unsafe { &*self.storage.as_ptr().cast::<TOKEN_USER>() }
+            .User
+            .Sid
+    }
+}
+
+pub(crate) fn file_has_user_only_access(path: &Path) -> io::Result<bool> {
+    let file = match OpenOptions::new()
+        .access_mode(READ_CONTROL | FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    // Inspect the opened entry itself. A link target's ACL does not identify
+    // the authored link as one of our private regular config files.
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Ok(false);
+    }
+    has_user_only_access(&file)
+}
+
+pub(crate) fn has_user_only_access(file: &File) -> io::Result<bool> {
+    let mut needed = 0;
+    let sized = unsafe {
+        GetKernelObjectSecurity(
+            file.as_raw_handle(),
+            DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION,
+            ptr::null_mut(),
+            0,
+            &mut needed,
+        )
+    };
+    if sized != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid file security size",
+        ));
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() != Some(ERROR_INSUFFICIENT_BUFFER as i32) {
+        return Err(error);
+    }
+    if needed == 0 || needed as usize > MAX_SECURITY_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid file security size",
+        ));
+    }
+    let mut storage = vec![0_usize; (needed as usize).div_ceil(size_of::<usize>())];
+    let descriptor = storage.as_mut_ptr().cast();
+    let mut returned = 0;
+    if unsafe {
+        GetKernelObjectSecurity(
+            file.as_raw_handle(),
+            DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION,
+            descriptor,
+            needed,
+            &mut returned,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if returned == 0 || returned > needed {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid file security data",
+        ));
+    }
+    let mut control = 0;
+    let mut revision = 0;
+    if unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut owner = ptr::null_mut();
+    let mut owner_defaulted = 0;
+    if unsafe { GetSecurityDescriptorOwner(descriptor, &mut owner, &mut owner_defaulted) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if owner.is_null() {
+        return Ok(false);
+    }
+    if unsafe { IsValidSid(owner) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid file owner identity",
+        ));
+    }
+    let user = UserSid::current()?;
+    if unsafe { EqualSid(owner, user.as_sid()) } == 0 {
+        return Ok(false);
+    }
+    let mut present = 0;
+    let mut defaulted = 0;
+    let mut dacl = MaybeUninit::<*mut ACL>::uninit();
+    if unsafe {
+        GetSecurityDescriptorDacl(descriptor, &mut present, dacl.as_mut_ptr(), &mut defaulted)
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if control & SE_DACL_PROTECTED == 0 || present == 0 || defaulted != 0 {
+        return Ok(false);
+    }
+    // SAFETY: success with a present DACL initializes this output, including
+    // a possible null DACL. A nonnull pointer borrows the still-owned `storage`.
+    let dacl = unsafe { dacl.assume_init() };
+    if dacl.is_null() {
+        return Ok(false);
+    }
+    if unsafe { (*dacl).AceCount } != 1 {
+        return Ok(false);
+    }
+    let mut ace = MaybeUninit::<*mut std::ffi::c_void>::uninit();
+    if unsafe { GetAce(dacl, 0, ace.as_mut_ptr()) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: GetAce initializes the entry pointer on success. The entry stays
+    // inside the descriptor buffer, which is neither resized nor freed here.
+    let ace = unsafe { ace.assume_init() };
+    if ace.is_null() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "missing file access entry",
+        ));
+    }
+    let header = unsafe { &*ace.cast::<ACE_HEADER>() };
+    if u32::from(header.AceType) != ACCESS_ALLOWED_ACE_TYPE
+        || header.AceFlags != 0
+        || usize::from(header.AceSize) < size_of::<ACCESS_ALLOWED_ACE>()
+    {
+        return Ok(false);
+    }
+    let ace = unsafe { &*ace.cast::<ACCESS_ALLOWED_ACE>() };
+    if ace.Mask != FILE_ALL_ACCESS {
+        return Ok(false);
+    }
+    let sid = ptr::from_ref(&ace.SidStart).cast_mut().cast();
+    if unsafe { IsValidSid(sid) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid file access identity",
+        ));
+    }
+    Ok(unsafe { EqualSid(sid, user.as_sid()) } != 0)
+}
+
+#[cfg(test)]
+pub(crate) fn assert_private_file_security(file: &File) {
+    assert!(has_user_only_access(file).unwrap());
+}

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fs;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -694,7 +694,7 @@ fn ensure_object_field<'a>(
 }
 
 fn write_config_value(config_path: &Path, value: &Value) -> Result<(), String> {
-    // Preserve private Unix access when replacing the inode. Other authored
+    // Preserve private access when replacing the file. Other authored
     // files retain the existing writer's access and replacement behavior.
     #[cfg(unix)]
     {
@@ -742,12 +742,18 @@ fn write_config_value(config_path: &Path, value: &Value) -> Result<(), String> {
             Err(error) => return Err(error.to_string()),
         }
     }
+    #[cfg(windows)]
+    if crate::infra::windows_security::file_has_user_only_access(config_path)
+        .map_err(|error| error.to_string())?
+    {
+        return replace_private_config(stage_private_config(config_path, value)?, config_path);
+    }
     let mut rewritten = serde_json::to_string_pretty(value).map_err(|error| error.to_string())?;
     rewritten.push('\n');
     write_file_replacing_path(config_path, rewritten.as_bytes())
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn replace_private_config(
     staged: tempfile::NamedTempFile,
     config_path: &Path,
@@ -758,7 +764,7 @@ fn replace_private_config(
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn stage_private_config(
     config_path: &Path,
     value: &Value,
@@ -770,9 +776,16 @@ fn stage_private_config(
     let mut builder = tempfile::Builder::new();
     builder.prefix(".openclaw-config-");
     // Establish protection at creation, before writing any authentication bytes.
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(windows, target_os = "macos")))]
     let mut staged = builder
         .tempfile_in(parent)
+        .map_err(|error| error.to_string())?;
+    #[cfg(windows)]
+    let mut staged = builder
+        .make_in(
+            parent,
+            crate::infra::windows_security::create_private_file_new,
+        )
         .map_err(|error| error.to_string())?;
     #[cfg(target_os = "macos")]
     let mut staged = builder
@@ -785,23 +798,32 @@ fn stage_private_config(
     Ok(staged)
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn write_private_config(staged: &mut tempfile::NamedTempFile, value: &Value) -> Result<(), String> {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
-
-    // Verify the applied protection while the empty file has a cleanup owner.
-    let metadata = staged
-        .as_file()
-        .metadata()
-        .map_err(|error| error.to_string())?;
-    if !metadata.is_file()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.permissions().mode() & 0o077 != 0
+    // Verify protection while the empty file has a cleanup owner.
+    #[cfg(unix)]
     {
-        return Err("filesystem did not apply private OpenClaw config access".to_string());
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let metadata = staged
+            .as_file()
+            .metadata()
+            .map_err(|error| error.to_string())?;
+        if !metadata.is_file()
+            || metadata.uid() != unsafe { libc::geteuid() }
+            || metadata.permissions().mode() & 0o077 != 0
+        {
+            return Err("filesystem did not apply private OpenClaw config access".to_string());
+        }
+        #[cfg(target_os = "macos")]
+        if !crate::infra::macos_security::file_has_no_extended_acl(staged.as_file())
+            .map_err(|error| error.to_string())?
+        {
+            return Err("filesystem did not apply private OpenClaw config access".to_string());
+        }
     }
-    #[cfg(target_os = "macos")]
-    if !crate::infra::macos_security::file_has_no_extended_acl(staged.as_file())
+    #[cfg(windows)]
+    if !crate::infra::windows_security::has_user_only_access(staged.as_file())
         .map_err(|error| error.to_string())?
     {
         return Err("filesystem did not apply private OpenClaw config access".to_string());
@@ -1499,6 +1521,61 @@ mod tests {
             fs::metadata(&authored).unwrap().permissions().mode(),
             fs::metadata(&control).unwrap().permissions().mode()
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn private_config_replacement_preserves_windows_acl() {
+        let root = tempfile::tempdir().unwrap();
+        let paths = derive_env_paths(&root.path().join("custom-root"));
+        fs::create_dir_all(&paths.state_dir).unwrap();
+        let granted = std::process::Command::new("icacls")
+            .arg(&paths.state_dir)
+            .args(["/grant", "*S-1-1-0:(OI)(CI)F"])
+            .output()
+            .unwrap();
+        assert!(
+            granted.status.success(),
+            "could not prepare the custom-root ACL"
+        );
+        let mut unprotected = tempfile::Builder::new()
+            .tempfile_in(&paths.state_dir)
+            .unwrap();
+        let unprotected_path = unprotected.path().to_path_buf();
+        assert!(
+            write_private_config(
+                &mut unprotected,
+                &json!({"gateway": {"auth": {"token": "synthetic-unwritten-token"}}}),
+            )
+            .is_err()
+        );
+        assert_eq!(unprotected.as_file().metadata().unwrap().len(), 0);
+        drop(unprotected);
+        assert!(!unprotected_path.exists());
+        let staged = stage_private_config(
+            &paths.config_path,
+            &json!({"gateway": {"auth": {"mode": "token", "token": "synthetic-existing-token"}}}),
+        )
+        .unwrap();
+        crate::infra::windows_security::assert_private_file_security(staged.as_file());
+        replace_private_config(staged, &paths.config_path).unwrap();
+        let original = read_config_value(&paths.config_path).unwrap().unwrap();
+        ensure_minimum_local_openclaw_config(&paths, 19800).unwrap();
+        assert!(
+            crate::infra::windows_security::file_has_user_only_access(&paths.config_path).unwrap()
+        );
+        let updated = read_config_value(&paths.config_path).unwrap().unwrap();
+        assert!(updated["gateway"]["auth"] == original["gateway"]["auth"]);
+
+        let authored = paths.state_dir.join("authored.json");
+        fs::write(&authored, b"{\"gateway\":{\"auth\":{\"mode\":\"none\"}}}\n").unwrap();
+        assert!(!crate::infra::windows_security::file_has_user_only_access(&authored).unwrap());
+        write_config_value(
+            &authored,
+            &json!({"gateway": {"auth": {"mode": "none"}, "port": 19801}}),
+        )
+        .unwrap();
+        assert!(!crate::infra::windows_security::file_has_user_only_access(&authored).unwrap());
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where updating a private OpenClaw config on Windows could give the replacement file broader access inherited from its environment directory.

## Why This Change Was Made

Private replacements are created with a protected ACL and the current user as owner. OCM verifies the applied access before writing config data, then uses the existing atomic replacement path. Files with other authored access rules keep the existing writer behavior.

This builds on the shared config writer in #186.

## User Impact

Existing user-only config access survives OCM config updates. Auth settings and SecretRefs continue to follow the requested command's existing update rules.

## Evidence

- The existing native Windows regression covers a directory with inheritable access, rejection of an unprotected empty staging file, private replacement, preserved auth settings, and the ordinary writer fallback.
- That regression passed with the unchanged Windows helper and test on `9f0092b2`; the Windows CI job runs it again for this PR.
- Formatting, Linux and Windows GNU all-target checks, and three focused config/CLI cases passed on the extracted source. Fresh native Windows CI and review run on the published head.
