### PR TITLE
fix: wait for journal admission in self-update tests

### DIFF
--- a/tests/self_update_transaction_tests.rs
+++ b/tests/self_update_transaction_tests.rs
@@ -9,6 +9,7 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use flate2::{Compression, write::GzEncoder};
+use fs2::FileExt;
 use ocm::infra::download::file_sha256;
 use serde_json::{Value, json};
 use support::{TestDir, TestHttpServer, ocm_env, run_ocm_binary, stderr, write_executable_script};
@@ -215,6 +216,26 @@ process.exit(0);
         read_json(&self.root.child("bin/.ocm.self-update/receipt.json"))
     }
 
+    fn wait_for_update_lock(&self) {
+        let path = self.root.child("bin/.ocm.self-update/lock");
+        let lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap_or_else(|error| panic!("open update lock {}: {error}", path.display()));
+        // A receipt or daemon PID can be published before the worker or its
+        // inherited service-manager command releases admission to this journal.
+        wait_for(
+            || match FileExt::try_lock_exclusive(&lock) {
+                Ok(()) => true,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => false,
+                Err(error) => panic!("probe update lock {}: {error}", path.display()),
+            },
+            &format!("update journal lock release: {}", path.display()),
+        );
+        drop(lock);
+    }
+
     fn setup_gateway(&self) {
         let gateway = self.root.child("gateway");
         write_executable_script(
@@ -327,12 +348,15 @@ fn local_transaction_survives_gateway_teardown_and_recovers_failures() {
             .unwrap(),
         receipt
     );
+    success.wait_for_update_lock();
     let manager_before = fs::read(success.root.child("manager.log")).unwrap();
+    let no_op = success.run(&["self", "update", "--version", "9.9.9", "--json"]);
     assert!(
-        success
-            .run(&["self", "update", "--version", "9.9.9", "--json"])
-            .status
-            .success()
+        no_op.status.success(),
+        "same-version no-op: status={}, stdout={}, stderr={}",
+        no_op.status,
+        String::from_utf8_lossy(&no_op.stdout),
+        stderr(&no_op)
     );
     assert_eq!(
         fs::read(success.root.child("manager.log")).unwrap(),
@@ -416,10 +440,16 @@ fn local_transaction_survives_gateway_teardown_and_recovers_failures() {
         || crash.root.child("daemon.pid").exists(),
         "orphan activation completed",
     );
-    sleep(Duration::from_millis(200));
+    crash.wait_for_update_lock();
     let retry = crash.run(&["self", "update", "--version", "9.9.9"]);
     assert!(!retry.status.success());
-    assert!(stderr(&retry).contains("unfinished self-update"));
+    assert!(
+        stderr(&retry).contains("unfinished self-update"),
+        "retry after orphan activation: status={}, stdout={}, stderr={}",
+        retry.status,
+        String::from_utf8_lossy(&retry.stdout),
+        stderr(&retry)
+    );
     let recovered = crash.run(&["self", "update", "--recover"]);
     assert_eq!(
         crash.receipt()["phase"],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the self-update transaction test starts its next operation before the previous worker or activation command has released the update journal lock.

## Why This Change Was Made

Wait for exclusive admission to the existing journal before the same-version no-op and interrupted-update retry. The probe uses the production file-lock mechanism, fails on unexpected I/O errors, and releases its handle before the next CLI invocation. This replaces the orphan activation delay and preserves the busy, unfinished-update, and recovery assertions. Failed no-op and retry assertions now include the command output.

## User Impact

Developers get transaction checks that follow the worker lifecycle. Production update behavior is unchanged.

## Evidence

- Controlled baseline proof distinguishes a terminal update receipt from journal admission: a held lock rejects the next update, and releasing it admits the same no-op.
- `cargo fmt --check` and compilation of the affected integration test passed.
- The existing transaction case passed once on the exact source in 217.67 seconds, including its isolated offline candidate build.
- [Hosted CI](https://github.com/openclaw/ocm/actions/runs/34516044201) passed, including the full Linux/macOS suites, minimum Rust, Windows, and npm checks. The existing transaction case passed on Linux in 199.82s and macOS in 75.24s.
- [CodeQL](https://github.com/openclaw/ocm/actions/runs/34516040062) passed. Independent review is clean, and [ClawSweeper](https://github.com/openclaw/ocm/pull/211#issuecomment-5623752013) rated the exact head Platinum with no findings.
