### PR TITLE
fix: reap stopped daemons during refresh tests

### DIFF
--- a/tests/daemon_runtime_tests.rs
+++ b/tests/daemon_runtime_tests.rs
@@ -1487,11 +1487,16 @@ fn gateway_owned_daemon_refresh(npm: bool) {
 
     let deadline = Instant::now() + Duration::from_secs(15);
     let mut contract_met = false;
+    let mut daemon_status = None;
     while Instant::now() < deadline {
+        // This test owns the old daemon. Reap it so fake launchctl's kill -0
+        // observes its exit instead of polling a zombie through every retry.
+        daemon_status = daemon.try_wait().unwrap();
         let calls = fs::read_to_string(root.child("refresh-launchctl.log")).unwrap_or_default();
         let output = fs::read_to_string(&refresh_output_path).unwrap_or_default();
         let starts = fs::read_to_string(&started_path).unwrap_or_default();
-        contract_met = calls.lines().any(|line| line.starts_with("bootstrap "))
+        contract_met = daemon_status.is_some_and(|status| status.success())
+            && calls.lines().any(|line| line.starts_with("bootstrap "))
             && output.contains("\"action\": \"refresh\"")
             && starts.lines().count() >= 2;
         if contract_met {
@@ -1506,11 +1511,13 @@ fn gateway_owned_daemon_refresh(npm: bool) {
     if let Ok(pid) = fs::read_to_string(&replacement_daemon_pid_path) {
         let _ = Command::new("kill").args(["-INT", pid.trim()]).status();
     }
-    stop_process(&mut daemon);
+    if daemon_status.is_none() {
+        stop_process(&mut daemon);
+    }
 
     assert!(
         contract_met,
-        "gateway-owned daemon refresh did not complete and restart the Gateway\nprocess-groups={process_groups}\nlaunchctl-calls={calls}\nrefresh-output={output}\ngateway-starts={starts}"
+        "gateway-owned daemon refresh did not complete and restart the Gateway\nold-daemon-exit={daemon_status:?}\nprocess-groups={process_groups}\nlaunchctl-calls={calls}\nrefresh-output={output}\ngateway-starts={starts}"
     );
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where daemon refresh integration tests retain the original daemon as a zombie while waiting for its replacement. The fake launchctl polls `kill -0`, which continues to find the unreaped PID and exhausts its retry loop even after the daemon exits.

## Why This Change Was Made

Reap the test-owned daemon while observing refresh completion and require its successful exit. Cleanup skips a PID that has already been reaped. The existing 15-second deadline, refresh output, bootstrap and replacement Gateway checks are preserved.

## User Impact

The direct and npm refresh tests can complete promptly after the original daemon exits. Production service behavior is unchanged.

## Evidence

- On the same remote Linux runner, both existing direct/npm cases passed before and after; their combined test time fell from **11.09 s to 0.87 s**.
- Process observations showed the original daemons remaining zombies for about **5.2 s** before bootstrap on the baseline. With the repair, both were reaped before bootstrap; refresh callers survived in their own process groups and replacement Gateways started.
- `cargo fmt --check` and `cargo check --workspace --all-targets --locked` passed remotely. Both runs left no fixture processes.
- [Exact-head CI](https://github.com/openclaw/ocm/actions/runs/34508254287) passed, including the native macOS daemon suite (41/41, with both refresh cases), Linux tests, Rust 1.88, Windows compilation and the npm platform matrix.
