### PR TITLE
fix: keep gateways running during dev service setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Use `ocm dev` when you want an isolated source-run checkout with its own env roo
 
 On Unix, foreground Node commands wait until OCM records their process ownership before executing source or `NODE_OPTIONS` preload hooks. The gate preserves the command arguments, terminal input, and configured Node options after release.
 
-Before starting a new foreground session, OCM checks that a running background daemon uses
+Before starting a new foreground session or service preparation, OCM checks that a running background daemon uses
 compatible ownership locks and that its runtime record identifies the current
 process. A daemon whose compatibility cannot be verified must finish starting
 or be refreshed before the session can claim ownership. During a maintenance
@@ -324,6 +324,15 @@ Repeating plain `ocm dev <env>` or `ocm dev <env> --watch` for the same active m
 Use `ocm dev status [env]` to inspect dev environments and temporary source watches on runtime or launcher environments. It reports the source path, gateway URL, and session ownership (`starting`, `active`, `restoring`, `inactive`, or `unknown`). Active foreground ownership can outlive the wrapper process and does not imply that the Gateway is ready. JSON reports backend watching as `sourceWatch.watching`, keeps `serviceRunning` separate from the saved `serviceDesiredRunning` policy and includes the watch PID, start time, and any inspection issue. `gatewayPortReachable` uses a 100 ms loopback TCP check; an open port does not establish Gateway identity or readiness. Status leaves watch metadata unchanged and omits lease tokens.
 
 Use `ocm dev stop <env>` from another terminal to cancel an owned plain or watched foreground session, including dependency preparation and onboarding. It waits for the source processes to stop and restores a background service previously taken over with `--watch --force`. The environment, configuration, source checkout, and dependencies remain available for the next run. `--json` reports `envName`, `stopped`, and `serviceRestored`; repeated stops after completion are harmless. Independently managed background services keep their existing stop commands.
+
+`ocm dev <env> --service` owns dependency preparation and onboarding until their
+processes finish. `ocm dev stop <env>` can cancel that preparation while keeping
+an already-running managed Gateway and its launch plan intact. Sibling service
+updates defer changes and restart requests for that Gateway until preparation
+ends; an explicit service stop or uninstall still takes effect. Successful
+preparation rechecks the environment, source binding, and service policy before
+starting the service. Repeating `--service` with an unchanged binding avoids an
+install/stop/start cycle.
 
 For new Unix foreground generations, output readers must finish before OCM clears child ownership. A read failure, missing output completion, raw termination signal, or lost controller retains an unfinished session. Stopping a matching process group alone cannot prove detached workers stopped; subsequent stop, watch, service-start, and destroy requests preserve that uncertainty. Ordinary acknowledged errors remain retryable after output completes. Onboarding keeps real terminal output: unsuccessful or cancelled onboarding without observed output remains unfinished, while successful interactive onboarding still works. Released legacy watch records retain their existing recovery rules, and Windows keeps its process-job cleanup proof. Unknown or pending ownership still requires operator verification. Use an updated OCM CLI and refresh an incompatible running daemon before starting a new foreground generation; updating files does not refresh an old process.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -644,6 +644,13 @@ changing mode requires stopping it first. `dev status --json` reports active
 ownership separately from `sourceWatch.watching`. Plain runs still refuse a
 running background service; temporary takeover remains `--watch --force`.
 
+`dev <env> --service` records its preparation children until verified completion.
+Use `dev stop <env>` to cancel setup; a managed Gateway already running keeps its
+launch plan, and deferred restart requests remain pending. Explicit service stop
+or uninstall still wins. After setup, OCM closes preparation and rechecks the
+same environment, source binding, and service policy under one operation lock
+before starting the managed service. An unchanged rerun keeps the running service.
+
 During foreground dependency installation, pnpm lifecycle reports distinguish a
 completed installation error from interrupted or unfinished build scripts. On
 Unix, uncertain script cleanup retains ownership even when pnpm returns a normal

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -26,8 +26,8 @@ use super::Cli;
 use super::render::RenderProfile;
 use crate::env::{
     CreateEnvironmentOptions, CreateSourceWatchOverrideOptions, EnvDevMeta, EnvMeta,
-    SourceWatchCompletion, SourceWatchEndpoint, SourceWatchLease, SourceWatchSession,
-    SourceWatchState,
+    SourceWatchCompletion, SourceWatchEndpoint, SourceWatchLease, SourceWatchMode,
+    SourceWatchSession, SourceWatchState,
 };
 use crate::infra::process::run_direct;
 #[cfg(unix)]
@@ -507,9 +507,7 @@ impl Cli {
 
         // Reject an already incompatible daemon before creating a new env or
         // worktree. Lease admission rechecks after any concurrent daemon change.
-        if !service_requested {
-            self.supervisor_service().preflight_source_watch_daemon()?;
-        }
+        self.supervisor_service().preflight_source_watch_daemon()?;
         let (meta, created) =
             self.ensure_dev_env(&name, repo_root.clone(), root.clone(), gateway_port)?;
         let stderr_profile = self.dev_stderr_profile();
@@ -523,37 +521,38 @@ impl Cli {
                 meta.name
             ));
         }
