### PR TITLE
fix: preserve registered dev sources during restore

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -508,7 +508,18 @@ not add crash recovery for an uncatchable process or machine failure.
 
 This policy belongs to the environment registration. Clone and import start with
 an empty list. A separately requested full snapshot, export, or clone still
-includes independent content. Full snapshot restore still rewinds that content.
+includes independent content. Full snapshot restore still rewinds unregistered
+independent content and the selected environment's own source.
+
+Restores and required rollbacks refuse checkpoints whose recorded scope would
+replace another named environment's registered dev source or required Git
+metadata, before service quiescence or restore staging. Explicit rollback checks
+both the selected checkpoint and its failure-recovery checkpoint. `--no-rollback`
+keeps its existing behavior. The check reads only known registered source paths
+and Git identity metadata, including surviving history for a missing worktree.
+Checkpoint traversal still leaves independent content opaque; post-copy updates
+and residue cleanup leave directory links untouched. Excluding only a worktree
+is insufficient when its required Git metadata remains in scope.
 
 ### Snapshots
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -990,6 +990,8 @@ impl Cli {
                     .environment_service()
                     .get_snapshot(name, snapshot_id)?;
                 self.environment_service().ensure_source_watch_allows_state_mutation_locked(name)?;
+                self.environment_service()
+                    .ensure_snapshot_restore_preserves_dev_sources_locked(&selected_snapshot)?;
                 let service_state = self
                     .service_service()
                     .quiesce_for_snapshot_locked(name)?;

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -776,11 +776,16 @@ impl Cli {
         self.save_upgrade_batch_journal(&journal_path, &summary)?;
 
         let checkpoint_label = format!("fast-batch-{batch_id}");
+        let rollback_enabled = options.failure_policy == UpgradeFleetFailurePolicy::Rollback;
         let checkpoint_results = self.run_parallel_batch_work(
             &options.env_names,
             options.parallel,
             move |cli, env_name| {
-                cli.create_upgrade_batch_checkpoint_locked(env_name, &checkpoint_label)
+                cli.create_upgrade_batch_checkpoint_locked(
+                    env_name,
+                    &checkpoint_label,
+                    rollback_enabled,
+                )
             },
         );
         for (env_name, result) in checkpoint_results {
@@ -957,8 +962,15 @@ impl Cli {
         &self,
         env_name: &str,
         label: &str,
+        rollback_enabled: bool,
     ) -> Result<EnvSnapshotSummary, String> {
         let interrupt_fence = UpgradeInterruptFence::enter()?;
+        if rollback_enabled {
+            self.environment_service()
+                .ensure_upgrade_rollback_preserves_dev_sources_locked(
+                    &self.environment_service().get(env_name)?,
+                )?;
+        }
         let prepared = self
             .environment_service()
             .prepare_upgrade_checkpoint_locked(env_name)?;
@@ -1198,7 +1210,8 @@ impl Cli {
                 record.id
             ));
         }
-        self.environment_service()
+        let snapshot = self
+            .environment_service()
             .get_snapshot(env_name, &record.snapshot_id)
             .map_err(|error| {
                 format!(
@@ -1206,6 +1219,10 @@ impl Cli {
                     record.id
                 )
             })?;
+        self.environment_service()
+            .ensure_snapshot_restore_preserves_dev_sources_locked(&snapshot)?;
+        self.environment_service()
+            .ensure_upgrade_rollback_preserves_dev_sources_locked(&current)?;
         self.verify_rollback_target_version(env_name, &record)?;
         let recovery = self.verify_rollback_source(env_name, &record)?;
         Ok(UpgradeRollbackPlan { record, recovery })
@@ -4353,6 +4370,10 @@ impl Cli {
         let interrupt_fence = UpgradeInterruptFence::enter()?;
         let snapshot_preparation_started = timings.start();
         let env_meta = self.environment_service().get(env_name)?;
+        if rollback_enabled {
+            self.environment_service()
+                .ensure_upgrade_rollback_preserves_dev_sources_locked(&env_meta)?;
+        }
         let prepared = self
             .environment_service()
             .prepare_upgrade_checkpoint_locked(env_name)?;

--- a/src/env/snapshots.rs
+++ b/src/env/snapshots.rs
@@ -3,14 +3,14 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
 
-use super::EnvironmentService;
+use super::{EnvMeta, EnvironmentService};
 use crate::store::{
     EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
-    create_env_snapshot, create_env_snapshot_from_preparation, get_env_snapshot,
-    list_all_env_snapshots, list_env_snapshots, now_utc, prepare_env_snapshot_capture,
-    prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture,
-    prepare_upgrade_snapshot_restore, remove_env_snapshot, rollback_env_snapshot_restore,
-    summarize_snapshot,
+    create_env_snapshot, create_env_snapshot_from_preparation,
+    ensure_restore_preserves_dev_sources, get_env_snapshot, list_all_env_snapshots,
+    list_env_snapshots, now_utc, prepare_env_snapshot_capture, prepare_env_snapshot_restore,
+    prepare_upgrade_checkpoint_capture, prepare_upgrade_snapshot_restore, remove_env_snapshot,
+    rollback_env_snapshot_restore, summarize_snapshot,
 };
 use crate::supervisor::sync_supervisor_env_if_present;
 
@@ -198,6 +198,34 @@ impl<'a> EnvironmentService<'a> {
     ) -> Result<EnvSnapshotSummary, String> {
         let snapshot = get_env_snapshot(env_name, snapshot_id, self.env, self.cwd)?;
         Ok(summarize_snapshot(&snapshot))
+    }
+
+    pub(crate) fn ensure_snapshot_restore_preserves_dev_sources_locked(
+        &self,
+        snapshot: &EnvSnapshotSummary,
+    ) -> Result<(), String> {
+        ensure_restore_preserves_dev_sources(
+            &self.get(&snapshot.env_name)?,
+            snapshot
+                .upgrade_scope
+                .as_ref()
+                .map(|scope| scope.independent_paths.as_slice())
+                .unwrap_or_default(),
+            self.env,
+            self.cwd,
+        )
+    }
+
+    pub(crate) fn ensure_upgrade_rollback_preserves_dev_sources_locked(
+        &self,
+        meta: &EnvMeta,
+    ) -> Result<(), String> {
+        ensure_restore_preserves_dev_sources(
+            meta,
+            &meta.upgrade_independent_paths,
+            self.env,
+            self.cwd,
+        )
     }
 
     pub fn restore_snapshot(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -94,8 +94,8 @@ pub use runtimes::{
 };
 pub(crate) use snapshots::{
     EnvSnapshotRestoreTransaction, PreparedEnvSnapshotCapture, commit_env_snapshot_restore,
-    create_env_snapshot_from_preparation, prepare_env_snapshot_capture,
-    prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture,
+    create_env_snapshot_from_preparation, ensure_restore_preserves_dev_sources,
+    prepare_env_snapshot_capture, prepare_env_snapshot_restore, prepare_upgrade_checkpoint_capture,
     prepare_upgrade_snapshot_restore, rollback_env_snapshot_restore,
     validate_upgrade_independent_paths,
 };

--- a/src/store/snapshots.rs
+++ b/src/store/snapshots.rs
@@ -18,9 +18,8 @@ use super::checkpoints::{
     create_tree_checkpoint_from_preparation, default_snapshot_storage_kind,
     prepare_scoped_tree_checkpoint_in, remove_tree_if_present,
 };
-use super::common::{
-    copy_dir_recursive, copy_path_recursive, load_json_files, path_exists, read_json, write_json,
-};
+use super::common::{copy_path_recursive, load_json_files, path_exists, read_json, write_json};
+use super::dev_sources::{contains_existing, path_identity, registered_dev_source_footprint};
 use super::layout::{
     derive_env_paths, display_path, snapshot_archive_path, snapshot_checkpoint_path,
     snapshot_env_dir, snapshot_meta_path, validate_name,
@@ -439,6 +438,94 @@ pub fn summarize_snapshot(meta: &EnvSnapshotMeta) -> EnvSnapshotSummary {
     }
 }
 
+pub(crate) fn ensure_restore_preserves_dev_sources(
+    target: &EnvMeta,
+    independent: &[PathBuf],
+    env: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Result<(), String> {
+    super::with_locked_environments(env, cwd, |envs| {
+        if !envs
+            .iter()
+            .any(|meta| meta.name != target.name && meta.dev.is_some())
+        {
+            return Ok(());
+        }
+        let target_root = Path::new(&target.root);
+        if !independent.is_empty() {
+            super::checkpoint_scope::validate_ancestors(target_root, independent)?;
+        }
+        // A full restore renames the root entry itself, including a final
+        // symlink. Resolve its parent without following that final entry.
+        let parent = fs::canonicalize(target_root.parent().unwrap_or(target_root))
+            .map_err(|error| error.to_string())?;
+        let root = parent.join(target_root.file_name().unwrap_or_default());
+        let root_identity = match fs::symlink_metadata(&root) {
+            Ok(_) => Some(path_identity(&root)?),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.to_string()),
+        };
+        let relative_to_root = |path: &Path| -> Result<Option<PathBuf>, String> {
+            if let Ok(relative) = path.strip_prefix(&root) {
+                return Ok(Some(relative.to_path_buf()));
+            }
+            // Compare known path ancestors for filesystem aliases, including
+            // macOS firmlinks. Never resolve or inspect an exclusion's contents.
+            if let Some(identity) = root_identity {
+                for ancestor in path.ancestors() {
+                    if path_identity(ancestor)? == identity {
+                        return Ok(Some(path.strip_prefix(ancestor).unwrap().to_path_buf()));
+                    }
+                }
+            }
+            Ok(None)
+        };
+        for meta in envs
+            .iter()
+            .filter(|meta| meta.name != target.name && meta.dev.is_some())
+        {
+            let Some(footprint) = registered_dev_source_footprint(meta, envs).map_err(|error| {
+                format!("cannot protect dev source for env {}: {error}", meta.name)
+            })?
+            else {
+                continue;
+            };
+            for (path, contents) in footprint
+                .entries
+                .iter()
+                .map(|path| (path, false))
+                .chain(footprint.content_roots.iter().map(|path| (path, true)))
+            {
+                let affected = if let Some(relative) = relative_to_root(path)? {
+                    !independent.iter().any(|excluded| {
+                        relative.starts_with(excluded)
+                            || (!contents && excluded.starts_with(&relative))
+                    })
+                } else {
+                    contents
+                        && contains_existing(
+                            path,
+                            if root_identity.is_some() {
+                                &root
+                            } else {
+                                &parent
+                            },
+                        )?
+                };
+                if affected {
+                    return Err(format!(
+                        "restoring env {} would replace registered dev source or Git metadata for env {} at {}; choose a checkpoint that preserves the complete source and Git metadata",
+                        target.name,
+                        meta.name,
+                        display_path(path)
+                    ));
+                }
+            }
+        }
+        Ok(())
+    })
+}
+
 pub fn restore_env_snapshot(
     options: RestoreEnvSnapshotOptions,
     env: &BTreeMap<String, String>,
@@ -483,6 +570,7 @@ fn prepare_env_snapshot_restore_with_binding(
         .as_ref()
         .map(|scope| scope.independent_paths.clone())
         .unwrap_or_default();
+    ensure_restore_preserves_dev_sources(&current, &independent, env, cwd)?;
     if !independent.is_empty() {
         super::checkpoint_scope::validate_ancestors(&current_paths.root, &independent)?;
         super::checkpoint_scope::validate_scoped_artifact(
@@ -514,7 +602,7 @@ fn prepare_env_snapshot_restore_with_binding(
                     extracted.metadata.format_version
                 ));
             }
-            copy_dir_recursive(&extracted.root_dir, &candidate_root)?;
+            copy_path_recursive(&extracted.root_dir, &candidate_root)?;
             let archived = extracted.metadata.env;
             (
                 EnvMeta {
@@ -585,7 +673,7 @@ fn prepare_env_snapshot_restore_with_binding(
                 fs::rename(&candidate_root, &current_paths.root)
                     .map_err(|error| error.to_string())?;
             }
-            if legacy_archive {
+            if legacy_archive && !restore_uses_directory_link(&current_paths.root)? {
                 rewrite_openclaw_config_for_target(
                     &current_paths,
                     Some(Path::new(&snapshot.source_root)),
@@ -852,9 +940,22 @@ fn should_discard_current_openclaw_restore_entry(name: &OsStr, is_dir: bool) -> 
     )
 }
 
+fn restore_uses_directory_link(root: &Path) -> Result<bool, String> {
+    // Captured links do not grant ownership of their live destinations.
+    for path in [root.to_path_buf(), root.join(".openclaw")] {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.is_symlink() => return Ok(true),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    Ok(false)
+}
+
 fn clear_snapshot_runtime_residue(root: &Path) -> Result<(), String> {
     let openclaw_root = root.join(".openclaw");
-    if !path_exists(&openclaw_root) {
+    if restore_uses_directory_link(root)? || !path_exists(&openclaw_root) {
         return Ok(());
     }
     let entries = match fs::read_dir(&openclaw_root) {

--- a/tests/upgrade_checkpoint_scope_tests.rs
+++ b/tests/upgrade_checkpoint_scope_tests.rs
@@ -476,3 +476,360 @@ fn full_backup_still_rewinds_declared_independent_content() {
     assert!(fixture.project.join("deleted").exists());
     assert!(!fixture.project.join("created").exists());
 }
+
+fn source_test_git(path: &std::path::Path, args: &[&str]) -> Vec<u8> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    output.stdout
+}
+
+impl Fixture {
+    fn with_dev_repo() -> Self {
+        let mut fixture = Self::new();
+        support::install_fake_service_manager(&fixture.root, &mut fixture.env);
+        for (path, contents) in [
+            (
+                "package.json",
+                r#"{"name":"openclaw","version":"2026.4.19"}"#,
+            ),
+            ("scripts/run-node.mjs", "// fixture\n"),
+            ("openclaw.mjs", "// fixture\n"),
+            ("extensions/codex/openclaw.plugin.json", r#"{"id":"codex"}"#),
+            (".gitignore", "node_modules/\n.env\n"),
+        ] {
+            write_text(&fixture.project.join(path), contents);
+        }
+        source_test_git(&fixture.project, &["init", "--quiet"]);
+        source_test_git(&fixture.project, &["add", "."]);
+        for (key, value) in [
+            ("user.name", "OCM Tests"),
+            ("user.email", "tests@example.com"),
+        ] {
+            source_test_git(&fixture.project, &["config", key, value]);
+        }
+        source_test_git(&fixture.project, &["commit", "--quiet", "-m", "fixture"]);
+        let bin = fixture.root.child("fake-dev-bin");
+        for name in ["pnpm", "node"] {
+            write_executable_script(&bin.join(name), "#!/bin/sh\nexit 0\n");
+        }
+        let path = fixture.env.get("PATH").cloned().unwrap_or_default();
+        fixture
+            .env
+            .insert("PATH".to_string(), format!("{}:{path}", bin.display()));
+        for (name, path) in [
+            ("OCM_PROOF_READY", "ready"),
+            ("OCM_PROOF_RELEASE", "release"),
+        ] {
+            fixture.env.insert(
+                name.to_string(),
+                fixture.root.child(path).display().to_string(),
+            );
+        }
+        write_text(&fixture.root.child("release"), "continue");
+        fixture
+    }
+
+    fn run_ok(&self, args: &[&str]) -> std::process::Output {
+        let output = self.run(args);
+        assert!(output.status.success(), "{args:?}: {}", stderr(&output));
+        output
+    }
+
+    fn source_scope(&self, include_git: bool) {
+        let mut args = vec![
+            "env",
+            "set-independent-paths",
+            "demo",
+            ".openclaw/workspace/projects/example/.worktrees",
+        ];
+        if include_git {
+            args.push(".openclaw/workspace/projects/example/.git");
+        }
+        self.run_ok(&args);
+    }
+
+    fn register_child(&self) {
+        self.run_ok(&["dev", "child", "--repo", self.project.to_str().unwrap()]);
+        write_text(
+            &self.project.join(".worktrees/child/authored"),
+            "current child work\n",
+        );
+        let child = ocm::store::get_environment("child", &self.env, self.root.path()).unwrap();
+        assert!(!PathBuf::from(child.root).starts_with(self.state.parent().unwrap()));
+    }
+
+    fn child_witness(&self) -> (Value, Vec<u8>, Vec<u8>, Vec<u8>) {
+        let source = self.project.join(".worktrees/child");
+        let identity = source_test_git(
+            &source,
+            &[
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-dir",
+                "--git-common-dir",
+                "--show-toplevel",
+                "HEAD",
+            ],
+        );
+        let private = PathBuf::from(String::from_utf8_lossy(&identity).lines().next().unwrap());
+        let child = ocm::store::get_environment("child", &self.env, self.root.path()).unwrap();
+        (
+            serde_json::to_value(child).unwrap(),
+            fs::read(source.join("authored")).unwrap(),
+            identity,
+            fs::read(private.join("gitdir")).unwrap(),
+        )
+    }
+}
+
+#[test]
+fn restore_and_explicit_rollback_preserve_registered_source_and_git_identity() {
+    // capture_git is irrelevant for the separately requested full snapshot.
+    for (action, capture_git, current_git, allowed) in [
+        ("full", false, true, false),
+        ("restore", false, true, false),
+        ("restore", true, false, true),
+        ("rollback", false, true, false),
+        ("rollback", true, false, false),
+        ("rollback", true, true, true),
+    ] {
+        let fixture = Fixture::with_dev_repo();
+        fixture.source_scope(capture_git);
+        let capture = if action == "full" {
+            fixture.run_ok(&["env", "snapshot", "create", "demo", "--json"])
+        } else {
+            fixture.run_ok(&["upgrade", "demo", "--runtime", "new", "--json"])
+        };
+        let capture: Value = serde_json::from_str(&stdout(&capture)).unwrap();
+        let id = capture[if action == "full" { "id" } else { "snapshotId" }]
+            .as_str()
+            .unwrap();
+        fixture.register_child();
+        fixture.source_scope(current_git);
+        if action == "full" {
+            let mut meta =
+                ocm::store::get_environment("demo", &fixture.env, fixture.root.path()).unwrap();
+            meta.service_enabled = true;
+            meta.service_running = true;
+            ocm::store::save_environment(meta, &fixture.env, fixture.root.path()).unwrap();
+        }
+        let child_before = fixture.child_witness();
+        let registry = ocm::store::env_registry_path(&fixture.env, fixture.root.path()).unwrap();
+        let registry_before = fs::read(&registry).unwrap();
+        let snapshots = ["env", "snapshot", "list", "demo", "--json"];
+        let snapshots_before = stdout(&fixture.run_ok(&snapshots));
+        let result = if action == "rollback" {
+            fixture.run(&["upgrade", "rollback", "demo", "--json"])
+        } else {
+            fixture.run(&["env", "snapshot", "restore", "demo", id])
+        };
+        assert_eq!(
+            result.status.success(),
+            allowed,
+            "{action}, captured Git={capture_git}, current Git={current_git}: {} {}",
+            stdout(&result),
+            stderr(&result)
+        );
+        if !allowed {
+            assert!(
+                stderr(&result).contains("registered dev source")
+                    && stderr(&result).contains("child"),
+                "{}",
+                stderr(&result)
+            );
+            if action != "rollback" {
+                let direct = ocm::store::restore_env_snapshot(
+                    ocm::env::RestoreEnvSnapshotOptions {
+                        env_name: "demo".to_string(),
+                        snapshot_id: id.to_string(),
+                    },
+                    &fixture.env,
+                    fixture.root.path(),
+                )
+                .unwrap_err();
+                assert!(
+                    direct.contains("registered dev source") && direct.contains("child"),
+                    "{direct}"
+                );
+            }
+            assert_eq!(fs::read(&registry).unwrap(), registry_before);
+            assert_eq!(stdout(&fixture.run_ok(&snapshots)), snapshots_before);
+        }
+        assert_eq!(fixture.child_witness(), child_before);
+        fixture.run_ok(&["dev", "child"]);
+    }
+}
+
+#[test]
+fn upgrade_requires_safe_rollback_but_respects_no_rollback() {
+    let mut fixture = Fixture::with_dev_repo();
+    fixture
+        .env
+        .insert("OCM_PROOF_FAIL".to_string(), "1".to_string());
+    fixture.register_child();
+    fixture.source_scope(false);
+    let child_before = fixture.child_witness();
+    let registry = ocm::store::env_registry_path(&fixture.env, fixture.root.path()).unwrap();
+    let registry_before = fs::read(&registry).unwrap();
+    let snapshots = ["env", "snapshot", "list", "demo", "--json"];
+    let snapshots_before = stdout(&fixture.run_ok(&snapshots));
+    let refused = fixture.run(&["upgrade", "demo", "--runtime", "new", "--json"]);
+    assert!(!refused.status.success());
+    assert!(stderr(&refused).contains("child"), "{}", stderr(&refused));
+    assert!(
+        !fixture.root.child("ready").exists(),
+        "unsafe upgrade reached finalizer"
+    );
+    assert_eq!(fs::read(&registry).unwrap(), registry_before);
+    assert_eq!(stdout(&fixture.run_ok(&snapshots)), snapshots_before);
+    assert_eq!(fixture.child_witness(), child_before);
+
+    let failed = fixture.run(&[
+        "upgrade",
+        "demo",
+        "--runtime",
+        "new",
+        "--no-rollback",
+        "--json",
+    ]);
+    assert!(!failed.status.success());
+    let receipt: Value = serde_json::from_str(&stdout(&failed)).unwrap();
+    assert_eq!(receipt["outcome"], "failed", "{receipt}");
+    assert_eq!(receipt["rollback"], "disabled");
+    assert!(
+        receipt["note"]
+            .as_str()
+            .is_some_and(|note| note.contains("openclaw update finalize failed")),
+        "{receipt}"
+    );
+    assert!(
+        fixture.root.child("ready").exists(),
+        "no-rollback did not reach finalizer"
+    );
+    let current = ocm::store::get_environment("demo", &fixture.env, fixture.root.path()).unwrap();
+    // The failed finalizer runs before the replacement binding is published.
+    assert_eq!(current.default_runtime.as_deref(), Some("old"));
+    assert_eq!(fixture.child_witness(), child_before);
+}
+
+fn check_snapshot_residue_preserves_source(root_link: bool) {
+    let fixture = Fixture::with_dev_repo();
+    fixture.register_child();
+    fixture.run_ok(&["env", "create", "linked"]);
+    let source = fixture.project.join(".worktrees/child");
+    let linked = fixture.root.child("ocm-home/envs/linked");
+    let link = if root_link {
+        linked
+    } else {
+        linked.join(".openclaw")
+    };
+    fs::remove_dir_all(&link).unwrap();
+    symlink(&source, &link).unwrap();
+    let residue = if root_link {
+        source.join(".openclaw")
+    } else {
+        source
+    };
+    write_text(&residue.join("Cargo.lock"), "authored source lock\n");
+    write_text(&residue.join("run/keep"), "authored source data\n");
+    let child_before = fixture.child_witness();
+    let snapshot = fixture.run_ok(&["env", "snapshot", "create", "linked", "--json"]);
+    let snapshot: Value = serde_json::from_str(&stdout(&snapshot)).unwrap();
+    fixture.run_ok(&[
+        "env",
+        "snapshot",
+        "restore",
+        "linked",
+        snapshot["id"].as_str().unwrap(),
+    ]);
+    let lock_preserved = fs::read(residue.join("Cargo.lock")).ok().as_deref()
+        == Some(b"authored source lock\n".as_slice());
+    let run_preserved = fs::read(residue.join("run/keep")).ok().as_deref()
+        == Some(b"authored source data\n".as_slice());
+    assert!(
+        lock_preserved && run_preserved,
+        "restore followed directory link (root={root_link}): source lock preserved={lock_preserved}, run data preserved={run_preserved}"
+    );
+    assert_eq!(fixture.child_witness(), child_before);
+}
+
+#[test]
+fn snapshot_residue_cleanup_preserves_state_directory_links() {
+    check_snapshot_residue_preserves_source(false);
+}
+
+#[test]
+fn snapshot_residue_cleanup_preserves_root_directory_links() {
+    check_snapshot_residue_preserves_source(true);
+}
+
+#[test]
+fn legacy_snapshot_restore_preserves_linked_registered_source() {
+    use ocm::infra::archive::{ArchivedEnvMeta, EnvArchiveMetadata, write_env_archive};
+    use ocm::store::{
+        get_env_snapshot, get_environment, snapshot_archive_path, snapshot_meta_path,
+    };
+
+    let fixture = Fixture::with_dev_repo();
+    fixture.register_child();
+    fixture.run_ok(&["env", "create", "linked"]);
+    let source = fixture.project.join(".worktrees/child");
+    let linked = fixture.root.child("ocm-home/envs/linked");
+    let state_link = linked.join(".openclaw");
+    fs::remove_dir_all(&state_link).unwrap();
+    symlink(&source, &state_link).unwrap();
+    let captured = fixture.run_ok(&["env", "snapshot", "create", "linked", "--json"]);
+    let captured: Value = serde_json::from_str(&stdout(&captured)).unwrap();
+    let id = captured["id"].as_str().unwrap();
+    let cwd = fixture.root.path();
+    let meta = get_environment("linked", &fixture.env, cwd).unwrap();
+    let mut archived: ArchivedEnvMeta =
+        serde_json::from_value(serde_json::to_value(&meta).unwrap()).unwrap();
+    archived.source_root = Some(meta.root.clone());
+    let archive = snapshot_archive_path("linked", id, &fixture.env, cwd).unwrap();
+    // Historical snapshots retained this link. Current export validates
+    // workspace containment, so use the original archive shape directly.
+    write_env_archive(
+        &EnvArchiveMetadata {
+            kind: "ocm-env-archive".to_string(),
+            format_version: 1,
+            exported_at: meta.updated_at,
+            env: archived,
+        },
+        &linked,
+        &archive,
+    )
+    .unwrap();
+    let mut snapshot = get_env_snapshot("linked", id, &fixture.env, cwd).unwrap();
+    snapshot.storage_kind = "tar-archive-v1".to_string();
+    snapshot.archive_path = archive.to_str().unwrap().to_string();
+    fs::write(
+        snapshot_meta_path("linked", id, &fixture.env, cwd).unwrap(),
+        serde_json::to_vec(&snapshot).unwrap(),
+    )
+    .unwrap();
+    let config = serde_json::to_vec(&serde_json::json!({
+        "gateway": {"port": meta.gateway_port.unwrap() + 100}
+    }))
+    .unwrap();
+    fs::write(source.join("openclaw.json"), &config).unwrap();
+    write_text(&source.join("browser/keep"), "authored source data\n");
+    let child_before = fixture.child_witness();
+    let restored = fixture.run(&["env", "snapshot", "restore", "linked", id]);
+    let config_unchanged = fs::read(source.join("openclaw.json")).ok().as_ref() == Some(&config);
+    let browser_preserved = fs::read(source.join("browser/keep")).ok().as_deref()
+        == Some(b"authored source data\n".as_slice());
+    assert!(
+        restored.status.success() && config_unchanged && browser_preserved,
+        "legacy restore followed state directory link: accepted={}, config unchanged={config_unchanged}, browser preserved={browser_preserved}; {}",
+        restored.status.success(),
+        stderr(&restored)
+    );
+    assert_eq!(fs::read_link(&state_link).unwrap(), source);
+    assert_eq!(fixture.child_witness(), child_before);
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where restoring or rolling back a containing environment could erase another named environment's dev checkout or Git registration while leaving its environment registration intact.

## Why This Change Was Made

Restore checks the selected checkpoint's recorded scope against other environments' registered source and Git dependencies before service quiescence and again before staging replacement. Required upgrade rollback also checks its recovery scope; explicit rollback checks both the selected checkpoint and its failure-recovery checkpoint. The check uses the operation lock already shared with source registration through restore acceptance.

## User Impact

Unsafe restores are refused before replacement. A checkpoint that preserves the complete dev source and Git metadata can still restore surrounding state. Legacy restore updates and runtime-residue cleanup preserve captured directory links without following their destinations. Full snapshots retain their behavior for the selected environment's own source and unregistered independent content, and disabled automatic rollback keeps its existing behavior.

## Evidence

- Existing-behavior controls reproduced source/Git loss during full restore and source modification through captured directory links, using isolated fixtures and real Git repositories.
- Remote Linux validation passed 50 positive cases: 10 checkpoint-scope cases, 39 snapshot cases, and the registration operation-lock case. All fixture processes and temporary state were cleaned up.
- Remote formatting and locked Linux/Windows GNU all-target compilation passed. Independent source review and the focused test correction review are complete.
- Replayed the unchanged restore commit onto the landed prerequisites with an identical range-diff. [Final hosted CI](https://github.com/openclaw/ocm/actions/runs/34505817866) passed every job, including Linux/macOS tests and Windows compilation; [CodeQL](https://github.com/openclaw/ocm/actions/runs/34505812934) also passed.
- The [current-head review attempt](https://github.com/openclaw/clawsweeper/actions/runs/34506549818) failed during the review service's manual admission step before producing a verdict. Independent review is clean; the standing reviewer-error policy applies without a claimed current rating.
