### PR TITLE
fix: lock source owners during dev registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ Plain and watched foreground sessions support `ocm dev stop <env>` and reuse a
 matching active session. `dev status` reports backend watching separately from
 session ownership.
 
+Creating or changing a dev binding is refused while an environment containing or
+owning its source, worktree path, or required Git metadata is busy with another operation.
+This also applies to local upgrade simulations; retry after that operation finishes.
+Unchanged source bindings remain writable during restore and recovery.
+
 New dev environments receive a private Gateway token in their initial config before
 the environment is registered. The token remains stable through restarts and
 source rebuilds, so paired clients can reconnect. Initialization never replaces an

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -97,6 +97,8 @@ ocm start luna --command 'pnpm openclaw' --cwd /path/to/openclaw --no-service
 Use this when you are developing OpenClaw locally or want a custom run command.
 
 For an isolated development worktree, use `ocm dev luna --repo /path/to/openclaw`.
+If an environment containing or owning the source or its required Git metadata is
+busy, retry dev creation or local upgrade simulation after its operation finishes.
 New dev environments publish a private config with a persistent Gateway token
 before registration, so paired clients can reconnect after a restart or source
 rebuild. Initialization preserves existing config files, including authored auth

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -25,9 +25,8 @@ use serde_json::Value;
 use super::Cli;
 use super::render::RenderProfile;
 use crate::env::{
-    CreateEnvironmentOptions, CreateSourceWatchOverrideOptions, EnvDevMeta, EnvMeta,
-    SourceWatchCompletion, SourceWatchEndpoint, SourceWatchLease, SourceWatchMode,
-    SourceWatchSession, SourceWatchState,
+    CreateEnvironmentOptions, CreateSourceWatchOverrideOptions, EnvMeta, SourceWatchCompletion,
+    SourceWatchEndpoint, SourceWatchLease, SourceWatchMode, SourceWatchSession, SourceWatchState,
 };
 use crate::infra::process::run_direct;
 #[cfg(unix)]
@@ -36,7 +35,7 @@ use crate::infra::process_identity::{ProcessIdentity, observe_process, process_s
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
 use crate::infra::terminal::{Cell, KeyValueRow, Tone, paint, render_key_value_card, render_table};
 use crate::openclaw_repo::{
-    detect_openclaw_checkout, discover_enclosing_openclaw_checkout, ensure_openclaw_worktree,
+    detect_openclaw_checkout, discover_enclosing_openclaw_checkout,
     ensure_source_dependency_install_target, inspect_source_dependencies,
     inspect_source_dependencies_with_runner,
 };
@@ -1313,29 +1312,20 @@ impl Cli {
         }
 
         let repo_root = self.resolve_dev_repo_root(repo_root)?;
-        let worktree_root = ensure_openclaw_worktree(&repo_root, name)?;
-
-        let created = self.environment_service().create(CreateEnvironmentOptions {
-            name: name.to_string(),
-            root,
-            gateway_port,
-            service_enabled: false,
-            service_running: false,
-            default_runtime: None,
-            default_launcher: None,
-            dev: Some(EnvDevMeta {
-                repo_root: display_path(&repo_root),
-                worktree_root: display_path(&worktree_root),
-            }),
-            protected: false,
-        });
-        let created = match created {
-            Ok(meta) => meta,
-            Err(error) => {
-                let _ = crate::openclaw_repo::remove_openclaw_worktree(&repo_root, &worktree_root);
-                return Err(error);
-            }
-        };
+        let created = self.environment_service().create_dev(
+            &repo_root,
+            CreateEnvironmentOptions {
+                name: name.to_string(),
+                root,
+                gateway_port,
+                service_enabled: false,
+                service_running: false,
+                default_runtime: None,
+                default_launcher: None,
+                dev: None,
+                protected: false,
+            },
+        )?;
 
         Ok((created, true))
     }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -15,11 +15,11 @@ use serde_json::{Value, json};
 
 use super::{Cli, render};
 use crate::env::{
-    CloneEnvironmentOptions, CreateEnvSnapshotOptions, EnvDevMeta, EnvSnapshotSummary,
+    CloneEnvironmentOptions, CreateEnvSnapshotOptions, EnvSnapshotSummary,
     RestoreEnvSnapshotOptions, resolve_runtime_run_dir,
 };
 use crate::infra::shell::{build_openclaw_dev_source_env, build_openclaw_env};
