### PR TITLE
fix: resolve dev UI paths that use environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ OCM prints the session's UI address, then its initial native owner link after
 both Vite and the Gateway Control UI document are ready. The native handoff keeps
 the Gateway identity and credentials; only the browser document moves to Vite.
 UI requires a local HTTP Gateway with Control UI enabled and installed UI dependencies.
+For a templated `gateway.controlUi.basePath` such as `${UI_BASE}`, OCM reads the
+effective path through the selected checkout's native config command. OpenClaw
+resolves its environment, `.env` files, and config-provided variables; OCM keeps
+that read private and leaves the authored config unchanged. An unresolved
+placeholder is an error: supply its value or use a concrete path before retrying.
+The resolved target stays captured for the session, including repeated starts
+from terminals with different environment variables. Literal paths need no
+additional config command.
 `--service` uses the background workflow without foreground watching or UI and
 rejects explicit `--watch` or `--ui`.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -133,6 +133,12 @@ reservation. Removing the environment releases it. `ocm dev status luna` reports
 the address. On Linux, macOS, and Windows, a matching repeated start requests a
 fresh native browser grant from the existing controller without restarting
 Gateway or Vite. Busy or unready requests report a pending link.
+Templated `gateway.controlUi.basePath` values are resolved by the selected
+checkout's native config command before startup, including OpenClaw's `.env`
+and config environment rules. The private read preserves the authored config,
+and repeated starts keep the original controller's resolved target. If variables
+remain unresolved, supply them or use a concrete base path before retrying;
+`--no-ui` still starts the Gateway without a UI target.
 Older OCM controllers retain address-only reuse and report fresh links as
 unavailable until that dev session is restarted.
 `ocm dev stop luna` stops the components together. A pending initial request gets

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -111,6 +111,7 @@ type SourceWatchResult<T> = Result<T, SourceWatchError>;
 #[derive(Clone, Copy)]
 enum SourcePreparationCommand {
     Source,
+    CapturedSource,
     DependencyInstall,
     DependencyProbe,
 }
