### PR TITLE
test: allocate complete port families for daemon fixtures

### DIFF
--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -3,7 +3,6 @@ mod support;
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
-use std::net::{Ipv4Addr, TcpListener};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Mutex, MutexGuard};
@@ -1260,10 +1259,6 @@ fn gateway_owned_upgrade_survives_its_source_process_group() {
     );
     install_fake_service_manager(&root, &mut env);
 
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let gateway_port = listener.local_addr().unwrap().port().to_string();
-    drop(listener);
-
     let old_started = root.child("old-started");
     let new_started = root.child("new-started");
     let upgrade_pid_path = root.child("upgrade-pid");
@@ -1301,18 +1296,11 @@ exec '{ocm}' "$@"
         );
         assert!(add.status.success(), "{}", stderr(&add));
     }
+    // Let creation select an available OpenClaw port family.
     let create = run_ocm(
         &cwd,
         &env,
-        &[
-            "env",
-            "create",
-            "self",
-            "--runtime",
-            "old-runtime",
-            "--port",
-            &gateway_port,
-        ],
+        &["env", "create", "self", "--runtime", "old-runtime"],
     );
     assert!(create.status.success(), "{}", stderr(&create));
     set_service_enabled(&cwd, &env, "self", true);
@@ -1419,10 +1407,6 @@ fn gateway_owned_daemon_refresh(npm: bool) {
         &replacement_daemon_pid_path,
     );
 
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-    let gateway_port = listener.local_addr().unwrap().port().to_string();
-    drop(listener);
-
     let started_path = root.child("gateway-started");
     let refresh_gate_path = root.child("refresh-gate");
     let refresh_pid_path = root.child("refresh-pid");
@@ -1461,18 +1445,11 @@ fn gateway_owned_daemon_refresh(npm: bool) {
         ],
     );
     assert!(add.status.success(), "{}", stderr(&add));
+    // Let creation select an available OpenClaw port family.
     let create = run_ocm(
         &cwd,
         &env,
-        &[
-            "env",
-            "create",
-            "self",
-            "--runtime",
-            "managed",
-            "--port",
-            &gateway_port,
-        ],
+        &["env", "create", "self", "--runtime", "managed"],
     );
     assert!(create.status.success(), "{}", stderr(&create));
     set_service_enabled(&cwd, &env, "self", true);


### PR DESCRIPTION
## What Problem This Solves

The Gateway-owned upgrade and refresh fixtures probed one free TCP port, then passed it as the explicit Gateway port. Startup checks the whole OpenClaw port family, so an occupied neighboring port could prevent the Gateway from starting before the lifecycle assertion ran.

## Why This Change Was Made

Let the existing `env create` allocator select an available port family. Both fake Gateways already read the resulting `gateway run --port` argument. Keep the existing upgrade, direct refresh and npm refresh assertions.

## User Impact

Daemon lifecycle tests use the supported port-selection path. Product behavior is unchanged.

## Evidence

- A controlled baseline run held the neighboring port while the base remained free: the daemon refused startup until the neighbor was released, then started without a configuration change.
- Crabbox formatting, locked all-target compilation and all three existing Gateway-owned lifecycle cases passed with an explicitly rebuilt OCM executable.
- The equivalent patch is integrated onto current main; full platform CI is required before landing.
