### PR TITLE
fix: allow disjoint missing Unicode roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Check Windows targets
         run: cargo check --workspace --all-targets --locked
       - name: Prove missing Unicode environment root isolation
+        timeout-minutes: 5
         run: cargo test --locked --test env_root_isolation_tests missing_unicode_
       - name: Prove private config writes
         run: cargo test --locked --lib private_config_

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Check Windows targets
         run: cargo check --workspace --all-targets --locked
+      - name: Prove missing Unicode environment root isolation
+        run: cargo test --locked --test env_root_isolation_tests missing_unicode_
       - name: Prove private config writes
         run: cargo test --locked --lib private_config_
       - name: Prove private Windows UI handoffs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,12 +560,14 @@ name = "ocm"
 version = "0.2.45"
 dependencies = [
  "base64",
+ "caseless",
  "ctrlc",
  "dialoguer",
  "filetime",
  "flate2",
  "fs2",
  "getrandom 0.4.3",
+ "icu_properties",
  "indicatif",
  "json5",
  "libc",
@@ -940,6 +951,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +988,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 ureq = { version = "3.3", default-features = false, features = ["rustls"] }
 indicatif = { version = "0.18", default-features = false, features = ["unicode-width"] }
 unicode-width = "0.2"
+caseless = "0.2"
+icu_properties = "2.3"
 terminal_size = "0.4"
 dialoguer = { version = "0.12", default-features = false }
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
@@ -53,6 +55,7 @@ xattr = "1.6"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_Globalization",
     "Win32_Security",
     "Win32_Storage_FileSystem",
     "Win32_System_Diagnostics_ToolHelp",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -526,6 +526,11 @@ disjoint custom roots remain valid. This applies to `env create`, `env clone`,
 `env import`, and new environments created by `start`, `setup`, `dev`, `migrate`,
 `adopt import`, or upgrade simulation.
 
+A registered root remains reserved while its directory is missing. Disjoint
+Unicode roots remain valid; case and normalization aliases of a missing root
+are still reserved. On Windows, an ambiguous missing 8.3 short name requires
+restoring the registered path before retrying.
+
 These operations also require a root outside registered dev sources. Missing borrowed
 source paths remain reserved until their binding is removed; missing paths of
 OCM-owned worktrees can still be reused. The root must neither contain

--- a/src/store/dev_sources.rs
+++ b/src/store/dev_sources.rs
@@ -204,7 +204,7 @@ fn windows_case_alias(left: &str, right: &str) -> Result<bool, String> {
     let left_len = i32::try_from(left.len()).map_err(|error| error.to_string())?;
     let right_len = i32::try_from(right.len()).map_err(|error| error.to_string())?;
     // Both buffers remain live for their explicit UTF-16 lengths. Use the OS
-    // uppercase table as well as Unicode folding (for example, dotless i).
+    // uppercase table as well as Unicode folding.
     let comparison =
         unsafe { CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) };
     if comparison == 0 {

--- a/src/store/dev_sources.rs
+++ b/src/store/dev_sources.rs
@@ -2,6 +2,9 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use caseless::Caseless;
+use icu_properties::{CodePointSetData, props::DefaultIgnorableCodePoint};
+
 use crate::env::{EnvDevMeta, EnvMeta};
 
 use super::display_path;
@@ -141,11 +144,8 @@ pub(crate) fn projected_path_relative(root: &Path, path: &Path) -> Result<Option
         if component == expected {
             continue;
         }
-        let component = component
-            .as_os_str()
-            .to_str()
-            .filter(|name| name.is_ascii());
-        let expected = expected.as_os_str().to_str().filter(|name| name.is_ascii());
+        let component = component.as_os_str().to_str();
+        let expected = expected.as_os_str().to_str();
         let (Some(component), Some(expected)) = (component, expected) else {
             return Err("cannot distinguish differently encoded missing source names; restore the source before retrying".to_string());
         };
@@ -154,9 +154,17 @@ pub(crate) fn projected_path_relative(root: &Path, path: &Path) -> Result<Option
             component.trim_end_matches(&['.', ' '][..]),
             expected.trim_end_matches(&['.', ' '][..]),
         );
-        // Missing names lack filesystem identity. Reserve possible case aliases
-        // without changing comparisons between existing entries.
-        if component.eq_ignore_ascii_case(expected) {
+        // Missing names lack filesystem identity. Reserve possible Unicode
+        // aliases without changing comparisons between existing entries.
+        if component.eq_ignore_ascii_case(expected)
+            || ((!component.is_ascii() || !expected.is_ascii())
+                && missing_name_characters(component)
+                    .compatibility_caseless_match(missing_name_characters(expected)))
+        {
+            continue;
+        }
+        #[cfg(windows)]
+        if windows_case_alias(component, expected)? {
             continue;
         }
         #[cfg(windows)]
@@ -170,12 +178,50 @@ pub(crate) fn projected_path_relative(root: &Path, path: &Path) -> Result<Option
     Ok(Some(actual.collect()))
 }
 
+fn missing_name_characters(name: &str) -> impl Iterator<Item = char> + '_ {
+    let ignorables = CodePointSetData::new::<DefaultIgnorableCodePoint>();
+    name.chars()
+        // HFS+ ignores formatting characters in filename comparisons. This is
+        // only a conservative reservation key; never rewrite a stored path.
+        .filter(move |character| !ignorables.contains(*character))
+        .map(|character| match character {
+            // HFS+ folds Georgian Asomtavruli to Mkhedruli, whereas modern
+            // Unicode folds it to Nuskhuri. Preserve both equivalences before
+            // applying standard Unicode compatibility caseless matching.
+            // https://developer.apple.com/library/archive/technotes/tn/tn1150.html
+            '\u{10a0}'..='\u{10c5}' => char::from_u32(character as u32 + 0x30).unwrap(),
+            '\u{2d00}'..='\u{2d25}' => char::from_u32(character as u32 - 0x1c30).unwrap(),
+            _ => character,
+        })
+}
+
+#[cfg(windows)]
+fn windows_case_alias(left: &str, right: &str) -> Result<bool, String> {
+    use windows_sys::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
+
+    let left: Vec<u16> = left.encode_utf16().collect();
+    let right: Vec<u16> = right.encode_utf16().collect();
+    let left_len = i32::try_from(left.len()).map_err(|error| error.to_string())?;
+    let right_len = i32::try_from(right.len()).map_err(|error| error.to_string())?;
+    // Both buffers remain live for their explicit UTF-16 lengths. Use the OS
+    // uppercase table as well as Unicode folding (for example, dotless i).
+    let comparison =
+        unsafe { CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) };
+    if comparison == 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    Ok(comparison == CSTR_EQUAL)
+}
+
 #[cfg(windows)]
 fn possible_short_name(name: &str) -> bool {
     let mut parts = name.split('.');
     let base = parts.next().unwrap_or_default();
     let extension = parts.next().unwrap_or_default();
-    !base.is_empty() && base.len() <= 8 && extension.len() <= 3 && parts.next().is_none()
+    !base.is_empty()
+        && base.encode_utf16().count() <= 8
+        && extension.encode_utf16().count() <= 3
+        && parts.next().is_none()
 }
 
 #[cfg(windows)]

