### PR TITLE
chore(release): bump version to 0.2.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.44"
+version = "0.2.45"
 dependencies = [
  "base64",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.44"
+version = "0.2.45"
 publish = false
 edition = "2024"
 rust-version = "1.88"


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This release branch is in the canonical repository, where maintainers already have write access. GitHub's fork-collaboration toggle does not apply.

</details>

## What Problem This Solves

Makes the independent development-directory checkpoint fix in #219 available through a published OCM release, together with the other changes already merged since v0.2.44.

## Why This Change Was Made

Prepare v0.2.45 by changing only the package version in Cargo.toml and Cargo.lock. The existing release workflow still requires exact-main CI, a verified signed annotated tag, complete platform assets, and macOS signing and notarization.

## User Impact

Operators can install the released checkpoint exclusion fix through the normal OCM update path. This version PR does not change runtime configuration, launch an OpenClaw update, or alter release credentials or automation.

## Evidence

- Version-only two-file diff, based on freshly fetched canonical main at 9d48e1e09e2ff44fa08ff0762e0b1ab61d439fa4 after #219 merged.
- #219 has 56 focused tests, all-target Cargo checking, initial independent validation through 137 CLI commands and final-head follow-up through 114 commands. All exact-head CI jobs passed.
- Locked version metadata, format, version consistency, and diff checks pass.
- Full release-PR CI and exact release-main CI are required before signing and dispatch. No unsigned-tag or signing bypass is used.
