### PR TITLE
fix: create owned worktrees with relative Git paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
         run: cargo check --workspace --all-targets --locked
       - name: Prove private config replacement
         run: cargo test --locked --lib private_config_
+      - name: Prove canonical owned worktree paths
+        run: cargo test --locked --lib openclaw_repo::tests::owned_worktree_uses_canonical_repository_paths -- --exact --nocapture
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.15.0'

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -415,11 +415,17 @@ pub(crate) fn ensure_openclaw_worktree(
         fs::create_dir_all(parent).map_err(|error| error.to_string())?;
     }
 
+    // Git accepts the canonical Windows repository for -C, but not a verbatim
+    // Windows path as its new worktree destination. Keep this owned path
+    // relative to that repository without changing the stored source identity.
+    let worktree_argument = worktree_root
+        .strip_prefix(&repo_root)
+        .map_err(|_| "OCM-owned worktree destination is outside its repository".to_string())?;
     let output = Command::new("git")
         .arg("-C")
         .arg(&repo_root)
         .args(["worktree", "add", "--detach"])
-        .arg(&worktree_root)
+        .arg(worktree_argument)
         .output()
         .map_err(|error| format!("failed to run git worktree add: {error}"))?;
     if !output.status.success() {
@@ -913,6 +919,25 @@ mod tests {
         run_git(&repo, &["add", "."]);
         run_git(&repo, &["commit", "-m", "init"]);
         (temp, repo)
+    }
+
+    #[test]
+    fn owned_worktree_uses_canonical_repository_paths() {
+        let (temp, repo) = init_openclaw_repo();
+        let spaced = temp.path().join("OpenClaw source");
+        fs::rename(repo, &spaced).unwrap();
+        let repo = fs::canonicalize(spaced).unwrap();
+        let original = fs::read(repo.join("package.json")).unwrap();
+        let worktree = ensure_openclaw_worktree(&repo, "plain.stop").unwrap();
+        assert!(worktree.is_absolute() && worktree.join(".git").is_file());
+        assert_eq!(fs::read(worktree.join("package.json")).unwrap(), original);
+        assert_eq!(
+            ensure_openclaw_worktree(&repo, "plain.stop").unwrap(),
+            worktree
+        );
+        remove_openclaw_worktree(&repo, &worktree).unwrap();
+        assert!(!worktree.exists());
+        assert_eq!(fs::read(repo.join("package.json")).unwrap(), original);
     }
 
     #[test]


### PR DESCRIPTION
## What Problem This Solves

Git for Windows rejects the canonical verbatim absolute destination passed when OCM creates an owned development or simulation worktree. Creation fails before the requested command starts.

## Why This Change Was Made

Pass the owned destination relative to the existing `git -C` repository. Keep canonical stored paths and the existing registration, checkout-identity, reuse, and cleanup checks.

## User Impact

Owned worktree creation supports canonical Windows repository paths without changing source ownership or removing authored files.

## Evidence

- Crabbox formatting and locked all-target compilation passed.
- A real Git test covers a canonical repository path with spaces, creation, reuse, removal, and preserved source bytes; four existing cleanup controls also pass.
- Native Windows CI passed the canonical-path create/reuse/remove regression, the existing native dev-stop case, and Windows lock and private-file controls.
- Linux, macOS, MSRV, formatting and CodeQL checks passed on the prior equivalent patch. Current-main CI and exact-head review are required before landing.
