### PR TITLE
fix: preserve registered dev sources during environment cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Environment creation, cloning, and import reject roots that overlap an already
 registered dev worktree that exists on disk, including source and destination
 path aliases. Choose a separate environment root to preserve the checkout.
 
+Removal, pruning, destroy, and simulation cleanup preserve other registered dev sources and the Git metadata they need. Remove dependent dev environments before deleting their containing environment or worktree.
+
 ### Try beta or pin a specific release
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -643,6 +643,10 @@ by an older OCM without usable stop ownership must be stopped from its original
 terminal. Environment removal clears completed watch records and retains the
 reusable synchronization lock files.
 
+Cleanup refuses to remove another registered dev source or its required Git
+metadata, including sources reached through path aliases. Destroy checks before
+signalling source workers; simulation checks before discarding generated files.
+
 `destroy` is the stronger cleanup path.
 
 ## Updating `ocm` itself

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -392,49 +392,49 @@ impl Cli {
             summary.service_uninstalled = true;
         }
 
-        if expected_state_token.is_some() {
-            summary.processes_terminated =
-                match self.terminate_env_processes_exact(&summary.process_candidates) {
-                    Ok(count) => count,
-                    Err(error) => {
-                        summary.processes_terminated = error.terminated;
-                        summary.code = Some("partial_apply".to_string());
-                        summary.blockers.push(format!(
-                            "process teardown failed after environment teardown began: {}",
-                            error.message
-                        ));
-                        if json_flag {
-                            self.print_json(&summary)?;
-                        } else {
-                            self.stdout_lines(render::env::env_destroy_preview(
-                                &summary,
-                                profile,
-                                &self.command_example(),
+        let removal = self.environment_service().remove_with_cleanup_locked(name, force, |meta| {
+            if expected_state_token.is_some() {
+                summary.processes_terminated =
+                    match self.terminate_env_processes_exact(&summary.process_candidates) {
+                        Ok(count) => count,
+                        Err(error) => {
+                            summary.processes_terminated = error.terminated;
+                            summary.code = Some("partial_apply".to_string());
+                            summary.blockers.push(format!(
+                                "process teardown failed after environment teardown began: {}",
+                                error.message
                             ));
+                            return Err(error.message);
                         }
-                        return Ok(1);
-                    }
-                };
-        } else {
-            summary.processes_terminated = self.terminate_env_processes(&env_meta)?;
-        }
-        let process_change = if expected_state_token.is_some() {
-            match self.destroy_process_candidates(&env_meta) {
-                Ok(candidates) if candidates.is_empty() => None,
-                Ok(_) => Some(
-                    "environment process state changed after teardown began; preview again to finish cleanup"
-                        .to_string(),
-                ),
-                Err(error) => Some(format!(
-                    "process state could not be verified after teardown began: {error}"
-                )),
+                    };
+            } else {
+                summary.processes_terminated = self.terminate_env_processes(meta)?;
             }
-        } else {
-            None
-        };
-        if let Some(blocker) = process_change {
-            summary.code = Some("partial_apply".to_string());
-            summary.blockers.push(blocker);
+            let process_change = if expected_state_token.is_some() {
+                match self.destroy_process_candidates(meta) {
+                    Ok(candidates) if candidates.is_empty() => None,
+                    Ok(_) => Some(
+                        "environment process state changed after teardown began; preview again to finish cleanup"
+                            .to_string(),
+                    ),
+                    Err(error) => Some(format!(
+                        "process state could not be verified after teardown began: {error}"
+                    )),
+                }
+            } else {
+                None
+            };
+            if let Some(blocker) = process_change {
+                summary.code = Some("partial_apply".to_string());
+                summary.blockers.push(blocker.clone());
+                return Err(blocker);
+            }
+            Ok(())
+        });
+        if let Err(error) = removal {
+            if summary.code.as_deref() != Some("partial_apply") {
+                return Err(error);
+            }
             if json_flag {
                 self.print_json(&summary)?;
             } else {
@@ -447,7 +447,6 @@ impl Cli {
             return Ok(1);
         }
 
-        self.environment_service().remove_locked(name, force)?;
         let _ = &operation_lock;
         summary.removed = true;
         summary.worktree_removed = env_meta
@@ -1240,6 +1239,15 @@ impl Cli {
         let mut snapshots = self.environment_service().list_snapshots(Some(name))?;
         snapshots.sort_by(|left, right| left.id.cmp(&right.id));
         let mut blockers = Vec::new();
+        let source_blocked = if let Err(error) =
+            crate::store::with_locked_environments(&self.env, &self.cwd, |envs| {
+                crate::store::ensure_environment_removal_preserves_dev_sources(&env_meta, envs)
+            }) {
+            blockers.push(error);
+            true
+        } else {
+            false
+        };
         let source_watch_session = self
             .environment_service()
             .source_watch_session(name)?
@@ -1255,7 +1263,7 @@ impl Cli {
         // its generation-bound protocol before taking the ordinary stable
         // process snapshot; a token-guarded apply refuses unfinished sessions.
         let process_inspection_deferred = source_watch_session.is_some() || source_watch_active;
-        let process_candidates = if process_inspection_deferred {
+        let process_candidates = if process_inspection_deferred || source_blocked {
             Vec::new()
         } else {
             self.destroy_process_candidates(&env_meta)?

--- a/src/cli/render/help.rs
+++ b/src/cli/render/help.rs
@@ -1549,6 +1549,7 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
                 "An ordinary --yes apply first stops and verifies the recorded source-watch generation. Unverifiable ownership blocks removal.",
                 "Guarded --if-state-token apply requires a stopped watch: run dev stop, then request a fresh destroy preview.",
                 "Destroy does not remove shared runtimes or launchers.",
+                "Other registered dev sources and their required Git metadata block containing cleanup, even with --force.",
                 "If the separate machine-wide OpenClaw service is using the env, destroy refuses to apply.",
                 "TTY output uses cards by default. Piped output stays plain.",
             ],
@@ -1573,6 +1574,7 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "Protected environments require `--force`.",
+                "Cleanup preserves other registered dev sources and their required Git metadata.",
                 "Active or unfinished source watches must be stopped with dev stop before remove or prune can delete their state.",
             ],
         ),
@@ -1600,6 +1602,7 @@ pub fn env_command_help(cmd: &str, action: &str) -> Option<String> {
             ],
             &[
                 "Active or unfinished source watches block removal; run dev stop for those envs first.",
+                "Cleanup preserves other registered dev sources and their required Git metadata.",
             ],
         ),
         "snapshot" => env_snapshot_help(cmd),

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -378,23 +378,32 @@ impl<'a> EnvironmentService<'a> {
     }
 
     pub(crate) fn remove_locked(&self, name: &str, force: bool) -> Result<EnvMeta, String> {
-        let meta = remove_environment_locked(name, force, self.env, self.cwd)?;
+        self.remove_with_cleanup_locked(name, force, |_| Ok(()))
+    }
+
+    pub(crate) fn remove_with_cleanup_locked(
+        &self,
+        name: &str,
+        force: bool,
+        before_remove: impl FnOnce(&EnvMeta) -> Result<(), String>,
+    ) -> Result<EnvMeta, String> {
+        let meta = remove_environment_locked(name, force, self.env, self.cwd, before_remove)?;
         sync_supervisor_env_if_present(self.env, self.cwd, name)?;
         Ok(meta)
     }
 
     pub(crate) fn remove_simulation(&self, name: &str) -> Result<EnvMeta, String> {
         let _lock = self.lock_operation(name)?;
-        self.ensure_source_watch_stopped(name)?;
-        let meta = get_environment(name, self.env, self.cwd)?;
-        if let Some(dev) = meta.dev.as_ref() {
-            prepare_openclaw_simulation_worktree_cleanup(
-                Path::new(&dev.repo_root),
-                Path::new(&dev.worktree_root),
-                &meta.name,
-            )?;
-        }
-        self.remove_locked(name, true)
+        self.remove_with_cleanup_locked(name, true, |meta| {
+            if let Some(dev) = meta.dev.as_ref() {
+                prepare_openclaw_simulation_worktree_cleanup(
+                    Path::new(&dev.repo_root),
+                    Path::new(&dev.worktree_root),
+                    &meta.name,
+                )?;
+            }
+            Ok(())
+        })
     }
 
     pub fn prune_candidates(&self, older_than_days: i64) -> Result<Vec<EnvMeta>, String> {

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -421,7 +422,7 @@ pub(crate) fn ensure_openclaw_worktree(
     let worktree_argument = worktree_root
         .strip_prefix(&repo_root)
         .map_err(|_| "OCM-owned worktree destination is outside its repository".to_string())?;
-    let output = Command::new("git")
+    let output = git_command()
         .arg("-C")
         .arg(&repo_root)
         .args(["worktree", "add", "--detach"])
@@ -514,7 +515,7 @@ fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), Strin
         return Ok(());
     }
 
-    let output = Command::new("git")
+    let output = git_command()
         .arg("-C")
         .arg(worktree_root)
         .args([
@@ -549,7 +550,7 @@ fn remove_generated_simulation_outputs(worktree_root: &Path) -> Result<(), Strin
 fn remove_registered_worktree(repo_root: &Path, worktree_root: &Path) -> Result<(), String> {
     ensure_worktree_clean(worktree_root)?;
 
-    let output = Command::new("git")
+    let output = git_command()
         .arg("-C")
         .arg(repo_root)
         .args(["worktree", "remove", "--force"])
@@ -571,7 +572,7 @@ fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
         return Ok(());
     }
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(["-c", "status.showUntrackedFiles=all"])
         .arg("-C")
         .arg(worktree_root)
@@ -601,7 +602,7 @@ fn ensure_worktree_clean(worktree_root: &Path) -> Result<(), String> {
 }
 
 fn ensure_no_ignored_local_files(worktree_root: &Path) -> Result<(), String> {
-    let worktree_output = Command::new("git")
+    let worktree_output = git_command()
         .arg("-C")
         .arg(worktree_root)
         .args([
@@ -624,7 +625,7 @@ fn ensure_no_ignored_local_files(worktree_root: &Path) -> Result<(), String> {
         return Err(format!("git ignored-file inspection failed: {detail}"));
     }
 
-    let submodule_output = Command::new("git")
+    let submodule_output = git_command()
         .arg("-C")
         .arg(worktree_root)
         .args([
@@ -674,7 +675,7 @@ fn is_disposable_ignored_path(path: &Path) -> bool {
 }
 
 fn registered_worktree_paths(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
-    let output = Command::new("git")
+    let output = git_command()
         .arg("-C")
         .arg(repo_root)
         .args(["worktree", "list", "--porcelain", "-z"])
@@ -684,7 +685,7 @@ fn registered_worktree_paths(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
         return parse_registered_worktree_paths(&output.stdout);
     }
 
-    let fallback = Command::new("git")
+    let fallback = git_command()
         .arg("-C")
         .arg(repo_root)
         .args([
@@ -779,7 +780,7 @@ fn is_existing_openclaw_worktree(repo_root: &Path, path: &Path) -> bool {
     detect_openclaw_checkout(path).is_some() && has_expected_worktree_identity(repo_root, path)
 }
 
-fn has_expected_worktree_identity(repo_root: &Path, path: &Path) -> bool {
+pub(crate) fn has_expected_worktree_identity(repo_root: &Path, path: &Path) -> bool {
     path.exists()
         && path.join(".git").exists()
         && git_top_level(path).is_some_and(|top_level| {
@@ -793,8 +794,139 @@ fn has_expected_worktree_identity(repo_root: &Path, path: &Path) -> bool {
         })
 }
 
-fn git_common_dir(path: &Path) -> Option<PathBuf> {
+pub(crate) fn git_common_dir(path: &Path) -> Option<PathBuf> {
     git_rev_parse_path(path, "--git-common-dir")
+}
+
+pub(crate) struct GitIdentityPaths {
+    pub(crate) entries: Vec<PathBuf>,
+    pub(crate) private_dir: PathBuf,
+    pub(crate) common_dir: PathBuf,
+    pub(crate) worktree_entry: Option<PathBuf>,
+}
+
+// Keep raw pointer paths: Git's resolved query output can erase an intermediate
+// symlink whose removal would break the recorded entry point.
+pub(crate) fn git_identity_paths(root: &Path) -> Result<Option<GitIdentityPaths>, String> {
+    match fs::metadata(root) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => return Ok(None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    }
+    let mut git_entry = None;
+    for ancestor in root.ancestors() {
+        let candidate = ancestor.join(".git");
+        match fs::symlink_metadata(&candidate) {
+            Ok(_) => {
+                git_entry = Some(candidate);
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    let Some(git_entry) = git_entry.or_else(|| git_rev_parse_path(root, "--git-dir")) else {
+        return Ok(None); // Missing/non-Git tuples remain valid store inputs.
+    };
+    let private_dir = if fs::metadata(&git_entry)
+        .map_err(|error| error.to_string())?
+        .is_dir()
+    {
+        git_entry.clone()
+    } else {
+        read_git_pointer(&git_entry, git_entry.parent().unwrap(), b"gitdir: ")?
+            .ok_or_else(|| format!("Git entry disappeared: {}", display_path(&git_entry)))?
+    };
+    let mut identity = git_registration_paths(&private_dir)?;
+    identity.entries.push(git_entry);
+    Ok(Some(identity))
+}
+
+pub(crate) fn git_registration_paths(private_dir: &Path) -> Result<GitIdentityPaths, String> {
+    let mut entries = Vec::new();
+    let common_pointer = private_dir.join("commondir");
+    let common_dir = if let Some(common) = read_git_pointer(&common_pointer, &private_dir, b"")? {
+        entries.push(common_pointer);
+        common
+    } else {
+        private_dir.to_path_buf()
+    };
+    let backlink = private_dir.join("gitdir");
+    let worktree_entry = read_git_pointer(&backlink, private_dir, b"")?;
+    if worktree_entry.is_some() {
+        entries.push(backlink);
+    }
+    Ok(GitIdentityPaths {
+        entries,
+        private_dir: private_dir.to_path_buf(),
+        common_dir,
+        worktree_entry,
+    })
+}
+
+pub(crate) fn worktree_registration_entries(
+    repo: &Path,
+    root: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    let Some(identity) = git_identity_paths(repo)? else {
+        return Ok(Vec::new());
+    };
+    git_registration_entries(&identity.common_dir, root)
+}
+
+pub(crate) fn git_registration_entries(common: &Path, root: &Path) -> Result<Vec<PathBuf>, String> {
+    let common = fs::canonicalize(common).map_err(|error| error.to_string())?;
+    let expected = normalize_worktree_path(root);
+    let mut entries = Vec::new();
+    let slots = match fs::read_dir(common.join("worktrees")) {
+        Ok(slots) => slots,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.to_string()),
+    };
+    for entry in slots {
+        let entry = entry.map_err(|error| error.to_string())?.path();
+        if let Some(backlink) = read_git_pointer(&entry.join("gitdir"), &entry, b"")?
+            && backlink.file_name().is_some_and(|name| name == ".git")
+            && backlink
+                .parent()
+                .is_some_and(|parent| normalize_worktree_path(parent) == expected)
+        {
+            entries.push(entry);
+        }
+    }
+    Ok(entries)
+}
+
+fn read_git_pointer(path: &Path, base: &Path, prefix: &[u8]) -> Result<Option<PathBuf>, String> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    if !metadata.is_file() || metadata.len() > 65536 {
+        return Err(format!(
+            "invalid Git identity pointer: {}",
+            display_path(path)
+        ));
+    }
+    let mut contents = Vec::new();
+    fs::File::open(path)
+        .map_err(|error| error.to_string())?
+        .take(65537)
+        .read_to_end(&mut contents)
+        .map_err(|error| error.to_string())?;
+    let value = trim_git_line(&contents)
+        .strip_prefix(prefix)
+        .filter(|value| !value.is_empty() && contents.len() <= 65536)
+        .ok_or_else(|| format!("invalid Git identity pointer: {}", display_path(path)))?;
+    let target = PathBuf::from(git_path_from_bytes(value)?);
+    // Do not collapse '..' before preceding symlinks have been followed.
+    Ok(Some(if target.is_absolute() {
+        target
+    } else {
+        base.join(target)
+    }))
 }
 
 fn git_top_level(path: &Path) -> Option<PathBuf> {
@@ -813,8 +945,19 @@ fn git_worktree_backlink(path: &Path) -> Option<PathBuf> {
     }
 }
 
+fn git_command() -> Command {
+    let mut command = Command::new("git");
+    // Inspection and mutation must use the checkout and index selected by -C.
+    command
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE");
+    command
+}
+
 fn git_rev_parse_path(path: &Path, selector: &str) -> Option<PathBuf> {
-    let output = Command::new("git")
+    let output = git_command()
         .arg("-C")
         .arg(path)
         .args(["rev-parse", selector])

--- a/src/store/dev_sources.rs
+++ b/src/store/dev_sources.rs
@@ -1,7 +1,8 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::env::EnvMeta;
+use crate::env::{EnvDevMeta, EnvMeta};
 
 use super::display_path;
 
@@ -31,14 +32,14 @@ fn destination_ancestor(path: &Path) -> Result<(PathBuf, bool), String> {
 }
 
 #[cfg(unix)]
-fn path_identity(path: &Path) -> Result<(u64, u64), String> {
+pub(crate) fn path_identity(path: &Path) -> Result<(u64, u64), String> {
     use std::os::unix::fs::MetadataExt;
     let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
     Ok((metadata.dev(), metadata.ino()))
 }
 
 #[cfg(windows)]
-fn path_identity(path: &Path) -> Result<(u64, u64), String> {
+pub(crate) fn path_identity(path: &Path) -> Result<(u64, u64), String> {
     use std::os::windows::fs::OpenOptionsExt;
     use std::os::windows::io::AsRawHandle;
     use windows_sys::Win32::Storage::FileSystem::{
@@ -63,11 +64,11 @@ fn path_identity(path: &Path) -> Result<(u64, u64), String> {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn path_identity(_path: &Path) -> Result<(u64, u64), String> {
+pub(crate) fn path_identity(_path: &Path) -> Result<(u64, u64), String> {
     Err("cannot establish dev source identity on this platform".to_string())
 }
 
-fn contains_existing(root: &Path, path: &Path) -> Result<bool, String> {
+pub(crate) fn contains_existing(root: &Path, path: &Path) -> Result<bool, String> {
     if path.starts_with(root) {
         return Ok(true);
     }
@@ -78,6 +79,284 @@ fn contains_existing(root: &Path, path: &Path) -> Result<bool, String> {
         }
     }
     Ok(false)
+}
+
+fn existing_cleanup_path(path: &Path) -> Result<Option<PathBuf>, String> {
+    match fs::canonicalize(path) {
+        Ok(path) => Ok(Some(path)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!(
+            "failed to resolve cleanup path {}: {error}",
+            display_path(path)
+        )),
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct SourceFootprint {
+    pub(crate) entries: BTreeSet<PathBuf>,
+    pub(crate) content_roots: BTreeSet<PathBuf>,
+}
+
+fn record_path_entries(
+    path: &Path,
+    entries: &mut BTreeSet<PathBuf>,
+    links: &mut BTreeSet<PathBuf>,
+) -> Result<PathBuf, String> {
+    let resolved = fs::canonicalize(path).map_err(|error| {
+        format!(
+            "cannot resolve source identity path {}: {error}",
+            display_path(path)
+        )
+    })?;
+    entries.insert(resolved.clone());
+    for ancestor in path.ancestors() {
+        if !fs::symlink_metadata(ancestor)
+            .map_err(|error| error.to_string())?
+            .is_symlink()
+        {
+            continue;
+        }
+        let parent = ancestor.parent().ok_or("source symlink has no parent")?;
+        let entry = fs::canonicalize(parent)
+            .map_err(|error| error.to_string())?
+            .join(ancestor.file_name().ok_or("source symlink has no name")?);
+        entries.insert(entry.clone());
+        if links.insert(entry) {
+            let target = fs::read_link(ancestor).map_err(|error| error.to_string())?;
+            let target = if target.is_absolute() {
+                target
+            } else {
+                parent.join(target)
+            };
+            record_path_entries(&target, entries, links)?;
+        }
+    }
+    Ok(resolved)
+}
+
+pub(crate) fn existing_source_path_entries(path: &Path) -> Result<BTreeSet<PathBuf>, String> {
+    let mut entries = BTreeSet::new();
+    record_path_entries(path, &mut entries, &mut BTreeSet::new())?;
+    Ok(entries)
+}
+
+fn append_git_footprint(
+    footprint: &mut SourceFootprint,
+    git: crate::openclaw_repo::GitIdentityPaths,
+    include_worktree_entry: bool,
+    links: &mut BTreeSet<PathBuf>,
+) -> Result<(), String> {
+    for path in git.entries {
+        record_path_entries(&path, &mut footprint.entries, links)?;
+    }
+    if include_worktree_entry && let Some(path) = git.worktree_entry {
+        record_path_entries(&path, &mut footprint.entries, links)?;
+    }
+    for path in [git.private_dir, git.common_dir] {
+        let resolved = record_path_entries(&path, &mut footprint.entries, links)?;
+        footprint.content_roots.insert(resolved);
+    }
+    Ok(())
+}
+
+// This primitive describes existing paths, not source eligibility. Registration
+// may retain absent/non-Git tuples; callers own that policy and path reservations.
+pub(crate) fn inspect_source_footprint(root: &Path) -> Result<SourceFootprint, String> {
+    let mut footprint = SourceFootprint::default();
+    if existing_cleanup_path(root)?.is_none() {
+        return Ok(footprint);
+    }
+    footprint.entries = existing_source_path_entries(root)?;
+    let mut links = BTreeSet::new();
+    if let Some(git) = crate::openclaw_repo::git_identity_paths(root)? {
+        let registrations = match git.worktree_entry.as_ref().and_then(|path| path.parent()) {
+            Some(worktree) => {
+                crate::openclaw_repo::git_registration_entries(&git.common_dir, worktree)?
+            }
+            None => Vec::new(),
+        };
+        append_git_footprint(&mut footprint, git, true, &mut links)?;
+        for path in registrations {
+            append_git_footprint(
+                &mut footprint,
+                crate::openclaw_repo::git_registration_paths(&path)?,
+                true,
+                &mut links,
+            )?;
+        }
+    }
+    Ok(footprint)
+}
+
+pub(crate) fn inspect_dev_source_metadata(dev: &EnvDevMeta) -> Result<SourceFootprint, String> {
+    let mut footprint = inspect_source_footprint(Path::new(&dev.repo_root))?;
+    let mut links = BTreeSet::new();
+    for path in crate::openclaw_repo::worktree_registration_entries(
+        Path::new(&dev.repo_root),
+        Path::new(&dev.worktree_root),
+    )? {
+        // Missing working files do not discard the slot's recoverable history.
+        // Preserve existing metadata, without reserving the absent .git entry.
+        append_git_footprint(
+            &mut footprint,
+            crate::openclaw_repo::git_registration_paths(&path)?,
+            false,
+            &mut links,
+        )?;
+    }
+    Ok(footprint)
+}
+
+pub(crate) fn inspect_dev_source_footprint(dev: &EnvDevMeta) -> Result<SourceFootprint, String> {
+    let mut footprint = inspect_dev_source_metadata(dev)?;
+    let worktree = inspect_source_footprint(Path::new(&dev.worktree_root))?;
+    footprint.entries.extend(worktree.entries);
+    footprint.content_roots.extend(worktree.content_roots);
+    if let Some(source) = existing_cleanup_path(Path::new(&dev.worktree_root))? {
+        footprint.content_roots.insert(source);
+    }
+    Ok(footprint)
+}
+
+pub(crate) fn registered_dev_source_footprint(
+    dev: &EnvDevMeta,
+) -> Result<Option<SourceFootprint>, String> {
+    if existing_cleanup_path(Path::new(&dev.worktree_root))?.is_some()
+        && !crate::openclaw_repo::has_expected_worktree_identity(
+            Path::new(&dev.repo_root),
+            Path::new(&dev.worktree_root),
+        )
+    {
+        return Err(format!(
+            "cannot verify Git identity for registered dev source {}",
+            dev.worktree_root
+        ));
+    }
+    let footprint = inspect_dev_source_footprint(dev)?;
+    Ok((!footprint.entries.is_empty()).then_some(footprint))
+}
+
+pub(crate) fn ensure_environment_removal_preserves_dev_sources(
+    target: &EnvMeta,
+    envs: &[EnvMeta],
+) -> Result<(), String> {
+    let mut footprints = Vec::new();
+    for meta in envs.iter().filter(|meta| meta.name != target.name) {
+        let Some(dev) = &meta.dev else { continue };
+        // Creation can reuse a missing worktree path for new env state. That
+        // state belongs to the new env; retain only the old record's repo data.
+        let replaced = if fs::symlink_metadata(Path::new(&dev.worktree_root).join(".git"))
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+        {
+            match (
+                existing_cleanup_path(Path::new(&dev.worktree_root))?,
+                existing_cleanup_path(Path::new(&target.root))?,
+            ) {
+                (Some(source), Some(root)) => path_identity(&source)? == path_identity(&root)?,
+                _ => false,
+            }
+        } else {
+            false
+        };
+        let footprint = if replaced {
+            Some(inspect_dev_source_metadata(dev)?)
+        } else {
+            registered_dev_source_footprint(dev)?
+        };
+        if let Some(footprint) = footprint {
+            footprints.push((meta.name.as_str(), footprint));
+        }
+    }
+    if footprints.is_empty() {
+        return Ok(());
+    }
+    let root_path = Path::new(&target.root);
+    let root = existing_cleanup_path(root_path)?;
+    let worktree = target
+        .dev
+        .as_ref()
+        .map(|dev| existing_cleanup_path(Path::new(&dev.worktree_root)))
+        .transpose()?
+        .flatten();
+    // Removing a final symlink also changes its containing source, even when
+    // the link resolves outside that source (or its destination is missing).
+    let entry_parent = if fs::symlink_metadata(root_path).is_ok_and(|meta| meta.is_symlink()) {
+        root_path
+            .parent()
+            .map(existing_cleanup_path)
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let mut registrations = Vec::new();
+    let mut registration_links = Vec::new();
+    if let Some(dev) = &target.dev {
+        for path in crate::openclaw_repo::worktree_registration_entries(
+            Path::new(&dev.repo_root),
+            Path::new(&dev.worktree_root),
+        )? {
+            if fs::symlink_metadata(&path)
+                .map_err(|error| error.to_string())?
+                .is_symlink()
+            {
+                // Git unlinks the administrative slot itself, not its referent.
+                let parent =
+                    fs::canonicalize(path.parent().unwrap()).map_err(|error| error.to_string())?;
+                registration_links.push(parent.join(path.file_name().unwrap()));
+            } else {
+                registrations.push(fs::canonicalize(path).map_err(|error| error.to_string())?);
+            }
+        }
+    }
+    if root.is_none()
+        && worktree.is_none()
+        && entry_parent.is_none()
+        && registrations.is_empty()
+        && registration_links.is_empty()
+    {
+        return Ok(());
+    }
+    let preserve = |path: &Path, owner: &str, contents: bool| -> Result<(), String> {
+        let mut affected = false;
+        // An owned child worktree may be removed from inside another source.
+        // Refuse only when that worktree itself contains a protected path.
+        for (root, symmetric) in [(root.as_ref(), true), (worktree.as_ref(), false)] {
+            if let Some(root) = root {
+                affected |= contains_existing(root, path)?
+                    || (symmetric && contents && contains_existing(path, root)?);
+            }
+        }
+        if let Some(parent) = &entry_parent
+            && contents
+        {
+            affected |= contains_existing(path, parent)?;
+        }
+        for root in &registrations {
+            affected |= contains_existing(root, path)?;
+        }
+        for entry in &registration_links {
+            affected |= path_identity(entry)? == path_identity(path)?;
+        }
+        if affected {
+            return Err(format!(
+                "cleanup for env {} would affect registered dev source for env {owner} at {}; remove the dependent dev env first",
+                target.name,
+                display_path(path)
+            ));
+        }
+        Ok(())
+    };
+    for (owner, footprint) in footprints {
+        for path in &footprint.entries {
+            preserve(path, owner, false)?;
+        }
+        for path in &footprint.content_roots {
+            preserve(path, owner, true)?;
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn ensure_root_outside_dev_sources(

--- a/src/store/dev_sources.rs
+++ b/src/store/dev_sources.rs
@@ -219,9 +219,46 @@ pub(crate) fn inspect_dev_source_footprint(dev: &EnvDevMeta) -> Result<SourceFoo
     Ok(footprint)
 }
 
+pub(crate) fn registered_dev_source_replaced(
+    meta: &EnvMeta,
+    envs: &[EnvMeta],
+) -> Result<bool, String> {
+    let Some(dev) = &meta.dev else {
+        return Ok(false);
+    };
+    if !fs::symlink_metadata(Path::new(&dev.worktree_root).join(".git"))
+        .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+    {
+        return Ok(false);
+    }
+    let Some(source) = existing_cleanup_path(Path::new(&dev.worktree_root))? else {
+        return Ok(false);
+    };
+    // Creation can reuse a missing worktree path for another env's state,
+    // regardless of that env's binding or the current cleanup target.
+    let source_identity = path_identity(&source)?;
+    for owner in envs.iter().filter(|owner| owner.name != meta.name) {
+        if let Some(root) = existing_cleanup_path(Path::new(&owner.root))?
+            && path_identity(&root)? == source_identity
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 pub(crate) fn registered_dev_source_footprint(
-    dev: &EnvDevMeta,
+    meta: &EnvMeta,
+    envs: &[EnvMeta],
 ) -> Result<Option<SourceFootprint>, String> {
+    let Some(dev) = &meta.dev else {
+        return Ok(None);
+    };
+    if registered_dev_source_replaced(meta, envs)? {
+        // Keep the old source's recoverable Git data, not the new state.
+        let footprint = inspect_dev_source_metadata(dev)?;
+        return Ok((!footprint.entries.is_empty()).then_some(footprint));
+    }
     if existing_cleanup_path(Path::new(&dev.worktree_root))?.is_some()
         && !crate::openclaw_repo::has_expected_worktree_identity(
             Path::new(&dev.repo_root),
@@ -243,28 +280,7 @@ pub(crate) fn ensure_environment_removal_preserves_dev_sources(
 ) -> Result<(), String> {
     let mut footprints = Vec::new();
     for meta in envs.iter().filter(|meta| meta.name != target.name) {
-        let Some(dev) = &meta.dev else { continue };
-        // Creation can reuse a missing worktree path for new env state. That
-        // state belongs to the new env; retain only the old record's repo data.
-        let replaced = if fs::symlink_metadata(Path::new(&dev.worktree_root).join(".git"))
-            .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
-        {
-            match (
-                existing_cleanup_path(Path::new(&dev.worktree_root))?,
-                existing_cleanup_path(Path::new(&target.root))?,
-            ) {
-                (Some(source), Some(root)) => path_identity(&source)? == path_identity(&root)?,
-                _ => false,
-            }
-        } else {
-            false
-        };
-        let footprint = if replaced {
-            Some(inspect_dev_source_metadata(dev)?)
-        } else {
-            registered_dev_source_footprint(dev)?
-        };
-        if let Some(footprint) = footprint {
+        if let Some(footprint) = registered_dev_source_footprint(meta, envs)? {
             footprints.push((meta.name.as_str(), footprint));
         }
     }

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -1044,7 +1044,7 @@ pub fn remove_environment(
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
     let _operation = lock_environment_operation(name, env, cwd)?;
-    remove_environment_locked(name, force, env, cwd)
+    remove_environment_locked(name, force, env, cwd, |_| Ok(()))
 }
 
 pub(crate) fn remove_environment_locked(
@@ -1052,6 +1052,7 @@ pub(crate) fn remove_environment_locked(
     force: bool,
     env: &BTreeMap<String, String>,
     cwd: &Path,
+    before_remove: impl FnOnce(&EnvMeta) -> Result<(), String>,
 ) -> Result<EnvMeta, String> {
     let safe_name = validate_name(name, "Environment name")?;
     let source_service = crate::env::EnvironmentService::new(env, cwd);
@@ -1069,6 +1070,11 @@ pub(crate) fn remove_environment_locked(
     }
 
     let paths = derive_env_paths(Path::new(&meta.root));
+
+    super::dev_sources::ensure_environment_removal_preserves_dev_sources(&meta, &registry.envs)?;
+    // Preliminary cleanup shares this registry lock through final deletion.
+    // It must not call back into registry-mutating operations.
+    before_remove(&meta)?;
 
     if let Some(dev) = meta.dev.as_ref() {
         remove_openclaw_worktree(Path::new(&dev.repo_root), Path::new(&dev.worktree_root))?;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,7 +1,7 @@
 mod checkpoint_scope;
 mod checkpoints;
 mod common;
-mod dev_sources;
+pub(crate) mod dev_sources;
 mod envs;
 mod gateway_ports;
 mod launchers;
@@ -25,6 +25,7 @@ pub(crate) use common::{
     ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, try_lock_file,
     write_json,
 };
+pub(crate) use dev_sources::ensure_environment_removal_preserves_dev_sources;
 pub(crate) use envs::{
     EnvironmentOperationLock, lock_env_registry, lock_environment_operation,
     remove_environment_locked,

--- a/tests/env_destroy_tests.rs
+++ b/tests/env_destroy_tests.rs
@@ -603,8 +603,17 @@ fn env_destroy_preserves_nested_registered_dev_source_and_worker() {
     fs::rename(init_openclaw_repo(&root), &repo).unwrap();
     let child = create_dev_source(&repo, "child", &env, cwd);
     let worktree = Path::new(&child.dev.as_ref().unwrap().worktree_root);
-    assert!(worktree.starts_with(Path::new(&parent.root)));
-    assert!(!Path::new(&child.root).starts_with(Path::new(&parent.root)));
+    let parent_root = fs::canonicalize(&parent.root).unwrap();
+    assert!(
+        fs::canonicalize(worktree)
+            .unwrap()
+            .starts_with(&parent_root)
+    );
+    assert!(
+        !fs::canonicalize(&child.root)
+            .unwrap()
+            .starts_with(&parent_root)
+    );
     let source = worktree.join("package.json");
     let source_before = fs::read(&source).unwrap();
     let mut aged = parent.clone();
@@ -861,9 +870,9 @@ fn env_remove_keeps_independent_owned_children_removable() {
 #[cfg(unix)]
 #[test]
 fn env_remove_preserves_missing_owned_worktree_recovery() {
-    for private_inside in [false, true] {
+    for (private_inside, dev_replacement) in [(false, false), (true, false), (true, true)] {
         let root = TestDir::new(&format!(
-            "env-remove-missing-owned-recovery-{private_inside}"
+            "env-remove-missing-owned-recovery-{private_inside}-{dev_replacement}"
         ));
         let mut env = ocm_launchd_env(&root);
         install_fake_launchctl(&root, &mut env);
@@ -913,18 +922,70 @@ fn env_remove_preserves_missing_owned_worktree_recovery() {
             !worktree.exists(),
             "cleanup must not recreate the missing worktree"
         );
-        let replacement = run_ocm(
-            root.path(),
-            &env,
-            &[
-                "env",
-                "create",
-                "replacement",
-                "--root",
-                &path_string(worktree),
-            ],
-        );
+        let replacement_root = if private_inside {
+            let alias = root.child("replacement-parent");
+            std::os::unix::fs::symlink(worktree.parent().unwrap(), &alias).unwrap();
+            alias.join(worktree.file_name().unwrap())
+        } else {
+            worktree.to_path_buf()
+        };
+        let replacement = if dev_replacement {
+            run_ocm(
+                root.path(),
+                &env,
+                &dev_plain(&[
+                    "replacement",
+                    "--repo",
+                    &path_string(&repo),
+                    "--root",
+                    &path_string(&replacement_root),
+                ]),
+            )
+        } else {
+            run_ocm(
+                root.path(),
+                &env,
+                &[
+                    "env",
+                    "create",
+                    "replacement",
+                    "--root",
+                    &path_string(&replacement_root),
+                ],
+            )
+        };
         assert!(replacement.status.success(), "{}", stderr(&replacement));
+        let replacement = get_environment("replacement", &env, root.path()).unwrap();
+        let replacement_before = serde_json::to_value(&replacement).unwrap();
+        let retained_state = Path::new(&replacement.root).join("retained-state.txt");
+        fs::write(&retained_state, "replacement state\n").unwrap();
+        let unrelated = run_ocm(root.path(), &env, &["env", "create", "unrelated"]);
+        assert!(unrelated.status.success(), "{}", stderr(&unrelated));
+        let removed = run_ocm(root.path(), &env, &["env", "remove", "unrelated"]);
+        assert!(
+            removed.status.success(),
+            "unrelated cleanup with replacement: {}",
+            stderr(&removed)
+        );
+        assert_eq!(
+            fs::read_to_string(&retained_state).unwrap(),
+            "replacement state\n"
+        );
+        assert_eq!(
+            serde_json::to_value(get_environment("replacement", &env, root.path()).unwrap())
+                .unwrap(),
+            replacement_before
+        );
+        assert!(
+            git(&repo, &["worktree", "list", "--porcelain"]).contains(&format!("HEAD {detached}"))
+        );
+        let refused = run_ocm(root.path(), &env, &["env", "remove", "parent"]);
+        assert!(!refused.status.success());
+        assert!(
+            stderr(&refused).contains("registered dev source"),
+            "{}",
+            stderr(&refused)
+        );
         for name in ["replacement", "child", "parent"] {
             let removed = run_ocm(root.path(), &env, &["env", "remove", name]);
             assert!(removed.status.success(), "{}: {}", name, stderr(&removed));

--- a/tests/env_destroy_tests.rs
+++ b/tests/env_destroy_tests.rs
@@ -13,7 +13,7 @@ use std::thread::sleep;
 #[cfg(unix)]
 use std::time::{Duration, Instant};
 
-use ocm::env::EnvDevMeta;
+use ocm::env::{EnvDevMeta, EnvMeta};
 use ocm::store::{get_environment, save_environment};
 
 use crate::support::{
@@ -171,6 +171,28 @@ fn install_fake_dev_runners(root: &TestDir, env: &mut BTreeMap<String, String>) 
     write_executable_script(&bin_dir.join("pnpm"), &pnpm);
     write_executable_script(&bin_dir.join("node"), &node);
     prepend_fake_bin(env, &bin_dir);
+}
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    stdout(&output).trim().to_string()
+}
+
+fn create_dev_source(
+    repo: &Path,
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> EnvMeta {
+    let created = run_ocm(cwd, env, &dev_plain(&[name, "--repo", &path_string(repo)]));
+    assert!(created.status.success(), "{}", stderr(&created));
+    get_environment(name, env, cwd).unwrap()
 }
 
 #[cfg(unix)]
@@ -563,6 +585,399 @@ fn env_destroy_yes_removes_dev_worktree() {
     let destroy = run_ocm(&cwd, &env, &["env", "destroy", "demo", "--yes"]);
     assert!(destroy.status.success(), "{}", stderr(&destroy));
     assert!(!worktree.exists(), "dev worktree should be removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn env_destroy_preserves_nested_registered_dev_source_and_worker() {
+    let root = TestDir::new("env-destroy-nested-dev-source");
+    let cwd = root.path();
+    let mut env = ocm_launchd_env(&root);
+    install_fake_launchctl(&root, &mut env);
+    install_fake_dev_runners(&root, &mut env);
+    let created = run_ocm(cwd, &env, &["env", "create", "parent"]);
+    assert!(created.status.success(), "{}", stderr(&created));
+    let parent = get_environment("parent", &env, cwd).unwrap();
+    let repo = Path::new(&parent.root).join(".openclaw/workspace/projects/openclaw");
+    fs::create_dir_all(repo.parent().unwrap()).unwrap();
+    fs::rename(init_openclaw_repo(&root), &repo).unwrap();
+    let child = create_dev_source(&repo, "child", &env, cwd);
+    let worktree = Path::new(&child.dev.as_ref().unwrap().worktree_root);
+    assert!(worktree.starts_with(Path::new(&parent.root)));
+    assert!(!Path::new(&child.root).starts_with(Path::new(&parent.root)));
+    let source = worktree.join("package.json");
+    let source_before = fs::read(&source).unwrap();
+    let mut aged = parent.clone();
+    aged.created_at -= time::Duration::days(30);
+    save_environment(aged, &env, cwd).unwrap();
+    let registry = ocm::store::env_registry_path(&env, cwd).unwrap();
+    let registry_before = fs::read(&registry).unwrap();
+    let direct = ocm::store::remove_environment("parent", true, &env, cwd).unwrap_err();
+    assert!(direct.contains("registered dev source"), "{direct}");
+    for args in [
+        vec!["env", "remove", "parent", "--force"],
+        vec!["env", "prune", "--older-than", "14", "--yes"],
+    ] {
+        let refused = run_ocm(cwd, &env, &args);
+        assert!(!refused.status.success(), "{}", stdout(&refused));
+        assert!(
+            stderr(&refused).contains("registered dev source"),
+            "{}",
+            stderr(&refused)
+        );
+    }
+    let mut worker = Command::new("python3")
+        .current_dir(worktree)
+        .args(["-c", "import time; time.sleep(60)"])
+        .env_clear()
+        .envs(&env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let destroy = run_ocm(
+        cwd,
+        &env,
+        &["env", "destroy", "parent", "--yes", "--force", "--json"],
+    );
+    let worker_alive = worker.try_wait().unwrap().is_none();
+    if worker_alive {
+        let _ = worker.kill();
+    }
+    let _ = worker.wait();
+    let source_unchanged = fs::read(&source).is_ok_and(|bytes| bytes == source_before);
+    let registry_unchanged = fs::read(&registry).unwrap() == registry_before;
+    assert!(
+        !destroy.status.success() && worker_alive && source_unchanged && registry_unchanged,
+        "destroy success={}, worker alive={worker_alive}, source unchanged={source_unchanged}, registry unchanged={registry_unchanged}; {} {}",
+        destroy.status.success(),
+        stdout(&destroy),
+        stderr(&destroy)
+    );
+    assert!(
+        stdout(&destroy).contains("registered dev source"),
+        "{}",
+        stdout(&destroy)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn env_cleanup_preserves_registered_dev_identity_paths() {
+    use std::os::unix::fs::symlink;
+    for layout in [
+        "common",
+        "repo-entry",
+        "source-bridge",
+        "git-bridge",
+        "private",
+        "repo-private",
+        "common-bridge",
+        "backlink-bridge",
+        "registry-bridge",
+    ] {
+        let root = TestDir::new(&format!("env-cleanup-identity-{layout}"));
+        let cwd = root.path();
+        let mut env = ocm_launchd_env(&root);
+        install_fake_launchctl(&root, &mut env);
+        install_fake_dev_runners(&root, &mut env);
+        let created = run_ocm(cwd, &env, &["env", "create", "parent"]);
+        assert!(created.status.success(), "{}", stderr(&created));
+        let parent = PathBuf::from(get_environment("parent", &env, cwd).unwrap().root);
+        let mut repo = init_openclaw_repo(&root);
+        if layout == "common" {
+            let contained = parent.join(".openclaw/workspace/projects/openclaw");
+            fs::create_dir_all(contained.parent().unwrap()).unwrap();
+            fs::rename(&repo, &contained).unwrap();
+            repo = root.child("outside-linked");
+            git(
+                &contained,
+                &["worktree", "add", "--detach", &path_string(&repo), "HEAD"],
+            );
+        } else if matches!(layout, "repo-entry" | "repo-private") {
+            let linked = if layout == "repo-entry" {
+                parent.join("linked")
+            } else {
+                root.child("outside-linked")
+            };
+            git(
+                &repo,
+                &["worktree", "add", "--detach", &path_string(&linked), "HEAD"],
+            );
+            repo = linked;
+        }
+        let pool = root.child("outside-pool");
+        fs::create_dir_all(&pool).unwrap();
+        let bridge = parent.join("bridge");
+        if matches!(layout, "repo-entry" | "source-bridge") {
+            symlink(&pool, &bridge).unwrap();
+            symlink(
+                if layout == "repo-entry" {
+                    &pool
+                } else {
+                    &bridge
+                },
+                repo.join(".worktrees"),
+            )
+            .unwrap();
+        } else if layout == "git-bridge" {
+            let metadata = root.child("outside-git");
+            fs::rename(repo.join(".git"), &metadata).unwrap();
+            symlink(&metadata, &bridge).unwrap();
+            symlink(&bridge, repo.join(".git")).unwrap();
+        }
+        let child = create_dev_source(&repo, "child", &env, cwd);
+        let worktree = Path::new(&child.dev.as_ref().unwrap().worktree_root);
+        let entrypoint = if layout == "repo-private" {
+            repo.as_path()
+        } else {
+            worktree
+        };
+        let private = PathBuf::from(git(entrypoint, &["rev-parse", "--absolute-git-dir"]));
+        let common = PathBuf::from(git(
+            entrypoint,
+            &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        ));
+        if matches!(layout, "private" | "repo-private") {
+            let moved = parent.join("private");
+            fs::rename(&private, &moved).unwrap();
+            fs::write(moved.join("commondir"), format!("{}\n", common.display())).unwrap();
+            symlink(&moved, &private).unwrap();
+        } else if layout == "common-bridge" {
+            symlink(&common, &bridge).unwrap();
+            fs::write(private.join("commondir"), format!("{}\n", bridge.display())).unwrap();
+        } else if layout == "backlink-bridge" {
+            symlink(worktree.parent().unwrap(), &bridge).unwrap();
+            fs::write(
+                private.join("gitdir"),
+                format!(
+                    "{}/.git\n",
+                    bridge.join(worktree.file_name().unwrap()).display()
+                ),
+            )
+            .unwrap();
+        } else if layout == "registry-bridge" {
+            let moved = root.child("outside-private");
+            fs::rename(&private, &moved).unwrap();
+            fs::write(moved.join("commondir"), format!("{}\n", common.display())).unwrap();
+            symlink(&moved, &bridge).unwrap();
+            symlink(&bridge, &private).unwrap();
+            fs::write(
+                worktree.join(".git"),
+                format!("gitdir: {}\n", moved.display()),
+            )
+            .unwrap();
+        }
+        let resumed = run_ocm(cwd, &env, &dev_plain(&["child"]));
+        assert!(resumed.status.success(), "{layout}: {}", stderr(&resumed));
+        let source_before = fs::read(worktree.join("package.json")).unwrap();
+        let registry = ocm::store::env_registry_path(&env, cwd).unwrap();
+        let registry_before = fs::read(&registry).unwrap();
+        let unrelated = root.child("unrelated-git");
+        fs::create_dir_all(&unrelated).unwrap();
+        git(&unrelated, &["init"]);
+        for overridden in [false, true] {
+            if overridden {
+                for key in ["GIT_DIR", "GIT_COMMON_DIR"] {
+                    env.insert(key.to_string(), path_string(&unrelated.join(".git")));
+                }
+                env.insert("GIT_WORK_TREE".to_string(), path_string(&unrelated));
+            }
+            let refused = run_ocm(
+                cwd,
+                &env,
+                &["env", "destroy", "parent", "--yes", "--force", "--json"],
+            );
+            assert!(!refused.status.success(), "{layout}: {}", stdout(&refused));
+            assert!(
+                stdout(&refused).contains("registered dev source"),
+                "{layout}: {} {}",
+                stdout(&refused),
+                stderr(&refused)
+            );
+            assert_eq!(fs::read(&registry).unwrap(), registry_before, "{layout}");
+            assert_eq!(
+                fs::read(worktree.join("package.json")).unwrap(),
+                source_before,
+                "{layout}"
+            );
+            git(worktree, &["status", "--porcelain"]);
+        }
+    }
+}
+
+#[test]
+fn env_remove_keeps_independent_owned_children_removable() {
+    let root = TestDir::new("env-remove-owned-child");
+    let repo = init_openclaw_repo(&root);
+    let mut env = ocm_launchd_env(&root);
+    install_fake_launchctl(&root, &mut env);
+    install_fake_dev_runners(&root, &mut env);
+    let parent = create_dev_source(&repo, "parent", &env, root.path());
+    let source = Path::new(&parent.dev.as_ref().unwrap().worktree_root);
+    create_dev_source(source, "child", &env, root.path());
+    let refused = run_ocm(root.path(), &env, &["env", "remove", "parent"]);
+    assert!(!refused.status.success());
+    assert!(
+        stderr(&refused).contains("registered dev source"),
+        "{}",
+        stderr(&refused)
+    );
+    let removed = run_ocm(root.path(), &env, &["env", "remove", "child"]);
+    assert!(removed.status.success(), "{}", stderr(&removed));
+
+    let tracked_file = source.join("scripts/run-node.mjs");
+    let original = fs::read(&tracked_file).unwrap();
+    let private = PathBuf::from(git(source, &["rev-parse", "--absolute-git-dir"]));
+    let misleading_index = root.child("misleading-index");
+    fs::copy(private.join("index"), &misleading_index).unwrap();
+    let hidden = Command::new("git")
+        .arg("-C")
+        .arg(source)
+        .args(["update-index", "--assume-unchanged", "scripts/run-node.mjs"])
+        .env("GIT_INDEX_FILE", &misleading_index)
+        .output()
+        .unwrap();
+    assert!(hidden.status.success(), "{}", stderr(&hidden));
+    fs::write(&tracked_file, "console.log('retained modification');\n").unwrap();
+    env.insert("GIT_INDEX_FILE".to_string(), path_string(&misleading_index));
+    let refused = run_ocm(root.path(), &env, &["env", "remove", "parent"]);
+    assert!(!refused.status.success());
+    assert!(
+        stderr(&refused).contains("modified or untracked files"),
+        "{}",
+        stderr(&refused)
+    );
+    assert_eq!(
+        fs::read_to_string(&tracked_file).unwrap(),
+        "console.log('retained modification');\n"
+    );
+    fs::write(&tracked_file, original).unwrap();
+    let removed = run_ocm(root.path(), &env, &["env", "remove", "parent"]);
+    assert!(removed.status.success(), "{}", stderr(&removed));
+}
+
+#[cfg(unix)]
+#[test]
+fn env_remove_preserves_missing_owned_worktree_recovery() {
+    for private_inside in [false, true] {
+        let root = TestDir::new(&format!(
+            "env-remove-missing-owned-recovery-{private_inside}"
+        ));
+        let mut env = ocm_launchd_env(&root);
+        install_fake_launchctl(&root, &mut env);
+        install_fake_dev_runners(&root, &mut env);
+        let created = run_ocm(root.path(), &env, &["env", "create", "parent"]);
+        assert!(created.status.success(), "{}", stderr(&created));
+        let parent = get_environment("parent", &env, root.path()).unwrap();
+        let mut repo = init_openclaw_repo(&root);
+        if !private_inside {
+            let contained = Path::new(&parent.root).join("project");
+            fs::rename(&repo, &contained).unwrap();
+            repo = contained;
+        }
+        let child = create_dev_source(&repo, "child", &env, root.path());
+        let worktree = Path::new(&child.dev.as_ref().unwrap().worktree_root);
+        fs::write(worktree.join("retained.txt"), "unique detached work\n").unwrap();
+        git(worktree, &["add", "retained.txt"]);
+        git(worktree, &["commit", "-m", "retain detached dev history"]);
+        let detached = git(worktree, &["rev-parse", "HEAD"]);
+        assert_ne!(detached, git(&repo, &["rev-parse", "HEAD"]));
+        if private_inside {
+            let private = PathBuf::from(git(worktree, &["rev-parse", "--absolute-git-dir"]));
+            let common = git(
+                worktree,
+                &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+            );
+            let moved = Path::new(&parent.root).join("private");
+            fs::rename(&private, &moved).unwrap();
+            fs::write(moved.join("commondir"), format!("{common}\n")).unwrap();
+            std::os::unix::fs::symlink(&moved, &private).unwrap();
+            let resumed = run_ocm(root.path(), &env, &dev_plain(&["child"]));
+            assert!(resumed.status.success(), "{}", stderr(&resumed));
+        }
+        fs::remove_dir_all(worktree).unwrap();
+        let refused = run_ocm(root.path(), &env, &["env", "remove", "parent"]);
+        assert!(!refused.status.success());
+        assert!(
+            stderr(&refused).contains("registered dev source"),
+            "{}",
+            stderr(&refused)
+        );
+        assert!(repo.join(".git").is_dir());
+        assert!(
+            git(&repo, &["worktree", "list", "--porcelain"]).contains(&format!("HEAD {detached}"))
+        );
+        assert!(
+            !worktree.exists(),
+            "cleanup must not recreate the missing worktree"
+        );
+        let replacement = run_ocm(
+            root.path(),
+            &env,
+            &[
+                "env",
+                "create",
+                "replacement",
+                "--root",
+                &path_string(worktree),
+            ],
+        );
+        assert!(replacement.status.success(), "{}", stderr(&replacement));
+        for name in ["replacement", "child", "parent"] {
+            let removed = run_ocm(root.path(), &env, &["env", "remove", name]);
+            assert!(removed.status.success(), "{}: {}", name, stderr(&removed));
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn env_remove_preserves_source_inside_owned_git_registration() {
+    for alias in [false, true] {
+        let root = TestDir::new(&format!("env-remove-registration-source-{alias}"));
+        let repo = init_openclaw_repo(&root);
+        if alias {
+            let pool = root.child("outside-pool");
+            fs::create_dir_all(&pool).unwrap();
+            std::os::unix::fs::symlink(pool, repo.join(".worktrees")).unwrap();
+        }
+        let mut env = ocm_launchd_env(&root);
+        install_fake_launchctl(&root, &mut env);
+        install_fake_dev_runners(&root, &mut env);
+        let owner = create_dev_source(&repo, "owner", &env, root.path());
+        let worktree = Path::new(&owner.dev.as_ref().unwrap().worktree_root);
+        let registration = PathBuf::from(git(worktree, &["rev-parse", "--absolute-git-dir"]));
+        let child_repo = registration.join("project");
+        git(
+            &repo,
+            &[
+                "clone",
+                "--quiet",
+                "--no-local",
+                &path_string(&repo),
+                &path_string(&child_repo),
+            ],
+        );
+        let child = create_dev_source(&child_repo, "child", &env, root.path());
+        let child_source = Path::new(&child.dev.as_ref().unwrap().worktree_root);
+        // Missing target files still leave a registration slot that Git removes.
+        fs::remove_dir_all(worktree).unwrap();
+        fs::remove_dir_all(&owner.root).unwrap();
+        let refused = run_ocm(root.path(), &env, &["env", "remove", "owner"]);
+        assert!(!refused.status.success());
+        assert!(
+            stderr(&refused).contains("registered dev source"),
+            "{}",
+            stderr(&refused)
+        );
+        assert!(child_source.join("package.json").is_file());
+        for name in ["child", "owner"] {
+            let removed = run_ocm(root.path(), &env, &["env", "remove", name]);
+            assert!(removed.status.success(), "{name}: {}", stderr(&removed));
+        }
+    }
 }
 
 #[test]

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -3231,6 +3231,128 @@ fn upgrade_simulate_reports_local_repo_doctor_failures() {
 
 #[cfg(unix)]
 #[test]
+fn upgrade_simulate_cleanup_preserves_registered_dev_source() {
+    for nested in [true, false] {
+        let root = TestDir::new(&format!("upgrade-simulate-registered-source-{nested}"));
+        let cwd = root.path();
+        let repo = init_openclaw_repo(&root);
+        let mut env = ocm_env(&root);
+        install_fake_node_and_npm(&root, &mut env, "22.22.3");
+        install_fake_simulation_pnpm(&root, &mut env);
+        env.insert("OCM_TEST_SIMULATION_DOCTOR_OK".to_string(), "1".to_string());
+        let protected_source = if nested {
+            env.insert("OCM_TEST_SOURCE_REPO".to_string(), path_string(&repo));
+            env.insert(
+                "OCM_TEST_SOURCE_CLI".to_string(),
+                path_string(&support::ocm_test_binary_path()),
+            );
+            env.insert(
+                "OCM_TEST_SOURCE_LOG".to_string(),
+                path_string(&root.child("child.log")),
+            );
+            let pnpm = root.child("fake-sim-bin/pnpm");
+            let original = fs::read_to_string(&pnpm).unwrap();
+            write_executable_script(
+                &pnpm,
+                &format!(
+                    r#"#!/bin/sh
+if [ "$1" = build ]; then
+  mkdir -p .artifacts
+  git clone --quiet --no-local "$OCM_TEST_SOURCE_REPO" .artifacts/project || exit 1
+  "$OCM_TEST_SOURCE_CLI" dev dependency --repo "$PWD/.artifacts/project" > "$OCM_TEST_SOURCE_LOG" 2>&1 || exit 1
+fi
+{}"#,
+                    original
+                ),
+            );
+            None
+        } else {
+            let created = run_ocm(
+                cwd,
+                &env,
+                &support::dev_plain(&["dependency", "--repo", &path_string(&repo)]),
+            );
+            assert!(created.status.success(), "{}", stderr(&created));
+            let peer = ocm::store::get_environment("dependency", &env, cwd).unwrap();
+            let source = PathBuf::from(peer.dev.unwrap().worktree_root);
+            fs::create_dir_all(source.join("dist")).unwrap();
+            fs::write(source.join("dist/sentinel"), "retained peer output\n").unwrap();
+            Some(source)
+        };
+        let started = run_ocm(
+            cwd,
+            &env,
+            &[
+                "start",
+                "demo",
+                "--command",
+                "pnpm openclaw",
+                "--cwd",
+                &path_string(&repo),
+                "--no-service",
+            ],
+        );
+        assert!(started.status.success(), "{}", stderr(&started));
+        if let Some(source) = &protected_source {
+            env.insert("GIT_DIR".to_string(), path_string(&repo.join(".git")));
+            env.insert(
+                "GIT_COMMON_DIR".to_string(),
+                path_string(&repo.join(".git")),
+            );
+            env.insert("GIT_WORK_TREE".to_string(), path_string(source));
+            env.insert(
+                "GIT_INDEX_FILE".to_string(),
+                path_string(&repo.join(".git/index")),
+            );
+        }
+        let simulated = run_ocm(
+            cwd,
+            &env,
+            &[
+                "upgrade",
+                "simulate",
+                "demo",
+                "--to",
+                &path_string(&repo),
+                "--json",
+            ],
+        );
+        let result: Value = serde_json::from_str(&stdout(&simulated)).unwrap();
+        assert_eq!(result["outcome"], "passed", "{result:#}");
+        let simulation_name = result["simulationEnv"].as_str().unwrap();
+        if let Some(source) = protected_source {
+            assert!(simulated.status.success(), "{result:#}");
+            assert_eq!(result["cleanup"], "cleaned", "{result:#}");
+            assert_eq!(
+                fs::read_to_string(source.join("dist/sentinel")).unwrap(),
+                "retained peer output\n"
+            );
+            assert!(!repo.join(".worktrees").join(simulation_name).exists());
+            assert!(ocm::store::get_environment(simulation_name, &env, cwd).is_err());
+        } else {
+            assert_eq!(result["cleanup"], "failed", "{result:#}");
+            assert!(
+                stdout(&simulated).contains("registered dev source"),
+                "{result:#}"
+            );
+            let child = ocm::store::get_environment("dependency", &env, cwd).unwrap();
+            assert!(
+                Path::new(&child.dev.unwrap().worktree_root)
+                    .join("package.json")
+                    .is_file()
+            );
+            let simulation = ocm::store::get_environment(simulation_name, &env, cwd).unwrap();
+            assert!(
+                Path::new(&simulation.dev.unwrap().worktree_root)
+                    .join(".artifacts/build.json")
+                    .is_file()
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn upgrade_simulate_preserves_passed_outcome_when_cleanup_fails() {
     let root = TestDir::new("upgrade-simulate-cleanup-outcome");
     let cwd = root.child("workspace");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users removing, pruning, or destroying an environment could delete another environment's registered dev source and Git metadata when those paths were inside the cleanup target. Destroy could also terminate workers using that source. Simulation cleanup could erase a registered source inside generated build output.

## Why This Change Was Made

Inspect registered source entry points, their required Git metadata, and the symlink paths connecting them before cleanup. Keep the environment registry locked through broad process teardown and final deletion. Apply the same repository and index selection to Git inspection and mutation.

Preserve directional removal of independent owned child worktrees, recoverable metadata for missing worktrees, and registered replacement state created at a formerly missing source path. Replacement ownership comes from the registry and applies to plain and dev-bound environments. The stored dev metadata format remains unchanged.

## User Impact

Cleanup explains which dependent dev environment must be removed first. Registered sources and their workers survive a refused cleanup, including sources reached through aliases or external Git metadata. README, usage guidance, and command help describe the boundary.

## Evidence

- Baseline `f9f2acc`: a real CLI destroy reported success after terminating a nested registered source's worker and deleting that source. A paired metadata case also reproduced deletion of required Git common metadata.
- Remote formatting, `cargo check --workspace --all-targets --locked`, and 19 focused tests passed on the corrected source. Coverage includes nine Git layouts with and without inherited selectors, plain and dev-bound replacement state through aliases, dirty and missing worktrees, partial teardown, watch stopping, and simulation cleanup.
- The replacement control reproduces unrelated-cleanup refusal on the earlier executable and passes on the corrected executable while preserving replacement bytes, registration, and detached Git history. Earlier permitted-child, Git-slot, and simulation-selector controls remain applicable.
- Two native CLI orderings passed: registration first preserves the source and worker; cleanup first holds the registry lock and rejects subsequent publication of the removed source. Both finish with an empty environment registry. This proof is reused across the replacement-only correction; lock and callback behavior is unchanged.
- Test fixtures and their process groups were removed. Full platform CI and exact-head review passed on the prepared commit.
