### PR TITLE
chore(release): bump version to 0.2.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.43"
+version = "0.2.44"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.43"
+version = "0.2.44"
 publish = false
 edition = "2024"
 rust-version = "1.88"


### PR DESCRIPTION
## What Problem This Solves

Prepares OCM v0.2.44 so changes merged since v0.2.43 can be published through the signed binary and npm release workflows.

## Why This Change Was Made

Advances only the package version in `Cargo.toml` and `Cargo.lock`. Binary publication remains gated by exact-main CI, signed-tag verification, macOS signing and notarization, and complete asset checks; npm publication remains a separate protected workflow.

## User Impact

Once publication completes, users can install OCM v0.2.44 from the supported binary, Homebrew reconciliation, and npm distribution paths. This version-only PR does not otherwise change runtime behavior.

## Evidence

- Exact diff contains only the two matching `0.2.44` version changes.
- Crabbox passed formatting, all-target compile checks, 33 automatic-release tests, and 13 npm release tests. Its broad Rust run hit an environment-only cross-filesystem hard-link fixture; the exact hosted Linux and macOS suites passed.
- All exact-head CI jobs passed, including four npm platform/version jobs; all four CodeQL analyses and both Socket checks passed.
- Independent static review found no issues. ClawSweeper rated exact head `ea28774563fc96b6e49ca94fb3cec2ecbf504179` Platinum with no findings.
- After merge, exact-main CI, signed/notarized binary publication, protected npm publication, provenance, and consumer checks remain required.