-        let watch_stop = (!service_requested)
-            .then(install_source_watch_signal_handler)
-            .transpose()?;
-        let mut source_watch_lease = if !service_requested {
-            Some(
-                match self
-                    .environment_service()
-                    .acquire_source_watch_lease(&meta.name, force, watch)
-                {
-                    Ok(lease) => lease,
-                    Err(error) => {
-                        // A competing invocation may have claimed the lease after the first lookup.
-                        let current = self.environment_service().get(&meta.name)?;
-                        if self.try_reuse_dev_watch(
+        let watch_stop = Some(install_source_watch_signal_handler()?);
+        let mode = if service_requested {
+            SourceWatchMode::ServicePreparation
+        } else {
+            SourceWatchMode::Foreground { watching: watch }
+        };
+        let mut source_watch_lease = Some(
+            match self
+                .environment_service()
+                .acquire_source_watch_lease(&meta.name, force, mode)
+            {
+                Ok(lease) => lease,
+                Err(error) => {
+                    // A competing invocation may have claimed the lease after the first lookup.
+                    let current = self.environment_service().get(&meta.name)?;
+                    if !service_requested
+                        && self.try_reuse_dev_watch(
                             &current,
                             repo_root.as_deref(),
                             root.as_deref(),
                             gateway_port,
                             onboard,
                             watch,
-                        )? {
-                            return Ok(0);
-                        }
-                        return Err(error);
+                        )?
+                    {
+                        return Ok(0);
                     }
-                },
-            )
-        } else {
-            None
-        };
-        // Foreground preparation belongs to the lease owner, including a newly created env.
+                    return Err(error);
+                }
+            },
+        );
+        // Preparation belongs to the lease owner, including a newly created env.
         // A losing invocation must not rewrite config before returning the winner's status.
         let prepared = (|| {
             let current = self.environment_service().get(&meta.name)?;
@@ -629,6 +628,51 @@ impl Cli {
         }
 
         if service_requested {
+            let env_service = self.environment_service();
+            let _operation = env_service.lock_operation(&meta.name)?;
+            let lease = source_watch_lease
+                .as_mut()
+                .ok_or_else(|| "service preparation ownership is missing".to_string())?;
+            let service_policy_revision = lease.service_preparation_revision();
+            let cancelled = source_watch_cancelled(lease, watch_stop.as_deref().unwrap())?;
+            let code = finish_source_watch_session(
+                &meta.name,
+                lease,
+                Ok(if cancelled { 130 } else { 0 }),
+                Ok(()),
+                false,
+            )?;
+            drop(source_watch_lease.take());
+            if code != 0 {
+                return Ok(code);
+            }
+            // Keep replacement and service policy changes out of the handoff.
+            let current = env_service.get(&meta.name)?;
+            if current.root != meta.root
+                || current.created_at != meta.created_at
+                || current
+                    .dev
+                    .as_ref()
+                    .map(|dev| (&dev.repo_root, &dev.worktree_root))
+                    != meta
+                        .dev
+                        .as_ref()
+                        .map(|dev| (&dev.repo_root, &dev.worktree_root))
+                || current.default_runtime != meta.default_runtime
+                || current.default_launcher != meta.default_launcher
+                || Some(crate::store::environment_service_policy_revision(
+                    &meta.name, &self.env, &self.cwd,
+                )?) != service_policy_revision
+            {
+                return Err("the environment, source binding, or service policy changed during service preparation; its current service policy was preserved".to_string());
+            }
+            self.validate_existing_dev_request(
+                &current,
+                repo_root.as_deref(),
+                root.as_deref(),
+                gateway_port,
+            )?;
+            let current = env_service.apply_effective_gateway_port(current)?;
             self.stderr_lines(render_dev_run_step(
                 "Service",
                 format!(
@@ -637,10 +681,12 @@ impl Cli {
                 ),
                 stderr_profile,
             ));
-            self.service_service().install(&meta.name)?;
-            self.service_service().start(&meta.name)?;
+            // Start installs an absent daemon without install's running=false transition.
+            self.service_service()
+                .start_action_locked(&meta.name)?
+                .ensure_gateway_ready()?;
             self.stdout_lines(render_dev_service_started(
-                &meta,
+                &current,
                 &self.command_example(),
                 self.dev_stdout_profile(),
             ));
@@ -795,10 +841,11 @@ impl Cli {
         let meta = existing;
         let watch_stop = install_source_watch_signal_handler()?;
         let mut source_watch_lease = Some(
-            match self
-                .environment_service()
-                .acquire_source_watch_lease(&meta.name, true, true)
-            {
+            match self.environment_service().acquire_source_watch_lease(
+                &meta.name,
+                true,
+                SourceWatchMode::Foreground { watching: true },
+            ) {
                 Ok(lease) => lease,
                 Err(error) => {
                     if self.try_reuse_dev_watch(
@@ -1120,15 +1167,24 @@ impl Cli {
             SourceWatchState::Active(active) => Some(active.watching.unwrap_or(true)),
             _ => {
                 let lease = env_service.observe_source_watch_lease(&meta.name)?;
-                env_service
+                let session = env_service
                     .source_watch_session(&meta.name)?
                     .filter(|session| {
                         !session.closed
                             && lease.as_ref().is_some_and(|lease| {
                                 lease.held && lease.lease_id == session.lease_id
                             })
-                    })
-                    .map(|session| session.is_watching())
+                    });
+                if session
+                    .as_ref()
+                    .is_some_and(|session| session.service_preparation)
+                {
+                    return Err(format!(
+                        "dev env {} has active service preparation; finish or stop it before starting a foreground session",
+                        meta.name
+                    ));
+                }
+                session.map(|session| session.is_watching())
             }
         };
         // Legacy starting watches may lack mode metadata. Keep their progress

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -242,7 +242,7 @@ pub fn logs_help(cmd: &str) -> String {
 pub fn dev_help(cmd: &str) -> String {
     render_group(
         "Development envs",
-        "Provision OpenClaw dev envs from a checkout worktree, bootstrap the minimum local config, and run the gateway in the foreground with bundled plugins resolved from that source checkout. Existing runtime or launcher envs can also be temporarily taken over with --repo <path> --watch --force; OCM keeps their binding unchanged, routes OpenClaw commands for that env through the watched checkout while watch is active, warns for installed plugins not present in the source tree, tees the foreground output to the env gateway logs, and restores a running background service when watch exits. Background service installation, start, and restart are refused while source watch is active. New foreground sessions require a compatible running daemon with verified process ownership; wait for startup or run service refresh-daemon --acknowledge-gateway-restarts from the updated OCM installation during a maintenance window. Confirmed stopped or unloaded daemons do not require refresh. New envs use the explicit --repo checkout or the checkout enclosing the current directory. Outside a checkout, pass --repo; neighboring and remembered repositories are not selected. Existing dev envs use their recorded source. Repeating a matching plain or --watch invocation returns the existing session status and link without setup or restart. Starting and restoring sessions report progress; they are not reported as ready. Stop the session before onboarding or changing --watch, source, root, or port. Reuse keeps the captured launch endpoint; an older watch without endpoint metadata must be stopped from its original terminal first.",
+        "Provision OpenClaw dev envs from a checkout worktree, bootstrap the minimum local config, and run the gateway in the foreground with bundled plugins resolved from that source checkout. Existing runtime or launcher envs can also be temporarily taken over with --repo <path> --watch --force; OCM keeps their binding unchanged, routes OpenClaw commands for that env through the watched checkout while watch is active, warns for installed plugins not present in the source tree, tees the foreground output to the env gateway logs, and restores a running background service when watch exits. Background service installation, start, and restart are refused while source watch is active. New foreground sessions and service preparation require a compatible running daemon with verified process ownership; wait for startup or run service refresh-daemon --acknowledge-gateway-restarts from the updated OCM installation during a maintenance window. Confirmed stopped or unloaded daemons do not require refresh. New envs use the explicit --repo checkout or the checkout enclosing the current directory. Outside a checkout, pass --repo; neighboring and remembered repositories are not selected. Existing dev envs use their recorded source. Repeating a matching plain or --watch invocation returns the existing session status and link without setup or restart. Starting and restoring sessions report progress; they are not reported as ready. Stop the session before onboarding or changing --watch, source, root, or port. Reuse keeps the captured launch endpoint; an older watch without endpoint metadata must be stopped from its original terminal first.",
         vec![format!(
             "{cmd} dev <env> [--repo <path>] [--root <path>] [--port <port>] [--watch] [--force] [--service] [--onboard]"
         )],
@@ -252,7 +252,7 @@ pub fn dev_help(cmd: &str) -> String {
                 ("status", "Show dev envs and active foreground sessions"),
                 (
                     "stop",
-                    "Stop an owned foreground dev session and restore any taken-over service",
+                    "Stop owned dev processes, including service preparation, and restore any taken-over service",
                 ),
             ],
         )],
@@ -280,7 +280,7 @@ pub fn dev_command_help(cmd: &str, action: &str) -> Option<String> {
     match action {
         "stop" => Some(render_leaf(
             "Stop foreground dev session",
-            "Ask the recorded foreground dev controller to stop its setup or gateway processes. Preserve the env, source checkout, dependencies, and configuration; report unverified completion without discarding ownership.",
+            "Ask the recorded dev controller to stop its setup or gateway processes, including --service preparation. Preserve the env, source checkout, dependencies, and configuration; report unverified completion without discarding ownership.",
             vec![format!("{cmd} dev stop <env> [--raw] [--json]")],
             &[
                 (
@@ -299,7 +299,7 @@ pub fn dev_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "Waits for the owned source processes to stop before restoring a background service taken over by --watch --force.",
-                "Stops plain and watched foreground dev sessions, including setup; independently managed background services remain separate.",
+                "Stops plain and watched foreground dev sessions, including setup. Also cancels --service preparation while preserving an already-running managed Gateway; explicit service stop or uninstall still takes effect.",
                 "For new Unix foreground generations, a lost controller, raw termination signal, or incomplete output retains unfinished ownership even if the recorded process group stops. Stop/reuse/service-start/destroy cannot erase that uncertainty. Released legacy records keep their recovery rules.",
                 "Ordinary acknowledged errors remain retryable after output completes. Onboarding keeps real terminal output; cancellation or failure without observed output retains ownership, while successful onboarding remains supported.",
                 "During Unix foreground preparation, pnpm lifecycle reports distinguish completed install errors from interrupted or unfinished build scripts; uncertain script cleanup retains ownership even if pnpm returns an ordinary error or succeeds after an optional build. Installer stdin stays interactive when run from a terminal; human output is streamed.",

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -31,7 +31,7 @@ pub use snapshots::{
     UpgradeCheckpointScope, select_snapshot_prune_candidates,
 };
 pub(crate) use source_watch::{
-    CreateSourceWatchOverrideOptions, SourceWatchLease, SourceWatchState,
+    CreateSourceWatchOverrideOptions, SourceWatchLease, SourceWatchMode, SourceWatchState,
 };
 pub use source_watch::{SourceWatchEndpoint, SourceWatchOverride};
 pub(crate) use source_watch_session::{SourceWatchCompletion, SourceWatchSession};

--- a/src/env/source_watch.rs
+++ b/src/env/source_watch.rs
@@ -71,6 +71,22 @@ pub(crate) enum SourceWatchState {
     Restoring,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum SourceWatchMode {
+    Foreground { watching: bool },
+    ServicePreparation,
+}
+
+impl SourceWatchMode {
+    pub(super) fn is_watching(self) -> bool {
+        matches!(self, Self::Foreground { watching: true })
+    }
+
+    pub(super) fn is_service_preparation(self) -> bool {
+        matches!(self, Self::ServicePreparation)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct CreateSourceWatchOverrideOptions {
     pub(crate) env_name: String,
@@ -85,6 +101,7 @@ pub(crate) struct SourceWatchLease {
     lease_id: String,
     lock_file: File,
     service_was_running: bool,
+    service_preparation_revision: Option<u64>,
     watching: bool,
     session_paths: SourceWatchSessionPaths,
     session: Option<SourceWatchSession>,
@@ -104,6 +121,10 @@ impl SourceWatchLease {
 
     pub(crate) fn service_was_running(&self) -> bool {
         self.service_was_running
+    }
+
+    pub(crate) fn service_preparation_revision(&self) -> Option<u64> {
+        self.service_preparation_revision
     }
 
     pub(crate) fn session(&self) -> Option<&SourceWatchSession> {
@@ -333,6 +354,7 @@ impl<'a> EnvironmentService<'a> {
             lease_id: session.lease_id.clone(),
             lock_file,
             service_was_running: session.restore_service,
+            service_preparation_revision: None,
             watching: session.is_watching(),
             session_paths,
             session: Some(session),
@@ -446,7 +468,7 @@ impl<'a> EnvironmentService<'a> {
         &self,
         env_name: &str,
         allow_service_takeover: bool,
-        watching: bool,
+        mode: SourceWatchMode,
     ) -> Result<SourceWatchLease, String> {
         let env_name = validate_name(env_name, "Environment name")?;
         // Match service updates: operation, daemon lifecycle, then Gateway
@@ -458,10 +480,22 @@ impl<'a> EnvironmentService<'a> {
         } else {
             Some(supervisor.lock_daemon_lifecycle()?)
         };
+        // A planner must not publish a pre-admission view after preparation
+        // claims the environment. Take its existing state lock before admission.
+        let _state_lock = mode
+            .is_service_preparation()
+            .then(|| supervisor.lock_state_publication())
+            .transpose()?;
         let _admission_lock = self.lock_gateway_admission(&env_name)?;
         supervisor.ensure_source_watch_daemon_compatible()?;
         let meta = self.get(&env_name)?;
-        if meta.service_running && !allow_service_takeover {
+        let service_preparation_revision = mode
+            .is_service_preparation()
+            .then(|| {
+                crate::store::environment_service_policy_revision(&env_name, self.env, self.cwd)
+            })
+            .transpose()?;
+        if meta.service_running && !allow_service_takeover && !mode.is_service_preparation() {
             return Err(format!(
                 "dev env {env_name} is already running in the background; stop it first or rerun with --watch --force to take it over temporarily"
             ));
@@ -527,15 +561,16 @@ impl<'a> EnvironmentService<'a> {
         // lease, even if its child PID has since been reused by another process.
         remove_file_if_present(&override_path)?;
         #[cfg(any(target_os = "linux", target_os = "macos", windows))]
-        let session = Some(session_paths.create_session(&meta, &lease_id, watching)?);
+        let session = Some(session_paths.create_session(&meta, &lease_id, mode)?);
         #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
         let session = None;
         Ok(SourceWatchLease {
             env_name,
             lease_id,
             lock_file,
-            service_was_running: meta.service_running,
-            watching,
+            service_was_running: meta.service_running && !mode.is_service_preparation(),
+            service_preparation_revision,
+            watching: mode.is_watching(),
             session_paths,
             session,
             #[cfg(windows)]

--- a/src/env/source_watch_session.rs
+++ b/src/env/source_watch_session.rs
@@ -15,6 +15,7 @@ use crate::store::{display_path, source_watch_override_path, validate_name, writ
 const LEGACY_SESSION_KIND: &str = "ocm-source-watch-session";
 const WATCH_V2_SESSION_KIND: &str = "ocm-source-watch-session-v2";
 const SESSION_KIND: &str = "ocm-source-foreground-session-v1";
+const SERVICE_PREPARATION_SESSION_KIND: &str = "ocm-source-service-preparation-session-v1";
 const STOP_KIND: &str = "ocm-source-watch-stop";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -32,6 +33,8 @@ pub(crate) struct SourceWatchSession {
     pub(crate) child_spawn_pending: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) watching: Option<bool>,
+    #[serde(default)]
+    pub(crate) service_preparation: bool,
     pub(crate) restore_service: bool,
     #[serde(default)]
     pub(crate) closed: bool,
@@ -87,10 +90,15 @@ impl SourceWatchSessionPaths {
         &self,
         meta: &EnvMeta,
         lease_id: &str,
-        watching: bool,
+        mode: super::SourceWatchMode,
     ) -> Result<SourceWatchSession, String> {
         let session = SourceWatchSession {
-            kind: SESSION_KIND.to_string(),
+            kind: if mode.is_service_preparation() {
+                SERVICE_PREPARATION_SESSION_KIND
+            } else {
+                SESSION_KIND
+            }
+            .to_string(),
             env_name: meta.name.clone(),
             lease_id: lease_id.to_string(),
             env_root: meta.root.clone(),
@@ -99,7 +107,8 @@ impl SourceWatchSessionPaths {
             controller: current_process_identity()?,
             child: None,
             child_spawn_pending: false,
-            watching: Some(watching),
+            watching: Some(mode.is_watching()),
+            service_preparation: mode.is_service_preparation(),
             restore_service: false,
             closed: false,
             completion: None,
@@ -118,8 +127,16 @@ impl SourceWatchSessionPaths {
         };
         if !matches!(
             session.kind.as_str(),
-            SESSION_KIND | WATCH_V2_SESSION_KIND | LEGACY_SESSION_KIND
+            SESSION_KIND
+                | SERVICE_PREPARATION_SESSION_KIND
+                | WATCH_V2_SESSION_KIND
+                | LEGACY_SESSION_KIND
         ) || (session.kind == SESSION_KIND && session.watching.is_none())
+            || (session.kind == SERVICE_PREPARATION_SESSION_KIND
+                && (!session.service_preparation
+                    || session.watching != Some(false)
+                    || session.restore_service))
+            || (session.service_preparation && session.kind != SERVICE_PREPARATION_SESSION_KIND)
             || session.env_name != env_name
             || session.lease_id.trim().is_empty()
             || session.controller.pid == 0
@@ -255,11 +272,30 @@ impl SourceWatchSessionPaths {
 
 impl SourceWatchSession {
     pub(crate) fn is_watching(&self) -> bool {
-        self.kind != SESSION_KIND || self.watching.unwrap_or(true)
+        matches!(
+            self.kind.as_str(),
+            LEGACY_SESSION_KIND | WATCH_V2_SESSION_KIND
+        ) || self.watching.unwrap_or(true)
     }
 
     pub(crate) fn is_legacy_watch(&self) -> bool {
         self.kind == LEGACY_SESSION_KIND
+    }
+
+    pub(crate) fn service_preparation_is_active(
+        &self,
+        env_service: &EnvironmentService<'_>,
+    ) -> Result<bool, String> {
+        if !self.service_preparation {
+            return Ok(false);
+        }
+        // Completion is published before the controller releases its lease.
+        // Keep the running plan through that handoff, when ordinary admission
+        // still observes a starting owner without a foreground override.
+        Ok(!self.closed
+            || env_service
+                .observe_source_watch_lease(&self.env_name)?
+                .is_some_and(|lease| lease.held && lease.lease_id == self.lease_id))
     }
 
     #[cfg(unix)]
@@ -498,6 +534,7 @@ mod tests {
             child: None,
             child_spawn_pending: false,
             watching: Some(false),
+            service_preparation: false,
             restore_service: false,
             closed: false,
             completion: None,
@@ -554,25 +591,34 @@ mod tests {
             restored_only.unsafe_cleanup_error().is_none(),
             "verified child cleanup permits restoration retry"
         );
-        for (kind, watching, valid) in [
-            (SESSION_KIND, Some(false), true),
-            (WATCH_V2_SESSION_KIND, None, true),
-            (LEGACY_SESSION_KIND, None, true),
-            (SESSION_KIND, None, false),
-            ("ocm-dev-source-session", Some(false), false),
-            ("ocm-dev-source-session-v2", Some(false), false),
-            ("ocm-dev-foreground-session", Some(false), false),
-            ("ocm-dev-foreground-session-v2", Some(false), false),
+        for (kind, watching, preparation, valid) in [
+            (SESSION_KIND, Some(false), false, true),
+            (WATCH_V2_SESSION_KIND, None, false, true),
+            (LEGACY_SESSION_KIND, None, false, true),
+            (SESSION_KIND, None, false, false),
+            (SERVICE_PREPARATION_SESSION_KIND, Some(false), true, true),
+            (SERVICE_PREPARATION_SESSION_KIND, Some(false), false, false),
+            (SERVICE_PREPARATION_SESSION_KIND, Some(true), true, false),
+            (SERVICE_PREPARATION_SESSION_KIND, None, true, false),
+            (SESSION_KIND, Some(false), true, false),
+            ("ocm-dev-source-session", Some(false), false, false),
+            ("ocm-dev-source-session-v2", Some(false), false, false),
+            ("ocm-dev-foreground-session", Some(false), false, false),
+            ("ocm-dev-foreground-session-v2", Some(false), false, false),
         ] {
             let mut candidate = legacy.clone();
             candidate.kind = kind.to_string();
             candidate.watching = watching;
+            candidate.service_preparation = preparation;
             write_json(&paths.session, &candidate).unwrap();
             let loaded = paths.load_session("demo");
             assert_eq!(loaded.is_ok(), valid, "{kind}");
             if valid {
                 let loaded = loaded.unwrap().unwrap();
-                assert_eq!(loaded.is_watching(), kind != SESSION_KIND);
+                assert_eq!(
+                    loaded.is_watching(),
+                    matches!(kind, LEGACY_SESSION_KIND | WATCH_V2_SESSION_KIND)
+                );
                 #[cfg(unix)]
                 assert_eq!(
                     loaded.requires_controller_completion(),
@@ -600,6 +646,7 @@ mod tests {
             child: None,
             child_spawn_pending: false,
             watching: Some(false),
+            service_preparation: false,
             restore_service: false,
             closed: false,
             completion: None,

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -223,6 +223,19 @@ fn bump_service_policy_revision(registry: &mut EnvRegistry, name: &str) -> u64 {
     *revision
 }
 
+pub(crate) fn environment_service_policy_revision(
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<u64, String> {
+    let name = validate_name(name, "Environment name")?;
+    Ok(load_env_registry(env, cwd)?
+        .service_policy_revisions
+        .get(&name)
+        .copied()
+        .unwrap_or_default())
+}
+
 pub fn list_environments(
     env: &BTreeMap<String, String>,
     cwd: &Path,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -31,8 +31,8 @@ pub(crate) use envs::{
     remove_environment_locked,
 };
 pub(crate) use envs::{
-    EnvironmentServicePolicyChange, restore_environment_service_policy,
-    set_environment_service_policy,
+    EnvironmentServicePolicyChange, environment_service_policy_revision,
+    restore_environment_service_policy, set_environment_service_policy,
 };
 pub use envs::{
     clone_environment, create_environment, export_environment, get_environment, import_environment,

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -45,9 +45,10 @@ use openclaw_handoff::{
 const SUPERVISOR_STATE_KIND: &str = "ocm-supervisor-state";
 const SUPERVISOR_RUNTIME_KIND: &str = "ocm-supervisor-runtime";
 // This capability covers the current admission filename through child publication.
-// Version 8 covers foreground-session admission and retained completion ownership.
+// Version 9 adds service-preparation admission and running-service retention to
+// foreground-session admission and retained completion ownership.
 // Values 2 through 6 were used by incompatible development snapshots.
-const GATEWAY_ADMISSION_VERSION: u32 = 8;
+const GATEWAY_ADMISSION_VERSION: u32 = 9;
 const SUPERVISOR_POLL_INTERVAL_MS: u64 = 200;
 const SUPERVISOR_RESTART_DELAY_MS: u64 = 1_000;
 const SUPERVISOR_MAX_RESTART_DELAY_MS: u64 = 30_000;
@@ -580,6 +581,10 @@ impl<'a> SupervisorService<'a> {
         lock_file(&lock_path, "managed service lifecycle")
     }
 
+    pub(crate) fn lock_state_publication(&self) -> Result<crate::store::ExclusiveFileLock, String> {
+        lock_supervisor_state(&supervisor_state_path(self.env, self.cwd)?)
+    }
+
     pub(crate) fn has_desired_running_services(&self) -> Result<bool, String> {
         Ok(list_environments(self.env, self.cwd)?
             .iter()
@@ -663,6 +668,7 @@ impl<'a> SupervisorService<'a> {
 
         let mut children = Vec::new();
         let mut skipped_envs = Vec::new();
+        let mut preparation_state: Option<SupervisorState> = None;
         for env_meta in envs {
             let name = env_meta.name.clone();
             if !env_meta.service_enabled {
@@ -677,6 +683,46 @@ impl<'a> SupervisorService<'a> {
                     env_name: name,
                     reason: "service is stopped".to_string(),
                 });
+                continue;
+            }
+            if let Some(session) = env_service.source_watch_session(&name)?
+                && session.service_preparation_is_active(&env_service)?
+            {
+                if !session.restore_target_matches(&env_meta) {
+                    return Err(format!(
+                        "env {name} changed during service preparation; its previous service plan was retained"
+                    ));
+                }
+                // Preparation does not take over an existing Gateway. Preserve
+                // its exact plan across sibling syncs/config edits; the shared
+                // admission gate still prevents any new process from starting.
+                if preparation_state.is_none() {
+                    let path = supervisor_state_path(self.env, self.cwd)?;
+                    if path.try_exists().map_err(|error| {
+                        format!("failed inspecting service state during preparation: {error}")
+                    })? {
+                        let previous: SupervisorState = read_json(&path)?;
+                        if previous.kind != SUPERVISOR_STATE_KIND
+                            || previous.ocm_home != display_path(&ocm_home)
+                        {
+                            return Err(
+                                "service preparation found an incompatible saved service plan"
+                                    .to_string(),
+                            );
+                        }
+                        preparation_state = Some(previous);
+                    }
+                }
+                if let Some(previous) = preparation_state
+                    .as_ref()
+                    .and_then(|state| state.children.iter().find(|child| child.env_name == name))
+                {
+                    children.push(previous.clone());
+                } else {
+                    return Err(format!(
+                        "cannot preserve the saved service plan for env {name} during preparation; the existing plan was left unchanged"
+                    ));
+                }
                 continue;
             }
             match env_service
@@ -1073,9 +1119,11 @@ impl<'a> SupervisorService<'a> {
         let mut managed_child_count = active_state.children.len();
         let mut child_results = Vec::new();
 
+        let env_service = EnvironmentService::new(self.env, self.cwd);
         while !stop_requested.load(Ordering::SeqCst) {
             let mut runtime_dirty = refresh_active_state(
                 state_path,
+                &env_service,
                 &mut active_state,
                 &mut managed_child_count,
                 &mut running,
@@ -1084,6 +1132,7 @@ impl<'a> SupervisorService<'a> {
             );
             runtime_dirty |= process_exited_children(
                 state_path,
+                &env_service,
                 &stop_requested,
                 &mut active_state,
                 &mut managed_child_count,
@@ -1518,23 +1567,116 @@ fn read_updated_supervisor_state(
 
 fn refresh_active_state(
     state_path: &Path,
+    env_service: &EnvironmentService<'_>,
     active_state: &mut SupervisorState,
     managed_child_count: &mut usize,
     running: &mut BTreeMap<String, RunningSupervisorChild>,
     pending: &mut BTreeMap<String, PendingSupervisorChild>,
     inactive: &mut BTreeMap<String, InactiveSupervisorChild>,
 ) -> bool {
-    let Some(next_state) = read_updated_supervisor_state(state_path, active_state) else {
+    let Some(mut next_state) = read_updated_supervisor_state(state_path, active_state) else {
         return false;
+    };
+    let restart_requests = new_supervisor_restart_requests(active_state, &next_state);
+    let admission_locks = match retain_running_services_during_preparation(
+        env_service,
+        running,
+        &restart_requests,
+        &mut next_state,
+    ) {
+        Ok(Some(locks)) => locks,
+        Ok(None) => return false,
+        Err(error) => {
+            eprintln!("ocm service: service preparation deferred state reconciliation: {error}");
+            return false;
+        }
     };
     let restart_requests = new_supervisor_restart_requests(active_state, &next_state);
     let mut runtime_dirty = reconcile_running_children(running, pending, inactive, &next_state);
     runtime_dirty |=
         reconcile_restart_requests(&restart_requests, running, pending, inactive, &next_state);
+    drop(admission_locks);
     *managed_child_count = next_state.children.len();
     *active_state = next_state;
     clear_processed_restart_requests(state_path, &restart_requests);
     runtime_dirty
+}
+
+// Only updates that would change a live child need preparation inspection.
+// Keep the actual owner's spec rather than trusting a stale saved plan. Deferred
+// restart requests stay on disk and are omitted only from this in-memory view,
+// so they are observed again after preparation ends. Return the admission locks
+// through reconciliation so preparation cannot begin between inspection and stop.
+fn retain_running_services_during_preparation(
+    env_service: &EnvironmentService<'_>,
+    running: &BTreeMap<String, RunningSupervisorChild>,
+    restart_requests: &[SupervisorRestartRequest],
+    next_state: &mut SupervisorState,
+) -> Result<Option<Vec<crate::store::ExclusiveFileLock>>, String> {
+    let desired = child_map(&next_state.children);
+    let restarting: BTreeSet<_> = restart_requests
+        .iter()
+        .map(|request| request.env_name.as_str())
+        .collect();
+    let affected: Vec<_> = running
+        .iter()
+        .filter_map(|(name, child)| {
+            (desired.get(name).is_none_or(|spec| *spec != child.spec)
+                || restarting.contains(name.as_str()))
+            .then_some(name.clone())
+        })
+        .collect();
+    if affected.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let mut admission_locks = Vec::with_capacity(affected.len());
+    for name in &affected {
+        let Some(admission) = env_service.try_lock_gateway_admission(name)? else {
+            return Ok(None);
+        };
+        admission_locks.push(admission);
+    }
+    let metas: BTreeMap<_, _> = env_service
+        .list()?
+        .into_iter()
+        .map(|meta| (meta.name.clone(), meta))
+        .collect();
+    for name in affected {
+        let Some(meta) = metas.get(&name) else {
+            continue;
+        };
+        // An explicit stop/disable remains authoritative during preparation.
+        if !meta.service_enabled || !meta.service_running {
+            continue;
+        }
+        let Some(session) = env_service.source_watch_session(&name)? else {
+            continue;
+        };
+        if !session.service_preparation_is_active(env_service)? {
+            continue;
+        }
+        if !session.restore_target_matches(meta) {
+            return Err(format!(
+                "env {name} changed during its recorded service preparation"
+            ));
+        }
+        let existing = &running
+            .get(&name)
+            .expect("affected running child exists")
+            .spec;
+        next_state.children.retain(|child| child.env_name != name);
+        next_state.children.push(existing.clone());
+        next_state
+            .skipped_envs
+            .retain(|skipped| skipped.env_name != name);
+        next_state
+            .restart_requests
+            .retain(|request| request.env_name != name);
+    }
+    next_state
+        .children
+        .sort_by(|left, right| left.env_name.cmp(&right.env_name));
+    Ok(Some(admission_locks))
 }
 
 fn reconcile_running_children(
@@ -1765,6 +1907,7 @@ fn collect_exited_children(
 
 fn process_exited_children(
     state_path: &Path,
+    env_service: &EnvironmentService<'_>,
     stop_requested: &AtomicBool,
     active_state: &mut SupervisorState,
     managed_child_count: &mut usize,
@@ -1792,6 +1935,7 @@ fn process_exited_children(
         ));
         runtime_dirty |= refresh_active_state(
             state_path,
+            env_service,
             active_state,
             managed_child_count,
             running,
@@ -3478,6 +3622,299 @@ mod tests {
                 request_id: "restart-1".to_string(),
             }]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn service_preparation_preserves_running_spec_and_deferred_restart() {
+        struct RunningFixture(BTreeMap<String, RunningSupervisorChild>);
+        impl Drop for RunningFixture {
+            fn drop(&mut self) {
+                for child in self.0.values_mut() {
+                    stop_supervisor_child(child);
+                }
+            }
+        }
+        for change in ["removed", "changed", "restart"] {
+            let root = tempfile::tempdir().unwrap();
+            let env = BTreeMap::from([
+                ("HOME".to_string(), display_path(&root.path().join("home"))),
+                (
+                    "OCM_HOME".to_string(),
+                    display_path(&root.path().join("store")),
+                ),
+                (
+                    "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+                    "unsupported".to_string(),
+                ),
+            ]);
+            let service = EnvironmentService::new(&env, root.path());
+            let meta = service
+                .create(crate::env::CreateEnvironmentOptions {
+                    name: "demo".to_string(),
+                    root: None,
+                    gateway_port: Some(19999),
+                    service_enabled: false,
+                    service_running: false,
+                    default_runtime: None,
+                    default_launcher: None,
+                    dev: None,
+                    protected: false,
+                })
+                .unwrap();
+            crate::store::set_environment_service_policy(
+                &meta.name,
+                Some(true),
+                Some(true),
+                &env,
+                root.path(),
+            )
+            .unwrap();
+            let supervisor = SupervisorService::new(&env, root.path());
+            let state_path = supervisor_state_path(&env, root.path()).unwrap();
+            let mut original = child_spec("demo", 19999);
+            original.binary_path = Some("/bin/sleep".to_string());
+            original.args = vec!["30".to_string()];
+            original.run_dir = display_path(root.path());
+            original.process_env = env.clone();
+            let child = Command::new("/bin/sleep")
+                .arg("30")
+                .current_dir(root.path())
+                .env_clear()
+                .envs(&env)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .process_group(0)
+                .spawn()
+                .unwrap();
+            let pid = child.id();
+            let mut running = RunningFixture(BTreeMap::from([(
+                "demo".to_string(),
+                RunningSupervisorChild {
+                    spec: original.clone(),
+                    child,
+                    restart_count: 0,
+                    quick_clean_restart_count: 0,
+                    restart_handoff_support: RestartHandoffSupport::Unsupported(
+                        "fixture".to_string(),
+                    ),
+                    started_at: Instant::now(),
+                },
+            )]));
+            let mut active = SupervisorState {
+                kind: SUPERVISOR_STATE_KIND.to_string(),
+                ocm_home: env["OCM_HOME"].clone(),
+                generated_at: now_utc(),
+                children: vec![original.clone()],
+                skipped_envs: Vec::new(),
+                restart_requests: Vec::new(),
+            };
+            let mut next = active.clone();
+            match change {
+                "removed" => next.children.clear(),
+                "changed" => next.children[0].args = vec!["29".to_string()],
+                "restart" => next.restart_requests.push(SupervisorRestartRequest {
+                    env_name: "demo".to_string(),
+                    request_id: "during-preparation".to_string(),
+                }),
+                _ => unreachable!(),
+            }
+            write_json(&state_path, &next).unwrap();
+            let mut count = 1;
+            let mut pending = BTreeMap::new();
+            let mut inactive = BTreeMap::new();
+            let admission = service.lock_gateway_admission("demo").unwrap();
+            assert!(!refresh_active_state(
+                &state_path,
+                &service,
+                &mut active,
+                &mut count,
+                &mut running.0,
+                &mut pending,
+                &mut inactive
+            ));
+            let owner = running.0.get_mut("demo").unwrap();
+            assert_eq!(owner.child.id(), pid);
+            assert!(owner.child.try_wait().unwrap().is_none());
+            let saved: SupervisorState = read_json(&state_path).unwrap();
+            assert!(supervisor_state_equivalent(&saved, &next));
+            drop(admission);
+
+            let mut preparation = std::thread::scope(|scope| {
+                let state_lock = supervisor.lock_state_publication().unwrap();
+                let (started_tx, started_rx) = std::sync::mpsc::channel();
+                let (lease_tx, lease_rx) = std::sync::mpsc::channel();
+                let service = &service;
+                let worker = scope.spawn(move || {
+                    started_tx.send(()).unwrap();
+                    let lease = service.acquire_source_watch_lease(
+                        "demo",
+                        false,
+                        crate::env::SourceWatchMode::ServicePreparation,
+                    );
+                    assert!(lease_tx.send(lease).is_ok());
+                });
+                started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+                assert!(matches!(
+                    lease_rx.recv_timeout(Duration::from_millis(150)),
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+                ));
+                assert!(service.source_watch_session("demo").unwrap().is_none());
+                assert!(
+                    service
+                        .observe_source_watch_lease("demo")
+                        .unwrap()
+                        .is_none()
+                );
+                drop(state_lock);
+                let lease = lease_rx
+                    .recv_timeout(Duration::from_secs(10))
+                    .unwrap()
+                    .unwrap();
+                worker.join().unwrap();
+                lease
+            });
+            if state_path.exists() {
+                fs::remove_file(&state_path).unwrap();
+            }
+            let missing_plan = supervisor.sync().unwrap_err();
+            assert!(
+                missing_plan.contains("cannot preserve the saved service plan"),
+                "{missing_plan}"
+            );
+            assert!(
+                !state_path.exists(),
+                "missing preparation plan must not be published as an omission"
+            );
+
+            write_json(&state_path, &active).unwrap();
+            assert_eq!(supervisor.sync().unwrap().children, active.children);
+            for invalid in ["kind", "home"] {
+                let mut incompatible = active.clone();
+                if invalid == "kind" {
+                    incompatible.kind = "incompatible".to_string();
+                } else {
+                    incompatible.ocm_home = display_path(&root.path().join("other-store"));
+                }
+                write_json(&state_path, &incompatible).unwrap();
+                let error = supervisor.sync().unwrap_err();
+                assert!(error.contains("incompatible saved service plan"), "{error}");
+                let saved: SupervisorState = read_json(&state_path).unwrap();
+                assert!(supervisor_state_equivalent(&saved, &incompatible));
+            }
+            write_json(&state_path, &next).unwrap();
+            assert!(
+                !refresh_active_state(
+                    &state_path,
+                    &service,
+                    &mut active,
+                    &mut count,
+                    &mut running.0,
+                    &mut pending,
+                    &mut inactive
+                ),
+                "{change}"
+            );
+            let owner = running.0.get_mut("demo").unwrap();
+            assert_eq!(owner.child.id(), pid);
+            assert!(
+                owner.child.try_wait().unwrap().is_none(),
+                "{change} stopped the running service during preparation"
+            );
+            assert_eq!(owner.spec, original);
+            assert_eq!(active.children, vec![original]);
+            assert_eq!(count, 1);
+            assert!(pending.is_empty());
+            assert!(active.restart_requests.is_empty());
+
+            if change == "restart" {
+                let saved: SupervisorState = read_json(&state_path).unwrap();
+                assert_eq!(
+                    saved.restart_requests.len(),
+                    1,
+                    "deferred restart must remain on disk"
+                );
+                preparation.finish_session(false, None, false).unwrap();
+                assert!(
+                    service
+                        .source_watch_session("demo")
+                        .unwrap()
+                        .unwrap()
+                        .closed
+                );
+                assert_eq!(supervisor.sync().unwrap().children, active.children);
+                let retained: SupervisorState = read_json(&state_path).unwrap();
+                assert_eq!(retained.restart_requests, saved.restart_requests);
+                assert!(!refresh_active_state(
+                    &state_path,
+                    &service,
+                    &mut active,
+                    &mut count,
+                    &mut running.0,
+                    &mut pending,
+                    &mut inactive
+                ));
+                let owner = running.0.get_mut("demo").unwrap();
+                assert_eq!(owner.child.id(), pid);
+                assert!(owner.child.try_wait().unwrap().is_none());
+                assert_eq!(owner.spec, active.children[0]);
+                assert!(pending.is_empty());
+                let retained: SupervisorState = read_json(&state_path).unwrap();
+                assert_eq!(retained.restart_requests, saved.restart_requests);
+                drop(preparation);
+                assert!(refresh_active_state(
+                    &state_path,
+                    &service,
+                    &mut active,
+                    &mut count,
+                    &mut running.0,
+                    &mut pending,
+                    &mut inactive
+                ));
+                assert!(running.0.is_empty());
+                assert_eq!(pending["demo"].restart_count, 1);
+                let saved: SupervisorState = read_json(&state_path).unwrap();
+                assert!(saved.restart_requests.is_empty());
+                assert!(!refresh_active_state(
+                    &state_path,
+                    &service,
+                    &mut active,
+                    &mut count,
+                    &mut running.0,
+                    &mut pending,
+                    &mut inactive
+                ));
+                assert_eq!(pending["demo"].restart_count, 1);
+            } else {
+                crate::store::set_environment_service_policy(
+                    &meta.name,
+                    (change == "changed").then_some(false),
+                    (change == "removed").then_some(false),
+                    &env,
+                    root.path(),
+                )
+                .unwrap();
+                next.children.clear();
+                write_json(&state_path, &next).unwrap();
+                assert!(
+                    refresh_active_state(
+                        &state_path,
+                        &service,
+                        &mut active,
+                        &mut count,
+                        &mut running.0,
+                        &mut pending,
+                        &mut inactive
+                    ),
+                    "explicit stop/disable must remain effective during preparation"
+                );
+                assert!(running.0.is_empty());
+                assert!(pending.is_empty());
+                assert_eq!(count, 0);
+                preparation.finish_session(false, None, false).unwrap();
+            }
+        }
     }
 
     #[test]

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -1195,6 +1195,12 @@ fn lock_supervisor_state(state_path: &Path) -> Result<crate::store::ExclusiveFil
     lock_file(&lock_path, "supervisor state")
 }
 
+fn try_lock_supervisor_state(
+    state_path: &Path,
+) -> Result<Option<crate::store::ExclusiveFileLock>, String> {
+    crate::store::try_lock_file(&state_path.with_extension("lock"), "supervisor state")
+}
+
 struct RunningSupervisorChild {
     spec: SupervisorChildSpec,
     child: Child,
@@ -1574,28 +1580,37 @@ fn refresh_active_state(
     pending: &mut BTreeMap<String, PendingSupervisorChild>,
     inactive: &mut BTreeMap<String, InactiveSupervisorChild>,
 ) -> bool {
+    if read_updated_supervisor_state(state_path, active_state).is_none() {
+        return false;
+    }
+    // Preparation publishes ownership under this lock. Re-read the plan under
+    // it and keep it through reconciliation; Gateway admission gates starts.
+    let state_lock = match try_lock_supervisor_state(state_path) {
+        Ok(Some(lock)) => lock,
+        Ok(None) => return false,
+        Err(error) => {
+            eprintln!("ocm service: failed locking updated state for reconciliation: {error}");
+            return false;
+        }
+    };
     let Some(mut next_state) = read_updated_supervisor_state(state_path, active_state) else {
         return false;
     };
     let restart_requests = new_supervisor_restart_requests(active_state, &next_state);
-    let admission_locks = match retain_running_services_during_preparation(
+    if let Err(error) = retain_running_services_during_preparation(
         env_service,
         running,
         &restart_requests,
         &mut next_state,
     ) {
-        Ok(Some(locks)) => locks,
-        Ok(None) => return false,
-        Err(error) => {
-            eprintln!("ocm service: service preparation deferred state reconciliation: {error}");
-            return false;
-        }
-    };
+        eprintln!("ocm service: service preparation deferred state reconciliation: {error}");
+        return false;
+    }
     let restart_requests = new_supervisor_restart_requests(active_state, &next_state);
     let mut runtime_dirty = reconcile_running_children(running, pending, inactive, &next_state);
     runtime_dirty |=
         reconcile_restart_requests(&restart_requests, running, pending, inactive, &next_state);
-    drop(admission_locks);
+    drop(state_lock);
     *managed_child_count = next_state.children.len();
     *active_state = next_state;
     clear_processed_restart_requests(state_path, &restart_requests);
@@ -1605,14 +1620,14 @@ fn refresh_active_state(
 // Only updates that would change a live child need preparation inspection.
 // Keep the actual owner's spec rather than trusting a stale saved plan. Deferred
 // restart requests stay on disk and are omitted only from this in-memory view,
-// so they are observed again after preparation ends. Return the admission locks
-// through reconciliation so preparation cannot begin between inspection and stop.
+// so they are observed again after preparation ends. The caller holds the state
+// publication lock through reconciliation to exclude new preparation ownership.
 fn retain_running_services_during_preparation(
     env_service: &EnvironmentService<'_>,
     running: &BTreeMap<String, RunningSupervisorChild>,
     restart_requests: &[SupervisorRestartRequest],
     next_state: &mut SupervisorState,
-) -> Result<Option<Vec<crate::store::ExclusiveFileLock>>, String> {
+) -> Result<(), String> {
     let desired = child_map(&next_state.children);
     let restarting: BTreeSet<_> = restart_requests
         .iter()
@@ -1627,14 +1642,7 @@ fn retain_running_services_during_preparation(
         })
         .collect();
     if affected.is_empty() {
-        return Ok(Some(Vec::new()));
-    }
-    let mut admission_locks = Vec::with_capacity(affected.len());
-    for name in &affected {
-        let Some(admission) = env_service.try_lock_gateway_admission(name)? else {
-            return Ok(None);
-        };
-        admission_locks.push(admission);
+        return Ok(());
     }
     let metas: BTreeMap<_, _> = env_service
         .list()?
@@ -1676,7 +1684,7 @@ fn retain_running_services_during_preparation(
     next_state
         .children
         .sort_by(|left, right| left.env_name.cmp(&right.env_name));
-    Ok(Some(admission_locks))
+    Ok(())
 }
 
 fn reconcile_running_children(
@@ -3724,7 +3732,7 @@ mod tests {
             let mut count = 1;
             let mut pending = BTreeMap::new();
             let mut inactive = BTreeMap::new();
-            let admission = service.lock_gateway_admission("demo").unwrap();
+            let state_lock = supervisor.lock_state_publication().unwrap();
             assert!(!refresh_active_state(
                 &state_path,
                 &service,
@@ -3739,7 +3747,7 @@ mod tests {
             assert!(owner.child.try_wait().unwrap().is_none());
             let saved: SupervisorState = read_json(&state_path).unwrap();
             assert!(supervisor_state_equivalent(&saved, &next));
-            drop(admission);
+            drop(state_lock);
 
             let mut preparation = std::thread::scope(|scope| {
                 let state_lock = supervisor.lock_state_publication().unwrap();

--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1979,7 +1979,7 @@ fn daemon_run_persists_live_runtime_children() {
     let cleared = wait_for_runtime_children(&runtime_path, 0, None, Duration::from_secs(5))
         .expect("daemon runtime state did not clear after shutdown");
     assert!(cleared["updatedAt"].as_str().is_some());
-    assert_eq!(gateway_admission["version"], 8);
+    assert_eq!(gateway_admission["version"], 9);
     assert_eq!(gateway_admission["process"]["pid"], daemon_pid);
     assert!(
         gateway_admission["process"]["startedAt"]

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -2769,6 +2769,13 @@ fn dev_command_can_start_a_background_service() {
     let show_json: Value = serde_json::from_str(&stdout(&show)).unwrap();
     assert_eq!(show_json["serviceEnabled"], true);
     assert_eq!(show_json["serviceRunning"], true);
+    #[cfg(unix)]
+    {
+        let preparation = read_source_watch_session(&root);
+        assert_eq!(preparation["servicePreparation"], true);
+        assert_eq!(preparation["closed"], true);
+        assert_eq!(preparation["restoreService"], false);
+    }
 
     let status = run_ocm(&cwd, &env, &["service", "status", "demo", "--json"]);
     assert!(status.status.success(), "{}", stderr(&status));
@@ -3863,20 +3870,140 @@ setInterval(() => { if (fs.existsSync(path.join(root,'source-watch.release'))) p
 
 #[cfg(unix)]
 #[test]
+fn dev_service_preparation_cancellation_preserves_its_running_service() {
+    let root = TestDir::new("dev-service-owned-preparation");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = service_env_with_gateway_admission(&root);
+    install_fake_dev_runners(&root, &mut env);
+    let initial = run_ocm(
+        &cwd,
+        &env,
+        &["dev", "demo", "--repo", &path_string(&repo), "--service"],
+    );
+    assert!(initial.status.success(), "{}", stderr(&initial));
+    let meta = get_environment("demo", &env, &cwd).unwrap();
+    assert!(meta.service_running && meta.service_enabled);
+    let state_path = root.child("ocm-home/supervisor/state.json");
+    let initial_state: Value = serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+    assert_eq!(initial_state["children"].as_array().unwrap().len(), 1);
+    let config_path = Path::new(&meta.root).join(".openclaw/openclaw.json");
+    let original_config = fs::read(&config_path).unwrap();
+    let (started, _, _) = install_blocking_fake_dev_runners(&root, &mut env);
+    let mut preparation = DevWatchFixture::spawn(
+        &root,
+        &cwd,
+        &env,
+        &["dev", "demo", "--service", "--onboard"],
+    );
+    assert!(wait_for_path(&started, Duration::from_secs(10)));
+    let session = read_source_watch_session(&root);
+    assert_eq!(session["servicePreparation"], true);
+    assert_eq!(session["watching"], false);
+    assert_eq!(session["restoreService"], false);
+    assert!(session["child"]["pid"].is_number());
+    assert!(get_environment("demo", &env, &cwd).unwrap().service_running);
+
+    let mut edited_config: Value = serde_json::from_slice(&original_config).unwrap();
+    edited_config["gateway"]["port"] = (meta.gateway_port.unwrap() + 1000).into();
+    let edited_config = serde_json::to_vec(&edited_config).unwrap();
+    fs::write(&config_path, &edited_config).unwrap();
+    let supervisor = ocm::supervisor::SupervisorService::new(&env, &cwd);
+    supervisor.sync().unwrap();
+    let during: Value = serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+    assert_eq!(
+        during["children"], initial_state["children"],
+        "preparation changed the running service plan"
+    );
+    let conflicting_start = run_ocm(&cwd, &env, &["service", "start", "demo"]);
+    assert!(!conflicting_start.status.success());
+    let conflicting_foreground = run_ocm(&cwd, &env, &["dev", "demo"]);
+    assert!(!conflicting_foreground.status.success());
+    assert!(stderr(&conflicting_foreground).contains("service preparation"));
+
+    let stopped = run_dev_stop(&cwd, &env);
+    assert!(stopped.status.success(), "{}", stderr(&stopped));
+    let output = preparation.wait_without_release();
+    assert_eq!(output.status.code(), Some(130), "{}", stderr(&output));
+    assert_eq!(
+        serde_json::from_str::<Value>(&stdout(&stopped)).unwrap()["serviceRestored"],
+        false
+    );
+    let completed = read_source_watch_session(&root);
+    assert_eq!(completed["closed"], true);
+    assert_eq!(completed["restoreService"], false);
+    let after = get_environment("demo", &env, &cwd).unwrap();
+    assert!(after.service_running && after.service_enabled);
+    assert_eq!(
+        after
+            .dev
+            .as_ref()
+            .map(|dev| (&dev.repo_root, &dev.worktree_root)),
+        meta.dev
+            .as_ref()
+            .map(|dev| (&dev.repo_root, &dev.worktree_root))
+    );
+    assert_eq!(fs::read(&config_path).unwrap(), edited_config);
+    let after_state: Value = serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+    assert_eq!(after_state["children"], initial_state["children"]);
+
+    // A completed preparation does not make an unchanged --service rerun an
+    // install/stop/start cycle. The native start owner retains the same plan.
+    fs::write(&config_path, original_config).unwrap();
+    let repeated = run_ocm(&cwd, &env, &["dev", "demo", "--service"]);
+    assert!(repeated.status.success(), "{}", stderr(&repeated));
+    let repeated_state: Value = serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+    assert_eq!(repeated_state["children"], initial_state["children"]);
+    assert_eq!(
+        repeated_state["restartRequests"],
+        initial_state["restartRequests"]
+    );
+    assert!(get_environment("demo", &env, &cwd).unwrap().service_running);
+
+    // A newer stop intent wins even when the service was already stopped.
+    drop(preparation);
+    fs::remove_file(root.child("source-watch.release")).unwrap();
+    fs::remove_file(&started).unwrap();
+    let stop = run_ocm(&cwd, &env, &["service", "stop", "demo"]);
+    assert!(stop.status.success(), "{}", stderr(&stop));
+    let preparation = DevWatchFixture::spawn(
+        &root,
+        &cwd,
+        &env,
+        &["dev", "demo", "--service", "--onboard"],
+    );
+    assert!(wait_for_path(&started, Duration::from_secs(10)));
+    let stop = run_ocm(&cwd, &env, &["service", "stop", "demo"]);
+    assert!(stop.status.success(), "{}", stderr(&stop));
+    let output = preparation.finish();
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("service policy changed during service preparation"));
+    assert!(!get_environment("demo", &env, &cwd).unwrap().service_running);
+    assert_eq!(read_source_watch_session(&root)["closed"], true);
+    let final_state: Value = serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+    assert!(final_state["children"].as_array().unwrap().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
 fn dev_stop_cancels_owned_preparation_before_gateway_start() {
-    for (phase, watching) in [
-        ("dependencies", true),
-        ("probe", true),
-        ("onboard", true),
-        ("dependencies", false),
-        ("probe", false),
-        ("onboard", false),
+    for (phase, mode) in [
+        ("dependencies", "watch"),
+        ("probe", "watch"),
+        ("onboard", "watch"),
+        ("dependencies", "plain"),
+        ("probe", "plain"),
+        ("onboard", "plain"),
+        ("dependencies", "service"),
+        ("probe", "service"),
+        ("onboard", "service"),
     ] {
-        let root = TestDir::new(&format!("dev-stop-{phase}-{watching}"));
+        let root = TestDir::new(&format!("dev-stop-{phase}-{mode}"));
         let repo = init_openclaw_repo(&root);
         let cwd = root.child("workspace");
         fs::create_dir_all(&cwd).unwrap();
-        let mut env = ocm_env(&root);
+        let mut env = service_env_with_gateway_admission(&root);
         install_probe_aware_fake_dev_runners(&root, &mut env);
         let prepare = run_ocm(
             &cwd,
@@ -3908,10 +4035,10 @@ fn dev_stop_cancels_owned_preparation_before_gateway_start() {
         } else {
             write_executable_script(&root.child("fake-dev-bin/pnpm"), &script);
         }
-        let mut args = if watching {
-            dev_watch(&["demo", "--watch"])
-        } else {
-            dev_plain(&["demo"])
+        let mut args = match mode {
+            "watch" => dev_watch(&["demo", "--watch"]),
+            "service" => vec!["dev", "demo", "--service"],
+            _ => dev_plain(&["demo"]),
         };
         if phase == "onboard" {
             args.push("--onboard");
@@ -3928,7 +4055,8 @@ fn dev_stop_cancels_owned_preparation_before_gateway_start() {
             .unwrap();
         let session = read_source_watch_session(&root);
         assert_eq!(session["child"]["pid"], pid);
-        assert_eq!(session["watching"], watching);
+        assert_eq!(session["watching"], mode == "watch");
+        assert_eq!(session["servicePreparation"], mode == "service");
         let status = run_ocm(&cwd, &env, &["dev", "status", "demo", "--json"]);
         let stopped = run_dev_stop(&cwd, &env);
         let watched = watch.finish();
@@ -3957,6 +4085,7 @@ fn dev_stop_cancels_owned_preparation_before_gateway_start() {
         assert!(worktree.join("package.json").is_file());
         assert!(Path::new(&meta.root).is_dir());
         assert_eq!(read_source_watch_session(&root)["closed"], true);
+        assert!(!get_environment("demo", &env, &cwd).unwrap().service_running);
     }
 }
 

--- a/tests/source_watch_daemon_admission_tests.rs
+++ b/tests/source_watch_daemon_admission_tests.rs
@@ -155,7 +155,7 @@ impl AdmissionFixture {
                 && runtime["gatewayAdmission"]["process"]["pid"] == pid
             {
                 assert_eq!(runtime["children"], json!([]));
-                assert_eq!(runtime["gatewayAdmission"]["version"], 8);
+                assert_eq!(runtime["gatewayAdmission"]["version"], 9);
                 assert!(
                     runtime["gatewayAdmission"]["process"]["startedAt"]
                         .as_str()
@@ -340,18 +340,26 @@ fn dev_watch_requires_the_current_managed_daemon_capability() {
 fn dev_foreground_rejects_unknown_daemon_before_creating_an_environment() {
     let mut fixture = AdmissionFixture::new("dev-daemon-preflight");
     let mut old_runtime = fixture.start_daemon();
-    old_runtime["gatewayAdmission"]["version"] = json!(7);
+    old_runtime["gatewayAdmission"]["version"] = json!(8);
     write_json_replacing_path(&fixture.runtime, &old_runtime);
     let registry = env_registry_path(&fixture.env, &fixture.cwd).unwrap();
     let before = fs::read(&registry).unwrap();
     let root = fixture.root.child("fresh-env");
     let repo_arg = path_string(&fixture.repo);
     let root_arg = path_string(&root);
-    for (watching, state) in [(true, "starting"), (false, "starting"), (false, "running")] {
+    for (mode, state) in [
+        ("watch", "starting"),
+        ("plain", "starting"),
+        ("plain", "running"),
+        ("service", "starting"),
+        ("service", "running"),
+    ] {
         fixture.set_manager_state(state, fixture.daemon.as_ref().unwrap().id());
         let mut args = vec!["dev", "fresh", "--repo", &repo_arg, "--root", &root_arg];
-        if watching {
-            args.push("--watch");
+        match mode {
+            "watch" => args.push("--watch"),
+            "service" => args.push("--service"),
+            _ => {}
         }
         let rejected = run_ocm(&fixture.cwd, &fixture.env, &args);
         assert!(!rejected.status.success());

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -409,7 +409,7 @@ pub fn enable_fake_daemon_gateway_admission(
     let (started_at, process_scope) = fixture_process_ownership();
     let capability =
         serde_json::from_value::<ocm::supervisor::SupervisorGatewayAdmission>(serde_json::json!({
-            "version": 8,
+            "version": 9,
             "process": { "pid": std::process::id(), "startedAt": started_at },
             "processScope": process_scope,
         }))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `ocm dev stop <env>` could not cancel preparation started by `ocm dev <env> --service`. Preparation must also preserve a managed Gateway already running while other environments update the supervisor plan.

## Why This Change Was Made

Service preparation uses the existing recorded child completion and cancellation path. The supervisor retains the saved and live launch specifications and defers restart requests during preparation. Verified completion, binding and service-policy revalidation, and managed service start share the existing operation lock. The handoff preserves newer explicit stop requests, including an idempotent stop, and avoids the temporary stop caused by a separate service installation.

## User Impact

`ocm dev stop <env>` can cancel service preparation while retaining the environment and source. OCM keeps an already-running managed Gateway and its launch plan during preparation; explicit service stop or uninstall remains effective. Supported watch and foreground records retain their recovery rules. A running daemon must support the updated preparation contract before admission.

## Evidence

Remote formatting and locked workspace/all-target compilation passed with freshly rebuilt, hash-verified executables. Targeted Rust checks cover preparation cancellation, live specification retention, concurrent plan publication, the closed-record/held-lease handoff, deferred restarts, newer service policy, supported session records, stale source rejection, and cleanup/restore integration.

Six native scenarios passed with actual OpenClaw source, real Linux daemon and Gateway processes, and an isolated service-manager adapter. They cover an older running daemon and supported watch session, current-client reuse and stop, refusal before mutation, acknowledged daemon replacement preserving the saved plan and configuration, preparation after refresh, and fresh service startup followed by repeated setup with unchanged Gateway process identities. All fixture processes and worktrees were cleaned up without forced termination or fallback removal.

Independent implementation and integration review is clean.
