### PR TITLE
fix: detect existing Claude logins in supervised gateways

### DIFF
--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -67,6 +67,9 @@ const SERVICE_PROXY_ENV_KEYS: [&str; 8] = [
     "all_proxy",
 ];
 const SERVICE_EXTRA_ENV_KEYS: [&str; 2] = ["NODE_EXTRA_CA_CERTS", "NODE_USE_SYSTEM_CA"];
+// Native CLIs use the account name to find their existing login (for example,
+// Claude's macOS Keychain account). Keep it across both service boundaries.
+const SERVICE_USER_ENV_KEYS: [&str; 2] = ["USER", "LOGNAME"];
 const SUPERVISED_CHILD_BASE_ENV_KEYS: [&str; 5] = ["HOME", "PATH", "OCM_HOME", "OCM_SELF", "SHELL"];
 const SUPERVISED_CHILD_RUNTIME_ENV_KEYS: [&str; 4] =
     ["NODE_OPTIONS", "NODE_ENV", "NODE_PATH", "PNPM_HOME"];
@@ -2571,7 +2574,10 @@ fn supervisor_service_environment(
             service_env.insert(key.to_string(), value.trim().to_string());
         }
     }
-    for key in SERVICE_EXTRA_ENV_KEYS {
+    for key in SERVICE_EXTRA_ENV_KEYS
+        .into_iter()
+        .chain(SERVICE_USER_ENV_KEYS)
+    {
         if let Some(value) = process_env
             .get(key)
             .filter(|value| !value.trim().is_empty())
@@ -2830,6 +2836,7 @@ fn stable_supervised_child_env_key(key: &str) -> bool {
         || key.starts_with("npm_config_")
         || key.starts_with("COREPACK_")
         || SUPERVISED_CHILD_BASE_ENV_KEYS.contains(&key)
+        || SERVICE_USER_ENV_KEYS.contains(&key)
         || SUPERVISED_CHILD_RUNTIME_ENV_KEYS.contains(&key)
         || SERVICE_PROXY_ENV_KEYS.contains(&key)
         || SERVICE_EXTRA_ENV_KEYS.contains(&key)
@@ -4091,6 +4098,36 @@ mod tests {
         assert!(!process_env.contains_key("OPENCLAW_LAUNCHD_LABEL"));
         assert!(!process_env.contains_key("OPENCLAW_SYSTEMD_UNIT"));
         assert!(!process_env.contains_key("OPENCLAW_WINDOWS_TASK_NAME"));
+    }
+
+    #[test]
+    fn service_environments_preserve_only_nonempty_user_identity() {
+        for (user, logname) in [(" fixture-user ", "fixture-login"), (" ", "")] {
+            let env = BTreeMap::from([
+                ("USER".to_string(), user.to_string()),
+                ("LOGNAME".to_string(), logname.to_string()),
+                ("GH_TOKEN".to_string(), "fixture-token".to_string()),
+                ("LD_PRELOAD".to_string(), "fixture.so".to_string()),
+                (
+                    "DYLD_INSERT_LIBRARIES".to_string(),
+                    "fixture.dylib".to_string(),
+                ),
+            ]);
+            for actual in [
+                supervisor_service_environment(&env, Path::new("/fixture"), Path::new("/bin/ocm")),
+                build_supervised_openclaw_env(env),
+            ] {
+                for (key, value) in [("USER", user), ("LOGNAME", logname)] {
+                    assert_eq!(
+                        actual.get(key).map(String::as_str),
+                        (!value.trim().is_empty()).then_some(value.trim())
+                    );
+                }
+                for excluded in ["GH_TOKEN", "LD_PRELOAD", "DYLD_INSERT_LIBRARIES"] {
+                    assert!(!actual.contains_key(excluded));
+                }
+            }
+        }
     }
 
     #[test]

--- a/tests/service_command_tests.rs
+++ b/tests/service_command_tests.rs
@@ -351,6 +351,61 @@ fn service_install_enables_the_env_and_installs_the_ocm_service() {
 }
 
 #[test]
+fn service_start_preserves_native_cli_identity_across_service_boundaries() {
+    for systemd in [false, true] {
+        let root = TestDir::new("service-native-cli-identity");
+        let cwd = root.child("workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let mut env = if systemd {
+            systemd_env(&root)
+        } else {
+            launchd_env(&root)
+        };
+        env.insert("USER".to_string(), "fixture-user".to_string());
+        env.insert("LOGNAME".to_string(), "fixture-user".to_string());
+        env.insert("GH_TOKEN".to_string(), "fixture-token".to_string());
+        env.insert(
+            "CODEX_SESSION_ID".to_string(),
+            "fixture-session".to_string(),
+        );
+        let marker = root.child("native-cli-identity.txt");
+        write_executable_script(
+            &root.child("fake-bin/openclaw"),
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"${{USER-unset}}:${{LOGNAME-unset}}:${{GH_TOKEN-unset}}:${{CODEX_SESSION_ID-unset}}\" > '{}'\n",
+                path_string(&marker)
+            ),
+        );
+        setup_launcher_env(&cwd, &env);
+        let started = run_ocm(&cwd, &env, &["service", "start", "demo", "--json"]);
+        assert!(started.status.success(), "{}", stderr(&started));
+
+        let definition =
+            fs::read_to_string(managed_service_definition_path(&env, &cwd, "ocm")).unwrap();
+        for key in ["USER", "LOGNAME"] {
+            let expected = if systemd {
+                format!("Environment=\"{key}=fixture-user\"")
+            } else {
+                format!("<key>{key}</key>\n      <string>fixture-user</string>")
+            };
+            assert!(definition.contains(&expected), "{definition}");
+        }
+        assert!(!definition.contains("fixture-token"));
+        assert!(!definition.contains("fixture-session"));
+
+        // The daemon must launch with the saved identity, not an ambient shell's.
+        env.remove("USER");
+        env.remove("LOGNAME");
+        let run = run_ocm(&cwd, &env, &["__daemon", "run", "--once", "--json"]);
+        assert!(run.status.success(), "{}", stderr(&run));
+        assert_eq!(
+            fs::read_to_string(&marker).unwrap(),
+            "fixture-user:fixture-user:unset:unset\n"
+        );
+    }
+}
+
+#[test]
 fn service_install_uses_valid_path_ocm_for_dev_artifact() {
     let root = TestDir::new("service-install-valid-path-ocm");
     let cwd = root.child("workspace");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users who had already signed in to Claude Code saw the OpenClaw UI report that Claude was not logged in when the gateway ran under OCM.

## Why This Change Was Made

OCM discarded `USER` and `LOGNAME` when constructing both the background service environment and the supervised gateway environment. Claude's native login lookup needs the account identity. Preserve those nonempty values at both boundaries, using the existing environment allowlist. Credentials and terminal session variables remain excluded.

## User Impact

Supervised gateways can detect the same existing native CLI login as the user's terminal, without copying tokens or adding a provider-specific environment workaround.

## Evidence

- Unmodified `305f965a16982fd38bff27125a915d0b5984366c`: both service boundaries dropped the supplied identity. The same CLI fixture passes on this PR.
- A native Claude probe with the actual failing service environment became authenticated when only `USER` was restored. Native Opus and Sonnet gateway turns then succeeded.
- The regression exercises launchd and systemd registration and executes a real capture-only child from the saved plan with the daemon caller's identity removed.
- Empty-value and secret-exclusion controls are covered. Formatting, all-target compilation, and the focused regression pass.
- 391 library tests and all 40 service-command tests pass. The local full suite encountered two failures also reproduced on unmodified main: `bin_wrapper_runs_with_an_overridden_home` and the `sibling_was_started` assertion in `daemon_defers_a_saved_service_start_until_source_watch_releases_the_env`. PR CI is still running.
- Source-blind validation passed all four clauses across eight identity fixtures and nine real supervised child runs, including absent/empty identity, a second account, persisted-state reuse, and secret-exclusion controls.
- Autoreview: no findings in the selected scope; default P0 threshold.

- json: [green.json](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/native-cli-identity/c7f42eac624c/20260912/green.json?X-Amz-Expires=604800&X-Amz-Date=20260912T073423Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260912%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f6f45ebdc7362b0aa063b89d382267dd7e0b88ce00af870bcad19d33f078a9bc)
- json: [proof-manifest.json](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/native-cli-identity/c7f42eac624c/20260912/proof-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260912T073423Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260912%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=df188317c54b8058ecfc59fe4de0b1ec4bf5fc315c9564849bef76174804f6eb)
- json: [red.json](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/native-cli-identity/c7f42eac624c/20260912/red.json?X-Amz-Expires=604800&X-Amz-Date=20260912T073423Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260912%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=05fcf40dd83fa1619759954f137a50756b010a19dc8325c2fe63711de7b6a877)
- manifest: [artifact-manifest.json](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/native-cli-identity/c7f42eac624c/20260912/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260912T073425Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260912%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=5d90783f2b56b5ec3ca7673f20d6a2e671f06f3196909a2088e7054dd6d264b2)


The PR's non-required macOS npm jobs hit the pre-existing fork limitation: `MACOS_TEAM_ID` is empty, so signature verification rejects `--team-id ''`. This is tracked separately in #216. The Windows CI job passed.

- json: [behavior-validation.json](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/native-cli-identity/c7f42eac624c/20260912-validated/behavior-validation.json?X-Amz-Expires=604800&X-Amz-Date=20260912T073655Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260912%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=70942db82f9b3ab273e00e55cb275e94a36343ae4bcc4cdd34b41b23ef485859)
- md: [behavior-validation.md](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjI2MzA2MDIwMg/ocm/native-cli-identity/c7f42eac624c/20260912-validated/behavior-validation.md?X-Amz-Expires=604800&X-Amz-Date=20260912T073655Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260912%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=2cc0821e1ae135947221aaca4940f364c0f66f155183850a71556ce4a4f00d10)