--- a/tests/dev_source_isolation_tests.rs
+++ b/tests/dev_source_isolation_tests.rs
@@ -225,6 +225,37 @@ fn borrowed(source: &Path) -> EnvDevMeta {
 }
 
 #[test]
+fn missing_unicode_borrowed_sources_preserve_aliases_and_allow_siblings() {
+    let fixture = TestDir::new("missing-unicode-borrowed-source");
+    let cwd = fixture.path();
+    let env = ocm_env(&fixture);
+    let source = init_checkout(&fixture.child("projects/café-source"));
+    create("developer", None, Some(borrowed(&source)), &env, cwd).unwrap();
+    let retained = fixture.child("retained");
+    fs::rename(&source, &retained).unwrap();
+    let registry = env_registry_path(&env, cwd).unwrap();
+    let before = fs::read(&registry).unwrap();
+
+    for destination in [
+        source.clone(),
+        source.with_file_name("CAFE\u{301}-SOURCE").join("state"),
+    ] {
+        let error = create("blocked", Some(&destination), None, &env, cwd).unwrap_err();
+        assert!(error.contains("overlaps borrowed source"), "{error}");
+        assert_eq!(fs::read(&registry).unwrap(), before);
+        assert!(!destination.exists());
+    }
+    let sibling = source.with_file_name("日本語の環境ルート");
+    create("sibling", Some(&sibling), None, &env, cwd).unwrap();
+    assert!(sibling.join(".openclaw/workspace").is_dir());
+    assert!(!source.exists());
+    assert_eq!(
+        fs::read_to_string(retained.join("scripts/run-node.mjs")).unwrap(),
+        "// retained source\n"
+    );
+}
+
+#[test]
 fn missing_borrowed_sources_remain_reserved_until_the_binding_is_removed() {
     let fixture = TestDir::new("missing-borrowed-reservations");
     let cwd = fixture.path();

--- a/tests/env_root_isolation_tests.rs
+++ b/tests/env_root_isolation_tests.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::Path;
 use std::process::Output;
 
-use ocm::store::env_registry_path;
+use ocm::store::{env_registry_path, get_environment};
 
 use support::{TestDir, ocm_env, path_string, run_ocm, stderr, write_text};
 
@@ -176,6 +176,111 @@ fn missing_registered_roots_still_reserve_their_locations() {
     let sibling = reserved.with_file_name("reserved-sibling");
     let accepted = admit(&fixture, &env, "create", "sibling", &sibling);
     assert!(accepted.status.success(), "{}", stderr(&accepted));
+}
+
+#[test]
+fn missing_unicode_roots_allow_disjoint_siblings() {
+    for (reserved_name, sibling_name) in [
+        ("日本語の環境ルート", "second-environment"),
+        ("reserved-environment", "日本語の環境ルート"),
+        ("日本語の環境ルート", "开发环境-configuration"),
+        ("café-environment", "résumé-environment"),
+        ("ქართული-environment", "second-environment"),
+        ("👩\u{200d}💻-environment", "second-environment"),
+        #[cfg(not(windows))]
+        ("日本語", "second-environment"),
+    ] {
+        let fixture = TestDir::new("missing-unicode-root-siblings");
+        let env = ocm_env(&fixture);
+        template(&fixture, &env);
+        let reserved = fixture.child("roots").join(reserved_name);
+        let created = admit(&fixture, &env, "create", "reserved", &reserved);
+        assert!(created.status.success(), "{}", stderr(&created));
+        write_text(&reserved.join(".openclaw/workspace/keep.txt"), "retained\n");
+        let displaced = fixture.child("displaced");
+        fs::rename(&reserved, &displaced).unwrap();
+
+        for action in ["create", "clone", "import"] {
+            let name = format!("sibling-{action}");
+            let destination = reserved.with_file_name(format!("{sibling_name}-{action}"));
+            let accepted = admit(&fixture, &env, action, &name, &destination);
+            assert!(accepted.status.success(), "{}", stderr(&accepted));
+            assert!(destination.join(".openclaw/workspace").is_dir());
+            assert_eq!(
+                get_environment(&name, &env, fixture.path()).unwrap().name,
+                name
+            );
+            assert!(!reserved.exists());
+            assert_eq!(
+                fs::read_to_string(displaced.join(".openclaw/workspace/keep.txt")).unwrap(),
+                "retained\n"
+            );
+        }
+    }
+}
+
+#[test]
+fn missing_unicode_root_aliases_remain_reserved() {
+    for (reserved_name, alias_name) in [
+        ("café-environment", "CAFE\u{301}-ENVIRONMENT"),
+        ("Σ-environment", "ς-environment"),
+        ("K-environment", "k-environment"),
+        ("repo\u{200c}-environment", "repo-environment"),
+        ("Ⴀ-environment", "ა-environment"),
+        ("Ⴀ-environment", "ⴀ-environment"),
+        ("Ა-environment", "ⴀ-environment"),
+        #[cfg(windows)]
+        ("I-environment", "ı-environment"),
+    ] {
+        let fixture = TestDir::new("missing-unicode-root-aliases");
+        let env = ocm_env(&fixture);
+        template(&fixture, &env);
+        let reserved = fixture.child("roots").join(reserved_name);
+        let created = admit(&fixture, &env, "create", "reserved", &reserved);
+        assert!(created.status.success(), "{}", stderr(&created));
+        write_text(&reserved.join(".openclaw/workspace/keep.txt"), "retained\n");
+        let displaced = fixture.child("displaced");
+        fs::rename(&reserved, &displaced).unwrap();
+        let registry = env_registry_path(&env, fixture.path()).unwrap();
+        let before = fs::read(&registry).unwrap();
+        let alias = reserved.with_file_name(alias_name);
+
+        for action in ["create", "clone", "import"] {
+            let rejected = admit(&fixture, &env, action, "blocked", &alias.join("child"));
+            assert!(!rejected.status.success());
+            assert!(
+                stderr(&rejected).contains("overlaps environment reserved root"),
+                "{}",
+                stderr(&rejected)
+            );
+            assert_eq!(fs::read(&registry).unwrap(), before);
+            assert!(!reserved.exists());
+            assert!(!alias.exists());
+            assert_eq!(
+                fs::read_to_string(displaced.join(".openclaw/workspace/keep.txt")).unwrap(),
+                "retained\n"
+            );
+        }
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn missing_unicode_short_names_remain_ambiguous() {
+    let fixture = TestDir::new("missing-unicode-short-name");
+    let env = ocm_env(&fixture);
+    let reserved = fixture.child("roots/日本語");
+    let created = admit(&fixture, &env, "create", "reserved", &reserved);
+    assert!(created.status.success(), "{}", stderr(&created));
+    fs::rename(&reserved, fixture.child("displaced")).unwrap();
+    let registry = env_registry_path(&env, fixture.path()).unwrap();
+    let before = fs::read(&registry).unwrap();
+    let destination = reserved.with_file_name("second-environment");
+    let rejected = admit(&fixture, &env, "create", "blocked", &destination);
+    assert!(!rejected.status.success());
+    assert!(stderr(&rejected).contains("cannot distinguish missing Windows short-name aliases"));
+    assert_eq!(fs::read(&registry).unwrap(), before);
+    assert!(!destination.exists());
 }
 
 #[cfg(unix)]

--- a/tests/env_root_isolation_tests.rs
+++ b/tests/env_root_isolation_tests.rs
@@ -241,8 +241,6 @@ fn missing_unicode_root_aliases_remain_reserved() {
         ("Ⴀ-environment", "ა-environment"),
         ("Ⴀ-environment", "ⴀ-environment"),
         ("Ა-environment", "ⴀ-environment"),
-        #[cfg(windows)]
-        ("I-environment", "ı-environment"),
     ] {
         let fixture = TestDir::new("missing-unicode-root-aliases");
         let env = ocm_env(&fixture);
@@ -259,7 +257,10 @@ fn missing_unicode_root_aliases_remain_reserved() {
 
         for action in ["create", "clone", "import"] {
             let rejected = admit(&fixture, &env, action, "blocked", &alias.join("child"));
-            assert!(!rejected.status.success());
+            assert!(
+                !rejected.status.success(),
+                "{action} admitted {alias_name:?} for missing {reserved_name:?}"
+            );
             assert!(
                 stderr(&rejected).contains("overlaps environment reserved root"),
                 "{}",
@@ -274,6 +275,35 @@ fn missing_unicode_root_aliases_remain_reserved() {
             );
         }
     }
+}
+
+#[cfg(windows)]
+#[test]
+fn missing_unicode_windows_ordinal_names_remain_distinct() {
+    let fixture = TestDir::new("missing-unicode-windows-ordinal");
+    let env = ocm_env(&fixture);
+    let reserved = fixture.child("roots/I-environment");
+    let distinct = reserved.with_file_name("ı-environment");
+    let created = admit(&fixture, &env, "create", "reserved", &reserved);
+    assert!(created.status.success(), "{}", stderr(&created));
+    write_text(&reserved.join(".openclaw/workspace/keep.txt"), "retained\n");
+
+    // Verify the filesystem distinguishes these names before testing the
+    // missing-path policy. Windows ordinal casing leaves dotless i unchanged.
+    fs::create_dir(&distinct).expect("Windows must distinguish I from dotless i");
+    fs::remove_dir(&distinct).unwrap();
+    let displaced = fixture.child("displaced");
+    fs::rename(&reserved, &displaced).unwrap();
+
+    let destination = distinct.join("child");
+    let accepted = admit(&fixture, &env, "create", "sibling", &destination);
+    assert!(accepted.status.success(), "{}", stderr(&accepted));
+    assert!(destination.join(".openclaw/workspace").is_dir());
+    assert!(!reserved.exists());
+    assert_eq!(
+        fs::read_to_string(displaced.join(".openclaw/workspace/keep.txt")).unwrap(),
+        "retained\n"
+    );
 }
 
 #[cfg(windows)]

--- a/tests/env_root_isolation_tests.rs
+++ b/tests/env_root_isolation_tests.rs
@@ -31,6 +31,13 @@ fn admit(
 fn template(fixture: &TestDir, env: &BTreeMap<String, String>) {
     let created = run_ocm(fixture.path(), env, &["env", "create", "template"]);
     assert!(created.status.success(), "{}", stderr(&created));
+    let port = get_environment("template", env, fixture.path())
+        .unwrap()
+        .gateway_port;
+    assert!(
+        port.is_some_and(|port| (1..=u16::MAX as u32).contains(&port)),
+        "invalid fixture gateway port: {port:?}"
+    );
     let exported = run_ocm(
         fixture.path(),
         env,
@@ -206,9 +213,14 @@ fn missing_unicode_roots_allow_disjoint_siblings() {
             let accepted = admit(&fixture, &env, action, &name, &destination);
             assert!(accepted.status.success(), "{}", stderr(&accepted));
             assert!(destination.join(".openclaw/workspace").is_dir());
-            assert_eq!(
-                get_environment(&name, &env, fixture.path()).unwrap().name,
-                name
+            let registered = get_environment(&name, &env, fixture.path()).unwrap();
+            assert_eq!(registered.name, name);
+            assert!(
+                registered
+                    .gateway_port
+                    .is_some_and(|port| (1..=u16::MAX as u32).contains(&port)),
+                "invalid sibling gateway port: {:?}",
+                registered.gateway_port
             );
             assert!(!reserved.exists());
             assert_eq!(

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -300,6 +300,12 @@ pub fn base_env(home: &Path) -> BTreeMap<String, String> {
     if let Ok(path) = std::env::var("PATH") {
         env.insert("PATH".to_string(), path);
     }
+    #[cfg(windows)]
+    {
+        // Windows system DLLs still need SystemRoot in an isolated environment.
+        let system_root = std::env::var("SystemRoot").expect("Windows fixture requires SystemRoot");
+        env.insert("SystemRoot".to_string(), system_root);
+    }
     env
 }
 


### PR DESCRIPTION
Related: #217

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Creating, cloning, or importing an environment could be refused a disjoint root when another registered root was missing and either path contained Unicode characters. For example, on macOS and Linux, a missing registered `roots/日本語` incorrectly blocked a new `roots/second`.

## Why This Change Was Made

The shared missing-path comparison treated every unequal non-ASCII name as ambiguous. It now distinguishes names using Unicode compatibility caseless matching while reserving case, normalization, ignored-character, and historical macOS aliases. Existing filesystem identity checks and stored paths remain authoritative when entries exist. Windows also uses its native uppercase comparison and retains conservative refusal for uncertain 8.3 aliases.

## User Impact

Users can create, clone, and import environments at disjoint Unicode roots even when a sibling environment directory is temporarily missing. Overlapping roots and missing borrowed sources remain protected. The usage guide explains missing-root reservations and restoring a missing Windows root when a possible short-name alias cannot be ruled out.

## Evidence

- Before: actual CLI probes reproduced all six affected create/clone/import cases across both Unicode-name orientations; the revision before the root guard accepted them.
- The final remote Rust 1.88 bundle passed formatting, locked all-target compilation, and 86 affected tests covering root/source isolation, destruction, snapshots, checkpoint scope, and simulation cloning. Direct CLI checks accepted create/clone/import at disjoint roots and rejected overlap and normalization aliases while preserving registered paths, displaced content, and rejected destinations.
- [Native Windows execution](https://github.com/openclaw/ocm/actions/runs/34654541884/job/103443953263) passed all four focused tests. These cover distinct siblings, seven portable alias pairs through create/clone/import, short-name ambiguity, and a real filesystem distinction before admitting I/dotless-i roots. Isolated Windows child processes now retain `SystemRoot`, and setup asserts valid gateway ports.
- [Full CI](https://github.com/openclaw/ocm/actions/runs/34654541884) passed, including Linux/macOS test suites, Windows checks, the Rust 1.88 minimum, formatting, and npm platform/version lanes. [CodeQL](https://github.com/openclaw/ocm/actions/runs/34654536969) also passed. The final changed-path local preflight passed in 6.0 seconds.
- Independent engineering review completed with no outstanding findings. The [final ClawSweeper attempt](https://github.com/openclaw/clawsweeper/actions/runs/34654960558) failed during queue admission before review because manual review publication was disabled; it produced no rating for the final commit.
