### PR TITLE
fix: preserve Gateway operations during startup

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -344,6 +344,12 @@ ocm service status mira
 
 Use `service install` when you want a background service for an environment that was created with `--no-service`, or when you want to bring an older env under background management later.
 
+On Unix, OCM waits for Gateway PID publication before moving a matching caller
+out of the Gateway process group during daemon refresh, snapshot, or upgrade
+maintenance. This protects the caller from the supervisor's signals to that
+group. A systemd unit stop or restart can still terminate the caller through its
+service cgroup.
+
 ### Read logs
 
 ```bash

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -185,8 +185,8 @@ impl<'a> ServiceService<'a> {
         }
         preserve_operation_owner_before_managed_gateway_stop(
             name,
-            status.child_pid,
             self.env,
+            self.cwd,
             &format!("quiescing env \"{name}\""),
         )?;
         if state.running {
@@ -299,10 +299,21 @@ impl<'a> ServiceService<'a> {
 #[cfg(unix)]
 pub(crate) fn preserve_operation_owner_before_managed_gateway_stop(
     target_env: &str,
-    managed_gateway_pid: Option<u32>,
     env: &BTreeMap<String, String>,
+    cwd: &Path,
     operation: &str,
 ) -> Result<(), String> {
+    if env.get("OCM_ACTIVE_ENV").map(String::as_str) != Some(target_env) {
+        return Ok(());
+    }
+    // A Gateway can invoke OCM before spawn publishes its PID. Admission stays
+    // locked through that publication; preserve the caller before releasing it.
+    // The guard must drop before the caller begins stop or restart work.
+    let _admission =
+        crate::env::EnvironmentService::new(env, cwd).lock_gateway_admission(target_env)?;
+    let managed_gateway_pid =
+        crate::supervisor::SupervisorService::new(env, cwd).runtime_child_pid(target_env)?;
+
     // SAFETY: getpgrp has no preconditions and does not mutate memory.
     let process_group = unsafe { libc::getpgrp() };
     if !operation_owner_is_in_managed_gateway_group(
@@ -336,8 +347,8 @@ pub(crate) fn preserve_operation_owner_before_managed_gateway_stop(
 #[cfg(not(unix))]
 pub(crate) fn preserve_operation_owner_before_managed_gateway_stop(
     _target_env: &str,
-    _managed_gateway_pid: Option<u32>,
     _env: &BTreeMap<String, String>,
+    _cwd: &Path,
     _operation: &str,
 ) -> Result<(), String> {
     Ok(())

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -763,17 +763,10 @@ impl<'a> SupervisorService<'a> {
         let Some(active_env) = self.env.get("OCM_ACTIVE_ENV") else {
             return Ok(());
         };
-        let managed_gateway_pid = self.read_runtime_state()?.and_then(|runtime| {
-            runtime
-                .children
-                .into_iter()
-                .find(|child| child.env_name == *active_env)
-                .map(|child| child.pid)
-        });
         crate::service::preserve_operation_owner_before_managed_gateway_stop(
             active_env,
-            managed_gateway_pid,
             self.env,
+            self.cwd,
             "refreshing the OCM background service",
         )
     }
@@ -968,6 +961,17 @@ impl<'a> SupervisorService<'a> {
                 "cannot start source watch: {error}; wait for daemon startup or refresh it from the updated OCM installation with \"ocm service refresh-daemon --acknowledge-gateway-restarts\" during a maintenance window"
             )
         })
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn runtime_child_pid(&self, name: &str) -> Result<Option<u32>, String> {
+        Ok(self.read_runtime_state()?.and_then(|runtime| {
+            runtime
+                .children
+                .into_iter()
+                .find(|child| child.env_name == name)
+                .map(|child| child.pid)
+        }))
     }
 
     fn read_runtime_state(&self) -> Result<Option<SupervisorRuntimeState>, String> {

--- a/tests/gateway_operation_tests.rs
+++ b/tests/gateway_operation_tests.rs
@@ -1,0 +1,276 @@
+#![cfg(target_os = "linux")]
+
+mod support;
+
+use std::fs::{self, File, OpenOptions};
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use ocm::env::EnvironmentService;
+use ocm::store::{now_utc, supervisor_runtime_path};
+use ocm::supervisor::{SupervisorRuntimeChild, SupervisorRuntimeState, SupervisorService};
+
+use support::{
+    TestDir, install_fake_launchctl, ocm_env, ocm_test_binary_path, path_string, run_ocm, stderr,
+    write_executable_script, write_json_replacing_path,
+};
+
+struct OwnedProcess(Child);
+
+impl Drop for OwnedProcess {
+    fn drop(&mut self) {
+        if self.0.try_wait().ok().flatten().is_none() {
+            // SAFETY: this unreaped fixture child either owns this process group
+            // or has not detached yet. No unrelated process group is selected.
+            unsafe { libc::kill(-(self.0.id() as libc::pid_t), libc::SIGKILL) };
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+}
+
+fn admission_has_waiter(admission: &File, pid: u32) -> bool {
+    let metadata = admission.metadata().unwrap();
+    let identity = format!(
+        "{:02x}:{:02x}:{}",
+        libc::major(metadata.dev()),
+        libc::minor(metadata.dev()),
+        metadata.ino()
+    );
+    let pid = pid.to_string();
+    fs::read_to_string("/proc/locks")
+        .unwrap()
+        .lines()
+        .any(|line| {
+            let fields = line.split_whitespace().collect::<Vec<_>>();
+            fields.get(1) == Some(&"->")
+                && fields.get(2) == Some(&"FLOCK")
+                && fields.get(5) == Some(&pid.as_str())
+                && fields.get(6) == Some(&identity.as_str())
+        })
+}
+
+#[test]
+fn gateway_owned_refresh_waits_for_pid_publication() {
+    gateway_owned_operation_waits_for_pid_publication(false);
+}
+
+#[test]
+fn gateway_owned_snapshot_waits_for_pid_publication() {
+    gateway_owned_operation_waits_for_pid_publication(true);
+}
+
+fn gateway_owned_operation_waits_for_pid_publication(snapshot: bool) {
+    let root = TestDir::new("gateway-operation-publication");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    env.insert("OCM_INTERNAL_SERVICE_MANAGER".into(), "launchd".into());
+    install_fake_launchctl(&root, &mut env);
+    for args in [
+        vec!["launcher", "add", "stable", "--command", "openclaw"],
+        vec!["env", "create", "demo", "--launcher", "stable"],
+        vec!["service", "start", "demo"],
+    ] {
+        let output = run_ocm(&cwd, &env, &args);
+        assert!(output.status.success(), "{}", stderr(&output));
+    }
+    let spec = SupervisorService::new(&env, &cwd)
+        .sync()
+        .unwrap()
+        .children
+        .remove(0);
+    let runtime_path = supervisor_runtime_path(&env, &cwd).unwrap();
+    let publish = |pid: Option<u32>| {
+        let runtime = SupervisorRuntimeState {
+            kind: "ocm-supervisor-runtime".into(),
+            ocm_home: env["OCM_HOME"].clone(),
+            daemon_version: Some(env!("CARGO_PKG_VERSION").into()),
+            gateway_admission: None,
+            updated_at: now_utc(),
+            services: Vec::new(),
+            children: pid
+                .into_iter()
+                .map(|pid| SupervisorRuntimeChild {
+                    env_name: spec.env_name.clone(),
+                    binding_kind: spec.binding_kind.clone(),
+                    binding_name: spec.binding_name.clone(),
+                    pid,
+                    restart_count: 0,
+                    child_port: spec.child_port,
+                    stdout_path: spec.stdout_path.clone(),
+                    stderr_path: spec.stderr_path.clone(),
+                })
+                .collect(),
+        };
+        write_json_replacing_path(&runtime_path, &runtime);
+    };
+    publish(None);
+
+    // Stand in for a Gateway with an actual, fixture-owned process group. Both
+    // CLI commands use their normal entry points and process-preservation code.
+    let spawn_gateway = || {
+        OwnedProcess(
+            Command::new("/bin/sleep")
+                .arg("30")
+                .env_clear()
+                .current_dir(&cwd)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .process_group(0)
+                .spawn()
+                .unwrap(),
+        )
+    };
+    let mut gateway = spawn_gateway();
+    let gateway_pid = gateway.0.id();
+
+    // Block the fake manager at shutdown so even a broken refresh cannot finish
+    // before the fixture delivers the same group signal as the real supervisor.
+    let stop_requested = root.child("stop-requested");
+    let stop_released = root.child("stop-released");
+    let manager = root.child("controlled-launchctl");
+    write_executable_script(
+        &manager,
+        &format!(
+            r#"#!/bin/sh
+if [ "$1" = bootout ] && [ ! -f '{released}' ]; then
+  : > '{requested}'
+  attempt=0
+  while [ ! -f '{released}' ] && [ "$attempt" -lt 500 ]; do
+    /bin/sleep 0.01
+    attempt=$((attempt + 1))
+  done
+  [ -f '{released}' ] || exit 1
+fi
+exec '{manager}' "$@"
+"#,
+            released = path_string(&stop_released),
+            requested = path_string(&stop_requested),
+            manager = env["OCM_INTERNAL_LAUNCHCTL_BIN"],
+        ),
+    );
+    let mut operation_env = env.clone();
+    operation_env.insert("OCM_INTERNAL_LAUNCHCTL_BIN".into(), path_string(&manager));
+    operation_env.insert("OCM_ACTIVE_ENV".into(), "demo".into());
+    operation_env.insert("OPENCLAW_SERVICE_KIND".into(), "gateway".into());
+
+    let admission_path = root.child("ocm-home/source-watch/demo.admission");
+    fs::create_dir_all(admission_path.parent().unwrap()).unwrap();
+    let admission = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(admission_path)
+        .unwrap();
+    admission.lock_exclusive().unwrap();
+    let output_path = root.child("operation-output");
+    let output = File::create(&output_path).unwrap();
+    let args = if snapshot {
+        vec!["env", "snapshot", "create", "demo", "--json"]
+    } else {
+        vec![
+            "service",
+            "refresh-daemon",
+            "--acknowledge-gateway-restarts",
+            "--json",
+        ]
+    };
+    let mut operation = OwnedProcess(
+        Command::new(ocm_test_binary_path())
+            .args(args)
+            .env_clear()
+            .envs(&operation_env)
+            .current_dir(&cwd)
+            .stdin(Stdio::null())
+            .stdout(output.try_clone().unwrap())
+            .stderr(output)
+            .process_group(gateway_pid as i32)
+            .spawn()
+            .unwrap(),
+    );
+
+    // Observe the kernel's waiter for this exact process and lock, not a sleep
+    // that merely hopes the command has reached the unpublished-PID interval.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let waited_for_publication = loop {
+        if admission_has_waiter(&admission, operation.0.id()) {
+            break true;
+        }
+        if stop_requested.exists()
+            || operation.0.try_wait().unwrap().is_some()
+            || Instant::now() >= deadline
+        {
+            break false;
+        }
+        sleep(Duration::from_millis(5));
+    };
+    // SAFETY: the fixture owns this live command process.
+    let initial_group = unsafe { libc::getpgid(operation.0.id() as libc::pid_t) };
+    publish(Some(gateway_pid));
+    drop(admission);
+
+    let env_service = EnvironmentService::new(&env, &cwd);
+    let mut stopped = false;
+    let mut stop_group = None;
+    let mut replacement = None;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let result = loop {
+        let desired_running = env_service.get("demo").unwrap().service_running;
+        if !stopped && (stop_requested.exists() || !desired_running) {
+            // SAFETY: both the process and the group are owned by this fixture.
+            stop_group = Some(unsafe { libc::getpgid(operation.0.id() as libc::pid_t) });
+            assert_eq!(
+                unsafe { libc::kill(-(gateway_pid as libc::pid_t), libc::SIGTERM) },
+                0
+            );
+            gateway.0.wait().unwrap();
+            publish(None);
+            fs::write(&stop_released, "stopped\n").unwrap();
+            stopped = true;
+        }
+        if snapshot && stopped && desired_running && replacement.is_none() {
+            let child = spawn_gateway();
+            publish(Some(child.0.id()));
+            replacement = Some(child);
+        }
+        if let Some(status) = operation.0.try_wait().unwrap() {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            break None;
+        }
+        sleep(Duration::from_millis(5));
+    };
+    let output = fs::read_to_string(output_path).unwrap();
+    assert!(
+        waited_for_publication,
+        "command did not wait for Gateway publication: {output}"
+    );
+    assert_eq!(initial_group, gateway_pid as libc::pid_t);
+    assert!(stopped, "command never stopped its Gateway: {output}");
+    assert_eq!(
+        stop_group,
+        Some(operation.0.id() as libc::pid_t),
+        "OCM was not preserved before stop: {output}"
+    );
+    assert!(
+        result.is_some_and(|status| status.success()),
+        "command did not survive Gateway stop: {result:?}\n{output}"
+    );
+    assert!(env_service.get("demo").unwrap().service_running);
+    if snapshot {
+        assert!(
+            replacement.is_some(),
+            "snapshot did not restore the service"
+        );
+    } else {
+        assert!(output.contains("\"action\": \"refresh\""), "{output}");
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an OCM daemon refresh, snapshot, or upgrade started inside a managed Gateway could be terminated by the supervisor’s Gateway process-group shutdown when that Gateway had started running but its PID was not yet visible to OCM.

## Why This Change Was Made

Both preservation callers now use the existing Gateway admission lock to read the published PID and preserve the calling process before shutdown. The lock is released before stop, restart, or convergence work. Existing process-group checks and the Windows no-op remain unchanged.

## User Impact

Gateway-started maintenance commands move out of the Gateway process group before the supervisor stops it, including during this startup interval. Snapshot and upgrade flows retain their existing service restoration policy.

## Evidence

- Two Linux regressions invoke the real OCM commands while admission is held and no Gateway PID is published, then verify preservation through group termination and snapshot service restoration.
- Both unchanged controls fail at the intended boundary against the earlier implementation: refresh reaches shutdown before publication; snapshot retains its caller in the Gateway group at shutdown.
- Formatting, all-target compilation, and the focused command controls passed after a fresh OCM build. Existing daemon refresh (native and npm), upgrade, and snapshot controls passed on Linux and macOS.
- [CI](https://github.com/openclaw/ocm/actions/runs/34473095024) passed, including Rust 1.88, Windows checks, full Linux/macOS suites, and npm installation checks.