@@ -697,10 +698,10 @@ impl Cli {
                 .environment_service()
                 .apply_effective_gateway_port(current)?;
             if ui {
-                crate::store::dev_ui_gateway_url(
-                    &derive_env_paths(Path::new(&prepared.root)),
-                    prepared.gateway_port.unwrap_or_default(),
-                )?;
+                let base = crate::store::dev_ui_gateway_base_path(&derive_env_paths(Path::new(
+                    &prepared.root,
+                )))?;
+                crate::store::dev_ui_gateway_url(&base, prepared.gateway_port.unwrap_or_default())?;
             }
             self.bootstrap_dev_env(&prepared)?;
             Ok::<_, String>(prepared)
@@ -759,7 +760,7 @@ impl Cli {
             )
             .and_then(|code| {
                 if code == 0 && ui {
-                    self.prepare_dev_ui(
+                    return self.prepare_dev_ui(
                         &meta,
                         dev.execution_source_root()?,
                         source_watch_lease
@@ -768,7 +769,7 @@ impl Cli {
                         watch_stop
                             .as_deref()
                             .ok_or_else(|| "dev UI cancellation state is missing".to_string())?,
-                    )?;
+                    );
                 }
                 Ok(code)
             });
@@ -1057,8 +1058,11 @@ impl Cli {
         if !matches!(&preparation, Ok(0)) {
             return finish_source_watch_session(&meta.name, lease, preparation, Ok(()), false);
         }
-        if ui && let Err(error) = self.prepare_dev_ui(&meta, &repo_root, lease, &watch_stop) {
-            return finish_source_watch_session(&meta.name, lease, Err(error), Ok(()), false);
+        if ui {
+            let preparation = self.prepare_dev_ui(&meta, &repo_root, lease, &watch_stop);
+            if !matches!(&preparation, Ok(0)) {
+                return finish_source_watch_session(&meta.name, lease, preparation, Ok(()), false);
+            }
         }
         let stderr_profile = self.dev_stderr_profile();
         self.stderr_lines(render_source_watch_takeover_summary(
@@ -1666,7 +1670,10 @@ impl Cli {
             return Ok(None);
         }
         lease.configure_child(&mut command);
-        let terminal = !matches!(kind, SourcePreparationCommand::DependencyProbe);
+        let terminal = !matches!(
+            kind,
+            SourcePreparationCommand::DependencyProbe | SourcePreparationCommand::CapturedSource
+        );
         let mut guard = SourceWatchProcessGuard::new_with_terminal(terminal)?;
         #[cfg(unix)]
         {

--- a/src/cli/dev/ui.rs
+++ b/src/cli/dev/ui.rs
@@ -640,14 +640,13 @@ impl Cli {
         source: &Path,
         lease: &mut SourceWatchLease,
         stop: &AtomicBool,
-    ) -> SourceWatchResult<()> {
+    ) -> SourceWatchResult<i32> {
         if source_watch_cancelled(lease, stop)? {
-            return Err("dev UI setup was cancelled".to_string().into());
+            return Ok(130);
         }
-        let gateway_url = crate::store::dev_ui_gateway_url(
-            &derive_env_paths(Path::new(&meta.root)),
-            meta.gateway_port.unwrap_or_default(),
-        )?;
+        let base =
+            crate::store::dev_ui_gateway_base_path(&derive_env_paths(Path::new(&meta.root)))?;
+        crate::store::dev_ui_gateway_url(&base, meta.gateway_port.unwrap_or_default())?;
         if !source.join("scripts/ui.js").is_file() || !source.join("ui/index.html").is_file() {
             return Err("the selected source does not contain the native Control UI development entry point".to_string().into());
         }
@@ -682,17 +681,32 @@ for (const name of ['vite', 'dompurify']) {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        let output = self
-            .run_owned_source_watch_command(
-                probe,
-                lease,
-                stop,
-                SourcePreparationCommand::DependencyProbe,
-            )?
-            .ok_or_else(|| SourceWatchError::from("dev UI setup was cancelled".to_string()))?;
+        let Some(output) = self.run_owned_source_watch_command(
+            probe,
+            lease,
+            stop,
+            SourcePreparationCommand::DependencyProbe,
+        )?
+        else {
+            return Ok(130);
+        };
+        if source_watch_cancelled(lease, stop)? {
+            return Ok(130);
+        }
         if !output.status.success() {
             return Err("Control UI dependencies are not ready; run pnpm install --frozen-lockfile in the selected checkout before retrying dev, or use --no-ui for Gateway-only development".to_string().into());
         }
+        let base = if base.contains("${") {
+            let Some(base) = self.resolve_native_dev_ui_base_path(meta, source, lease, stop)?
+            else {
+                return Ok(130);
+            };
+            base
+        } else {
+            base
+        };
+        let gateway_url =
+            crate::store::dev_ui_gateway_url(&base, meta.gateway_port.unwrap_or_default())?;
         let service = self.environment_service();
         let _operation = service.lock_operation(&meta.name)?;
         // Serialize selection, persistent reservation, and the session claim
@@ -733,7 +747,60 @@ for (const name of ['vite', 'dompurify']) {
                 gateway_url: gateway_url.clone(),
             })
         })?;
-        Ok(())
+        Ok(0)
+    }
+
+    fn resolve_native_dev_ui_base_path(
+        &self,
+        meta: &EnvMeta,
+        source: &Path,
+        lease: &mut SourceWatchLease,
+        stop: &AtomicBool,
+    ) -> SourceWatchResult<Option<String>> {
+        let mut command = source_watch_node_command(
+            "scripts/run-node.mjs",
+            &[
+                "config".to_string(),
+                "get".to_string(),
+                "gateway.controlUi.basePath".to_string(),
+                "--json".to_string(),
+            ],
+        );
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .env_clear()
+            .envs(build_openclaw_dev_source_env(meta, &self.env, source))
+            .current_dir(source);
+        // Use OpenClaw's read-only config command so its dotenv, config.env and
+        // shell environment rules stay owned by the selected source. Both
+        // output streams stay private, including failures and cancellation.
+        let Some(output) = self.run_owned_source_watch_command(
+            command,
+            lease,
+            stop,
+            SourcePreparationCommand::CapturedSource,
+        )?
+        else {
+            return Ok(None);
+        };
+        if source_watch_cancelled(lease, stop)? {
+            return Ok(None);
+        }
+        if !output.status.success() {
+            return Err(format!(
+                "OpenClaw could not resolve gateway.controlUi.basePath; inspect it with {} @{} -- config get gateway.controlUi.basePath --json before retrying dev, or use --no-ui",
+                self.command_example(), meta.name,
+            ).into());
+        }
+        let base: String = serde_json::from_slice(&output.stdout).map_err(|_| {
+            "OpenClaw did not return a string for gateway.controlUi.basePath; use a literal URL path or --no-ui".to_string()
+        })?;
+        if base.contains("${") {
+            return Err("gateway.controlUi.basePath still contains an environment placeholder; set its variables in the environment or OpenClaw config, use a concrete URL path, or pass --no-ui".to_string().into());
+        }
+        Ok(Some(base))
     }
 
     pub(super) fn run_source_gateway_ui(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -66,7 +66,7 @@ pub use layout::{
 };
 pub(crate) use openclaw_config::{
     OpenClawConfigAudit, audit_openclaw_config, clear_skip_bootstrap_for_openclaw_onboarding,
-    dev_ui_gateway_url, ensure_minimum_local_openclaw_config,
+    dev_ui_gateway_base_path, dev_ui_gateway_url, ensure_minimum_local_openclaw_config,
     normalize_new_environment_sandbox_origin, openclaw_config_include_paths,
     openclaw_config_uses_includes, reject_include_owned_agent_workspaces,
     reject_include_owned_sandbox_origin, repair_openclaw_config,

--- a/src/store/openclaw_config.rs
+++ b/src/store/openclaw_config.rs
@@ -602,7 +602,7 @@ fn minimum_local_config_value(
     Ok(value)
 }
 
-pub(crate) fn dev_ui_gateway_url(paths: &EnvPaths, port: u32) -> Result<String, String> {
+pub(crate) fn dev_ui_gateway_base_path(paths: &EnvPaths) -> Result<String, String> {
     let config = load_effective_openclaw_config(&paths.config_path)?
         .map(|config| config.value)
         .unwrap_or_else(|| json!({}));
@@ -631,9 +631,14 @@ pub(crate) fn dev_ui_gateway_url(paths: &EnvPaths, port: u32) -> Result<String, 
     }
     let base = match control_ui.and_then(|value| value.get("basePath")) {
         None | Some(Value::Null) => "",
-        Some(Value::String(value)) => value.trim().trim_matches('/'),
+        Some(Value::String(value)) => value,
         Some(_) => return Err("gateway.controlUi.basePath must be a URL path".to_string()),
     };
+    Ok(base.to_string())
+}
+
+pub(crate) fn dev_ui_gateway_url(base: &str, port: u32) -> Result<String, String> {
+    let base = base.trim().trim_matches('/');
     if base.contains(['?', '#', '\\']) || base.split('/').any(|part| matches!(part, "." | "..")) {
         return Err("gateway.controlUi.basePath must be a URL path without a query, fragment, or dot segments".to_string());
     }

--- a/tests/dev_command_tests.rs
+++ b/tests/dev_command_tests.rs
@@ -1574,6 +1574,7 @@ fn dev_ui_reuse_gets_fresh_grants_without_restarting_components() {
         let ui = initial_ui_process(&root, "ui", &mut controller);
         ui_dashboard_pid(&root, 1);
         wait_for_ui_command_cleanup(&root);
+        assert!(!root.child("config-attempts").exists());
         let initial = read_source_watch_session(&root);
         assert_eq!(initial["kind"], "ocm-source-ui-session-v1");
         assert_eq!(initial["watching"], watching);
@@ -1615,6 +1616,201 @@ fn dev_ui_reuse_gets_fresh_grants_without_restarting_components() {
         assert!(!stdout(&output).contains("synthetic-owner-grant-2"));
         assert!(!stdout(&output).contains("synthetic-owner-grant-3"));
         assert!(!ui_handoff_directory(&initial).exists());
+    }
+}
+
+#[cfg(unix)]
+fn create_ui_config_environment(
+    repo: &Path,
+    env: &std::collections::BTreeMap<String, String>,
+) -> ocm::env::EnvMeta {
+    ocm::store::create_environment(
+        ocm::env::CreateEnvironmentOptions {
+            name: "demo".to_string(),
+            root: None,
+            gateway_port: None,
+            service_enabled: false,
+            service_running: false,
+            default_runtime: None,
+            default_launcher: None,
+            dev: Some(EnvDevMeta::Borrowed {
+                source_root: path_string(&fs::canonicalize(repo).unwrap()),
+            }),
+            protected: false,
+        },
+        env,
+        repo,
+    )
+    .unwrap()
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_ui_resolves_native_config_once_and_reuses_the_captured_target() {
+    let _serial = INITIAL_UI_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (variant, expected_base) in [
+        ("caller", "/caller"),
+        ("config", "/configured"),
+        ("config-vars", "/vars"),
+        ("workspace-dotenv", "/workspace"),
+        ("state-dotenv", "/state"),
+    ] {
+        let root = TestDir::new(&format!("dev-ui-native-config-{variant}"));
+        let mut env = ocm_env(&root);
+        let repo = prepare_initial_ui_repo(&root, &mut env);
+        env.insert("OCM_ACTIVE_ENV".to_string(), "another-env".to_string());
+        env.insert("OPENCLAW_GATEWAY_PORT".to_string(), "1".to_string());
+        let meta = create_ui_config_environment(&repo, &env);
+        let config_path = Path::new(&meta.root).join(".openclaw/openclaw.json");
+        let include_path = config_path.with_file_name("control-ui.json");
+        let include = br#"{"basePath":"${UI_BASE}/${OCM_ACTIVE_ENV}/${OPENCLAW_GATEWAY_PORT}"}"#;
+        fs::write(&include_path, include).unwrap();
+        let mut config: Value = serde_json::from_slice(&fs::read(&config_path).unwrap()).unwrap();
+        config["gateway"]["controlUi"] = serde_json::json!({"$include": "./control-ui.json"});
+        config["env"] = serde_json::json!({"vars": {"UI_BASE": "/vars"}});
+        if variant != "config-vars" {
+            config["env"]["UI_BASE"] = "/configured".into();
+        }
+        match variant {
+            "caller" => {
+                env.insert("UI_BASE".to_string(), "/caller".to_string());
+            }
+            "workspace-dotenv" => fs::write(repo.join(".env"), "UI_BASE=/workspace\n").unwrap(),
+            "state-dotenv" => {
+                fs::write(config_path.with_file_name(".env"), "UI_BASE=/state\n").unwrap()
+            }
+            _ => {}
+        }
+        let config_bytes = serde_json::to_vec_pretty(&config).unwrap();
+        fs::write(&config_path, &config_bytes).unwrap();
+        fs::write(root.child("gateway-document-ready"), "ready").unwrap();
+        let args = ["dev", "demo", "--no-watch", "--ui"];
+        let mut controller = DevWatchFixture::spawn(&root, &repo, &env, &args);
+        let gateway = initial_ui_process(&root, "gateway", &mut controller);
+        let ui = initial_ui_process(&root, "ui", &mut controller);
+        ui_dashboard_pid(&root, 1);
+        wait_for_ui_command_cleanup(&root);
+        let expected = format!(
+            "http://127.0.0.1:{}{expected_base}/demo/{}/",
+            gateway["port"].as_u64().unwrap(),
+            gateway["port"].as_u64().unwrap(),
+        );
+        let initial = read_source_watch_session(&root);
+        assert_eq!(initial["ui"]["target"]["gatewayUrl"], expected, "{variant}");
+        assert_eq!(ui["gatewayUrl"], expected, "{variant}");
+        let native_reads = fs::read(root.child("config-attempts")).unwrap();
+        assert_eq!(String::from_utf8_lossy(&native_reads).lines().count(), 1);
+
+        let mut caller_env = env.clone();
+        caller_env.insert("UI_BASE".to_string(), "/different-caller".to_string());
+        let mut caller = DevWatchFixture::spawn_caller(&root, &repo, &caller_env, &args);
+        let reused = caller.wait_without_release_for(Duration::from_secs(5));
+        assert!(reused.status.success(), "{variant}: {}", stderr(&reused));
+        assert!(stdout(&reused).contains("synthetic-owner-grant-2"));
+        assert_eq!(
+            fs::read(root.child("config-attempts")).unwrap(),
+            native_reads
+        );
+        assert_eq!(read_source_watch_session(&root)["ui"], initial["ui"]);
+        assert_eq!(fs::read(&config_path).unwrap(), config_bytes);
+        assert_eq!(fs::read(&include_path).unwrap(), include);
+        let stopped = run_dev_stop(&repo, &env);
+        assert!(stopped.status.success(), "{variant}: {}", stderr(&stopped));
+        let output = controller.wait_without_release();
+        assert_eq!(output.status.code(), Some(130));
+        assert!(stdout(&output).contains("synthetic-owner-grant-1"));
+        assert!(!stderr(&output).contains("synthetic-private-config"));
+        assert_eq!(read_source_watch_session(&root)["closed"], true);
+        for process in [gateway, ui] {
+            assert!(wait_for_process_exit(
+                process["pid"].as_u64().unwrap() as u32,
+                Duration::from_secs(3),
+            ));
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn dev_ui_native_config_failures_and_cancellation_preserve_private_output_and_state() {
+    let _serial = INITIAL_UI_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (variant, expected) in [
+        ("fail", "could not resolve gateway.controlUi.basePath"),
+        ("malformed", "did not return a string"),
+        ("unresolved", "still contains an environment placeholder"),
+        ("unsafe-path", "without a query, fragment, or dot segments"),
+        ("cancel", ""),
+    ] {
+        let root = TestDir::new(&format!("dev-ui-config-{variant}"));
+        let mut env = ocm_env(&root);
+        let repo = prepare_initial_ui_repo(&root, &mut env);
+        let meta = create_ui_config_environment(&repo, &env);
+        let config_path = Path::new(&meta.root).join(".openclaw/openclaw.json");
+        let mut config: Value = serde_json::from_slice(&fs::read(&config_path).unwrap()).unwrap();
+        config["gateway"]["controlUi"] = serde_json::json!({"basePath": "${UI_BASE}"});
+        let config_bytes = serde_json::to_vec_pretty(&config).unwrap();
+        fs::write(&config_path, &config_bytes).unwrap();
+        if variant != "unresolved" {
+            env.insert(
+                "UI_BASE".to_string(),
+                if variant == "unsafe-path" {
+                    "/../private"
+                } else {
+                    "/console"
+                }
+                .to_string(),
+            );
+        }
+        if matches!(variant, "fail" | "malformed" | "cancel") {
+            fs::write(
+                root.child(if variant == "cancel" {
+                    "config-hold".to_string()
+                } else {
+                    format!("config-{variant}")
+                }),
+                "hold",
+            )
+            .unwrap();
+        }
+        let mut controller =
+            DevWatchFixture::spawn(&root, &repo, &env, &["dev", "demo", "--no-watch", "--ui"]);
+        assert!(wait_for_path(
+            &root.child("config-attempts"),
+            Duration::from_secs(10)
+        ));
+        let query_pid = fs::read_to_string(root.child("config-attempts"))
+            .unwrap()
+            .trim()
+            .parse::<u32>()
+            .unwrap();
+        if variant == "cancel" {
+            let stopped = run_dev_stop(&repo, &env);
+            assert!(stopped.status.success(), "{}", stderr(&stopped));
+        }
+        let output = controller.wait_without_release();
+        assert_eq!(
+            output.status.code(),
+            Some(if variant == "cancel" { 130 } else { 1 })
+        );
+        assert!(
+            stderr(&output).contains(expected),
+            "{variant}: {}",
+            stderr(&output)
+        );
+        assert!(!stdout(&output).contains("synthetic-private-config"));
+        assert!(!stderr(&output).contains("synthetic-private-config"));
+        assert!(!root.child("gateway.json").exists());
+        assert!(!root.child("ui.json").exists());
+        assert_eq!(fs::read(&config_path).unwrap(), config_bytes);
+        let session = read_source_watch_session(&root);
+        assert_eq!(session["closed"], true, "{variant}");
+        assert!(session["ui"]["children"].as_object().unwrap().is_empty());
+        assert!(session["ui"]["pending"].is_null());
+        assert!(wait_for_process_exit(query_pid, Duration::from_secs(3)));
     }
 }
 

--- a/tests/support/dev_ui.cjs
+++ b/tests/support/dev_ui.cjs
@@ -7,17 +7,60 @@ const root = process.env.OCM_TEST_DEV_UI_DIR;
 const file = (name) => path.join(root, name);
 const exists = (name) => fs.existsSync(file(name));
 const config = JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8"));
+const controlUi = config.gateway.controlUi?.$include
+  ? JSON.parse(fs.readFileSync(path.resolve(path.dirname(process.env.OPENCLAW_CONFIG_PATH), config.gateway.controlUi.$include), "utf8"))
+  : config.gateway.controlUi;
+// Controlled peers implement only the config inputs used by these CLI tests.
+// Native OpenClaw remains the authority for its complete config/env semantics.
+const nativeEnv = {...process.env};
+for (const dotenv of [path.join(process.cwd(), ".env"), path.join(path.dirname(process.env.OPENCLAW_CONFIG_PATH), ".env")]) {
+  if (!fs.existsSync(dotenv)) continue;
+  for (const line of fs.readFileSync(dotenv, "utf8").split(/\r?\n/)) {
+    const entry = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(line);
+    if (entry && nativeEnv[entry[1]] === undefined) nativeEnv[entry[1]] = entry[2];
+  }
+}
+for (const [key, value] of Object.entries({...config.env?.vars, ...config.env})) {
+  if (typeof value === "string" && value.trim() && !value.includes("${") && !nativeEnv[key]?.trim()) {
+    nativeEnv[key] = value;
+  }
+}
+const resolvedBase = String(controlUi?.basePath ?? "").replace(/\$\$?\{([A-Z_][A-Z0-9_]*)\}/g,
+  (reference, name) => reference.startsWith("$$") ? reference.slice(1) : nativeEnv[name] || reference);
 const gatewayPort = Number(process.env.OPENCLAW_GATEWAY_PORT);
-const base = String(config.gateway.controlUi?.basePath ?? "").replace(/^\/+|\/+$/g, "");
+const base = resolvedBase.replace(/^\/+|\/+$/g, "");
 const documentPath = base ? `/${base}/` : "/";
 const gatewayUrl = `http://127.0.0.1:${gatewayPort}${documentPath}`;
-const role = process.argv.includes("dashboard")
+const role = process.argv.includes("config")
+  ? "config"
+  : process.argv.includes("dashboard")
   ? "dashboard"
   : process.argv[1].endsWith("ui.js")
     ? "ui"
     : "gateway";
 
-if (role === "dashboard") {
+if (role === "config") {
+  if (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(["config", "get", "gateway.controlUi.basePath", "--json"])) {
+    throw new Error("unexpected native config read");
+  }
+  fs.appendFileSync(file("config-attempts"), `${process.pid}\n`);
+  process.stderr.write("synthetic-private-config-diagnostic\n");
+  process.once("SIGTERM", () => process.exit(143));
+  const timer = setInterval(() => {
+    if (exists("source-watch.release")) process.exit(0);
+    if (exists("config-hold")) return;
+    clearInterval(timer);
+    if (exists("config-fail")) {
+      process.stdout.write("synthetic-private-config-output\n");
+      process.exit(7);
+    }
+    if (exists("config-malformed")) {
+      process.stdout.write("synthetic-private-config-output\n");
+    } else {
+      console.log(JSON.stringify(resolvedBase));
+    }
+  }, 20);
+} else if (role === "dashboard") {
   const attempts = file("dashboard-attempts");
   fs.appendFileSync(attempts, `${process.pid}\n`);
   const count = fs.readFileSync(attempts, "utf8").trim().split("\n").length;

--- a/tests/support/dev_ui.cjs
+++ b/tests/support/dev_ui.cjs
@@ -12,16 +12,21 @@ const controlUi = config.gateway.controlUi?.$include
   : config.gateway.controlUi;
 // Controlled peers implement only the config inputs used by these CLI tests.
 // Native OpenClaw remains the authority for its complete config/env semantics.
-const nativeEnv = {...process.env};
+const nativeEnv = {
+  UI_BASE: process.env.UI_BASE,
+  OCM_TEST_UI_BASE: process.env.OCM_TEST_UI_BASE,
+  OCM_ACTIVE_ENV: process.env.OCM_ACTIVE_ENV,
+  OPENCLAW_GATEWAY_PORT: process.env.OPENCLAW_GATEWAY_PORT,
+};
 for (const dotenv of [path.join(process.cwd(), ".env"), path.join(path.dirname(process.env.OPENCLAW_CONFIG_PATH), ".env")]) {
   if (!fs.existsSync(dotenv)) continue;
   for (const line of fs.readFileSync(dotenv, "utf8").split(/\r?\n/)) {
     const entry = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(line);
-    if (entry && nativeEnv[entry[1]] === undefined) nativeEnv[entry[1]] = entry[2];
+    if (entry && Object.hasOwn(nativeEnv, entry[1]) && nativeEnv[entry[1]] === undefined) nativeEnv[entry[1]] = entry[2];
   }
 }
 for (const [key, value] of Object.entries({...config.env?.vars, ...config.env})) {
-  if (typeof value === "string" && value.trim() && !value.includes("${") && !nativeEnv[key]?.trim()) {
+  if (Object.hasOwn(nativeEnv, key) && typeof value === "string" && value.trim() && !value.includes("${") && !nativeEnv[key]?.trim()) {
     nativeEnv[key] = value;
   }
 }

--- a/tests/support/windows_dev_stop.cjs
+++ b/tests/support/windows_dev_stop.cjs
@@ -159,14 +159,14 @@ async function start(name, watching = true, withUi = false, defaults = false) {
   if (withUi && takeover) {
     fs.mkdirSync(path.join(envRoot, '.openclaw'), {recursive:true});
     fs.writeFileSync(path.join(envRoot, '.openclaw', 'openclaw.json'), JSON.stringify({
-      gateway:{controlUi:{basePath:'/console'}, auth:{mode:'token', token:'synthetic-fixture-auth'}},
+      gateway:{controlUi:{basePath:'${OCM_TEST_UI_BASE}'}, auth:{mode:'token', token:'synthetic-fixture-auth'}},
     }));
   }
   const modes = defaults ? [] : [watching ? '--watch' : '--no-watch', withUi ? '--ui' : '--no-ui'];
   const args = ['dev',name,...(defaults ? [] : ['--repo',repo]),...(takeover ? ['--force'] : ['--root',envRoot,'--port',port]),...modes];
   const sourceEnv = {
     ...env,
-    ...(withUi ? {OCM_TEST_DEV_UI_DIR:directory, OCM_TEST_DEV_UI_DESCENDANTS:'1'} : {}),
+    ...(withUi ? {OCM_TEST_DEV_UI_DIR:directory, OCM_TEST_DEV_UI_DESCENDANTS:'1', OCM_TEST_UI_BASE:'/console'} : {}),
     NoDe_CoMpIlE_CaChE: path.join(directory, 'inherited-cache'),
     nOdE_dIsAbLe_CoMpIlE_cAcHe: '0',
     NODE_OPTIONS: '--no-warnings'
@@ -288,6 +288,7 @@ for (const [signal, code] of [['SIGINT',130],['SIGTERM',143]]) process.once(sign
       'Completed initial handoff was not acknowledged');
     assert.match(normal.output(), /UI: http:\/\/127\.0\.0\.1:\d+\/#bootstrapToken=synthetic-owner-grant-1/);
     assert.ok(!normal.output().includes('synthetic-legacy'));
+    assert.ok(!fs.existsSync(path.join(normal.directory, 'config-attempts')), 'Default path ran an extra config command');
     const active = JSON.parse(run(['dev','status',normal.name,'--json']).stdout);
     assert.equal(active.sourceWatch.state, 'active', 'Held watch lease was not readable by dev status');
     assert.equal(active.sourceWatch.watching, true);
@@ -438,6 +439,10 @@ for (const [signal, code] of [['SIGINT',130],['SIGTERM',143]]) process.once(sign
     results.push('native plain named stop, descendant cleanup, env/source preservation');
 
     const crashed = await start('crashed', true, true);
+    assert.equal(fs.readFileSync(path.join(crashed.directory, 'config-attempts'), 'utf8').trim().split(/\r?\n/).length, 1,
+      'Native config must be resolved once before UI startup');
+    assert.ok(session(crashed.name).ui.target.gatewayUrl.endsWith('/console/'), 'Native config did not resolve the UI path');
+    assert.ok(!crashed.output().includes('synthetic-private-config'), 'Native config output reached the terminal');
     await crash(crashed);
     await stop(crashed.name);
     await checkPreserved(crashed);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `ocm dev` left the UI link pending when `gateway.controlUi.basePath` used an environment variable such as `${UI_BASE}`. The Gateway could be healthy at `/console/` while OCM probed the encoded placeholder path.

## Why This Change Was Made

For templated paths, the foreground owner reads only the base path through the selected checkout's native config command, then applies the existing loopback and path validation. OpenClaw owns include and environment resolution, including `.env` and config-provided variables. The resolved target remains captured for the session.

## User Impact

Initial and repeated dev commands can obtain UI links for the effective configured path. Literal paths avoid the extra config command. Failed reads and unresolved or invalid paths produce actionable errors before Gateway and Vite start; query output stays private, and stopping during the read preserves verified cleanup.

## Evidence

- The released-binary baseline requested `/$%7BUI_BASE%7D/` eleven times and received 404 while `/console/` returned 200, leaving both initial and repeated starts without a dashboard handoff.
- Focused CLI coverage exercises includes, caller/config environment precedence, checkout/state `.env` files, selected environment identity, captured-target reuse, private failure output, invalid paths, and cancellation.
- Remote validation passed: `cargo fmt --check`, `cargo check --workspace --all-targets --locked`, the native-config and private failure/cancellation CLI tests, and the existing literal-path fresh-link reuse test.
