### PR TITLE
chore(release): bump version to 0.2.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "ocm"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "base64",
  "caseless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocm"
-version = "0.2.45"
+version = "0.2.46"
 publish = false
 edition = "2024"
 rust-version = "1.88"


### PR DESCRIPTION
## What Problem This Solves

Prepare OCM v0.2.46 so users can receive the native Claude login discovery fix merged in #222.

## Why This Change Was Made

The release script changes the package version from 0.2.45 to 0.2.46 in Cargo.toml and Cargo.lock. After squash merge and successful CI on that exact main commit, the same script signs the release tag and dispatches the protected release workflow.

## User Impact

The release includes the account-name preservation fix for background services and supervised gateways, allowing native CLI providers to find existing logins after service definitions and launch plans are refreshed.

## Evidence

- Base: freshly fetched canonical main at `c749b58c14fac479a1273e7a29842955be88aa16`.
- Inspected the complete diff: two version replacements, with no source or dependency changes.
- #222 passed all five required checks, Autoreview, and independent source-blind behavior validation.
- Used the release script’s `--skip-checks` option to avoid repeating local full-suite checks for a version-only change. This PR’s required CI and the exact-main release CI gate remain enforced.