-use crate::openclaw_repo::{detect_openclaw_checkout, ensure_openclaw_worktree};
+use crate::openclaw_repo::detect_openclaw_checkout;
 use crate::runtime::releases::{
     OpenClawRelease, compare_runtime_release_versions, is_official_openclaw_releases_url,
     normalize_openclaw_channel_selector, official_openclaw_releases_url,
@@ -38,8 +38,9 @@ use crate::store::{
     install_runtime_from_selected_official_openclaw_release, list_upgrade_history,
     lock_env_registry, lock_upgrade_batch, lock_upgrade_participant, lock_upgrade_transaction,
     remove_runtime, remove_upgrade_recovery, resolve_absolute_path, runtime_install_root,
-    runtime_integrity_issue, runtime_meta_path, save_environment, save_upgrade_history_record,
-    upgrade_history_recovery_dir, upgrade_history_runtime_recovery_dir, write_json,
+    runtime_integrity_issue, runtime_meta_path, save_environment_with_dev_registration,
+    save_upgrade_history_record, upgrade_history_recovery_dir,
+    upgrade_history_runtime_recovery_dir, with_prepared_dev_source, write_json,
 };
 
 const UPGRADE_INTERRUPT_REQUESTED: usize = 1 << (usize::BITS - 1);
@@ -1970,15 +1971,24 @@ impl Cli {
                 ))
             }
             UpgradeSimulationTarget::LocalRepo { repo_root, .. } => {
-                let worktree_root = ensure_openclaw_worktree(repo_root, simulation_name)?;
                 let mut meta = self.environment_service().get(simulation_name)?;
                 meta.default_runtime = None;
                 meta.default_launcher = None;
-                meta.dev = Some(EnvDevMeta {
-                    repo_root: display_path(repo_root),
-                    worktree_root: display_path(&worktree_root),
-                });
-                let mut meta = save_environment(meta, &self.env, &self.cwd)?;
+                let mut meta = with_prepared_dev_source(
+                    repo_root,
+                    simulation_name,
+                    &self.env,
+                    &self.cwd,
+                    |dev, registration| {
+                        meta.dev = Some(dev);
+                        save_environment_with_dev_registration(
+                            meta,
+                            registration,
+                            &self.env,
+                            &self.cwd,
+                        )
+                    },
+                )?;
                 meta = self
                     .environment_service()
                     .apply_effective_gateway_port(meta)?;

--- a/src/env/lifecycle.rs
+++ b/src/env/lifecycle.rs
@@ -11,11 +11,11 @@ use crate::openclaw_repo::{
 use crate::runtime::RuntimeService;
 use crate::store::{
     EnvironmentOperationLock, clone_environment, clone_environment_for_simulation,
-    create_environment_with_validated_runtime, export_environment, get_environment,
-    get_runtime_verified, import_environment, list_environments, lock_environment_operation,
-    now_utc, remove_environment_locked, resolve_config_gateway_port,
-    resolve_effective_gateway_ports, resolve_env_gateway_port, save_environment,
-    set_environment_service_policy,
+    create_environment_with_dev_registration, create_environment_with_validated_runtime,
+    export_environment, get_environment, get_runtime_verified, import_environment,
+    list_environments, lock_environment_operation, now_utc, remove_environment_locked,
+    resolve_config_gateway_port, resolve_effective_gateway_ports, resolve_env_gateway_port,
+    save_environment, set_environment_service_policy, with_prepared_dev_source,
 };
 use crate::supervisor::{sync_supervisor_env_if_present, sync_supervisor_if_present};
 
@@ -245,6 +245,22 @@ impl<'a> EnvironmentService<'a> {
 
     pub fn create(&self, options: CreateEnvironmentOptions) -> Result<EnvMeta, String> {
         let meta = create_environment_with_validated_runtime(options, self.env, self.cwd)?;
+        sync_supervisor_env_if_present(self.env, self.cwd, &meta.name)?;
+        Ok(meta)
+    }
+
+    pub(crate) fn create_dev(
+        &self,
+        repo: &Path,
+        mut options: CreateEnvironmentOptions,
+    ) -> Result<EnvMeta, String> {
+        let name = options.name.clone();
+        let meta =
+            with_prepared_dev_source(repo, &name, self.env, self.cwd, |dev, registration| {
+                options.dev = Some(dev);
+                create_environment_with_dev_registration(options, registration, self.env, self.cwd)
+            })?;
+        // A sync error must preserve source whose binding was already published.
         sync_supervisor_env_if_present(self.env, self.cwd, &meta.name)?;
         Ok(meta)
     }

--- a/src/openclaw_repo.rs
+++ b/src/openclaw_repo.rs
@@ -382,10 +382,15 @@ pub(crate) fn validate_openclaw_worktree(
     Ok(())
 }
 
+pub(crate) struct OpenClawWorktree {
+    pub(crate) root: PathBuf,
+    pub(crate) created: bool,
+}
+
 pub(crate) fn ensure_openclaw_worktree(
     repo_root: &Path,
     env_name: &str,
-) -> Result<PathBuf, String> {
+) -> Result<OpenClawWorktree, String> {
     let repo_root = detect_openclaw_checkout(repo_root)
         .ok_or_else(|| format!("OpenClaw checkout not found at {}", display_path(repo_root)))?;
     let worktree_root = default_worktree_root(&repo_root, env_name);
@@ -396,7 +401,10 @@ pub(crate) fn ensure_openclaw_worktree(
         if !worktree_root.exists() {
             remove_registered_worktree(&repo_root, &worktree_root)?;
         } else if is_existing_openclaw_worktree(&repo_root, &worktree_root) {
-            return Ok(worktree_root);
+            return Ok(OpenClawWorktree {
+                root: worktree_root,
+                created: false,
+            });
         } else {
             return Err(format!(
                 "registered worktree is not a valid OpenClaw checkout: {}",
@@ -446,7 +454,10 @@ pub(crate) fn ensure_openclaw_worktree(
         ));
     }
 
-    Ok(worktree_root)
+    Ok(OpenClawWorktree {
+        root: worktree_root,
+        created: true,
+    })
 }
 
 pub(crate) fn remove_openclaw_worktree(
@@ -1072,12 +1083,13 @@ mod tests {
         let repo = fs::canonicalize(spaced).unwrap();
         let original = fs::read(repo.join("package.json")).unwrap();
         let worktree = ensure_openclaw_worktree(&repo, "plain.stop").unwrap();
+        assert!(worktree.created);
+        let worktree = worktree.root;
         assert!(worktree.is_absolute() && worktree.join(".git").is_file());
         assert_eq!(fs::read(worktree.join("package.json")).unwrap(), original);
-        assert_eq!(
-            ensure_openclaw_worktree(&repo, "plain.stop").unwrap(),
-            worktree
-        );
+        let reused = ensure_openclaw_worktree(&repo, "plain.stop").unwrap();
+        assert!(!reused.created);
+        assert_eq!(reused.root, worktree);
         remove_openclaw_worktree(&repo, &worktree).unwrap();
         assert!(!worktree.exists());
         assert_eq!(fs::read(repo.join("package.json")).unwrap(), original);
@@ -1086,7 +1098,7 @@ mod tests {
     #[test]
     fn simulation_cleanup_discards_ignored_outputs_only_for_owned_worktree() {
         let (_temp, repo) = init_openclaw_repo();
-        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
+        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap().root;
         for relative in [
             "node_modules/pkg/index.js",
             "extensions/demo/node_modules/pkg/index.js",
@@ -1123,7 +1135,7 @@ mod tests {
     #[test]
     fn simulation_cleanup_preserves_untracked_files() {
         let (_temp, repo) = init_openclaw_repo();
-        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
+        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap().root;
         fs::write(worktree.join("operator-notes.txt"), "preserve\n").unwrap();
 
         prepare_openclaw_simulation_worktree_cleanup(&repo, &worktree, "demo-sim").unwrap();
@@ -1138,7 +1150,7 @@ mod tests {
     #[test]
     fn simulation_cleanup_preserves_non_build_ignored_files() {
         let (_temp, repo) = init_openclaw_repo();
-        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
+        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap().root;
         fs::write(worktree.join(".env"), "PRIVATE_VALUE=preserve\n").unwrap();
         let generated = worktree.join("dist/index.js");
         fs::create_dir_all(generated.parent().unwrap()).unwrap();
@@ -1158,7 +1170,7 @@ mod tests {
     #[test]
     fn simulation_cleanup_does_not_touch_replaced_unregistered_checkout() {
         let (_temp, repo) = init_openclaw_repo();
-        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap();
+        let worktree = ensure_openclaw_worktree(&repo, "demo-sim").unwrap().root;
         run_git(
             &repo,
             &[

--- a/src/store/dev_registration.rs
+++ b/src/store/dev_registration.rs
@@ -1,0 +1,327 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::env::{EnvDevMeta, EnvMeta};
+use crate::openclaw_repo::{
+    default_worktree_root, ensure_openclaw_worktree, remove_openclaw_worktree,
+};
+
+use super::dev_sources::{
+    DevSourceRemoval, SourceFootprint, ensure_dev_worktree_removal_preserves_dev_sources,
+    existing_source_path_entries, inspect_dev_source_footprint, inspect_source_footprint,
+    path_identity,
+};
+use super::envs::{environment_operation_lock_path, try_lock_environment_operation};
+use super::{
+    EnvironmentOperationLock, display_path, list_environments, validate_name,
+    with_locked_environments,
+};
+
+#[derive(PartialEq, Eq)]
+struct SourceIdentity {
+    repo: SourceFootprint,
+    footprint: SourceFootprint,
+    paths: BTreeMap<PathBuf, (u64, u64)>,
+    locations: Vec<PathBuf>,
+    preparation_paths: BTreeSet<PathBuf>,
+}
+
+fn registration_path(path: &Path) -> Result<(PathBuf, BTreeSet<PathBuf>), String> {
+    let mut pending = path.to_path_buf();
+    let mut entries = BTreeSet::new();
+    loop {
+        let mut existing = pending.as_path();
+        loop {
+            match fs::canonicalize(existing) {
+                Ok(resolved) => {
+                    entries.extend(existing_source_path_entries(existing)?);
+                    let suffix = pending
+                        .strip_prefix(existing)
+                        .map_err(|error| error.to_string())?;
+                    return Ok((resolved.join(suffix), entries));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.to_string()),
+            }
+            // A registered symlink root may outlive its target during restore.
+            // Follow only this known link, retaining its own entry as a dependency.
+            match fs::read_link(existing) {
+                Ok(target) => {
+                    let parent = existing.parent().ok_or("source link has no parent")?;
+                    entries.extend(existing_source_path_entries(parent)?);
+                    let entry = fs::canonicalize(parent)
+                        .map_err(|error| error.to_string())?
+                        .join(existing.file_name().ok_or("source link has no name")?);
+                    if !entries.insert(entry) {
+                        return Err("dev source contains a symlink cycle".to_string());
+                    }
+                    let target = if target.is_absolute() {
+                        target
+                    } else {
+                        parent.join(target)
+                    };
+                    pending = target.join(
+                        pending
+                            .strip_prefix(existing)
+                            .map_err(|error| error.to_string())?,
+                    );
+                    break;
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::NotFound | std::io::ErrorKind::InvalidInput
+                    ) =>
+                {
+                    existing = existing
+                        .parent()
+                        .ok_or("dev source has no existing ancestor")?;
+                }
+                Err(error) => return Err(error.to_string()),
+            }
+        }
+    }
+}
+
+fn source_identity(dev: &EnvDevMeta) -> Result<SourceIdentity, String> {
+    let repo = inspect_source_footprint(Path::new(&dev.repo_root))?;
+    let mut footprint = inspect_dev_source_footprint(dev)?;
+    let mut preparation_paths = repo.entries.clone();
+    preparation_paths.extend(repo.content_roots.iter().cloned());
+    let mut locations = Vec::new();
+    // Before worktree creation, retain the existing path through .worktrees,
+    // including symlinks into another environment. This reserves no new paths.
+    for root in [&dev.repo_root, &dev.worktree_root] {
+        let (resolved, entries) = registration_path(Path::new(root))?;
+        locations.push(resolved);
+        preparation_paths.extend(entries.iter().cloned());
+        footprint.entries.extend(entries);
+    }
+    let paths = footprint
+        .entries
+        .iter()
+        .chain(&footprint.content_roots)
+        .map(|path| Ok((path.clone(), path_identity(path)?)))
+        .collect::<Result<_, String>>()?;
+    Ok(SourceIdentity {
+        repo,
+        footprint,
+        paths,
+        locations,
+        preparation_paths,
+    })
+}
+
+fn containing_environments(
+    identity: &SourceIdentity,
+    envs: &[EnvMeta],
+) -> Result<BTreeSet<String>, String> {
+    let mut owners = BTreeSet::new();
+    for meta in envs {
+        if DevSourceRemoval::environment(meta)?
+            .affected_path(&identity.footprint)?
+            .is_some()
+        {
+            owners.insert(meta.name.clone());
+            continue;
+        }
+        // Displaced roots still belong to the operation that will restore them.
+        for root in std::iter::once(meta.root.as_str())
+            .chain(meta.dev.as_ref().map(|dev| dev.worktree_root.as_str()))
+        {
+            let (root, _) = registration_path(Path::new(root))?;
+            if !root.exists()
+                && identity
+                    .locations
+                    .iter()
+                    .any(|path| path.starts_with(&root))
+            {
+                owners.insert(meta.name.clone());
+                break;
+            }
+        }
+    }
+    Ok(owners)
+}
+
+fn source_tuple(dev: Option<&EnvDevMeta>) -> Option<(&str, &str)> {
+    dev.map(|dev| (dev.repo_root.as_str(), dev.worktree_root.as_str()))
+}
+
+fn source_changed(name: &str, dev: Option<&EnvDevMeta>, envs: &[EnvMeta]) -> bool {
+    dev.is_some()
+        && source_tuple(dev)
+            != source_tuple(
+                envs.iter()
+                    .find(|meta| meta.name == name)
+                    .and_then(|meta| meta.dev.as_ref()),
+            )
+}
+
+#[derive(Default)]
+pub(crate) struct DevSourceRegistration {
+    source: Option<(EnvDevMeta, SourceIdentity)>,
+    owners: BTreeSet<String>,
+    _locks: Vec<EnvironmentOperationLock>,
+    held_files: BTreeSet<(u64, u64)>,
+}
+
+impl DevSourceRegistration {
+    pub(crate) fn acquire(
+        name: &str,
+        dev: Option<&EnvDevMeta>,
+        env: &BTreeMap<String, String>,
+        cwd: &Path,
+    ) -> Result<Self, String> {
+        let name = validate_name(name, "Environment name")?;
+        let Some(dev) = dev else {
+            return Ok(Self::default());
+        };
+        let envs = list_environments(env, cwd)?;
+        if !source_changed(&name, Some(dev), &envs) {
+            return Ok(Self::default());
+        }
+        Self::lock_source(dev, &envs, env, cwd)
+    }
+
+    fn lock_source(
+        dev: &EnvDevMeta,
+        envs: &[EnvMeta],
+        env: &BTreeMap<String, String>,
+        cwd: &Path,
+    ) -> Result<Self, String> {
+        let identity = source_identity(dev)?;
+        let mut registration = Self {
+            source: Some((dev.clone(), identity)),
+            ..Self::default()
+        };
+        registration.lock_owners(envs, env, cwd)?;
+        Ok(registration)
+    }
+
+    fn lock_owners(
+        &mut self,
+        envs: &[EnvMeta],
+        env: &BTreeMap<String, String>,
+        cwd: &Path,
+    ) -> Result<(), String> {
+        let Some((_, identity)) = &self.source else {
+            return Err(Self::changed());
+        };
+        let owners = containing_environments(identity, envs)?;
+        for owner in owners.difference(&self.owners).cloned().collect::<Vec<_>>() {
+            let path = environment_operation_lock_path(&owner, env, cwd)?;
+            // Distinct registered names can share a lock on case-insensitive filesystems.
+            if !path_identity(&path).is_ok_and(|identity| self.held_files.contains(&identity)) {
+                let lock = try_lock_environment_operation(&owner, env, cwd)?.ok_or_else(|| format!(
+                    "cannot register dev source while environment {owner} has an operation in progress; retry after it finishes"
+                ))?;
+                self.held_files.insert(path_identity(&path)?);
+                self._locks.push(lock);
+            }
+            self.owners.insert(owner);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn recheck(
+        &self,
+        name: &str,
+        dev: Option<&EnvDevMeta>,
+        envs: &[EnvMeta],
+    ) -> Result<(), String> {
+        // Recovery writes can run with the target operation lock already held,
+        // including while its source is displaced. Recheck the tuple under registry.
+        if !source_changed(name.trim(), dev, envs) {
+            return Ok(());
+        }
+        self.recheck_source(dev.ok_or("missing dev source")?, envs)
+    }
+
+    fn recheck_source(&self, dev: &EnvDevMeta, envs: &[EnvMeta]) -> Result<(), String> {
+        let Some((expected, identity)) = &self.source else {
+            return Err(Self::changed());
+        };
+        if source_tuple(Some(expected)) != source_tuple(Some(dev))
+            || source_identity(dev)? != *identity
+        {
+            return Err(Self::changed());
+        }
+        if !containing_environments(identity, envs)?.is_subset(&self.owners) {
+            return Err(Self::changed());
+        }
+        Ok(())
+    }
+
+    fn prepared(&mut self, dev: &EnvDevMeta, created: bool) -> Result<(), String> {
+        let Some((expected, before)) = &self.source else {
+            return Err(Self::changed());
+        };
+        let after = source_identity(dev)?;
+        if source_tuple(Some(expected)) != source_tuple(Some(dev))
+            || (!created && *before != after)
+            || before.repo != after.repo
+            || before.preparation_paths.iter().any(|path| {
+                !path_identity(path).is_ok_and(|current| before.paths.get(path) == Some(&current))
+            })
+        {
+            return Err(Self::changed());
+        }
+        self.source = Some((dev.clone(), after));
+        Ok(())
+    }
+
+    fn changed() -> String {
+        "dev source or containing environment changed during registration; retry the command"
+            .to_string()
+    }
+}
+
+pub(crate) fn with_prepared_dev_source<T>(
+    repo: &Path,
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+    publish: impl FnOnce(EnvDevMeta, &DevSourceRegistration) -> Result<T, String>,
+) -> Result<T, String> {
+    let name = validate_name(name, "Environment name")?;
+    let dev = EnvDevMeta {
+        repo_root: display_path(repo),
+        worktree_root: display_path(&default_worktree_root(repo, &name)),
+    };
+    let mut registration =
+        DevSourceRegistration::lock_source(&dev, &list_environments(env, cwd)?, env, cwd)?;
+    with_locked_environments(env, cwd, |envs| registration.recheck_source(&dev, envs))?;
+    let worktree = ensure_openclaw_worktree(repo, &name)?;
+    let result = registration
+        .prepared(&dev, worktree.created)
+        .and_then(|()| publish(dev.clone(), &registration));
+    if let Err(error) = result {
+        if worktree.created {
+            // Publication locks have dropped. A newly registered owner may now
+            // need its operation lock for cleanup, acquired before registry.
+            let cleanup = list_environments(env, cwd)
+                .and_then(|envs| registration.lock_owners(&envs, env, cwd))
+                .and_then(|()| {
+                    with_locked_environments(env, cwd, |envs| {
+                        registration.recheck_source(&dev, envs)?;
+                        ensure_dev_worktree_removal_preserves_dev_sources(&name, &dev, envs)?;
+                        remove_openclaw_worktree(repo, &worktree.root)
+                    })
+                });
+            if let Err(cleanup) = cleanup {
+                return Err(format!(
+                    "{error}; prepared worktree retained at {}: {cleanup}",
+                    display_path(&worktree.root)
+                ));
+            }
+        }
+        return Err(error);
+    }
+    result
+}
+
+#[cfg(test)]
+#[path = "dev_registration_tests.rs"]
+mod tests;

--- a/src/store/dev_registration_tests.rs
+++ b/src/store/dev_registration_tests.rs
@@ -1,0 +1,191 @@
+use std::process::Command;
+
+use super::*;
+use crate::env::CreateEnvironmentOptions;
+use crate::store::{
+    create_environment, create_environment_with_validated_runtime, derive_env_paths,
+    get_environment, lock_environment_operation, save_environment,
+    save_environment_with_dev_registration, save_environment_with_validated_launcher,
+    save_environment_with_validated_runtime,
+};
+
+type Save = fn(EnvMeta, &BTreeMap<String, String>, &Path) -> Result<EnvMeta, String>;
+const SAVES: [Save; 3] = [
+    save_environment,
+    save_environment_with_validated_launcher,
+    save_environment_with_validated_runtime,
+];
+
+fn options(name: &str, dev: Option<EnvDevMeta>) -> CreateEnvironmentOptions {
+    CreateEnvironmentOptions {
+        name: name.to_string(),
+        root: None,
+        gateway_port: Some(19789),
+        service_enabled: false,
+        service_running: false,
+        default_runtime: None,
+        default_launcher: None,
+        dev,
+        protected: false,
+    }
+}
+
+fn owned_source(repo: &Path) -> EnvDevMeta {
+    fs::create_dir_all(repo.join("scripts")).unwrap();
+    fs::write(repo.join("package.json"), r#"{"name":"openclaw"}"#).unwrap();
+    fs::write(repo.join("scripts/run-node.mjs"), "").unwrap();
+    for args in [&["init"][..], &["add", "."], &["commit", "-m", "fixture"]] {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", repo.join("unused-global-config"))
+            .args([
+                "-c",
+                "user.name=OCM Tests",
+                "-c",
+                "user.email=tests@example.invalid",
+            ])
+            .args(["-c", "commit.gpgsign=false"])
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let worktree = ensure_openclaw_worktree(repo, "child").unwrap();
+    assert!(worktree.created);
+    EnvDevMeta {
+        repo_root: display_path(repo),
+        worktree_root: display_path(&worktree.root),
+    }
+}
+
+fn fixture() -> (tempfile::TempDir, BTreeMap<String, String>, EnvDevMeta) {
+    let temp = tempfile::tempdir().unwrap();
+    let env = BTreeMap::from([
+        ("HOME".to_string(), display_path(&temp.path().join("home"))),
+        (
+            "OCM_HOME".to_string(),
+            display_path(&temp.path().join("ocm-home")),
+        ),
+    ]);
+    let parent = create_environment(options("parent", None), &env, temp.path()).unwrap();
+    let repo = derive_env_paths(Path::new(&parent.root))
+        .workspace_dir
+        .join("openclaw");
+    let dev = owned_source(&repo);
+    (temp, env, dev)
+}
+
+#[test]
+fn every_publisher_refuses_a_new_or_changed_source_during_its_owners_operation() {
+    let (temp, env, dev) = fixture();
+    let cwd = temp.path();
+    let mut changed = create_environment(options("child", Some(dev.clone())), &env, cwd).unwrap();
+    let replacement = ensure_openclaw_worktree(Path::new(&dev.repo_root), "replacement").unwrap();
+    changed.dev.as_mut().unwrap().worktree_root = display_path(&replacement.root);
+    let _owner = lock_environment_operation("parent", &env, cwd).unwrap();
+    for save in SAVES {
+        let error = save(changed.clone(), &env, cwd).unwrap_err();
+        assert!(
+            error.contains("parent has an operation in progress"),
+            "{error}"
+        );
+    }
+    for create in [
+        create_environment,
+        create_environment_with_validated_runtime,
+    ] {
+        let error = create(options("new-child", changed.dev.clone()), &env, cwd).unwrap_err();
+        assert!(
+            error.contains("parent has an operation in progress"),
+            "{error}"
+        );
+    }
+    let current = get_environment("child", &env, cwd).unwrap();
+    assert_eq!(source_tuple(current.dev.as_ref()), source_tuple(Some(&dev)));
+    assert!(get_environment("new-child", &env, cwd).is_err());
+}
+
+#[test]
+fn unchanged_source_saves_allow_locked_recovery_with_displaced_source() {
+    let (temp, env, dev) = fixture();
+    let cwd = temp.path();
+    let mut child = create_environment(options("child", Some(dev.clone())), &env, cwd).unwrap();
+    let mut pending = create_environment(options("pending", None), &env, cwd).unwrap();
+    pending.dev = Some(dev.clone());
+    let _owner = lock_environment_operation("parent", &env, cwd).unwrap();
+    let _target = lock_environment_operation("child", &env, cwd).unwrap();
+    let parent = get_environment("parent", &env, cwd).unwrap();
+    fs::rename(&parent.root, temp.path().join("displaced-parent")).unwrap();
+    for save in SAVES {
+        child.protected = !child.protected;
+        save(child.clone(), &env, cwd).unwrap();
+        let current = get_environment("child", &env, cwd).unwrap();
+        assert_eq!(current.protected, child.protected);
+        assert_eq!(source_tuple(current.dev.as_ref()), source_tuple(Some(&dev)));
+    }
+    drop(_target);
+    for save in SAVES {
+        assert!(
+            save(pending.clone(), &env, cwd)
+                .unwrap_err()
+                .contains("parent has an operation in progress")
+        );
+    }
+    let error = create_environment(options("new-child", Some(dev.clone())), &env, cwd).unwrap_err();
+    assert!(
+        error.contains("parent has an operation in progress"),
+        "{error}"
+    );
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(temp.path().join("missing-parent"), &parent.root).unwrap();
+        let independent = owned_source(&temp.path().join("independent"));
+        create_environment(options("independent", Some(independent)), &env, cwd).unwrap();
+        let error =
+            create_environment(options("new-child", Some(dev.clone())), &env, cwd).unwrap_err();
+        assert!(
+            error.contains("parent has an operation in progress"),
+            "{error}"
+        );
+    }
+    drop(_owner);
+    create_environment(options("new-child", Some(dev)), &env, cwd).unwrap();
+}
+
+#[test]
+fn publication_rechecks_late_owners_and_replaced_source_without_taking_locks() {
+    let (temp, env, dev) = fixture();
+    let cwd = temp.path();
+    let mut child = create_environment(options("child", None), &env, cwd).unwrap();
+    let mut late = create_environment(options("late", None), &env, cwd).unwrap();
+    child.dev = Some(dev.clone());
+    let registration =
+        DevSourceRegistration::acquire("child", child.dev.as_ref(), &env, cwd).unwrap();
+    let original_root = late.root.clone();
+    late.root = dev.repo_root.clone();
+    save_environment(late.clone(), &env, cwd).unwrap();
+    let late_lock = environment_operation_lock_path("late", &env, cwd).unwrap();
+    assert!(!late_lock.exists());
+    let error = save_environment_with_dev_registration(child.clone(), &registration, &env, cwd)
+        .unwrap_err();
+    assert!(error.contains("changed during registration"), "{error}");
+    assert!(
+        !late_lock.exists(),
+        "registry recheck attempted to acquire a new owner lock"
+    );
+    late.root = original_root;
+    save_environment(late, &env, cwd).unwrap();
+    fs::rename(&dev.repo_root, temp.path().join("original-source")).unwrap();
+    let replacement = owned_source(Path::new(&dev.repo_root));
+    assert_eq!(source_tuple(Some(&replacement)), source_tuple(Some(&dev)));
+    let error =
+        save_environment_with_dev_registration(child, &registration, &env, cwd).unwrap_err();
+    assert!(error.contains("changed during registration"), "{error}");
+    assert!(get_environment("child", &env, cwd).unwrap().dev.is_none());
+}

--- a/src/store/dev_sources.rs
+++ b/src/store/dev_sources.rs
@@ -287,92 +287,138 @@ pub(crate) fn ensure_environment_removal_preserves_dev_sources(
     if footprints.is_empty() {
         return Ok(());
     }
-    let root_path = Path::new(&target.root);
-    let root = existing_cleanup_path(root_path)?;
-    let worktree = target
-        .dev
-        .as_ref()
-        .map(|dev| existing_cleanup_path(Path::new(&dev.worktree_root)))
-        .transpose()?
-        .flatten();
-    // Removing a final symlink also changes its containing source, even when
-    // the link resolves outside that source (or its destination is missing).
-    let entry_parent = if fs::symlink_metadata(root_path).is_ok_and(|meta| meta.is_symlink()) {
-        root_path
-            .parent()
-            .map(existing_cleanup_path)
-            .transpose()?
-            .flatten()
-    } else {
-        None
-    };
-    let mut registrations = Vec::new();
-    let mut registration_links = Vec::new();
-    if let Some(dev) = &target.dev {
-        for path in crate::openclaw_repo::worktree_registration_entries(
-            Path::new(&dev.repo_root),
-            Path::new(&dev.worktree_root),
-        )? {
-            if fs::symlink_metadata(&path)
-                .map_err(|error| error.to_string())?
-                .is_symlink()
-            {
-                // Git unlinks the administrative slot itself, not its referent.
-                let parent =
-                    fs::canonicalize(path.parent().unwrap()).map_err(|error| error.to_string())?;
-                registration_links.push(parent.join(path.file_name().unwrap()));
-            } else {
-                registrations.push(fs::canonicalize(path).map_err(|error| error.to_string())?);
-            }
-        }
-    }
-    if root.is_none()
-        && worktree.is_none()
-        && entry_parent.is_none()
-        && registrations.is_empty()
-        && registration_links.is_empty()
-    {
-        return Ok(());
-    }
-    let preserve = |path: &Path, owner: &str, contents: bool| -> Result<(), String> {
-        let mut affected = false;
-        // An owned child worktree may be removed from inside another source.
-        // Refuse only when that worktree itself contains a protected path.
-        for (root, symmetric) in [(root.as_ref(), true), (worktree.as_ref(), false)] {
-            if let Some(root) = root {
-                affected |= contains_existing(root, path)?
-                    || (symmetric && contents && contains_existing(path, root)?);
-            }
-        }
-        if let Some(parent) = &entry_parent
-            && contents
-        {
-            affected |= contains_existing(path, parent)?;
-        }
-        for root in &registrations {
-            affected |= contains_existing(root, path)?;
-        }
-        for entry in &registration_links {
-            affected |= path_identity(entry)? == path_identity(path)?;
-        }
-        if affected {
-            return Err(format!(
-                "cleanup for env {} would affect registered dev source for env {owner} at {}; remove the dependent dev env first",
-                target.name,
-                display_path(path)
-            ));
-        }
-        Ok(())
-    };
+    let removal = DevSourceRemoval::environment(target)?;
     for (owner, footprint) in footprints {
-        for path in &footprint.entries {
-            preserve(path, owner, false)?;
-        }
-        for path in &footprint.content_roots {
-            preserve(path, owner, true)?;
+        if let Some(path) = removal.affected_path(&footprint)? {
+            return Err(source_removal_error(&target.name, owner, path));
         }
     }
     Ok(())
+}
+
+pub(crate) fn ensure_dev_worktree_removal_preserves_dev_sources(
+    name: &str,
+    dev: &EnvDevMeta,
+    envs: &[EnvMeta],
+) -> Result<(), String> {
+    let removal = DevSourceRemoval::worktree(dev)?;
+    for meta in envs {
+        if let Some(footprint) = registered_dev_source_footprint(meta, envs)?
+            && let Some(path) = removal.affected_path(&footprint)?
+        {
+            return Err(source_removal_error(name, &meta.name, path));
+        }
+    }
+    Ok(())
+}
+
+fn source_removal_error(name: &str, owner: &str, path: &Path) -> String {
+    format!(
+        "cleanup for env {name} would affect registered dev source for env {owner} at {}; remove the dependent dev env first",
+        display_path(path)
+    )
+}
+
+// Both removal and registration use the actual deletion boundaries. In
+// particular, an owned child worktree does not own its shared common directory.
+pub(crate) struct DevSourceRemoval {
+    root: Option<PathBuf>,
+    worktree: Option<PathBuf>,
+    entry_parent: Option<PathBuf>,
+    registrations: Vec<PathBuf>,
+    registration_links: Vec<PathBuf>,
+}
+
+impl DevSourceRemoval {
+    pub(crate) fn environment(target: &EnvMeta) -> Result<Self, String> {
+        Self::new(Some(Path::new(&target.root)), target.dev.as_ref())
+    }
+
+    fn worktree(dev: &EnvDevMeta) -> Result<Self, String> {
+        Self::new(None, Some(dev))
+    }
+
+    fn new(root_path: Option<&Path>, dev: Option<&EnvDevMeta>) -> Result<Self, String> {
+        let root = root_path.map(existing_cleanup_path).transpose()?.flatten();
+        let worktree = dev
+            .map(|dev| existing_cleanup_path(Path::new(&dev.worktree_root)))
+            .transpose()?
+            .flatten();
+        // Removing a final symlink also changes its containing source, even when
+        // the link resolves outside that source (or its destination is missing).
+        let entry_parent = match root_path {
+            Some(path) if fs::symlink_metadata(path).is_ok_and(|meta| meta.is_symlink()) => path
+                .parent()
+                .map(existing_cleanup_path)
+                .transpose()?
+                .flatten(),
+            _ => None,
+        };
+        let mut registrations = Vec::new();
+        let mut registration_links = Vec::new();
+        if let Some(dev) = dev {
+            for path in crate::openclaw_repo::worktree_registration_entries(
+                Path::new(&dev.repo_root),
+                Path::new(&dev.worktree_root),
+            )? {
+                if fs::symlink_metadata(&path)
+                    .map_err(|error| error.to_string())?
+                    .is_symlink()
+                {
+                    // Git unlinks the administrative slot itself, not its referent.
+                    let parent = fs::canonicalize(path.parent().unwrap())
+                        .map_err(|error| error.to_string())?;
+                    registration_links.push(parent.join(path.file_name().unwrap()));
+                } else {
+                    registrations.push(fs::canonicalize(path).map_err(|error| error.to_string())?);
+                }
+            }
+        }
+        Ok(Self {
+            root,
+            worktree,
+            entry_parent,
+            registrations,
+            registration_links,
+        })
+    }
+
+    pub(crate) fn affected_path<'a>(
+        &self,
+        footprint: &'a SourceFootprint,
+    ) -> Result<Option<&'a Path>, String> {
+        for (path, contents) in footprint
+            .entries
+            .iter()
+            .map(|path| (path, false))
+            .chain(footprint.content_roots.iter().map(|path| (path, true)))
+        {
+            let mut affected = false;
+            // An owned child worktree may be removed from inside another source.
+            // Refuse only when that worktree itself contains a protected path.
+            for (root, symmetric) in [(self.root.as_ref(), true), (self.worktree.as_ref(), false)] {
+                if let Some(root) = root {
+                    affected |= contains_existing(root, path)?
+                        || (symmetric && contents && contains_existing(path, root)?);
+                }
+            }
+            if let Some(parent) = &self.entry_parent
+                && contents
+            {
+                affected |= contains_existing(path, parent)?;
+            }
+            for root in &self.registrations {
+                affected |= contains_existing(root, path)?;
+            }
+            for entry in &self.registration_links {
+                affected |= path_identity(entry)? == path_identity(path)?;
+            }
+            if affected {
+                return Ok(Some(path));
+            }
+        }
+        Ok(None)
+    }
 }
 
 pub(crate) fn ensure_root_outside_dev_sources(

--- a/src/store/envs.rs
+++ b/src/store/envs.rs
@@ -33,7 +33,7 @@ use super::layout::{
 };
 use super::now_utc;
 use super::{
-    OpenClawWorkspaceRuntime, clear_nonportable_runtime_state,
+    DevSourceRegistration, OpenClawWorkspaceRuntime, clear_nonportable_runtime_state,
     normalize_new_environment_sandbox_origin, openclaw_config_include_paths,
     openclaw_config_uses_includes, openclaw_env_archive_options,
     reject_include_owned_agent_workspaces, reject_include_owned_sandbox_origin,
@@ -99,9 +99,7 @@ pub(crate) struct EnvRegistryLock {
     file: File,
 }
 
-pub(crate) struct EnvironmentOperationLock {
-    file: File,
-}
+pub(crate) type EnvironmentOperationLock = super::common::ExclusiveFileLock;
 
 impl Drop for EnvRegistryLock {
     fn drop(&mut self) {
@@ -109,10 +107,19 @@ impl Drop for EnvRegistryLock {
     }
 }
 
-impl Drop for EnvironmentOperationLock {
-    fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.file);
-    }
+pub(super) fn environment_operation_lock_path(
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<PathBuf, String> {
+    // Every env binding, service, snapshot, and guarded-destroy mutation shares
+    // this lock. Bypassing it can make an accepted destroy token stale.
+    let safe_name = validate_name(name, "Environment name")?;
+    Ok(resolve_store_paths(env, cwd)?
+        .home
+        .join("locks")
+        .join("environments")
+        .join(format!("{safe_name}.lock")))
 }
 
 pub(crate) fn lock_environment_operation(
@@ -120,34 +127,21 @@ pub(crate) fn lock_environment_operation(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvironmentOperationLock, String> {
-    // Every env binding, service, snapshot, and guarded-destroy mutation shares
-    // this lock. Bypassing it can make an accepted destroy token stale.
-    let safe_name = validate_name(name, "Environment name")?;
-    let lock_dir = resolve_store_paths(env, cwd)?
-        .home
-        .join("locks")
-        .join("environments");
-    ensure_dir(&lock_dir)?;
-    let lock_path = lock_dir.join(format!("{safe_name}.lock"));
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
-        .open(&lock_path)
-        .map_err(|error| {
-            format!(
-                "failed to open environment operation lock {}: {error}",
-                display_path(&lock_path)
-            )
-        })?;
-    file.lock_exclusive().map_err(|error| {
-        format!(
-            "failed to lock environment operation {}: {error}",
-            display_path(&lock_path)
-        )
-    })?;
-    Ok(EnvironmentOperationLock { file })
+    super::lock_file(
+        &environment_operation_lock_path(name, env, cwd)?,
+        "environment operation",
+    )
+}
+
+pub(super) fn try_lock_environment_operation(
+    name: &str,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<Option<EnvironmentOperationLock>, String> {
+    super::try_lock_file(
+        &environment_operation_lock_path(name, env, cwd)?,
+        "environment operation",
+    )
 }
 
 pub(crate) fn lock_env_registry(
@@ -257,7 +251,17 @@ pub fn get_environment(
 }
 
 pub fn save_environment(
+    meta: EnvMeta,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
+    let registration = DevSourceRegistration::acquire(&meta.name, meta.dev.as_ref(), env, cwd)?;
+    save_environment_with_dev_registration(meta, &registration, env, cwd)
+}
+
+pub(crate) fn save_environment_with_dev_registration(
     mut meta: EnvMeta,
+    registration: &DevSourceRegistration,
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
@@ -265,6 +269,7 @@ pub fn save_environment(
     let _admission_lock = service.lock_gateway_admission(&meta.name)?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
+    registration.recheck(&meta.name, meta.dev.as_ref(), &registry.envs)?;
     let policy_changed = find_environment(&registry, &meta.name).is_some_and(|current| {
         current.service_enabled != meta.service_enabled
             || current.service_running != meta.service_running
@@ -286,8 +291,10 @@ pub(crate) fn save_environment_with_validated_launcher(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
+    let registration = DevSourceRegistration::acquire(&meta.name, meta.dev.as_ref(), env, cwd)?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
+    registration.recheck(&meta.name, meta.dev.as_ref(), &registry.envs)?;
     meta = canonicalize_launcher_binding(meta, env, cwd)?;
     meta = upsert_environment(&mut registry, meta)?;
     write_env_registry(&mut registry, env, cwd)?;
@@ -300,8 +307,10 @@ pub(crate) fn save_environment_with_validated_runtime(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
+    let registration = DevSourceRegistration::acquire(&meta.name, meta.dev.as_ref(), env, cwd)?;
     let _lock = lock_env_registry(env, cwd)?;
     let mut registry = load_env_registry(env, cwd)?;
+    registration.recheck(&meta.name, meta.dev.as_ref(), &registry.envs)?;
     if let Some(runtime_name) = meta.default_runtime.as_deref() {
         meta.default_runtime =
             Some(super::runtimes::get_runtime_verified(runtime_name, env, cwd)?.name);
@@ -393,7 +402,7 @@ pub fn create_environment(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
-    create_environment_with_runtime_validation(options, false, env, cwd)
+    create_environment_with_runtime_validation(options, false, None, env, cwd)
 }
 
 pub(crate) fn create_environment_with_validated_runtime(
@@ -401,16 +410,34 @@ pub(crate) fn create_environment_with_validated_runtime(
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
-    create_environment_with_runtime_validation(options, true, env, cwd)
+    create_environment_with_runtime_validation(options, true, None, env, cwd)
+}
+
+pub(crate) fn create_environment_with_dev_registration(
+    options: CreateEnvironmentOptions,
+    registration: &DevSourceRegistration,
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<EnvMeta, String> {
+    create_environment_with_runtime_validation(options, true, Some(registration), env, cwd)
 }
 
 fn create_environment_with_runtime_validation(
     options: CreateEnvironmentOptions,
     validate_runtime: bool,
+    registration: Option<&DevSourceRegistration>,
     env: &BTreeMap<String, String>,
     cwd: &Path,
 ) -> Result<EnvMeta, String> {
     let name = validate_name(&options.name, "Environment name")?;
+    let acquired;
+    let registration = match registration {
+        Some(registration) => registration,
+        None => {
+            acquired = DevSourceRegistration::acquire(&name, options.dev.as_ref(), env, cwd)?;
+            &acquired
+        }
+    };
     let service = crate::env::EnvironmentService::new(env, cwd);
     let _admission_lock = service.lock_gateway_admission(&name)?;
     if options.service_enabled && options.service_running {
@@ -421,6 +448,7 @@ fn create_environment_with_runtime_validation(
     if find_environment(&registry, &name).is_some() {
         return Err(format!("environment \"{name}\" already exists"));
     }
+    registration.recheck(&name, options.dev.as_ref(), &registry.envs)?;
     let default_runtime = if validate_runtime {
         options
             .default_runtime

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,6 +1,7 @@
 mod checkpoint_scope;
 mod checkpoints;
 mod common;
+mod dev_registration;
 pub(crate) mod dev_sources;
 mod envs;
 mod gateway_ports;
@@ -25,6 +26,7 @@ pub(crate) use common::{
     ExclusiveFileLock, copy_dir_recursive, ensure_dir, lock_file, read_json, try_lock_file,
     write_json,
 };
+pub(crate) use dev_registration::{DevSourceRegistration, with_prepared_dev_source};
 pub(crate) use dev_sources::ensure_environment_removal_preserves_dev_sources;
 pub(crate) use envs::{
     EnvironmentOperationLock, lock_env_registry, lock_environment_operation,
@@ -40,11 +42,12 @@ pub use envs::{
 };
 pub(crate) use envs::{
     clone_environment_for_simulation, clone_environment_with_sandbox_origin,
-    create_environment_with_validated_runtime, import_environment_with_sandbox_origin,
+    create_environment_with_dev_registration, create_environment_with_validated_runtime,
+    import_environment_with_sandbox_origin,
 };
 pub(crate) use envs::{
-    save_environment_with_validated_launcher, save_environment_with_validated_runtime,
-    with_locked_environments,
+    save_environment_with_dev_registration, save_environment_with_validated_launcher,
+    save_environment_with_validated_runtime, with_locked_environments,
 };
 pub(crate) use gateway_ports::{
     openclaw_port_family_available, openclaw_port_family_range, resolve_config_gateway_port,

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -25,8 +25,8 @@ use serde_json::Value;
 
 use crate::support::{
     TestDir, dev_plain, dev_watch, enable_fake_daemon_gateway_admission,
-    install_fake_service_manager, ocm_env, path_string, run_ocm, stderr, stdout,
-    write_executable_script,
+    hold_environment_operation, install_fake_service_manager, ocm_env, path_string, run_ocm,
+    stderr, stdout, write_executable_script,
 };
 
 fn init_openclaw_repo(root: &TestDir) -> PathBuf {
@@ -916,6 +916,167 @@ fn dev_command_provisions_worktree_bootstraps_config_and_runs_gateway() {
         let updated: Value = json5::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
         assert_eq!(updated["gateway"]["auth"], auth);
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_registration_rejects_a_busy_containing_environment_before_preparing_source() {
+    let root = TestDir::new("dev-registration-operation-lock");
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    install_fake_dev_runners(&root, &mut env);
+    let parent = run_ocm(&cwd, &env, &["env", "create", "parent"]);
+    assert!(parent.status.success(), "{}", stderr(&parent));
+    let parent = get_environment("parent", &env, &cwd).unwrap();
+    let source = Path::new(&parent.root).join(".openclaw/workspace/openclaw");
+    fs::rename(init_openclaw_repo(&root), &source).unwrap();
+
+    let lock = hold_environment_operation(&root, "parent");
+    let registry = ocm::store::env_registry_path(&env, &cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+    let mut child = DevWatchFixture::spawn(
+        &root,
+        &cwd,
+        &env,
+        &dev_plain(&["child", "--repo", &path_string(&source)]),
+    );
+    let rejected = child.wait_without_release();
+    assert!(
+        !rejected.status.success(),
+        "dev published a child while its containing environment operation was locked"
+    );
+    assert!(
+        stderr(&rejected).contains("parent"),
+        "{}",
+        stderr(&rejected)
+    );
+    assert_eq!(fs::read(&registry).unwrap(), before);
+    assert!(!source.join(".worktrees/child").exists());
+    assert!(!source.join(".git/worktrees/child").exists());
+    assert!(!root.child("pnpm.log").exists());
+
+    let independent = init_openclaw_repo(&root);
+    let allowed = run_ocm(
+        &cwd,
+        &env,
+        &dev_plain(&["independent", "--repo", &path_string(&independent)]),
+    );
+    assert!(allowed.status.success(), "{}", stderr(&allowed));
+    drop(lock);
+    let created = run_ocm(
+        &cwd,
+        &env,
+        &dev_plain(&["child", "--repo", &path_string(&source)]),
+    );
+    assert!(created.status.success(), "{}", stderr(&created));
+    let dev = get_environment("child", &env, &cwd).unwrap().dev.unwrap();
+    assert_eq!(
+        dev.repo_root,
+        path_string(&fs::canonicalize(&source).unwrap())
+    );
+    assert!(Path::new(&dev.worktree_root).join(".git").exists());
+    let _child_operation = hold_environment_operation(&root, "child");
+    let before_nested = fs::read(&registry).unwrap();
+    let mut nested = DevWatchFixture::spawn(
+        &root,
+        &cwd,
+        &env,
+        &dev_plain(&["grandchild", "--repo", &dev.worktree_root]),
+    );
+    let rejected = nested.wait_without_release();
+    assert!(!rejected.status.success());
+    assert!(
+        stderr(&rejected).contains("environment child has an operation in progress"),
+        "{}",
+        stderr(&rejected)
+    );
+    assert_eq!(fs::read(&registry).unwrap(), before_nested);
+    assert!(
+        !Path::new(&dev.worktree_root)
+            .join(".worktrees/grandchild")
+            .exists()
+    );
+    // A sibling uses the common repository without depending on child's assets.
+    let sibling = run_ocm(
+        &cwd,
+        &env,
+        &dev_plain(&["sibling", "--repo", &path_string(&source)]),
+    );
+    assert!(sibling.status.success(), "{}", stderr(&sibling));
+}
+
+#[test]
+fn dev_registration_cleanup_preserves_reused_and_published_worktrees() {
+    let root = TestDir::new("dev-registration-cleanup");
+    let repo = init_openclaw_repo(&root);
+    let cwd = root.child("workspace");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut env = ocm_env(&root);
+    let occupied = root.child("occupied");
+    fs::create_dir_all(&occupied).unwrap();
+    fs::write(occupied.join("sentinel"), "keep").unwrap();
+    for name in ["fresh", "reused"] {
+        let worktree = repo.join(".worktrees").join(name);
+        if name == "reused" {
+            let added = Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .args(["worktree", "add", "--detach"])
+                .arg(&worktree)
+                .output()
+                .unwrap();
+            assert!(added.status.success(), "{}", stderr(&added));
+        }
+        let rejected = run_ocm(
+            &cwd,
+            &env,
+            &dev_plain(&[
+                name,
+                "--repo",
+                &path_string(&repo),
+                "--root",
+                &path_string(&occupied),
+            ]),
+        );
+        assert!(!rejected.status.success());
+        assert!(
+            stderr(&rejected).contains("root already exists and is not empty"),
+            "{}",
+            stderr(&rejected)
+        );
+        assert_eq!(worktree.exists(), name == "reused");
+        assert_eq!(
+            repo.join(".git/worktrees").join(name).exists(),
+            name == "reused"
+        );
+        assert!(get_environment(name, &env, &cwd).is_err());
+    }
+    // Let daemon preflight pass so the corrupt state fails after publication.
+    env.insert(
+        "OCM_INTERNAL_SERVICE_MANAGER".to_string(),
+        "unsupported".to_string(),
+    );
+    let state = ocm::store::supervisor_state_path(&env, &cwd).unwrap();
+    fs::create_dir_all(&state).unwrap();
+    let sync_failed = run_ocm(
+        &cwd,
+        &env,
+        &dev_plain(&["published", "--repo", &path_string(&repo)]),
+    );
+    assert!(!sync_failed.status.success());
+    let published = get_environment("published", &env, &cwd)
+        .unwrap()
+        .dev
+        .unwrap();
+    assert!(Path::new(&published.worktree_root).join(".git").is_file());
+    assert!(state.is_dir());
+    #[cfg(unix)]
+    assert!(
+        stderr(&sync_failed).contains("directory"),
+        "{}",
+        stderr(&sync_failed)
+    );
 }
 
 #[test]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -227,6 +227,20 @@ pub fn base_env(home: &Path) -> BTreeMap<String, String> {
     env
 }
 
+pub fn hold_environment_operation(root: &TestDir, name: &str) -> fs::File {
+    let path = root.child(format!("ocm-home/locks/environments/{name}.lock"));
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .unwrap();
+    fs2::FileExt::lock_exclusive(&lock).unwrap();
+    lock
+}
+
 pub fn ocm_env(root: &TestDir) -> BTreeMap<String, String> {
     let home = root.child("home");
     let ocm_home = root.child("ocm-home");

--- a/tests/upgrade_command_tests.rs
+++ b/tests/upgrade_command_tests.rs
@@ -25,9 +25,9 @@ use sha2::{Digest, Sha512};
 use tar::{Builder, Header};
 
 use crate::support::{
-    TestDir, TestHttpServer, install_fake_launchctl, install_fake_node_and_npm, ocm_env,
-    path_string, run_ocm, stderr, stdout, write_executable_script, write_json_replacing_path,
-    write_text,
+    TestDir, TestHttpServer, hold_environment_operation, install_fake_launchctl,
+    install_fake_node_and_npm, ocm_env, path_string, run_ocm, stderr, stdout,
+    write_executable_script, write_json_replacing_path, write_text,
 };
 
 fn append_tar_file(
@@ -3363,6 +3363,13 @@ fn upgrade_simulate_preserves_passed_outcome_when_cleanup_fails() {
     install_fake_node_and_npm(&root, &mut env, "22.22.3");
     install_fake_simulation_pnpm(&root, &mut env);
 
+    let parent = run_ocm(&cwd, &env, &["env", "create", "parent"]);
+    assert!(parent.status.success(), "{}", stderr(&parent));
+    let parent = ocm::store::get_environment("parent", &env, &cwd).unwrap();
+    let source = Path::new(&parent.root).join(".openclaw/workspace/openclaw");
+    fs::rename(repo, &source).unwrap();
+    let repo = source;
+
     let start = run_ocm(
         &cwd,
         &env,
@@ -3377,6 +3384,28 @@ fn upgrade_simulate_preserves_passed_outcome_when_cleanup_fails() {
         ],
     );
     assert!(start.status.success(), "{}", stderr(&start));
+
+    let lock = hold_environment_operation(&root, "parent");
+    let blocked = run_ocm(
+        &cwd,
+        &env,
+        &[
+            "upgrade",
+            "simulate",
+            "demo",
+            "--to",
+            &path_string(&repo),
+            "--raw",
+        ],
+    );
+    assert!(!blocked.status.success());
+    assert!(
+        stdout(&blocked).contains("environment parent has an operation in progress"),
+        "{}",
+        stdout(&blocked)
+    );
+    assert!(!repo.join(".worktrees").exists());
+    drop(lock);
 
     env.insert("OCM_TEST_SIMULATION_DOCTOR_OK".to_string(), "1".to_string());
     env.insert(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where creating a dev environment from source belonging to another environment could prepare a worktree and publish its binding during an operation on the source owner. Local upgrade simulations and direct store updates could register the same overlapping dependency.

## Why This Change Was Made

Builds on #200.

Registration acquires the existing operation locks for environments that can affect the selected source, including owned worktrees and their Git registration metadata. It checks identity and current owners again under the registry lock before publication. Unchanged source tuples remain writable during restore and recovery.

## User Impact

Retry new or changed dev bindings after the source owner's operation finishes. Independent sibling worktrees remain usable. Failed registration preserves reused or already-published source, and safely cleans up worktrees created by the rejected attempt.

## Evidence

The baseline CLI reproduction confirmed that a child could be published while its containing environment's operation lock was held. The regression checks rejection before source preparation, successful retry, nested owned sources, and independent sibling creation.

Remote formatting, locked workspace/all-target compilation, and 20 distinct focused cases passed across the registration and integration gates. The final source passed seven affected dev cases with a freshly built CLI, including dependency failure/retry and foreground reuse/stop. Independent implementation and integration reviews found no blockers.

[Final-head CI](https://github.com/openclaw/ocm/actions/runs/34503102157) and [CodeQL](https://github.com/openclaw/ocm/actions/runs/34503100604) passed. [ClawSweeper](https://github.com/openclaw/ocm/pull/201#issuecomment-5619684463) rated the exact head Platinum with no findings.
